### PR TITLE
docs: add Synapse recruiter-readiness audit report

### DIFF
--- a/RECRUITER_READINESS_AUDIT_2026-04-09.md
+++ b/RECRUITER_READINESS_AUDIT_2026-04-09.md
@@ -1,0 +1,194 @@
+# Synapse Recruiter-Readiness Audit
+
+## 1. Executive Verdict
+**Verdict: Close, but not ready**
+
+Synapse already demonstrates serious ambition, thoughtful workflow design, and substantial AI product depth. However, several trust and coherence gaps in the first-run experience, product messaging consistency, and perceived production readiness will likely make recruiters treat it as an advanced prototype rather than a polished portfolio-grade product.
+
+- **Confidence level:** High (0.82)
+- **Biggest strengths:** End-to-end PRD → mockups → artifacts pipeline, branch-based refinement model, rich feature depth, and strong technical implementation signals.
+- **Biggest risks:** First-impression clarity is weak, onboarding friction is high (API key/setup + minimal contextual guidance), and quality signals are mixed (stale docs, “Beta” + pseudo-enterprise status labels, large bundle warnings).
+- **Fastest path to “ready”:** Tighten the first 60 seconds (clear value proposition + guided quickstart), harden trust signals (real status/telemetry copy, consistent documentation), and showcase one undeniable “hero flow” with polished deterministic demo data.
+
+## 2. Inferred Product Intent
+### What Synapse appears to be
+An AI-native product definition workspace that converts rough product ideas into structured PRDs, then expands those into design/engineering artifacts and iterative feedback loops.
+
+### Who it appears to be for
+- Early-stage product builders (founders, PMs, designer-engineers).
+- AI-native prototypers who want to move from concept to structured implementation artifacts rapidly.
+
+### What problem it appears to solve
+Bridging the gap between fuzzy product ideation and production-oriented documentation by making requirements, mockups, and implementation outputs part of one iterative system.
+
+### What the builder appears to be demonstrating
+- Full-stack product architecture and state modeling.
+- Applied LLM orchestration with structured outputs and multi-step workflows.
+- Product-thinking beyond a single prompt box (versioning, branching, history, stale artifacts, export).
+
+## 3. Scorecard
+| Category | Score (1-10) | Why |
+|---|---:|---|
+| Product Legitimacy | **7.2** | Concept and workflow are coherent, but “serious product” perception is reduced by onboarding ambiguity, messaging inconsistency, and some faux-status UI language. |
+| User Utility | **7.8** | High potential practical value across PRD, artifacts, and exports; utility depends heavily on model quality and user prompt quality without enough scaffolding. |
+| Wow Factor | **7.5** | Strong conceptual wow (branchable PRD + artifact pipeline), but first-run wow can be muted before users reach the strongest moments. |
+| UX / Visual Polish | **7.1** | Modern and mostly clean UI; some copy/interaction rough edges and clarity issues in gating and empty states reduce polish. |
+| Functional Readiness | **8.1** | Lint/build/tests pass; architecture appears robust. Remaining concerns are runtime variability and edge-state communication. |
+| Engineering Credibility | **8.3** | Good modularization, schema-driven generation, state persistence, and typed flows. Bundle size warnings + stale architectural docs weaken perceived rigor. |
+| Portfolio / Narrative Strength | **6.9** | Strong substance, but narrative is undersold in-product; recruiters may miss the strongest technical differentiators quickly. |
+| Overall Recruiter Impression | **7.4** | Impresses technical reviewers who dig in, but not yet maximized for cold recruiter evaluation in 2–3 minutes. |
+
+## 4. First-Impression Analysis
+### First 10 seconds
+**Likely reaction:** “Looks polished and modern, but what exactly is this?”
+
+- **Confusion points:** Home title says “Welcome to Synapse..” (awkward punctuation), and core value proposition is not immediately explicit on the primary screen.
+- **Delight points:** Clean dark visual styling and fast, focused input-centered layout.
+- **Trust-building moments:** Presence of examples and settings.
+- **Trust-eroding moments:** “Beta” badge + unclear setup prerequisites before meaningful output.
+
+### First 30 seconds
+**Likely reaction:** “This might be powerful, but I need to figure out the workflow.”
+
+- **Confusion points:** User must infer process order and why stages unlock only after “Mark Final.”
+- **Delight points:** Example prompts and prompt enhancement imply thoughtful authoring support.
+- **Trust-building moments:** Dedicated “Meet Synapse” page explains stages.
+- **Trust-eroding moments:** Product explanation lives behind a dismissible banner and secondary route rather than being integrated directly into the primary creation flow.
+
+### First 2 minutes
+**Likely reaction:** “This is deeper than expected; probably a serious project, but still somewhat prototype-ish.”
+
+- **Confusion points:** LLM dependency (bring-your-own key) and variable output quality can obscure product value if first generation underwhelms.
+- **Delight points:** Branch workflows, consolidated history, and multi-artifact pipeline are portfolio-grade differentiators.
+- **Trust-building moments:** Export capabilities and stage-based model indicate thoughtful product scope.
+- **Trust-eroding moments:** Inconsistent documentation fidelity versus code reality can be interpreted as lack of maintenance discipline.
+
+## 5. Deep Findings by Category
+
+### 5.1 Product Legitimacy
+1) **Observation:** Core concept is coherent: idea intake, structured PRD generation, branch refinement, downstream artifacts, and history.
+- **Why it matters:** Coherence is the strongest signal that this is a product, not a feature demo.
+- **Impact on recruiter perception:** Positive; indicates product systems thinking.
+- **Recommended fix:** Keep this structure, but surface it directly in the initial creation UI with an inline 3-step “How Synapse works” panel.
+
+2) **Observation:** Some UI copy feels less production-trustworthy (e.g., “Welcome to Synapse..”, pseudo-operational status block in settings).
+- **Why it matters:** Recruiters quickly spot “cosmetic enterprise theater” vs real operational signals.
+- **Impact on recruiter perception:** Mild credibility erosion.
+- **Recommended fix:** Replace decorative status/version claims with meaningful trust text (privacy note, generation reliability expectations, model/latency caveats).
+
+3) **Observation:** Documentation appears partially stale relative to architecture changes.
+- **Why it matters:** Inconsistency between docs and code can signal weak maintenance discipline.
+- **Impact on recruiter perception:** Medium trust loss for senior technical evaluators.
+- **Recommended fix:** Add a “Current architecture (as of date)” section and prune legacy references.
+
+### 5.2 User Utility
+1) **Observation:** Synapse supports actionable outputs beyond PRD text (screen inventory, data model, implementation plan, prompt pack, etc.).
+- **Why it matters:** Practical artifacts are materially useful for teams and interview discussions.
+- **Impact on recruiter perception:** Strong positive utility signal.
+- **Recommended fix:** Add one-click “Generate recruiter demo bundle” preset to guarantee high-quality first output.
+
+2) **Observation:** Utility is constrained by requiring users to provide their own Gemini key and prompt quality.
+- **Why it matters:** Cold evaluators may churn before seeing value.
+- **Impact on recruiter perception:** High risk in portfolio context.
+- **Recommended fix:** Include a no-key interactive demo project (pre-generated canonical outputs) accessible from home.
+
+3) **Observation:** Stage gating (“Mark Final” requirement) is logical but not always self-explanatory.
+- **Why it matters:** Hidden rules reduce perceived intuitiveness.
+- **Impact on recruiter perception:** Moderate UX friction.
+- **Recommended fix:** Add explicit inline copy on disabled tabs with tooltip explaining unlock condition and rationale.
+
+### 5.3 Wow Factor
+1) **Observation:** The strongest “wow” is downstream from onboarding (branch-and-consolidate + multi-artifact synthesis).
+- **Why it matters:** Recruiters often spend <2 minutes; wow must happen early.
+- **Impact on recruiter perception:** Potential under-realization of strength.
+- **Recommended fix:** Introduce a hero quick demo button on home (“Watch Synapse generate a full product package in 30 seconds”).
+
+2) **Observation:** Existing visual design is competent and consistent, but lacks a deliberate “signature moment.”
+- **Why it matters:** Memorable experiences create recall in hiring funnels.
+- **Impact on recruiter perception:** Good but not standout.
+- **Recommended fix:** Add one standout interaction (e.g., animated pipeline playback from idea to artifacts with meaningful deltas).
+
+### 5.4 Engineering / Product Credibility
+1) **Observation:** Modular service architecture, typed schemas, and persistent state slices signal strong engineering judgment.
+- **Why it matters:** Recruiters evaluate craftsmanship through structure and maintainability.
+- **Impact on recruiter perception:** Strong positive signal.
+- **Recommended fix:** Add a concise architecture diagram and “design decisions” section directly in-app (not just README).
+
+2) **Observation:** Build output warns about large chunk size and mixed dynamic/static imports.
+- **Why it matters:** Performance and bundling quality are expected for serious frontend work.
+- **Impact on recruiter perception:** Medium technical debt signal.
+- **Recommended fix:** Implement route/component-level code splitting for heavy generation/rendering surfaces; document perf budget.
+
+3) **Observation:** Client-side API key storage is practical for hobby tools but introduces trust concerns for polished portfolio sharing.
+- **Why it matters:** Security and operational judgment are scrutinized in senior interviews.
+- **Impact on recruiter perception:** Context-dependent risk.
+- **Recommended fix:** Add clear “local-only prototype security model” disclosure and optional proxy mode for production-grade handling.
+
+### 5.5 Functional Readiness
+1) **Observation:** Baseline quality checks pass (tests/lint/build).
+- **Why it matters:** Objective reliability signal.
+- **Impact on recruiter perception:** Positive.
+- **Recommended fix:** Add CI badge + commit status link in README for visible ongoing quality discipline.
+
+2) **Observation:** Real-world functional quality remains sensitive to LLM variability and missing deterministic fallback outputs.
+- **Why it matters:** Recruiters may see inconsistent outputs and misattribute to engineering quality.
+- **Impact on recruiter perception:** High demo risk.
+- **Recommended fix:** Provide curated deterministic demo artifacts with locked snapshots and inline explanation of stochastic behavior.
+
+3) **Observation:** Potential edge-state gaps likely exist around first-run error/loading transitions and empty stage context.
+- **Why it matters:** Trust is lost more from bad edge-case handling than happy-path power.
+- **Impact on recruiter perception:** Medium.
+- **Recommended fix:** Audit each stage with explicit empty/loading/error states and action guidance.
+
+### 5.6 Narrative Strength
+1) **Observation:** Project has strong interview story ingredients (pipeline, branching, artifacts, staleness, versioning), but they are not foregrounded in first-use UX.
+- **Why it matters:** Portfolio impact depends on communicability, not just capability.
+- **Impact on recruiter perception:** Under-selling technical depth.
+- **Recommended fix:** Add a recruiter-facing “Tour mode” that walks through three hero moments and links to architecture rationale.
+
+2) **Observation:** Some repository docs indicate historical context drift.
+- **Why it matters:** Narrative inconsistency dilutes confidence and makes it harder to present a crisp story.
+- **Impact on recruiter perception:** Moderate.
+- **Recommended fix:** Consolidate into one “CURRENT_STATE.md” with changelog-style “what’s now true.”
+
+## 6. Critical Blockers
+1. **No deterministic/demo-first experience for cold evaluators.**
+   - A recruiter without API setup patience may never reach the strongest workflow.
+2. **First-run value proposition not explicit enough in the primary screen.**
+   - The app’s differentiation is discoverable, but not immediately obvious.
+3. **Trust signal inconsistency across docs/UI (stale references and decorative system status language).**
+   - This can make the product feel less production-serious.
+
+## 7. High-Priority Weaknesses
+1. **Hero capabilities are buried behind setup + navigation steps.**
+2. **Stage gating logic is not sufficiently explained in-context.**
+3. **Performance perception risk from large bundle warnings and heavy client-side features.**
+4. **Portfolio narrative is not explicitly packaged for recruiter skim behavior.**
+
+## 8. Medium-Priority Polish Gaps
+1. Tighten copywriting consistency and tone across onboarding, settings, and stage headers.
+2. Improve empty/loading/error microcopy with clearer next actions.
+3. Add mobile-specific optimization notes or constraints if mobile parity is not guaranteed.
+4. Replace or clarify “Beta” indicators to avoid reducing credibility during recruiting outreach.
+
+## 9. Optional Enhancements
+1. Add shareable “public case study snapshot” links for each generated project.
+2. Add instrumentation dashboard for generation time/success rates.
+3. Add comparative mode showing “before/after branch consolidation” impact metrics.
+4. Add one polished template vertical (e.g., SaaS, marketplace, fintech) with best-practice seeds.
+
+## 10. Highest-Leverage Improvement Plan (Fastest Path to Ready)
+1. **Create a frictionless recruiter demo mode (must-have).**
+   - One click from home opens a fully-populated exemplar project with all stages.
+2. **Redesign first-screen messaging (must-have).**
+   - Explicitly answer: what Synapse is, who it’s for, and what outcome users get in <60 seconds.
+3. **Trust hardening pass (must-have).**
+   - Remove decorative status/version theatrics, align docs with current architecture, and add transparent caveats.
+4. **Showcase polish pass (should-have).**
+   - Add guided tour and one memorable animated “idea → artifacts” reveal.
+5. **Performance/story reinforcement (should-have).**
+   - Implement code splitting and publish a short engineering decisions panel to highlight intentional tradeoffs.
+
+---
+### Bottom Line
+Synapse is already a strong technical project with clear product ambition and real portfolio potential. It becomes recruiter-ready once the first-run experience is reoriented around **clarity + deterministic showcase + trust consistency** so evaluators immediately see both product value and engineering maturity.


### PR DESCRIPTION
### Motivation
- Provide a focused, structured recruiter-readiness audit for Synapse that assesses product legitimacy, user utility, wow factor, engineering credibility, and a prioritized improvement plan so the project can be safely shown to recruiters.

### Description
- Add `RECRUITER_READINESS_AUDIT_2026-04-09.md`, a 10-section deep audit that includes an executive verdict, inferred product intent, a scored rubric, first-impression analysis, detailed findings with recommended fixes, critical blockers, and a highest-leverage improvement plan.
- The audit file was created and committed on the current `work` branch as documentation intended to guide next steps for polish and demo readiness.

### Testing
- Ran `npm install` which completed successfully. 
- Ran `npm run test` and all tests passed (`2 files`, `15 tests` passed). 
- Ran `npm run build` which completed successfully but emitted bundle/chunk-size warnings (not blocking). 
- Ran `npm run lint` which completed without error. 
- Attempted `git pull origin main` which failed because no `origin` remote is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74a95e98c8321900d9cb05276ca28)