### PR TITLE
Replace placeholder infographic with live React components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "mark.js": "^8.11.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.1",
         "rehype-raw": "^7.0.0",
@@ -7186,6 +7187,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mark.js": "^8.11.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
     "rehype-raw": "^7.0.0",

--- a/src/components/MeetSynapsePage.tsx
+++ b/src/components/MeetSynapsePage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, ArrowRight, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { InfographicGallery } from './infographics';
 
 export function MeetSynapsePage() {
     const navigate = useNavigate();
@@ -28,22 +29,8 @@ export function MeetSynapsePage() {
                         An AI-native product definition environment that transforms your ideas into complete product specifications.
                     </p>
 
-                    {/* Placeholder banner */}
-                    <div className="flex items-center gap-3 px-4 py-3 mb-6 rounded-xl border border-amber-500/30 bg-amber-500/10 text-amber-300 text-sm">
-                        <AlertTriangle size={18} className="shrink-0" />
-                        <span>
-                            This infographic is a placeholder — the final version is in progress.
-                        </span>
-                    </div>
-
                     {/* Pipeline infographic */}
-                    <div className="rounded-2xl border border-neutral-700/50 bg-neutral-800/30 overflow-hidden">
-                        <img
-                            src="/synapse-pipeline.png"
-                            alt="Synapse Pipeline — AI-Native Product Definition System infographic showing the four stages: PRD Generation, UI Mockups, Artifacts, and History & Iteration"
-                            className="w-full h-auto"
-                        />
-                    </div>
+                    <InfographicGallery />
 
                     {/* CTA */}
                     <div className="mt-10 text-center">

--- a/src/components/infographics/FlowArrow.tsx
+++ b/src/components/infographics/FlowArrow.tsx
@@ -1,0 +1,38 @@
+interface FlowArrowProps {
+  direction?: 'right' | 'down';
+  className?: string;
+}
+
+export function FlowArrow({ direction = 'right', className = '' }: FlowArrowProps) {
+  if (direction === 'down') {
+    return (
+      <svg
+        className={`h-6 w-6 text-[#4a5a8a] ${className}`}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 5v14" />
+        <path d="M19 12l-7 7-7-7" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      className={`h-6 w-6 text-[#4a5a8a] ${className}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5 12h14" />
+      <path d="M12 5l7 7-7 7" />
+    </svg>
+  );
+}

--- a/src/components/infographics/InfographicGallery.tsx
+++ b/src/components/infographics/InfographicGallery.tsx
@@ -1,0 +1,17 @@
+import { SlideEntryPoint } from './SlideEntryPoint';
+import { SlidePRDGeneration } from './SlidePRDGeneration';
+import { SlideUIMockups } from './SlideUIMockups';
+import { SlideArtifacts } from './SlideArtifacts';
+import { SlideHistory } from './SlideHistory';
+
+export function InfographicGallery() {
+  return (
+    <div className="flex flex-col gap-8">
+      <SlideEntryPoint />
+      <SlidePRDGeneration />
+      <SlideUIMockups />
+      <SlideArtifacts />
+      <SlideHistory />
+    </div>
+  );
+}

--- a/src/components/infographics/InfographicSlide.tsx
+++ b/src/components/infographics/InfographicSlide.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+interface InfographicSlideProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function InfographicSlide({ title, children }: InfographicSlideProps) {
+  return (
+    <div className="relative min-h-[500px] overflow-hidden rounded-2xl bg-gradient-to-b from-[#0a1128] via-[#101d3a] to-[#0a1128] p-8 md:p-10">
+      {/* Dot grid overlay */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.04]"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle, #8b9cf7 1px, transparent 1px)',
+          backgroundSize: '24px 24px',
+        }}
+      />
+
+      {/* Content */}
+      <div className="relative z-10">
+        <h2 className="mb-8 text-center text-3xl font-bold tracking-tight text-white md:text-4xl">
+          {title}
+        </h2>
+        {children}
+      </div>
+
+      {/* Synapse star logo */}
+      <svg
+        className="absolute bottom-4 right-4 h-6 w-6 text-slate-500/40"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/infographics/SlideArtifacts.tsx
+++ b/src/components/infographics/SlideArtifacts.tsx
@@ -1,0 +1,131 @@
+import {
+  MdOutlineViewList,
+  MdOutlineAccountTree,
+  MdOutlineExtension,
+  MdOutlineAssignment,
+  MdOutlineStorage,
+  MdOutlineChatBubbleOutline,
+  MdOutlineDesignServices,
+  MdOutlineFactCheck,
+  MdOutlineBorderOuter,
+  MdOutlineAltRoute,
+  MdOutlineScreenshot,
+  MdOutlineThumbsUpDown,
+  MdOutlineAutorenew,
+} from 'react-icons/md';
+import { InfographicSlide } from './InfographicSlide';
+
+const artifacts = [
+  { icon: MdOutlineViewList, label: 'Screen Inventory' },
+  { icon: MdOutlineAccountTree, label: 'User Flows' },
+  { icon: MdOutlineExtension, label: 'Component Inventory' },
+  { icon: MdOutlineAssignment, label: 'Implementation Plan' },
+  { icon: MdOutlineStorage, label: 'Data Model' },
+  { icon: MdOutlineChatBubbleOutline, label: 'Prompt Pack' },
+  { icon: MdOutlineDesignServices, label: 'Design System' },
+];
+
+const markupTypes = [
+  { icon: MdOutlineFactCheck, label: 'Critique Board' },
+  { icon: MdOutlineBorderOuter, label: 'Wireframe Callout' },
+  { icon: MdOutlineAltRoute, label: 'Flow Annotation' },
+  { icon: MdOutlineScreenshot, label: 'Screenshot Annotation' },
+  { icon: MdOutlineThumbsUpDown, label: 'Design Feedback' },
+];
+
+const genControls = [
+  'Generate All',
+  'Generate One',
+  'Refine',
+  'Refresh Stale',
+];
+
+export function SlideArtifacts() {
+  return (
+    <InfographicSlide title="Stage 3 — Artifacts">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        {/* Artifact grid */}
+        <div className="flex-[60]">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {artifacts.map((a) => (
+              <div
+                key={a.label}
+                className="flex flex-col items-center rounded-xl border border-emerald-500/30 bg-[#111d35]/50 p-4 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]"
+              >
+                <a.icon size={22} className="mb-2 text-[#8b9cf7]" />
+                <span className="text-center text-sm font-bold text-white">
+                  {a.label}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Refine Loop */}
+        <div className="flex flex-[40] flex-col items-center justify-center rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <h3 className="mb-4 text-lg font-semibold text-white">
+            Refine Loop
+          </h3>
+          <div className="relative h-36 w-36">
+            <svg className="h-full w-full" viewBox="0 0 144 144">
+              {/* Circular arrow */}
+              <circle
+                cx="72"
+                cy="72"
+                r="50"
+                fill="none"
+                stroke="#4a5a8a"
+                strokeWidth="1.5"
+                strokeDasharray="6 4"
+              />
+              <polygon points="72,22 77,32 67,32" fill="#4a5a8a" />
+            </svg>
+            <MdOutlineAutorenew
+              size={28}
+              className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-[#8b9cf7]"
+            />
+          </div>
+          <div className="mt-3 flex flex-col items-center gap-1 text-xs text-slate-400">
+            <span>User instruction</span>
+            <span className="text-[#8b9cf7]">→ AI improves output →</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom row */}
+      <div className="mt-6 flex flex-col gap-4 md:flex-row">
+        {/* Generation Controls */}
+        <div className="flex-1 rounded-xl border border-emerald-500/20 bg-[#111d35]/50 p-4 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Generation Controls
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {genControls.map((ctrl) => (
+              <span
+                key={ctrl}
+                className="rounded-lg border border-emerald-500/30 bg-[#0d1829] px-3 py-1.5 text-xs text-slate-300"
+              >
+                {ctrl}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Markup Image Types */}
+        <div className="flex-1 rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-4 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Markup Image Types
+          </p>
+          <ul className="space-y-2">
+            {markupTypes.map((m) => (
+              <li key={m.label} className="flex items-center gap-2">
+                <m.icon size={16} className="text-[#8b9cf7]" />
+                <span className="text-sm text-slate-300">{m.label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </InfographicSlide>
+  );
+}

--- a/src/components/infographics/SlideEntryPoint.tsx
+++ b/src/components/infographics/SlideEntryPoint.tsx
@@ -1,0 +1,59 @@
+import {
+  MdOutlineChat,
+  MdDevices,
+  MdAutoAwesome,
+  MdDashboard,
+} from 'react-icons/md';
+import { InfographicSlide } from './InfographicSlide';
+import { FlowArrow } from './FlowArrow';
+
+const steps = [
+  {
+    icon: MdOutlineChat,
+    title: 'Describe Product Idea',
+    subtitle: 'Natural language or uploaded brief',
+  },
+  {
+    icon: MdDevices,
+    title: 'Select Platform',
+    subtitle: 'App or Web',
+  },
+  {
+    icon: MdAutoAwesome,
+    title: 'Enhance Prompt',
+    subtitle: 'Optional AI refinement',
+  },
+  {
+    icon: MdDashboard,
+    title: 'Enter Workspace',
+    subtitle: 'Your project hub',
+  },
+];
+
+export function SlideEntryPoint() {
+  return (
+    <InfographicSlide title="Entry Point — Project Creation">
+      <div className="flex flex-wrap items-center justify-center gap-3 md:gap-4">
+        {steps.map((step, i) => (
+          <div key={step.title} className="flex items-center gap-3 md:gap-4">
+            {/* Card */}
+            <div className="flex w-40 flex-col items-center rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)] md:w-48">
+              <step.icon size={22} className="mb-3 text-[#8b9cf7]" />
+              <p className="text-center text-base font-bold text-white">
+                {step.title}
+              </p>
+              <p className="mt-1 text-center text-sm text-slate-400">
+                {step.subtitle}
+              </p>
+            </div>
+
+            {/* Arrow between cards (not after the last) */}
+            {i < steps.length - 1 && (
+              <FlowArrow className="hidden shrink-0 md:block" />
+            )}
+          </div>
+        ))}
+      </div>
+    </InfographicSlide>
+  );
+}

--- a/src/components/infographics/SlideHistory.tsx
+++ b/src/components/infographics/SlideHistory.tsx
@@ -1,0 +1,72 @@
+import {
+  MdOutlineInfo,
+  MdOutlineRefresh,
+  MdOutlineMerge,
+  MdOutlineLayers,
+  MdOutlineChatBubble,
+  MdOutlineCheckCircle,
+  MdOutlineHistory,
+  MdOutlineDifference,
+  MdOutlineSkipNext,
+} from 'react-icons/md';
+import { InfographicSlide } from './InfographicSlide';
+
+const timelineNodes = [
+  { icon: MdOutlineInfo, label: 'Init' },
+  { icon: MdOutlineRefresh, label: 'Regenerated' },
+  { icon: MdOutlineMerge, label: 'Consolidated' },
+  { icon: MdOutlineLayers, label: 'Artifact Generated' },
+  { icon: MdOutlineRefresh, label: 'Artifact Regenerated' },
+  { icon: MdOutlineChatBubble, label: 'Feedback Created' },
+  { icon: MdOutlineCheckCircle, label: 'Feedback Applied' },
+];
+
+const userActions = [
+  { icon: MdOutlineHistory, label: 'View version' },
+  { icon: MdOutlineDifference, label: 'See diffs' },
+  { icon: MdOutlineSkipNext, label: 'Return to latest' },
+];
+
+export function SlideHistory() {
+  return (
+    <InfographicSlide title="History & Iteration">
+      {/* Timeline */}
+      <div className="mb-8 overflow-x-auto">
+        <div className="relative mx-auto flex min-w-[700px] items-start justify-between px-4">
+          {/* Connecting line */}
+          <div className="absolute left-8 right-8 top-5 h-px bg-purple-500/30" />
+
+          {timelineNodes.map((node) => (
+            <div
+              key={node.label}
+              className="relative z-10 flex flex-col items-center"
+              style={{ width: 90 }}
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-purple-500/40 bg-[#1a1530]">
+                <node.icon size={20} className="text-[#8b9cf7]" />
+              </div>
+              <span className="mt-2 text-center text-[11px] leading-tight text-slate-400">
+                {node.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* User Actions */}
+      <div className="mx-auto max-w-md rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+        <p className="mb-3 text-center text-xs font-semibold uppercase tracking-wider text-slate-400">
+          User Actions
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-5">
+          {userActions.map((a) => (
+            <div key={a.label} className="flex items-center gap-2">
+              <a.icon size={18} className="text-[#8b9cf7]" />
+              <span className="text-sm text-slate-300">{a.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </InfographicSlide>
+  );
+}

--- a/src/components/infographics/SlidePRDGeneration.tsx
+++ b/src/components/infographics/SlidePRDGeneration.tsx
@@ -1,0 +1,181 @@
+import {
+  MdOutlineVisibility,
+  MdOutlinePeople,
+  MdOutlineWarning,
+  MdOutlineStarOutline,
+  MdOutlineAccountTree,
+  MdOutlineReportProblem,
+  MdOutlineCode,
+  MdOutlineAttachMoney,
+  MdOutlineFlag,
+  MdOutlineSettings,
+  MdOutlineChecklist,
+  MdOutlineCallSplit,
+  MdOutlineFormatQuote,
+  MdOutlineApps,
+  MdOutlineChat,
+  MdOutlineMerge,
+  MdOutlineCommit,
+  MdOutlineDeleteSweep,
+  MdOutlineGridView,
+  MdOutlineEdit,
+  MdOutlineLock,
+} from 'react-icons/md';
+import { InfographicSlide } from './InfographicSlide';
+
+const prdSections = [
+  { icon: MdOutlineVisibility, label: 'Vision' },
+  { icon: MdOutlinePeople, label: 'Users' },
+  { icon: MdOutlineWarning, label: 'Problem' },
+  { icon: MdOutlineStarOutline, label: 'Features' },
+  { icon: MdOutlineAccountTree, label: 'Architecture' },
+  { icon: MdOutlineReportProblem, label: 'Risks' },
+  { icon: MdOutlineCode, label: 'Constraints' },
+];
+
+const featureDetails = [
+  { icon: MdOutlineAttachMoney, label: 'Value' },
+  { icon: MdOutlineFlag, label: 'Priority (MoSCoW)' },
+  { icon: MdOutlineSettings, label: 'Complexity' },
+  { icon: MdOutlineChecklist, label: 'Acceptance Criteria' },
+  { icon: MdOutlineCallSplit, label: 'Dependencies' },
+];
+
+const branchingNodes = [
+  { icon: MdOutlineFormatQuote, label: 'Highlight text' },
+  { icon: MdOutlineApps, label: 'Choose intent' },
+  { icon: MdOutlineChat, label: 'AI conversation' },
+  { icon: MdOutlineMerge, label: 'Consolidate' },
+  { icon: MdOutlineCommit, label: 'Commit version' },
+  { icon: MdOutlineDeleteSweep, label: 'Mark stale' },
+];
+
+const intents = ['Clarify', 'Expand', 'Specify', 'Replace', 'Alternative'];
+
+const userActions = [
+  { icon: MdOutlineGridView, label: 'Structured View' },
+  { icon: MdOutlineCode, label: 'Markdown View' },
+  { icon: MdOutlineEdit, label: 'Highlight to Branch' },
+  { icon: MdOutlineLock, label: 'Mark Final' },
+];
+
+export function SlidePRDGeneration() {
+  return (
+    <InfographicSlide title="Stage 1 — PRD Generation">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        {/* Left panel — Structured PRD */}
+        <div className="flex-[45] rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <h3 className="mb-4 text-lg font-semibold text-white">
+            AI Generates Structured PRD
+          </h3>
+          <ul className="space-y-2">
+            {prdSections.map((s) => (
+              <li key={s.label} className="flex items-center gap-2">
+                <s.icon size={18} className="text-[#8b9cf7]" />
+                <span className="text-sm text-slate-300">{s.label}</span>
+              </li>
+            ))}
+          </ul>
+
+          {/* Feature breakdown sub-panel */}
+          <div className="mt-4 rounded-lg border border-[#2a3a5c]/40 bg-[#0d1829]/60 p-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              Each Feature Includes
+            </p>
+            <ul className="space-y-1.5">
+              {featureDetails.map((f) => (
+                <li key={f.label} className="flex items-center gap-2">
+                  <f.icon size={16} className="text-[#8b9cf7]" />
+                  <span className="text-sm text-slate-300">{f.label}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* Right panel — Branching Loop */}
+        <div className="flex-[55] rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <h3 className="mb-4 text-lg font-semibold text-white">
+            Branching Loop
+          </h3>
+
+          {/* Circular flow — rendered as a ring of nodes */}
+          <div className="relative mx-auto mb-4 h-64 w-64">
+            {branchingNodes.map((node, i) => {
+              const angle = (i * 360) / branchingNodes.length - 90;
+              const rad = (angle * Math.PI) / 180;
+              const r = 100;
+              const cx = 128 + r * Math.cos(rad);
+              const cy = 128 + r * Math.sin(rad);
+              return (
+                <div
+                  key={node.label}
+                  className="absolute flex flex-col items-center"
+                  style={{
+                    left: cx - 28,
+                    top: cy - 28,
+                    width: 56,
+                  }}
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-[#2a3a5c]/60 bg-[#0d1829]">
+                    <node.icon size={18} className="text-[#8b9cf7]" />
+                  </div>
+                  <span className="mt-1 text-center text-[10px] leading-tight text-slate-400">
+                    {node.label}
+                  </span>
+                </div>
+              );
+            })}
+            {/* Center circular arrow (SVG) */}
+            <svg
+              className="absolute inset-0 h-full w-full"
+              viewBox="0 0 256 256"
+            >
+              <circle
+                cx="128"
+                cy="128"
+                r="70"
+                fill="none"
+                stroke="#4a5a8a"
+                strokeWidth="1.5"
+                strokeDasharray="6 4"
+              />
+              {/* Arrowhead */}
+              <polygon
+                points="128,58 133,68 123,68"
+                fill="#4a5a8a"
+              />
+            </svg>
+          </div>
+
+          {/* Intent badges */}
+          <div className="flex flex-wrap justify-center gap-2">
+            {intents.map((intent) => (
+              <span
+                key={intent}
+                className="rounded-full border border-[#2a3a5c]/60 bg-[#0d1829] px-3 py-1 text-xs text-slate-300"
+              >
+                {intent}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom bar — User Actions */}
+      <div className="mt-6 rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-4 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+        <p className="mb-3 text-center text-xs font-semibold uppercase tracking-wider text-slate-400">
+          User Actions
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          {userActions.map((a) => (
+            <div key={a.label} className="flex items-center gap-2">
+              <a.icon size={18} className="text-[#8b9cf7]" />
+              <span className="text-sm text-slate-300">{a.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </InfographicSlide>
+  );
+}

--- a/src/components/infographics/SlideUIMockups.tsx
+++ b/src/components/infographics/SlideUIMockups.tsx
@@ -1,0 +1,133 @@
+import {
+  MdOutlinePhoneIphone,
+  MdOutlineLaptopMac,
+  MdOutlineDevices,
+  MdOutlineTune,
+  MdOutlineEqualizer,
+  MdOutlineSignalCellularAlt,
+  MdOutlineCropSquare,
+  MdOutlineFilterNone,
+  MdOutlineShare,
+  MdOutlineRefresh,
+  MdOutlineCompareArrows,
+  MdOutlineRateReview,
+  MdOutlineArrowUpward,
+} from 'react-icons/md';
+import { InfographicSlide } from './InfographicSlide';
+
+const configGroups = [
+  {
+    title: 'Platform',
+    options: [
+      { icon: MdOutlinePhoneIphone, label: 'Mobile' },
+      { icon: MdOutlineLaptopMac, label: 'Desktop' },
+      { icon: MdOutlineDevices, label: 'Responsive' },
+    ],
+  },
+  {
+    title: 'Fidelity',
+    options: [
+      { icon: MdOutlineTune, label: 'Low' },
+      { icon: MdOutlineEqualizer, label: 'Mid' },
+      { icon: MdOutlineSignalCellularAlt, label: 'High' },
+    ],
+  },
+  {
+    title: 'Scope',
+    options: [
+      { icon: MdOutlineCropSquare, label: 'Single Screen' },
+      { icon: MdOutlineFilterNone, label: 'Multi-Screen' },
+      { icon: MdOutlineShare, label: 'Key Workflow' },
+    ],
+  },
+];
+
+const mockupActions = [
+  { icon: MdOutlineRefresh, label: 'Regenerate' },
+  { icon: MdOutlineCompareArrows, label: 'Compare Versions' },
+  { icon: MdOutlineRateReview, label: 'Extract Feedback' },
+];
+
+export function SlideUIMockups() {
+  return (
+    <InfographicSlide title="Stage 2 — UI Mockups">
+      {/* Config row */}
+      <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+        {configGroups.map((group) => (
+          <div
+            key={group.title}
+            className="rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]"
+          >
+            <h3 className="mb-3 text-center text-lg font-semibold text-white">
+              {group.title}
+            </h3>
+            <div className="flex justify-center gap-4">
+              {group.options.map((opt) => (
+                <div
+                  key={opt.label}
+                  className="flex flex-col items-center gap-1.5"
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-[#2a3a5c]/60 bg-[#0d1829]">
+                    <opt.icon size={20} className="text-[#8b9cf7]" />
+                  </div>
+                  <span className="text-xs text-slate-400">{opt.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Middle section */}
+      <div className="mb-6 flex flex-col gap-4 md:flex-row">
+        {/* AI Mockups panel */}
+        <div className="flex-[60] rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <h3 className="mb-4 text-lg font-semibold text-white">AI Mockups</h3>
+          {/* Simple wireframe illustration */}
+          <div className="flex flex-col gap-2 rounded-lg border border-[#2a3a5c]/40 bg-[#0d1829]/60 p-4">
+            {/* Header bar */}
+            <div className="h-3 w-1/3 rounded-sm bg-[#2a3a5c]/80" />
+            {/* Nav row */}
+            <div className="flex gap-2">
+              <div className="h-2 w-12 rounded-sm bg-[#2a3a5c]/50" />
+              <div className="h-2 w-12 rounded-sm bg-[#2a3a5c]/50" />
+              <div className="h-2 w-12 rounded-sm bg-[#2a3a5c]/50" />
+            </div>
+            {/* Content blocks */}
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              <div className="h-16 rounded bg-[#2a3a5c]/30" />
+              <div className="h-16 rounded bg-[#2a3a5c]/30" />
+            </div>
+            <div className="h-8 rounded bg-[#2a3a5c]/20" />
+          </div>
+        </div>
+
+        {/* User Actions */}
+        <div className="flex-[40] rounded-xl border border-[#2a3a5c]/60 bg-[#111d35]/50 p-5 shadow-[inset_0_1px_0_0_rgba(148,163,184,0.05)]">
+          <h3 className="mb-4 text-lg font-semibold text-white">
+            User Actions
+          </h3>
+          <ul className="space-y-3">
+            {mockupActions.map((a) => (
+              <li key={a.label} className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-[#2a3a5c]/60 bg-[#0d1829]">
+                  <a.icon size={18} className="text-[#8b9cf7]" />
+                </div>
+                <span className="text-sm text-slate-300">{a.label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* Bottom — Feedback to PRD */}
+      <div className="flex items-center justify-center gap-2 text-[#8b9cf7]">
+        <MdOutlineArrowUpward size={20} />
+        <span className="text-sm font-semibold text-slate-300">
+          Feedback to PRD
+        </span>
+        <MdOutlineArrowUpward size={20} />
+      </div>
+    </InfographicSlide>
+  );
+}

--- a/src/components/infographics/index.ts
+++ b/src/components/infographics/index.ts
@@ -1,0 +1,8 @@
+export { InfographicSlide } from './InfographicSlide';
+export { FlowArrow } from './FlowArrow';
+export { SlideEntryPoint } from './SlideEntryPoint';
+export { SlidePRDGeneration } from './SlidePRDGeneration';
+export { SlideUIMockups } from './SlideUIMockups';
+export { SlideArtifacts } from './SlideArtifacts';
+export { SlideHistory } from './SlideHistory';
+export { InfographicGallery } from './InfographicGallery';


### PR DESCRIPTION
Convert the static PNG pipeline infographic on the /about page into 5
interactive React + Tailwind slides using Material Design icons (react-icons).
Each slide faithfully reproduces the original infographic layout with a unified
dark navy design palette, consistent card styling, and stage-specific accent
colors (emerald for artifacts, purple for history timeline).

https://claude.ai/code/session_01HcDL7Qxbi1NPnsnwf2gC6j