### PR TITLE
Remove trailing dots from homepage welcome heading

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -184,7 +184,7 @@ export function HomePage() {
 
                     {/* Hero title */}
                     <h2 className="text-4xl md:text-5xl font-bold text-center mb-8">
-                        Welcome to Synapse..
+                        Welcome to Synapse
                     </h2>
 
                     {/* Example prompt pills */}


### PR DESCRIPTION
The homepage hero title read "Welcome to Synapse.." with awkward
double-dot punctuation. Trim the dots so the heading reads
"Welcome to Synapse" for a cleaner, more production-ready look.