### PR TITLE
feat(mockups): replace ASCII mockups with rendered HTML/Tailwind concepts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -523,6 +524,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -571,6 +573,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -582,22 +585,6 @@
       "dev": true,
       "license": "MPL-2.0",
       "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/vm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
-      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@edge-runtime/primitives": "4.1.0"
-      },
       "engines": {
         "node": ">=16"
       }
@@ -1828,8 +1815,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1970,6 +1956,7 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1979,6 +1966,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1989,6 +1977,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2051,6 +2040,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2457,6 +2447,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2497,7 +2488,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2714,6 +2704,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3155,8 +3146,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3248,6 +3238,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3643,7 +3634,6 @@
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -4067,6 +4057,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4350,7 +4341,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5521,6 +5511,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5612,6 +5603,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5765,7 +5757,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5781,7 +5772,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5834,6 +5824,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5843,6 +5834,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5864,8 +5856,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6116,7 +6107,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -6424,6 +6414,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6604,27 +6595,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6644,6 +6614,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6878,6 +6849,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7155,6 +7127,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -6,7 +6,18 @@ import { useProjectStore } from '../store/projectStore';
 import { generateMockup } from '../lib/llmProvider';
 import { StalenessBadge } from './StalenessBadge';
 import { FeedbackModal } from './FeedbackModal';
-import type { StructuredPRD, MockupSettings, MockupPlatform, MockupFidelity, MockupScope } from '../types';
+import { MockupViewer } from './mockups/MockupViewer';
+import type {
+    StructuredPRD,
+    MockupSettings,
+    MockupPlatform,
+    MockupFidelity,
+    MockupScope,
+    MockupPayload,
+    ArtifactVersion,
+    StalenessState,
+} from '../types';
+import { MOCKUP_HTML_V1 } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 
 interface MockupsViewProps {
@@ -34,7 +45,22 @@ const SCOPE_OPTIONS: { value: MockupScope; label: string }[] = [
     { value: 'single_screen', label: 'Single Screen' },
 ];
 
-export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsViewProps) {
+// Safely extract a MockupPayload from an ArtifactVersion. Returns null for
+// legacy markdown versions or unparseable content — callers fall back to the
+// legacy markdown renderer.
+const tryParsePayload = (version: ArtifactVersion): MockupPayload | null => {
+    const format = (version.metadata as { format?: string } | undefined)?.format;
+    if (format !== MOCKUP_HTML_V1) return null;
+    try {
+        const parsed = JSON.parse(version.content) as MockupPayload;
+        if (!parsed?.screens?.length) return null;
+        return parsed;
+    } catch {
+        return null;
+    }
+};
+
+export function MockupsView({ projectId, spineVersionId, prdContent, structuredPRD }: MockupsViewProps) {
     const {
         createArtifact, createArtifactVersion,
         getArtifacts, getArtifactVersions, setPreferredVersion,
@@ -68,16 +94,17 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                 notes: notes || undefined,
             };
 
-            const content = await generateMockup(prdContent, settings);
+            const payload = await generateMockup(prdContent, settings, structuredPRD);
 
-            const title = `Mockup — ${platform} / ${fidelity} / ${scope.replace('_', ' ')}`;
+            const title = payload.title?.trim()
+                || `Mockup — ${platform} / ${fidelity} / ${scope.replace('_', ' ')}`;
             const { artifactId } = createArtifact(projectId, 'mockup', title);
 
             createArtifactVersion(
                 projectId,
                 artifactId,
-                content,
-                { settings },
+                JSON.stringify(payload),
+                { settings, format: MOCKUP_HTML_V1 },
                 [{
                     id: uuidv4(),
                     sourceArtifactId: projectId,
@@ -106,13 +133,13 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                 platform: 'desktop', fidelity: 'mid', scope: 'key_workflow'
             };
 
-            const content = await generateMockup(prdContent, settings);
+            const payload = await generateMockup(prdContent, settings, structuredPRD);
 
             createArtifactVersion(
                 projectId,
                 artifactId,
-                content,
-                { settings },
+                JSON.stringify(payload),
+                { settings, format: MOCKUP_HTML_V1 },
                 [{
                     id: uuidv4(),
                     sourceArtifactId: projectId,
@@ -129,17 +156,133 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
         }
     };
 
-    const renderMockupContent = (content: string) => (
-        <div className="bg-white rounded-xl border border-neutral-200 p-6 prose prose-sm prose-neutral max-w-none overflow-auto max-h-[600px]">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-        </div>
+    // --- Rendering helpers ---
+
+    const renderVersionActions = (
+        artifactId: string,
+        preferred: ArtifactVersion,
+        allVersions: ArtifactVersion[],
+    ) => (
+        <>
+            <button
+                type="button"
+                onClick={() => handleRegenerate(artifactId)}
+                disabled={isGenerating}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition disabled:opacity-50"
+            >
+                {isGenerating ? 'Regenerating…' : 'Regenerate'}
+            </button>
+            <button
+                type="button"
+                onClick={() => { setCompareMode(!compareMode); setCompareVersions([null, null]); }}
+                disabled={allVersions.length < 2}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition disabled:opacity-50"
+            >
+                <GitCompare size={12} />
+                Compare
+            </button>
+            <button
+                type="button"
+                onClick={() => setFeedbackVersionId(preferred.id)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 border border-amber-200 rounded-md transition"
+            >
+                <MessageSquarePlus size={12} />
+                Extract Feedback
+            </button>
+            {allVersions.length > 1 && (
+                <select
+                    value={preferred.id}
+                    onChange={e => setPreferredVersion(projectId, artifactId, e.target.value)}
+                    className="ml-auto px-2 py-1 text-xs border border-neutral-200 rounded-md bg-white"
+                >
+                    {allVersions.map(v => (
+                        <option key={v.id} value={v.id}>
+                            v{v.versionNumber}{v.isPreferred ? ' (preferred)' : ''}
+                        </option>
+                    ))}
+                </select>
+            )}
+        </>
     );
+
+    const renderVersionBody = (
+        version: ArtifactVersion,
+        staleness: StalenessState,
+        actions: React.ReactNode,
+    ) => {
+        const payload = tryParsePayload(version);
+        if (payload) {
+            const settings = (version.metadata?.settings as MockupSettings) || {
+                platform: 'desktop', fidelity: 'mid', scope: 'key_workflow',
+            };
+            const sourceSpineVersionId = version.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId;
+            return (
+                <MockupViewer
+                    payload={payload}
+                    settings={settings}
+                    staleness={staleness}
+                    versionNumber={version.versionNumber}
+                    createdAt={version.createdAt}
+                    sourceSpineVersionId={sourceSpineVersionId}
+                    actions={actions}
+                />
+            );
+        }
+
+        // Legacy markdown fallback — renders old ASCII mockups so existing
+        // projects continue to work until they are regenerated.
+        return (
+            <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden">
+                <div className="px-5 pt-4 flex items-center gap-2">
+                    <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border border-amber-200 bg-amber-50 text-amber-700 font-medium">
+                        Legacy mockup
+                    </span>
+                    <StalenessBadge staleness={staleness} />
+                    <span className="text-[10px] text-neutral-400 ml-auto">
+                        v{version.versionNumber}
+                    </span>
+                </div>
+                <div className="px-5 py-4 prose prose-sm prose-neutral max-w-none overflow-auto max-h-[600px]">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{version.content}</ReactMarkdown>
+                </div>
+                <div className="px-5 py-3 border-t border-neutral-100 bg-neutral-50/40 flex items-center gap-2 flex-wrap">
+                    {actions}
+                </div>
+            </div>
+        );
+    };
 
     const renderCompareView = () => {
         if (!selectedArtifactId) return null;
         const versions = getArtifactVersions(projectId, selectedArtifactId);
+        const staleness = getArtifactStaleness(projectId, selectedArtifactId);
         const vA = versions.find(v => v.id === compareVersions[0]);
         const vB = versions.find(v => v.id === compareVersions[1]);
+
+        const renderSide = (v: ArtifactVersion | undefined) => {
+            if (!v) return <div className="text-neutral-400 text-sm italic">Select a version</div>;
+            const payload = tryParsePayload(v);
+            if (payload) {
+                const settings = (v.metadata?.settings as MockupSettings) || {
+                    platform: 'desktop', fidelity: 'mid', scope: 'key_workflow',
+                };
+                return (
+                    <MockupViewer
+                        payload={payload}
+                        settings={settings}
+                        staleness={staleness}
+                        versionNumber={v.versionNumber}
+                        createdAt={v.createdAt}
+                        sourceSpineVersionId={v.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId}
+                    />
+                );
+            }
+            return (
+                <div className="bg-white rounded-xl border border-neutral-200 p-5 prose prose-sm prose-neutral max-w-none overflow-auto max-h-[600px]">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{v.content}</ReactMarkdown>
+                </div>
+            );
+        };
 
         return (
             <div className="space-y-4">
@@ -169,16 +312,32 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                 <div className="grid grid-cols-2 gap-4">
                     <div>
                         <h4 className="text-xs font-bold text-neutral-500 uppercase mb-2">Version A {vA ? `(v${vA.versionNumber})` : ''}</h4>
-                        {vA ? renderMockupContent(vA.content) : <div className="text-neutral-400 text-sm italic">Select a version</div>}
+                        {renderSide(vA)}
                     </div>
                     <div>
                         <h4 className="text-xs font-bold text-neutral-500 uppercase mb-2">Version B {vB ? `(v${vB.versionNumber})` : ''}</h4>
-                        {vB ? renderMockupContent(vB.content) : <div className="text-neutral-400 text-sm italic">Select a version</div>}
+                        {renderSide(vB)}
                     </div>
                 </div>
             </div>
         );
     };
+
+    const renderGeneratingSkeleton = () => (
+        <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden animate-pulse">
+            <div className="px-5 pt-5 pb-4 border-b border-neutral-100">
+                <div className="h-5 bg-neutral-200 rounded w-1/3 mb-2" />
+                <div className="h-3 bg-neutral-100 rounded w-2/3" />
+            </div>
+            <div className="px-5 pt-4 pb-2 flex items-center gap-2">
+                <div className="h-6 w-24 bg-neutral-100 rounded-full" />
+                <div className="h-6 w-24 bg-neutral-100 rounded-full" />
+            </div>
+            <div className="px-5 pb-5">
+                <div className="h-[480px] bg-neutral-100 rounded-lg" />
+            </div>
+        </div>
+    );
 
     return (
         <div className="space-y-6">
@@ -194,6 +353,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                     )}
                 </div>
                 <button
+                    type="button"
                     onClick={() => setShowGeneratePanel(!showGeneratePanel)}
                     className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition text-sm font-medium"
                 >
@@ -219,6 +379,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                             {PLATFORM_OPTIONS.map(opt => (
                                 <button
                                     key={opt.value}
+                                    type="button"
                                     onClick={() => setPlatform(opt.value)}
                                     className={`block w-full text-left px-3 py-2 text-sm rounded-md mb-1 transition ${
                                         platform === opt.value
@@ -235,6 +396,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                             {FIDELITY_OPTIONS.map(opt => (
                                 <button
                                     key={opt.value}
+                                    type="button"
                                     onClick={() => setFidelity(opt.value)}
                                     className={`block w-full text-left px-3 py-2 text-sm rounded-md mb-1 transition ${
                                         fidelity === opt.value
@@ -251,6 +413,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                             {SCOPE_OPTIONS.map(opt => (
                                 <button
                                     key={opt.value}
+                                    type="button"
                                     onClick={() => setScope(opt.value)}
                                     className={`block w-full text-left px-3 py-2 text-sm rounded-md mb-1 transition ${
                                         scope === opt.value
@@ -288,6 +451,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
 
                     <div className="flex items-center gap-3 pt-2">
                         <button
+                            type="button"
                             onClick={handleGenerate}
                             disabled={isGenerating}
                             className="px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50"
@@ -295,6 +459,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                             {isGenerating ? 'Generating...' : 'Generate'}
                         </button>
                         <button
+                            type="button"
                             onClick={() => setShowGeneratePanel(false)}
                             className="px-4 py-2 text-neutral-500 hover:text-neutral-700 text-sm transition"
                         >
@@ -304,12 +469,17 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                 </div>
             )}
 
+            {/* Loading skeleton when generating the first mockup */}
+            {isGenerating && mockupArtifacts.length === 0 && renderGeneratingSkeleton()}
+
             {/* Mockup List */}
-            {mockupArtifacts.length === 0 && !showGeneratePanel ? (
+            {mockupArtifacts.length === 0 && !showGeneratePanel && !isGenerating ? (
                 <div className="text-center py-16 text-neutral-400">
                     <Image size={48} className="mx-auto mb-4 opacity-30" />
                     <p className="text-lg font-medium text-neutral-500 mb-2">No mockups yet</p>
-                    <p className="text-sm">Generate mockups from your PRD to explore visual directions.</p>
+                    <p className="text-sm max-w-md mx-auto">
+                        Generate polished UI concepts grounded in your PRD. Each run produces a rendered HTML preview you can navigate screen-by-screen.
+                    </p>
                 </div>
             ) : (
                 <div className="space-y-4">
@@ -323,6 +493,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
                             <div key={artifact.id} className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden">
                                 {/* Card Header */}
                                 <button
+                                    type="button"
                                     onClick={() => setSelectedArtifactId(isSelected ? null : artifact.id)}
                                     className="w-full flex items-center justify-between p-4 hover:bg-neutral-50/50 transition text-left"
                                 >
@@ -341,61 +512,16 @@ export function MockupsView({ projectId, spineVersionId, prdContent }: MockupsVi
 
                                 {/* Expanded Detail */}
                                 {isSelected && preferredVersion && (
-                                    <div className="border-t border-neutral-100 p-4 space-y-4">
-                                        {/* Action Bar */}
-                                        <div className="flex items-center gap-2 flex-wrap">
-                                            <button
-                                                onClick={() => handleRegenerate(artifact.id)}
-                                                disabled={isGenerating}
-                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition disabled:opacity-50"
-                                            >
-                                                Regenerate
-                                            </button>
-                                            <button
-                                                onClick={() => { setCompareMode(!compareMode); setCompareVersions([null, null]); }}
-                                                disabled={versions.length < 2}
-                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition disabled:opacity-50"
-                                            >
-                                                <GitCompare size={12} />
-                                                Compare
-                                            </button>
-                                            <button
-                                                onClick={() => setFeedbackVersionId(preferredVersion.id)}
-                                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 border border-amber-200 rounded-md transition"
-                                            >
-                                                <MessageSquarePlus size={12} />
-                                                Extract Feedback
-                                            </button>
-
-                                            {/* Version selector */}
-                                            {versions.length > 1 && (
-                                                <select
-                                                    value={preferredVersion.id}
-                                                    onChange={e => setPreferredVersion(projectId, artifact.id, e.target.value)}
-                                                    className="ml-auto px-2 py-1 text-xs border border-neutral-200 rounded-md bg-white"
-                                                >
-                                                    {versions.map(v => (
-                                                        <option key={v.id} value={v.id}>
-                                                            v{v.versionNumber}{v.isPreferred ? ' (preferred)' : ''}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            )}
-                                        </div>
-
-                                        {/* Content */}
-                                        {compareMode && isSelected ? (
+                                    <div className="border-t border-neutral-100 p-4">
+                                        {compareMode ? (
                                             renderCompareView()
                                         ) : (
-                                            renderMockupContent(preferredVersion.content)
+                                            renderVersionBody(
+                                                preferredVersion,
+                                                staleness,
+                                                renderVersionActions(artifact.id, preferredVersion, versions),
+                                            )
                                         )}
-
-                                        {/* Provenance */}
-                                        <div className="text-xs text-neutral-400 pt-2 border-t border-neutral-100">
-                                            Generated from PRD {preferredVersion.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId || 'unknown'}
-                                            {' · '}v{preferredVersion.versionNumber}
-                                            {' · '}{new Date(preferredVersion.createdAt).toLocaleString()}
-                                        </div>
                                     </div>
                                 )}
                             </div>

--- a/src/components/mockups/MockupHtmlPreview.tsx
+++ b/src/components/mockups/MockupHtmlPreview.tsx
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import type { MockupPlatform } from '../../types';
+import { buildMockupSrcDoc } from './buildMockupSrcDoc';
+
+type Props = {
+    html: string;
+    platform: MockupPlatform;
+    className?: string;
+};
+
+// Sandboxed iframe preview for a single mockup screen. `sandbox="allow-scripts"`
+// lets Tailwind CDN JIT-compile utility classes inside the iframe, but without
+// `allow-same-origin` the iframe is treated as cross-origin and cannot touch
+// Synapse state.
+export function MockupHtmlPreview({ html, platform, className }: Props) {
+    const srcDoc = useMemo(() => buildMockupSrcDoc(html), [html]);
+    const height = platform === 'mobile' ? 720 : 680;
+
+    return (
+        <iframe
+            title="Mockup preview"
+            srcDoc={srcDoc}
+            sandbox="allow-scripts"
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            className={`w-full bg-white rounded-lg border border-neutral-200 ${className ?? ''}`}
+            style={{ height }}
+        />
+    );
+}

--- a/src/components/mockups/MockupViewer.tsx
+++ b/src/components/mockups/MockupViewer.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Eye, Code2, ExternalLink } from 'lucide-react';
+import type { MockupPayload, MockupSettings, StalenessState } from '../../types';
+import { StalenessBadge } from '../StalenessBadge';
+import { MockupHtmlPreview } from './MockupHtmlPreview';
+import { buildMockupSrcDoc } from './buildMockupSrcDoc';
+
+type Props = {
+    payload: MockupPayload;
+    settings: MockupSettings;
+    staleness: StalenessState;
+    versionNumber: number;
+    createdAt: number;
+    sourceSpineVersionId?: string;
+    actions?: React.ReactNode;
+};
+
+type Mode = 'preview' | 'code';
+
+const SETTING_CHIP = 'text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border border-neutral-200 bg-neutral-50 text-neutral-600 font-medium';
+
+export function MockupViewer({
+    payload,
+    settings,
+    staleness,
+    versionNumber,
+    createdAt,
+    sourceSpineVersionId,
+    actions,
+}: Props) {
+    const [activeIdx, setActiveIdx] = useState(0);
+    const [mode, setMode] = useState<Mode>('preview');
+
+    // Clamp in case of payload mutation.
+    const safeIdx = Math.min(activeIdx, Math.max(0, payload.screens.length - 1));
+    const activeScreen = payload.screens[safeIdx];
+    const hasMultiple = payload.screens.length > 1;
+
+    const openInNewTab = useCallback(() => {
+        if (!activeScreen) return;
+        const doc = buildMockupSrcDoc(activeScreen.html);
+        const blob = new Blob([doc], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        const win = window.open(url, '_blank', 'noopener,noreferrer');
+        // Revoke once the new tab has had time to load. If window.open was
+        // blocked we still revoke so we don't leak the object URL.
+        setTimeout(() => URL.revokeObjectURL(url), 30_000);
+        if (!win) {
+            console.warn('[mockup] window.open blocked; object URL created but not opened');
+        }
+    }, [activeScreen]);
+
+    const codeString = useMemo(() => activeScreen?.html ?? '', [activeScreen]);
+
+    if (!activeScreen) {
+        return (
+            <div className="bg-white rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500">
+                This mockup version has no screens.
+            </div>
+        );
+    }
+
+    return (
+        <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden">
+            {/* Title strip */}
+            <div className="px-5 pt-5 pb-4 border-b border-neutral-100">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                        <h3 className="text-lg font-bold text-neutral-900 tracking-tight truncate">
+                            {payload.title}
+                        </h3>
+                        {payload.summary && (
+                            <p className="text-sm text-neutral-500 mt-0.5">{payload.summary}</p>
+                        )}
+                    </div>
+                    {/* Preview / Code toggle */}
+                    <div className="shrink-0 flex items-center bg-neutral-100 rounded-lg p-0.5 text-xs font-medium">
+                        <button
+                            type="button"
+                            onClick={() => setMode('preview')}
+                            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md transition ${
+                                mode === 'preview'
+                                    ? 'bg-white text-neutral-900 shadow-sm'
+                                    : 'text-neutral-500 hover:text-neutral-700'
+                            }`}
+                        >
+                            <Eye size={12} />
+                            Preview
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setMode('code')}
+                            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md transition ${
+                                mode === 'code'
+                                    ? 'bg-white text-neutral-900 shadow-sm'
+                                    : 'text-neutral-500 hover:text-neutral-700'
+                            }`}
+                        >
+                            <Code2 size={12} />
+                            Code
+                        </button>
+                    </div>
+                </div>
+
+                {/* Settings chips */}
+                <div className="flex flex-wrap items-center gap-1.5 mt-3">
+                    <span className={SETTING_CHIP}>{settings.platform}</span>
+                    <span className={SETTING_CHIP}>{settings.fidelity}-fi</span>
+                    <span className={SETTING_CHIP}>{settings.scope.replace('_', ' ')}</span>
+                    <StalenessBadge staleness={staleness} />
+                    <span className="text-[10px] text-neutral-400 ml-auto">
+                        v{versionNumber} · {new Date(createdAt).toLocaleDateString()}
+                    </span>
+                </div>
+            </div>
+
+            {/* Screen nav + open-in-tab */}
+            <div className="px-5 pt-4 pb-2 flex items-center gap-2 flex-wrap">
+                {hasMultiple ? (
+                    <div className="flex items-center gap-1 flex-wrap">
+                        {payload.screens.map((screen, idx) => {
+                            const selected = idx === safeIdx;
+                            return (
+                                <button
+                                    key={screen.id}
+                                    type="button"
+                                    onClick={() => setActiveIdx(idx)}
+                                    className={`text-xs px-3 py-1.5 rounded-full border transition ${
+                                        selected
+                                            ? 'bg-indigo-50 text-indigo-700 border-indigo-200 font-medium'
+                                            : 'bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-50'
+                                    }`}
+                                >
+                                    {idx + 1}. {screen.name}
+                                </button>
+                            );
+                        })}
+                    </div>
+                ) : (
+                    <div className="text-xs text-neutral-500 font-medium">{activeScreen.name}</div>
+                )}
+                <button
+                    type="button"
+                    onClick={openInNewTab}
+                    className="ml-auto flex items-center gap-1.5 text-xs text-neutral-500 hover:text-neutral-800 px-2 py-1 rounded-md hover:bg-neutral-50 transition"
+                    title="Open this screen in a new tab"
+                >
+                    <ExternalLink size={12} />
+                    Open
+                </button>
+            </div>
+
+            {/* Preview / Code body */}
+            <div className="px-5 pb-4">
+                {mode === 'preview' ? (
+                    <MockupHtmlPreview
+                        key={activeScreen.id}
+                        html={activeScreen.html}
+                        platform={settings.platform}
+                    />
+                ) : (
+                    <pre className="text-xs font-mono bg-neutral-900 text-neutral-100 rounded-lg p-4 overflow-auto max-h-[680px] whitespace-pre-wrap break-all">
+                        {codeString}
+                    </pre>
+                )}
+            </div>
+
+            {/* Screen description + notes */}
+            {(activeScreen.purpose || activeScreen.notes) && (
+                <div className="px-5 pb-4 space-y-1.5">
+                    {hasMultiple && (
+                        <div className="text-xs font-semibold text-neutral-700">{activeScreen.name}</div>
+                    )}
+                    {activeScreen.purpose && (
+                        <p className="text-sm text-neutral-600">{activeScreen.purpose}</p>
+                    )}
+                    {activeScreen.notes && (
+                        <p className="text-xs text-neutral-500 italic">Note: {activeScreen.notes}</p>
+                    )}
+                </div>
+            )}
+
+            {/* Actions + provenance */}
+            {actions && (
+                <div className="px-5 py-3 border-t border-neutral-100 bg-neutral-50/40 flex items-center gap-2 flex-wrap">
+                    {actions}
+                </div>
+            )}
+            <div className="px-5 py-2 text-[11px] text-neutral-400 border-t border-neutral-100">
+                Generated from PRD {sourceSpineVersionId ?? 'unknown'} · v{versionNumber} · {new Date(createdAt).toLocaleString()}
+            </div>
+        </div>
+    );
+}

--- a/src/components/mockups/buildMockupSrcDoc.ts
+++ b/src/components/mockups/buildMockupSrcDoc.ts
@@ -1,0 +1,47 @@
+// Sanitize a Gemini-generated HTML fragment and wrap it in a full HTML
+// document suitable for an iframe's `srcDoc`. Kept separate from the component
+// file so `react-refresh/only-export-components` stays happy and so the
+// helper can be reused by the "Open in new tab" flow in MockupViewer.
+
+const sanitizeHtmlFragment = (html: string): string => {
+    let out = html;
+    // Strip any stray <!doctype>, <html>, <head>, <body> wrappers the model
+    // may include despite instructions.
+    out = out.replace(/<!doctype[^>]*>/gi, '');
+    out = out.replace(/<\/?(html|head|body)\b[^>]*>/gi, '');
+    // Strip disallowed tags entirely.
+    out = out.replace(/<script\b[\s\S]*?<\/script>/gi, '');
+    out = out.replace(/<style\b[\s\S]*?<\/style>/gi, '');
+    out = out.replace(/<(link|meta|iframe|object|embed|base)\b[^>]*>/gi, '');
+    // Strip inline event handlers: onclick="...", onLoad='...', etc.
+    out = out.replace(/\son[a-z]+\s*=\s*"[^"]*"/gi, '');
+    out = out.replace(/\son[a-z]+\s*=\s*'[^']*'/gi, '');
+    out = out.replace(/\son[a-z]+\s*=\s*[^\s>]+/gi, '');
+    // Neutralize javascript: URLs.
+    out = out.replace(/(href|src)\s*=\s*"\s*javascript:[^"]*"/gi, '$1="#"');
+    out = out.replace(/(href|src)\s*=\s*'\s*javascript:[^']*'/gi, '$1="#"');
+    return out;
+};
+
+// Build the full document that goes into the iframe's srcDoc. Tailwind loads
+// from the CDN; the iframe's sandbox does NOT include `allow-same-origin`, so
+// even with `allow-scripts` the iframe cannot reach into the parent app.
+export const buildMockupSrcDoc = (fragment: string): string => {
+    const sanitized = sanitizeHtmlFragment(fragment);
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mockup preview</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html, body { margin: 0; padding: 0; background: #f5f5f5; }
+    body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+  </style>
+</head>
+<body>
+${sanitized}
+</body>
+</html>`;
+};

--- a/src/lib/schemas/mockupSchema.ts
+++ b/src/lib/schemas/mockupSchema.ts
@@ -1,0 +1,26 @@
+// Gemini JSON mode schema for rendered HTML/Tailwind mockup generation.
+// Mirrors MockupPayload in src/types/index.ts. The client-side `id` field on
+// each MockupScreen is assigned after parsing (via uuid) and is intentionally
+// not part of the model's output schema.
+export const mockupSchema = {
+    type: "OBJECT",
+    properties: {
+        version: { type: "STRING", enum: ["mockup_html_v1"] },
+        title: { type: "STRING" },
+        summary: { type: "STRING" },
+        screens: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    name: { type: "STRING" },
+                    purpose: { type: "STRING" },
+                    html: { type: "STRING" },
+                    notes: { type: "STRING" },
+                },
+                required: ["name", "purpose", "html"],
+            },
+        },
+    },
+    required: ["version", "title", "summary", "screens"],
+};

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -1,49 +1,176 @@
-import type { MockupSettings } from '../../types';
+import { v4 as uuidv4 } from 'uuid';
+import type {
+    MockupSettings,
+    MockupPayload,
+    MockupScreen,
+    StructuredPRD,
+} from '../../types';
 import { callGemini } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
+import { mockupSchema } from '../schemas/mockupSchema';
+
+// ---- Instruction tables (rewritten for polished HTML/Tailwind output) ----
 
 const FIDELITY_INSTRUCTIONS: Record<string, string> = {
-    low: 'Use simple ASCII wireframes with boxes, lines, and placeholder text. Focus on layout and content hierarchy, not visual detail.',
-    mid: 'Use structured text descriptions with clear component names, layout specifications, and content placeholders. Include navigation and interaction notes.',
-    high: 'Provide detailed, polished descriptions including typography, spacing, color suggestions, hover states, and micro-interactions.',
+    low: 'Fidelity: wireframe-leaning but still styled — neutral palette, clear boundaries, placeholder skeleton bars for charts/images. Avoid decorative color; prefer structure.',
+    mid: 'Fidelity: polished mid-fi — real copy, realistic table rows, stat tiles with numbers and deltas, sidebar nav with icons (SVG), consistent spacing. No decorative illustrations.',
+    high: 'Fidelity: high-fi SaaS polish — gradient hero accents, crisp cards with shadow-sm, stat deltas with colored chips, realistic activity feeds, inline SVG iconography, and tasteful use of a single accent color. Looks shippable.',
 };
 
 const PLATFORM_INSTRUCTIONS: Record<string, string> = {
-    desktop: 'Design for a desktop/laptop viewport (1280px+ width). Use appropriate navigation patterns like sidebars, top bars, and multi-column layouts.',
-    mobile: 'Design for mobile viewport (375px width). Use mobile patterns like bottom navigation, hamburger menus, and single-column layouts.',
-    responsive: 'Describe both desktop and mobile layouts, noting how the design adapts across breakpoints.',
+    desktop: 'Platform: desktop. Use a 1440px shell with a left sidebar (w-60) + top bar (h-14) + max-w-7xl main content. Multi-column grids where useful. Assume mouse/keyboard.',
+    mobile: 'Platform: mobile. Use a single-column layout constrained to ~390px (mx-auto max-w-[420px]) with a sticky top header and a bottom tab bar (5 items max). Large tap targets. Assume touch.',
+    responsive: 'Platform: responsive. Build a desktop-first shell (sidebar + topbar + content) but use responsive Tailwind classes (hidden md:block, grid-cols-1 md:grid-cols-3, etc.) so it collapses gracefully below md.',
 };
 
 const SCOPE_INSTRUCTIONS: Record<string, string> = {
-    single_screen: 'Generate a single, detailed screen mockup.',
-    multi_screen: 'Generate mockups for 3-5 key screens that represent the core experience.',
-    key_workflow: 'Generate mockups for a complete key user workflow, showing each step and transition.',
+    single_screen: 'Scope: exactly ONE screen. Make it the highest-value screen of the product (usually the primary dashboard or editor).',
+    multi_screen: 'Scope: 3 to 4 screens covering the core experience (e.g. dashboard, detail view, settings, or empty/onboarding). All screens must share the same shell, typography, and accent color.',
+    key_workflow: 'Scope: 3 to 5 screens forming a single linear workflow the primary persona would take end-to-end. Each screen should show the next logical step. Same shell, same style, same accent.',
 };
+
+// ---- Prompt construction ----
+
+const buildSystemPrompt = (settings: MockupSettings): string => {
+    const styleLine = settings.style ? `\nStyle direction from the user: ${settings.style}` : '';
+    const notesLine = settings.notes ? `\nEmphasis from the user: ${settings.notes}` : '';
+
+    return `You are a senior product designer at a top-tier SaaS company (think Linear, Notion, Vercel, Stripe). You generate high-fidelity UI *concepts* — not production code — for new products, grounded in a provided PRD. Your output MUST be valid JSON matching the provided response schema.
+
+## Visual language
+- Modern SaaS aesthetic. Generous whitespace. Clear hierarchy. 8px spacing scale.
+- Neutral base palette: white / neutral-50 / neutral-100 backgrounds, neutral-900 headings, neutral-500 secondary text, neutral-200 borders. Single accent color: indigo-600 for primary actions, indigo-50 / indigo-100 for tints — unless the user's style direction says otherwise.
+- Cards: rounded-xl or rounded-2xl, border border-neutral-200, shadow-sm, p-5 / p-6.
+- Type scale: text-xs / text-sm / text-base / text-lg / text-xl / text-2xl / text-3xl. Headings font-semibold or font-bold, tracking-tight for large headings.
+- Prefer real product patterns: topbar + sidebar shells, stat cards (label + large number + delta chip), data tables with zebra rows and hover states, kanban columns, timelines, split panes, chat sidebars, filter chips, breadcrumb trails, rich empty states, toast notifications, modal previews, activity feeds with avatars.
+- Use inline <svg> or CSS gradients for icons, avatars, charts, logos. NEVER reference external images or fonts.
+- Copy MUST be realistic and grounded in the actual product — use real persona names, feature names, and entity names from the PRD. NO "Lorem ipsum", NO "Button 1 / Button 2", NO generic "Item A / Item B".
+
+## Technical constraints (non-negotiable)
+- For each screen's \`html\` field, output ONLY a body fragment. Do NOT include \`<!doctype>\`, \`<html>\`, \`<head>\`, \`<body>\`, \`<meta>\`, \`<link>\`, or \`<script>\` tags. Tailwind is already loaded in the render sandbox.
+- No JavaScript. No inline event handlers (onclick, onload, onmouseover, etc.). No \`javascript:\` URLs.
+- No external stylesheets, no \`<style>\` tags, no \`<link>\` tags, no Google Fonts, no images from the internet.
+- Use Tailwind utility classes exclusively for styling.
+- Use semantic HTML: \`<header>\`, \`<nav>\`, \`<main>\`, \`<aside>\`, \`<section>\`, \`<article>\`, \`<table>\`, \`<ul>\`, \`<button type="button">\`.
+- Wrap EACH screen in a single top-level \`<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">\` so the sandbox renders a full-bleed surface.
+- Output must be valid HTML — every opening tag closed, attributes quoted.
+
+## Multi-screen coherence
+If you generate multiple screens, they MUST feel like the same product:
+- same accent color, same type scale, same sidebar/topbar shell, same component vocabulary, same persona names, same entity names.
+- prefer reusing one consistent shell (sidebar + topbar) across screens, only swapping the main content area.
+
+## Per-screen fields
+- \`name\`: short screen title (e.g. "Editor Dashboard", "Branch Review", "Onboarding Step 2").
+- \`purpose\`: ONE sentence explaining what this screen solves, for which persona, grounded in the PRD.
+- \`html\`: the body fragment following every constraint above.
+- \`notes\` (optional): 1–3 short assumptions or callouts the designer made.
+
+Also provide a top-level \`title\` (the overall concept name) and a \`summary\` (1–2 sentences framing the concept).
+
+${FIDELITY_INSTRUCTIONS[settings.fidelity]}
+${PLATFORM_INSTRUCTIONS[settings.platform]}
+${SCOPE_INSTRUCTIONS[settings.scope]}${styleLine}${notesLine}`;
+};
+
+const buildUserPrompt = (prdContent: string, structuredPRD?: StructuredPRD): string => {
+    const parts: string[] = [`Product PRD:\n---\n${prdContent}\n---`];
+
+    if (structuredPRD) {
+        const personas = structuredPRD.targetUsers?.slice(0, 6).join(', ');
+        const features = structuredPRD.features
+            ?.slice(0, 8)
+            .map(f => `- ${f.name}${f.description ? `: ${f.description}` : ''}`)
+            .join('\n');
+        const vision = structuredPRD.vision?.trim();
+        const problem = structuredPRD.coreProblem?.trim();
+
+        const structuredLines: string[] = ['Structured PRD summary (use these names in your copy):'];
+        if (vision) structuredLines.push(`Vision: ${vision}`);
+        if (problem) structuredLines.push(`Core problem: ${problem}`);
+        if (personas) structuredLines.push(`Personas: ${personas}`);
+        if (features) structuredLines.push(`Key features:\n${features}`);
+        parts.push(structuredLines.join('\n'));
+    }
+
+    parts.push('Generate the mockup JSON now. Remember: every screen must be grounded in this product, use real names from the PRD, and follow every technical constraint.');
+    return parts.join('\n\n');
+};
+
+// ---- Parsing / validation ----
+
+const parseMockupPayload = (raw: string): MockupPayload => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (e) {
+        throw new Error(`Mockup generation returned invalid JSON: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Mockup generation returned a non-object response.');
+    }
+
+    const obj = parsed as Record<string, unknown>;
+    const screensRaw = obj.screens;
+
+    if (!Array.isArray(screensRaw) || screensRaw.length === 0) {
+        throw new Error('Mockup generation returned no screens.');
+    }
+
+    const screens: MockupScreen[] = screensRaw.map((s, i) => {
+        if (!s || typeof s !== 'object') {
+            throw new Error(`Mockup screen ${i} is not an object.`);
+        }
+        const sObj = s as Record<string, unknown>;
+        const name = typeof sObj.name === 'string' ? sObj.name : '';
+        const purpose = typeof sObj.purpose === 'string' ? sObj.purpose : '';
+        const html = typeof sObj.html === 'string' ? sObj.html : '';
+        const notes = typeof sObj.notes === 'string' ? sObj.notes : undefined;
+
+        if (!name.trim() || !html.trim()) {
+            throw new Error(`Mockup screen ${i} is missing a name or html.`);
+        }
+
+        return {
+            id: uuidv4(),
+            name: name.trim(),
+            purpose: purpose.trim(),
+            html,
+            notes: notes?.trim() || undefined,
+        };
+    });
+
+    const title = typeof obj.title === 'string' && obj.title.trim()
+        ? obj.title.trim()
+        : 'Mockup concept';
+    const summary = typeof obj.summary === 'string' ? obj.summary.trim() : '';
+
+    return {
+        version: 'mockup_html_v1',
+        title,
+        summary,
+        screens,
+    };
+};
+
+// ---- Public API ----
 
 export const generateMockup = async (
     prdContent: string,
     settings: MockupSettings,
-    options?: ProviderOptions
-): Promise<string> => {
+    structuredPRD?: StructuredPRD,
+    options?: ProviderOptions,
+): Promise<MockupPayload> => {
     options?.onStatus?.('Generating mockup...');
 
-    const system = `You are an expert UI/UX designer. Generate text-based mockups for a product based on its PRD.
+    const system = buildSystemPrompt(settings);
+    const user = buildUserPrompt(prdContent, structuredPRD);
 
-${FIDELITY_INSTRUCTIONS[settings.fidelity]}
-${PLATFORM_INSTRUCTIONS[settings.platform]}
-${SCOPE_INSTRUCTIONS[settings.scope]}
+    const raw = await callGemini(system, user, {
+        responseMimeType: 'application/json',
+        responseSchema: mockupSchema,
+    });
 
-${settings.style ? `Style direction: ${settings.style}` : ''}
-${settings.notes ? `Additional notes: ${settings.notes}` : ''}
-
-For each screen, provide:
-1. Screen name and purpose
-2. Visual layout using ASCII art or structured description
-3. Component list with descriptions
-4. Navigation and interaction notes
-5. Content/copy placeholders
-
-Use clear section headers and consistent formatting throughout.`;
-
-    return callGemini(system, `Generate mockups based on this PRD:\n\n${prdContent}`);
+    return parseMockupPayload(raw);
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -267,6 +267,25 @@ export type MockupSettings = {
     selectedSections?: string[];
 };
 
+// Rendered HTML/Tailwind mockup payload (stored as JSON string in
+// ArtifactVersion.content; distinguished by metadata.format === 'mockup_html_v1').
+export type MockupScreen = {
+    id: string;       // stable per-screen id (uuid, assigned client-side)
+    name: string;     // screen title, e.g. "Editor Dashboard"
+    purpose: string;  // one-sentence rationale grounded in the PRD
+    html: string;     // static body fragment — no <html>/<head>/<script>
+    notes?: string;   // optional assumptions / callouts
+};
+
+export type MockupPayload = {
+    version: 'mockup_html_v1';
+    title: string;              // overall title, e.g. "Editor Workspace Concept"
+    summary: string;            // 1–2 sentence product framing
+    screens: MockupScreen[];    // always >= 1
+};
+
+export const MOCKUP_HTML_V1 = 'mockup_html_v1' as const;
+
 // Prompt artifact settings
 export type PromptTarget =
     | 'mockup'


### PR DESCRIPTION
## Summary
- Mockup stage now generates structured `MockupPayload` (title, summary, screens[]) via Gemini JSON mode against a new `mockupSchema`, grounded in the PRD (and `structuredPRD` when available).
- New `MockupViewer` + `MockupHtmlPreview` render each screen inside a sandboxed `srcDoc` iframe (`sandbox="allow-scripts"`, no same-origin) with Tailwind via CDN — screen pill nav, Preview/Code toggle, open-in-new-tab, metadata strip, matches Synapse's house style.
- Artifact/versioning/lineage/staleness wiring is unchanged; legacy markdown mockups fall back to `ReactMarkdown` with a "Legacy mockup" badge so existing data still renders.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Dev server verified end-to-end: 3-screen "Artisan Marketplace Concept" payload rendered with Tailwind, screen pill nav swaps iframes, Code toggle works, sanitizer strips `<script>`/inline handlers, legacy markdown fallback renders with amber badge, zero console errors
