### PR TITLE
fix: overhaul error handling to prevent content corruption and improve UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,21 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { HomePage } from './components/HomePage';
 import { ProjectWorkspace } from './components/ProjectWorkspace';
 import { MeetSynapsePage } from './components/MeetSynapsePage';
+import { GlobalErrorBoundary } from './components/GlobalErrorBoundary';
+import { ToastContainer } from './components/ToastContainer';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/about" element={<MeetSynapsePage />} />
-        <Route path="/p/:projectId" element={<ProjectWorkspace />} />
-      </Routes>
-    </BrowserRouter>
+    <GlobalErrorBoundary>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/about" element={<MeetSynapsePage />} />
+          <Route path="/p/:projectId" element={<ProjectWorkspace />} />
+        </Routes>
+        <ToastContainer />
+      </BrowserRouter>
+    </GlobalErrorBoundary>
   );
 }
 

--- a/src/components/ArtifactsView.tsx
+++ b/src/components/ArtifactsView.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
-import { Package, Plus, RefreshCcw, Sparkles, Loader2, CheckCircle2, XCircle, AlertTriangle, AlertCircle } from 'lucide-react';
+import { Package, Plus, RefreshCcw, Sparkles, Loader2, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
 import { ArtifactContentRenderer } from './renderers';
 import { useProjectStore } from '../store/projectStore';
 import { generateCoreArtifact, refineCoreArtifact } from '../lib/llmProvider';
 import { validateArtifactContent } from '../lib/artifactValidation';
+import { normalizeError, userMessage } from '../lib/errors';
+import { ErrorBanner } from './ErrorBanner';
 import { StalenessBadge } from './StalenessBadge';
 import { FeedbackModal } from './FeedbackModal';
 import { GenerationProgress } from './GenerationProgress';
@@ -121,7 +123,9 @@ export function ArtifactsView({ projectId, spineVersionId, prdContent, structure
 
             setExpandedId(artifactId);
         } catch (e) {
-            setError(e instanceof Error ? e.message : String(e));
+            const err = normalizeError(e);
+            console.error('[Artifact generation failed]', err.raw);
+            setError(userMessage(err));
         } finally {
             setGeneratingSubtype(null);
         }
@@ -159,7 +163,9 @@ export function ArtifactsView({ projectId, spineVersionId, prdContent, structure
             setRefineSubtype(null);
             setRefineInstruction('');
         } catch (e) {
-            setError(e instanceof Error ? e.message : String(e));
+            const err = normalizeError(e);
+            console.error('[Artifact refinement failed]', err.raw);
+            setError(userMessage(err));
         } finally {
             setGeneratingSubtype(null);
         }
@@ -202,18 +208,18 @@ export function ArtifactsView({ projectId, spineVersionId, prdContent, structure
         });
 
         const results = await withConcurrency(tasks, 3);
-        const errors = results
-            .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-            .map(r => r.reason instanceof Error ? r.reason.message : String(r.reason));
+        const failedCount = results.filter(r => r.status === 'rejected').length;
 
         results.forEach((r, i) => {
             if (r.status === 'rejected') {
+                console.error('[Stale artifact refresh failed]', r.reason);
                 setBundleStatus(prev => ({ ...prev, [staleArtifacts[i].subtype]: 'error' }));
             }
         });
 
-        if (errors.length > 0) {
-            setError(`${errors.length} artifact(s) failed: ${errors.join('; ')}`);
+        if (failedCount > 0) {
+            const succeeded = results.length - failedCount;
+            setError(`${failedCount} artifact(s) could not be refreshed.${succeeded > 0 ? ` ${succeeded} updated successfully.` : ''} You can retry the failed items individually.`);
         }
         setGeneratingSubtype(null);
     };
@@ -261,20 +267,19 @@ export function ArtifactsView({ projectId, spineVersionId, prdContent, structure
 
         // Run with concurrency limit of 3 to avoid Gemini rate limits
         const results = await withConcurrency(tasks, 3);
-
-        const errors = results
-            .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-            .map(r => r.reason instanceof Error ? r.reason.message : String(r.reason));
+        const failedCount = results.filter(r => r.status === 'rejected').length;
 
         // Mark failed ones
         results.forEach((r, i) => {
             if (r.status === 'rejected') {
+                console.error('[Bundle artifact generation failed]', r.reason);
                 setBundleStatus(prev => ({ ...prev, [CORE_ARTIFACTS[i].subtype]: 'error' }));
             }
         });
 
-        if (errors.length > 0) {
-            setError(`${errors.length} artifact(s) failed: ${errors.join('; ')}`);
+        if (failedCount > 0) {
+            const succeeded = results.length - failedCount;
+            setError(`${failedCount} of ${results.length} artifact(s) could not be generated.${succeeded > 0 ? ` ${succeeded} completed successfully.` : ''} You can retry the failed items individually.`);
         }
 
         setGeneratingSubtype(null);
@@ -323,14 +328,11 @@ export function ArtifactsView({ projectId, spineVersionId, prdContent, structure
             )}
 
             {error && (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700 flex items-start gap-3">
-                    <AlertCircle size={16} className="shrink-0 mt-0.5" />
-                    <div className="flex-1">
-                        <p className="font-medium mb-1">Generation failed</p>
-                        <p>{error}</p>
-                    </div>
-                    <button type="button" onClick={() => setError(null)} className="shrink-0 text-red-400 hover:text-red-600 text-xs font-medium">&times;</button>
-                </div>
+                <ErrorBanner
+                    title="Generation failed"
+                    message={error}
+                    onDismiss={() => setError(null)}
+                />
             )}
 
             {/* Bundle / stale refresh progress */}

--- a/src/components/BranchList.tsx
+++ b/src/components/BranchList.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { replyInBranch } from '../lib/llmProvider';
 import { Send, Maximize2, Trash2 } from 'lucide-react';
+import { normalizeError, userMessage } from '../lib/errors';
+import { useToastStore } from '../store/toastStore';
 import type { Branch, BranchMessage } from '../types';
 import { IntentHelperLabel } from '../lib/intentHelper';
 
@@ -40,14 +42,20 @@ export function BranchList({ projectId, spineVersionId, onConsolidate, onCanvasO
             addBranchMessage(projectId, branch.id, 'user', replyText.trim());
             setReplyInputs(prev => ({ ...prev, [branch.id]: '' }));
 
-            // Assistant response mock
             const response = await replyInBranch({
                 anchorText: branch.anchorText,
                 intent: replyText.trim(),
                 threadHistory: branch.messages
             });
             addBranchMessage(projectId, branch.id, 'assistant', response);
-
+        } catch (e) {
+            const err = normalizeError(e);
+            console.error('[Branch reply failed]', err.raw);
+            useToastStore.getState().addToast({
+                type: 'error',
+                title: 'Reply failed',
+                message: userMessage(err),
+            });
         } finally {
             setIsReplying(prev => ({ ...prev, [branch.id]: false }));
         }

--- a/src/components/ConsolidationModal.tsx
+++ b/src/components/ConsolidationModal.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useProjectStore } from '../store/projectStore';
 import { consolidateBranch, type ConsolidationResult, type ConsolidationScope } from '../lib/llmProvider';
 import { X, ArrowRight, Check, Loader2 } from 'lucide-react';
+import { normalizeError, userMessage } from '../lib/errors';
+import { ErrorBanner } from './ErrorBanner';
 import { GenerationProgress } from './GenerationProgress';
 import { CONSOLIDATION_STAGES } from './generationStages';
 import type { Branch } from '../types';
@@ -28,8 +30,9 @@ export function ConsolidationModal({ projectId, branch, spineText, onClose }: Co
             const res = await consolidateBranch(spineText, branch, selectedScope);
             setResult(res);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : 'Failed to generate patch. Please check your API key and connection.';
-            setError(message);
+            const normalized = normalizeError(err);
+            console.error('[Consolidation failed]', normalized.raw);
+            setError(userMessage(normalized));
         } finally {
             setIsConsolidating(false);
         }
@@ -86,15 +89,11 @@ export function ConsolidationModal({ projectId, branch, spineText, onClose }: Co
 
                 {/* Error Banner */}
                 {error && (
-                    <div className="mx-4 mt-4 p-3 bg-red-50 border border-red-100 rounded-lg text-sm text-red-600 flex items-start gap-2">
-                        <span className="font-semibold shrink-0">Failed:</span>
-                        <span className="flex-1">{error}</span>
-                        <button
-                            onClick={() => setError(null)}
-                            className="shrink-0 text-red-400 hover:text-red-600 text-xs font-medium"
-                        >
-                            &times;
-                        </button>
+                    <div className="mx-4 mt-4">
+                        <ErrorBanner
+                            message={error}
+                            onDismiss={() => setError(null)}
+                        />
                     </div>
                 )}
 

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,0 +1,61 @@
+import { AlertCircle, AlertTriangle } from 'lucide-react';
+
+interface ErrorBannerProps {
+    title?: string;
+    message: string;
+    onDismiss?: () => void;
+    onRetry?: () => void;
+    variant?: 'error' | 'warning';
+}
+
+const VARIANTS = {
+    error: {
+        bg: 'bg-red-50',
+        border: 'border-red-200',
+        text: 'text-red-700',
+        dismiss: 'text-red-400 hover:text-red-600',
+        icon: AlertCircle,
+        retryBg: 'bg-red-600 hover:bg-red-700',
+    },
+    warning: {
+        bg: 'bg-amber-50',
+        border: 'border-amber-200',
+        text: 'text-amber-700',
+        dismiss: 'text-amber-400 hover:text-amber-600',
+        icon: AlertTriangle,
+        retryBg: 'bg-amber-600 hover:bg-amber-700',
+    },
+};
+
+export function ErrorBanner({ title, message, onDismiss, onRetry, variant = 'error' }: ErrorBannerProps) {
+    const v = VARIANTS[variant];
+    const Icon = v.icon;
+
+    return (
+        <div className={`${v.bg} border ${v.border} rounded-lg p-4 text-sm ${v.text} flex items-start gap-3`}>
+            <Icon size={16} className="shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+                {title && <p className="font-medium mb-1">{title}</p>}
+                <p>{message}</p>
+                {onRetry && (
+                    <button
+                        type="button"
+                        onClick={onRetry}
+                        className={`mt-2 px-3 py-1 text-xs font-medium text-white rounded ${v.retryBg} transition`}
+                    >
+                        Try Again
+                    </button>
+                )}
+            </div>
+            {onDismiss && (
+                <button
+                    type="button"
+                    onClick={onDismiss}
+                    className={`shrink-0 ${v.dismiss} text-xs font-medium`}
+                >
+                    &times;
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/components/GlobalErrorBoundary.tsx
+++ b/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,90 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+interface Props {
+    children: ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+    error: Error | null;
+    showDetails: boolean;
+}
+
+/**
+ * App-wide error boundary. Catches render crashes anywhere in the component
+ * tree and shows a full-page recovery screen instead of a blank page.
+ */
+export class GlobalErrorBoundary extends Component<Props, State> {
+    state: State = { hasError: false, error: null, showDetails: false };
+
+    static getDerivedStateFromError(error: Error): Partial<State> {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        console.error('[GlobalErrorBoundary] Unhandled render error:', error, info.componentStack);
+    }
+
+    handleReload = () => {
+        window.location.reload();
+    };
+
+    handleGoHome = () => {
+        this.setState({ hasError: false, error: null, showDetails: false });
+        window.location.href = '/';
+    };
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div className="min-h-screen bg-neutral-50 flex items-center justify-center p-6">
+                    <div className="max-w-md w-full text-center">
+                        <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center mx-auto mb-4">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-red-500">
+                                <circle cx="12" cy="12" r="10" />
+                                <line x1="15" y1="9" x2="9" y2="15" />
+                                <line x1="9" y1="9" x2="15" y2="15" />
+                            </svg>
+                        </div>
+                        <h1 className="text-xl font-semibold text-neutral-900 mb-2">Something went wrong</h1>
+                        <p className="text-sm text-neutral-500 mb-6">
+                            An unexpected error occurred. Your data is safe in local storage.
+                        </p>
+                        <div className="flex items-center justify-center gap-3 mb-6">
+                            <button
+                                onClick={this.handleReload}
+                                className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition"
+                            >
+                                Reload Application
+                            </button>
+                            <button
+                                onClick={this.handleGoHome}
+                                className="px-4 py-2 bg-neutral-200 text-neutral-700 text-sm font-medium rounded-lg hover:bg-neutral-300 transition"
+                            >
+                                Go Home
+                            </button>
+                        </div>
+                        {this.state.error && (
+                            <div className="text-left">
+                                <button
+                                    onClick={() => this.setState(s => ({ showDetails: !s.showDetails }))}
+                                    className="text-xs text-neutral-400 hover:text-neutral-600 transition"
+                                >
+                                    {this.state.showDetails ? 'Hide' : 'Show'} technical details
+                                </button>
+                                {this.state.showDetails && (
+                                    <pre className="mt-2 p-3 bg-neutral-100 border border-neutral-200 rounded-lg text-xs text-neutral-600 overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
+                                        {this.state.error.message}
+                                        {this.state.error.stack && `\n\n${this.state.error.stack}`}
+                                    </pre>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -1,4 +1,4 @@
-import { Clock, FileText, Package, MessageSquare, CheckCircle } from 'lucide-react';
+import { Clock, FileText, Package, MessageSquare, CheckCircle, XCircle } from 'lucide-react';
 import { useProjectStore } from '../store/projectStore';
 import type { HistoryEventType } from '../types';
 
@@ -14,6 +14,7 @@ const EVENT_CONFIG: Record<HistoryEventType, { icon: typeof Clock; color: string
     ArtifactRegenerated: { icon: Package, color: 'text-purple-600', bgColor: 'bg-purple-50' },
     FeedbackCreated: { icon: MessageSquare, color: 'text-amber-600', bgColor: 'bg-amber-50' },
     FeedbackApplied: { icon: CheckCircle, color: 'text-emerald-600', bgColor: 'bg-emerald-50' },
+    GenerationFailed: { icon: XCircle, color: 'text-red-600', bgColor: 'bg-red-50' },
 };
 
 export function HistoryView({ projectId }: HistoryViewProps) {

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../store/projectStore';
 import { Settings, List, Plus, ArrowUp, Sparkles, X, Smartphone, Monitor, Loader2 } from 'lucide-react';
 import { SettingsModal } from './SettingsModal';
 import { ProjectDrawer } from './ProjectDrawer';
+import { normalizeError, userMessage } from '../lib/errors';
 import type { ProjectPlatform } from '../types';
 
 const EXAMPLE_PROMPTS = [
@@ -69,18 +70,22 @@ export function HomePage() {
                     useProjectStore.getState().updateSpineStructuredPRD(projectId, spineId, structuredPRD, markdown);
                 })
                 .catch((e) => {
-                    const errorMsg = e instanceof Error ? e.message : String(e);
-                    useProjectStore.getState().updateSpineText(
-                        projectId, spineId,
-                        `> **PRD generation encountered an error.** You can regenerate from the workspace menu.\n>\n> ${errorMsg}`
-                    );
+                    const err = normalizeError(e);
+                    console.error('[PRD generation failed]', err.raw);
+                    useProjectStore.getState().setSpineError(projectId, spineId, {
+                        message: userMessage(err),
+                        category: err.category,
+                        timestamp: err.timestamp,
+                    });
                 });
         }).catch((e) => {
-            const errorMsg = e instanceof Error ? e.message : String(e);
-            useProjectStore.getState().updateSpineText(
-                projectId, spineId,
-                `> **Failed to load generation module.** Try refreshing the page.\n>\n> ${errorMsg}`
-            );
+            const err = normalizeError(e);
+            console.error('[Module load failed]', err.raw);
+            useProjectStore.getState().setSpineError(projectId, spineId, {
+                message: 'Failed to load generation module. Try refreshing the page.',
+                category: err.category,
+                timestamp: err.timestamp,
+            });
         });
     };
 
@@ -95,8 +100,17 @@ export function HomePage() {
             const { enhancePrompt } = await import('../lib/llmProvider');
             const enhanced = await enhancePrompt(promptText.trim());
             setPromptText(enhanced);
-        } catch {
-            // Silently fail — user can retry
+        } catch (e) {
+            const err = normalizeError(e);
+            console.error('[Enhance prompt failed]', err.raw);
+            // Toast integration added in Phase 5 — for now uses toastStore directly
+            import('../store/toastStore').then(({ useToastStore }) => {
+                useToastStore.getState().addToast({
+                    type: 'warning',
+                    title: 'Prompt enhancement failed',
+                    message: 'Your original prompt was kept.',
+                });
+            }).catch(() => { /* toast store not yet available */ });
         } finally {
             setIsEnhancing(false);
         }

--- a/src/components/MarkupImageView.tsx
+++ b/src/components/MarkupImageView.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
-import { Layers, Plus, RefreshCcw, Download, AlertCircle, Loader2 } from 'lucide-react';
+import { Layers, Plus, RefreshCcw, Download, Loader2 } from 'lucide-react';
 import { useProjectStore } from '../store/projectStore';
 import { generateMarkupImage } from '../lib/llmProvider';
+import { normalizeError, userMessage } from '../lib/errors';
+import { ErrorBanner } from './ErrorBanner';
 import { MarkupImageRenderer } from './MarkupImageRenderer';
 import { GenerationProgress } from './GenerationProgress';
 import { getMarkupImageStages } from './generationStages';
@@ -55,7 +57,9 @@ export function MarkupImageView({ projectId, spineVersionId, prdContent, structu
 
             setSelectedArtifactId(artifactId);
         } catch (e) {
-            setError(e instanceof Error ? e.message : String(e));
+            const err = normalizeError(e);
+            console.error('[Markup image generation failed]', err.raw);
+            setError(userMessage(err));
         } finally {
             setGeneratingSubtype(null);
         }
@@ -80,7 +84,9 @@ export function MarkupImageView({ projectId, spineVersionId, prdContent, structu
                 parentVersionId,
             );
         } catch (e) {
-            setError(e instanceof Error ? e.message : String(e));
+            const err = normalizeError(e);
+            console.error('[Markup image generation failed]', err.raw);
+            setError(userMessage(err));
         } finally {
             setGeneratingSubtype(null);
         }
@@ -129,14 +135,11 @@ export function MarkupImageView({ projectId, spineVersionId, prdContent, structu
             )}
 
             {error && (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700 flex items-start gap-3">
-                    <AlertCircle size={16} className="shrink-0 mt-0.5" />
-                    <div className="flex-1">
-                        <p className="font-medium mb-1">Markup generation failed</p>
-                        <p>{error}</p>
-                    </div>
-                    <button type="button" onClick={() => setError(null)} className="shrink-0 text-red-400 hover:text-red-600 text-xs font-medium">&times;</button>
-                </div>
+                <ErrorBanner
+                    title="Markup generation failed"
+                    message={error}
+                    onDismiss={() => setError(null)}
+                />
             )}
 
             {/* Generate Buttons */}

--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
-import { Image, Plus, GitCompare, MessageSquarePlus, AlertCircle, AlertTriangle, RefreshCw, Sparkles, Monitor, Smartphone, Columns3, Loader2 } from 'lucide-react';
+import { Image, Plus, GitCompare, MessageSquarePlus, RefreshCw, Sparkles, Monitor, Smartphone, Columns3, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useProjectStore } from '../store/projectStore';
 import { generateMockup } from '../lib/llmProvider';
+import { normalizeError, userMessage } from '../lib/errors';
+import { ErrorBanner } from './ErrorBanner';
 import { StalenessBadge } from './StalenessBadge';
 import { FeedbackModal } from './FeedbackModal';
 import { MockupViewer } from './mockups/MockupViewer';
@@ -168,7 +170,9 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                 setWarning(`Generated with ${warnings.length} skipped screen(s): ${warnings.join(' ')}`);
             }
         } catch (e) {
-            setError(e instanceof Error ? e.message : String(e));
+            const err = normalizeError(e);
+            console.error('[Mockup generation failed]', err.raw);
+            setError(userMessage(err));
         } finally {
             setIsGenerating(false);
         }
@@ -205,7 +209,9 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
         } catch (e) {
             // On regeneration failure, the previous version is preserved — the
             // user still sees the last known good content.
-            setError(e instanceof Error ? e.message : String(e));
+            const err = normalizeError(e);
+            console.error('[Mockup regeneration failed]', err.raw);
+            setError(userMessage(err));
         } finally {
             setIsGenerating(false);
         }
@@ -428,18 +434,17 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
             </div>
 
             {error && (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700 flex items-start gap-3">
-                    <AlertCircle size={16} className="shrink-0 mt-0.5" />
-                    <span className="flex-1">{error}</span>
-                    <button type="button" onClick={() => setError(null)} className="shrink-0 text-red-400 hover:text-red-600 text-xs font-medium">&times;</button>
-                </div>
+                <ErrorBanner
+                    message={error}
+                    onDismiss={() => setError(null)}
+                />
             )}
             {warning && (
-                <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-700 flex items-start gap-3">
-                    <AlertTriangle size={16} className="shrink-0 mt-0.5" />
-                    <span className="flex-1">{warning}</span>
-                    <button type="button" onClick={() => setWarning(null)} className="shrink-0 text-amber-400 hover:text-amber-600 text-xs font-medium">&times;</button>
-                </div>
+                <ErrorBanner
+                    message={warning}
+                    variant="warning"
+                    onDismiss={() => setWarning(null)}
+                />
             )}
 
             {/* Generate Panel */}

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, RefreshCcw, LogOut, CheckCircle, Download, Settings, Chevr
 import { useState, useRef, useEffect } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { generateStructuredPRD, structuredPRDToMarkdown } from '../lib/llmProvider';
+import { normalizeError, userMessage } from '../lib/errors';
 import { GenerationProgress } from './GenerationProgress';
 import { PRD_GENERATION_STAGES, PRD_REGENERATION_STAGES } from './generationStages';
 import { SelectableSpine } from './SelectableSpine';
@@ -24,7 +25,7 @@ import type { Branch, PipelineStage, FeedbackItem } from '../types';
 export function ProjectWorkspace() {
     const { projectId } = useParams<{ projectId: string }>();
     const navigate = useNavigate();
-    const { getProject, getLatestSpine, regenerateSpine, updateSpineText, updateSpineStructuredPRD, getHistoryEvents, getBranchesForSpine, getSpineVersions, markSpineFinal, setProjectStage, createBranch: storCreateBranch, updateFeedbackStatus } = useProjectStore();
+    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, setSpineError, getHistoryEvents, getBranchesForSpine, getSpineVersions, markSpineFinal, setProjectStage, createBranch: storCreateBranch, updateFeedbackStatus } = useProjectStore();
     const [isGenerating, setIsGenerating] = useState(false);
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const [consolidatingBranch, setConsolidatingBranch] = useState<Branch | null>(null);
@@ -70,7 +71,7 @@ export function ProjectWorkspace() {
     const hasBranches = branches.length > 0;
 
     // Detect if the current spine is still waiting for initial generation
-    const isPRDGenerating = !!activeSpine && activeSpine.responseText === 'Generating PRD...' && !activeSpine.structuredPRD;
+    const isPRDGenerating = !!activeSpine && activeSpine.responseText === 'Generating PRD...' && !activeSpine.structuredPRD && !activeSpine.generationError;
 
     // Human-friendly version label
     const getVersionLabel = (spineId: string) => {
@@ -97,14 +98,14 @@ export function ProjectWorkspace() {
             const markdown = structuredPRDToMarkdown(structuredPRD);
             updateSpineStructuredPRD(projectId, newSpineId, structuredPRD, markdown);
         } catch (e) {
-            console.error(e);
+            const err = normalizeError(e);
+            console.error('[PRD regeneration failed]', err.raw);
             if (activeNewSpineId) {
-                const errorMsg = e instanceof Error ? e.message : String(e);
-                updateSpineText(
-                    projectId,
-                    activeNewSpineId,
-                    `> **Regeneration encountered an error.** You can try again from the workspace menu.\n>\n> ${errorMsg}`
-                );
+                setSpineError(projectId, activeNewSpineId, {
+                    message: userMessage(err),
+                    category: err.category,
+                    timestamp: err.timestamp,
+                });
             }
         } finally {
             setIsGenerating(false);
@@ -144,11 +145,13 @@ export function ProjectWorkspace() {
                         <ChevronLeft size={20} />
                     </button>
                     <span className="font-semibold truncate">{project.name}</span>
-                    <span className={`text-xs px-2 py-0.5 rounded whitespace-nowrap shrink-0 ${activeSpine?.isFinal ? 'bg-green-900/30 text-green-400 border border-green-800' : isPRDGenerating ? 'bg-indigo-900/30 text-indigo-400 border border-indigo-800' : 'bg-neutral-800 text-neutral-400'}`}>
+                    <span className={`text-xs px-2 py-0.5 rounded whitespace-nowrap shrink-0 ${activeSpine?.isFinal ? 'bg-green-900/30 text-green-400 border border-green-800' : activeSpine?.generationError ? 'bg-red-900/30 text-red-400 border border-red-800' : isPRDGenerating ? 'bg-indigo-900/30 text-indigo-400 border border-indigo-800' : 'bg-neutral-800 text-neutral-400'}`}>
                         {activeSpine
-                            ? isPRDGenerating
-                                ? 'Generating...'
-                                : `${getVersionLabel(activeSpine.id)} ${activeSpine.isFinal ? '(FINAL)' : ''}`
+                            ? activeSpine.generationError
+                                ? 'Generation Failed'
+                                : isPRDGenerating
+                                    ? 'Generating...'
+                                    : `${getVersionLabel(activeSpine.id)} ${activeSpine.isFinal ? '(FINAL)' : ''}`
                             : 'Initializing...'}
                     </span>
                 </div>
@@ -325,7 +328,28 @@ export function ProjectWorkspace() {
                                         )}
 
                                         {/* Don't render SelectableSpine for the placeholder text */}
-                                        {isPRDGenerating ? (
+                                        {activeSpine.generationError ? (
+                                            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+                                                <div className="flex items-start gap-3">
+                                                    <div className="shrink-0 mt-0.5 w-8 h-8 rounded-full bg-red-100 flex items-center justify-center">
+                                                        <RefreshCcw size={16} className="text-red-500" />
+                                                    </div>
+                                                    <div className="flex-1 min-w-0">
+                                                        <p className="font-semibold text-red-800 mb-1">PRD generation could not be completed</p>
+                                                        <p className="text-sm text-red-700 mb-4">{activeSpine.generationError.message}</p>
+                                                        <div className="flex items-center gap-3">
+                                                            <button
+                                                                onClick={handleRegenerate}
+                                                                disabled={isGenerating || hasBranches}
+                                                                className="px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition disabled:opacity-40"
+                                                            >
+                                                                Try Again
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ) : isPRDGenerating ? (
                                             <div className="space-y-4 animate-pulse">
                                                 <div className="h-5 bg-neutral-100 rounded w-2/5" />
                                                 <div className="space-y-2.5">

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,0 +1,45 @@
+import { useToastStore } from '../store/toastStore';
+import type { ToastType } from '../store/toastStore';
+import { AlertCircle, CheckCircle2, AlertTriangle, Info, X } from 'lucide-react';
+
+const TOAST_STYLES: Record<ToastType, { bg: string; border: string; icon: string; iconComponent: typeof AlertCircle }> = {
+    error:   { bg: 'bg-red-50',    border: 'border-red-200',    icon: 'text-red-500',    iconComponent: AlertCircle },
+    warning: { bg: 'bg-amber-50',  border: 'border-amber-200',  icon: 'text-amber-500',  iconComponent: AlertTriangle },
+    success: { bg: 'bg-green-50',  border: 'border-green-200',  icon: 'text-green-500',  iconComponent: CheckCircle2 },
+    info:    { bg: 'bg-blue-50',   border: 'border-blue-200',   icon: 'text-blue-500',   iconComponent: Info },
+};
+
+export function ToastContainer() {
+    const { toasts, removeToast } = useToastStore();
+
+    if (toasts.length === 0) return null;
+
+    return (
+        <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm w-full pointer-events-none">
+            {toasts.map(toast => {
+                const style = TOAST_STYLES[toast.type];
+                const Icon = style.iconComponent;
+                return (
+                    <div
+                        key={toast.id}
+                        className={`pointer-events-auto ${style.bg} ${style.border} border rounded-lg shadow-lg p-4 flex items-start gap-3 animate-in slide-in-from-right-5 duration-200`}
+                    >
+                        <Icon size={18} className={`shrink-0 mt-0.5 ${style.icon}`} />
+                        <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-neutral-900">{toast.title}</p>
+                            {toast.message && (
+                                <p className="text-xs text-neutral-600 mt-0.5">{toast.message}</p>
+                            )}
+                        </div>
+                        <button
+                            onClick={() => removeToast(toast.id)}
+                            className="shrink-0 text-neutral-400 hover:text-neutral-600 transition"
+                        >
+                            <X size={14} />
+                        </button>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,66 @@
+/**
+ * Centralized error normalization and user-friendly formatting.
+ *
+ * Every catch block in Synapse should use `normalizeError()` instead of
+ * ad-hoc `e instanceof Error ? e.message : String(e)` patterns, and
+ * `userMessage()` for anything shown in the UI.
+ */
+
+export type ErrorCategory =
+    | 'api_key_missing'
+    | 'rate_limited'
+    | 'safety_blocked'
+    | 'empty_response'
+    | 'network'
+    | 'parse_failure'
+    | 'unknown';
+
+export interface NormalizedError {
+    message: string;
+    category: ErrorCategory;
+    raw: string;
+    timestamp: number;
+}
+
+const CATEGORY_PATTERNS: [ErrorCategory, RegExp][] = [
+    ['api_key_missing', /missing gemini api key/i],
+    ['rate_limited', /429|resource exhausted|too many requests/i],
+    ['safety_blocked', /safety filter/i],
+    ['empty_response', /empty response/i],
+    ['network', /failed to fetch|networkerror|load failed|net::/i],
+    ['parse_failure', /failed to parse|invalid json|json\.parse|non-object response/i],
+];
+
+function classifyError(message: string): ErrorCategory {
+    for (const [category, pattern] of CATEGORY_PATTERNS) {
+        if (pattern.test(message)) return category;
+    }
+    return 'unknown';
+}
+
+/** Extract a message string from any thrown value. */
+export function normalizeError(e: unknown): NormalizedError {
+    const raw = e instanceof Error ? e.message : String(e);
+    const category = classifyError(raw);
+    return {
+        message: raw,
+        category,
+        raw,
+        timestamp: Date.now(),
+    };
+}
+
+const USER_MESSAGES: Record<ErrorCategory, string> = {
+    api_key_missing: 'API key not configured. Open Settings to add your Gemini API key.',
+    rate_limited: 'Too many requests. Wait a moment and try again.',
+    safety_blocked: 'Content was blocked by safety filters. Try adjusting your prompt.',
+    empty_response: 'No content was generated. Please try again.',
+    network: 'Network error. Check your internet connection and try again.',
+    parse_failure: 'The response could not be processed. Please try again.',
+    unknown: 'Something went wrong. Please try again.',
+};
+
+/** Return a calm, human-readable message suitable for product UI. */
+export function userMessage(err: NormalizedError): string {
+    return USER_MESSAGES[err.category];
+}

--- a/src/lib/services/branchService.ts
+++ b/src/lib/services/branchService.ts
@@ -50,21 +50,15 @@ export const consolidateBranch = async (
 export const replyInBranch = async (
     context: { anchorText: string, intent: string, threadHistory: { role: string; content: string }[] }
 ): Promise<string> => {
-    try {
-        const system = `You are a product management assistant helping a user refine a PRD. The user has selected the text: "${context.anchorText}". Please respond to their intent concisely. If they ask for a change, provide a "Suggested replacement for selected text:" block.`;
+    const system = `You are a product management assistant helping a user refine a PRD. The user has selected the text: "${context.anchorText}". Please respond to their intent concisely. If they ask for a change, provide a "Suggested replacement for selected text:" block.`;
 
-        let promptText = `Thread History:\n`;
-        if (context.threadHistory && context.threadHistory.length > 0) {
-            context.threadHistory.forEach(msg => {
-                promptText += `${msg.role.toUpperCase()}: ${msg.content}\n\n`;
-            });
-        }
-        promptText += `USER INTENT: ${context.intent}`;
-
-        return await callGemini(system, promptText);
-    } catch (e: unknown) {
-        console.error(e);
-        const errorMsg = e instanceof Error ? e.message : String(e);
-        return `Error: ${errorMsg}`;
+    let promptText = `Thread History:\n`;
+    if (context.threadHistory && context.threadHistory.length > 0) {
+        context.threadHistory.forEach(msg => {
+            promptText += `${msg.role.toUpperCase()}: ${msg.content}\n\n`;
+        });
     }
+    promptText += `USER INTENT: ${context.intent}`;
+
+    return await callGemini(system, promptText);
 };

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -12,6 +12,7 @@ export type SpineSlice = {
     getLatestSpine: ProjectState['getLatestSpine'];
     updateStructuredPRD: ProjectState['updateStructuredPRD'];
     updateSpineStructuredPRD: ProjectState['updateSpineStructuredPRD'];
+    setSpineError: ProjectState['setSpineError'];
 };
 
 export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = (set, get) => ({
@@ -106,6 +107,46 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
                 s.id === spineId ? { ...s, structuredPRD, responseText } : s
             );
             return { spineVersions: { ...state.spineVersions, [projectId]: updatedSpines } };
+        });
+    },
+
+    setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number } | null) => {
+        set((state) => {
+            const projectSpines = state.spineVersions[projectId] || [];
+            const spine = projectSpines.find(s => s.id === spineId);
+            if (!spine) return state;
+
+            const updatedSpines = projectSpines.map(s =>
+                s.id === spineId
+                    ? {
+                        ...s,
+                        generationError: error ?? undefined,
+                        // Clear placeholder so isPRDGenerating stops being true
+                        responseText: error && s.responseText === 'Generating PRD...' ? '' : s.responseText,
+                    }
+                    : s
+            );
+
+            const historyEvents = { ...state.historyEvents };
+            if (error) {
+                const events = historyEvents[projectId] || [];
+                historyEvents[projectId] = [
+                    ...events,
+                    {
+                        id: uuidv4(),
+                        projectId,
+                        spineVersionId: spineId,
+                        type: 'GenerationFailed' as const,
+                        description: `Generation failed: ${error.message}`,
+                        createdAt: error.timestamp,
+                    },
+                ];
+            }
+
+            return {
+                spineVersions: { ...state.spineVersions, [projectId]: updatedSpines },
+                historyEvents,
+            };
         });
     },
 });

--- a/src/store/toastStore.ts
+++ b/src/store/toastStore.ts
@@ -1,0 +1,61 @@
+/**
+ * Ephemeral toast notification store.
+ *
+ * Separate from projectStore so toasts are NOT persisted to localStorage.
+ */
+
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+
+export type ToastType = 'error' | 'success' | 'warning' | 'info';
+
+export interface Toast {
+    id: string;
+    type: ToastType;
+    title: string;
+    message?: string;
+    duration: number; // ms, 0 = sticky (user must dismiss)
+}
+
+interface ToastState {
+    toasts: Toast[];
+    addToast: (toast: Omit<Toast, 'id' | 'duration'> & { duration?: number }) => void;
+    removeToast: (id: string) => void;
+}
+
+const DEFAULT_DURATIONS: Record<ToastType, number> = {
+    error: 8000,
+    warning: 6000,
+    success: 4000,
+    info: 5000,
+};
+
+const MAX_TOASTS = 5;
+
+export const useToastStore = create<ToastState>((set) => ({
+    toasts: [],
+
+    addToast: (toast) => {
+        const id = uuidv4();
+        const duration = toast.duration ?? DEFAULT_DURATIONS[toast.type];
+        const newToast: Toast = { ...toast, id, duration };
+
+        set((state) => ({
+            toasts: [...state.toasts.slice(-(MAX_TOASTS - 1)), newToast],
+        }));
+
+        if (duration > 0) {
+            setTimeout(() => {
+                set((state) => ({
+                    toasts: state.toasts.filter(t => t.id !== id),
+                }));
+            }, duration);
+        }
+    },
+
+    removeToast: (id) => {
+        set((state) => ({
+            toasts: state.toasts.filter(t => t.id !== id),
+        }));
+    },
+}));

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -39,6 +39,9 @@ export interface ProjectState {
     updateStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD) => void;
     updateSpineStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD, responseText: string) => void;
 
+    // Error handling
+    setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number } | null) => void;
+
     // --- Artifact System Actions ---
     createArtifact: (projectId: string, type: ArtifactType, title: string, subtype?: CoreArtifactSubtype) => { artifactId: string };
     updateArtifact: (projectId: string, artifactId: string, updates: Partial<Pick<Artifact, 'title' | 'status'>>) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,11 @@ export type SpineVersion = {
     isLatest: boolean;
     isFinal: boolean;
     structuredPRD?: StructuredPRD;
+    generationError?: {
+        message: string;
+        category: string;
+        timestamp: number;
+    };
 };
 
 // --- Structured Artifact Content Types ---
@@ -304,7 +309,8 @@ export type HistoryEventType =
     | 'ArtifactGenerated'
     | 'ArtifactRegenerated'
     | 'FeedbackCreated'
-    | 'FeedbackApplied';
+    | 'FeedbackApplied'
+    | 'GenerationFailed';
 
 export type HistoryEvent = {
     id: string;


### PR DESCRIPTION
Errors no longer pollute artifact content. Previously, PRD generation
failures wrote error messages as markdown into spine responseText, and
branch reply failures stored "Error: ..." as assistant messages. Both
patterns persisted bad data to localStorage indistinguishably from
real content.

Key changes:
- Add generationError field to SpineVersion type with dedicated
  setSpineError store action that preserves last known good content
- Create centralized error normalization (src/lib/errors.ts) replacing
  11 scattered e instanceof Error patterns with user-friendly messages
- Add GlobalErrorBoundary wrapping the entire app for crash protection
- Add toast notification system for transient failures (enhance prompt,
  branch replies) instead of silent catches or error-as-content
- Create reusable ErrorBanner component replacing 4 ad-hoc inline
  error banner implementations with consistent styling
- Record GenerationFailed events in project history timeline
- Show "Generation Failed" badge in nav bar when spine has error
- Render dedicated error card with retry button for failed PRD generation
- Improve partial failure messaging for bundle artifact generation
  (e.g. "2 of 7 artifacts could not be generated. 5 completed successfully.")
- Remove error-as-content from branchService.replyInBranch

https://claude.ai/code/session_017JTgNxpgPg14R5wRbu42YC