### PR TITLE
Add PRD-alignment critique pass for mockup generation

### DIFF
--- a/docs/artifact-flow.md
+++ b/docs/artifact-flow.md
@@ -64,6 +64,31 @@ Once the user marks the spine `isFinal`, the Mockups stage unlocks.
 as a new `ArtifactVersion` of a mockup `Artifact`. `MockupsView` supports
 side-by-side version diffing.
 
+**Evaluation path:** `src/lib/mockupQuality.ts` + `src/lib/mockupAlignmentCritique.ts`
+
+Mockup outputs now pass two complementary gates before storage:
+
+1. **Heuristic quality gate** (`assessMockupHtmlQuality`) validates
+   structural HTML/UI integrity (unsafe tags, malformed shells,
+   placeholder copy, low semantic structure).
+2. **PRD-alignment critique** (`critiqueMockupAlignment`) scores each
+   surviving screen set against upstream product context (persona,
+   product purpose, entities, workflows, platform/scope/fidelity intent,
+   and product terminology).
+
+The critique returns a structured object optimized for downstream
+regeneration logic:
+
+- `alignmentScore` + `severity`
+- `missingConcepts`
+- `mismatchReasons`
+- `recommendations`
+- per-screen critique breakdown (`screens[]`)
+
+High-severity/low-score critique outcomes fail the generation run; medium
+or low issues are surfaced as warnings and persisted in mockup version
+metadata (`alignmentCritique`) for later refinement loops.
+
 ## 4. Spine → Core Artifacts (bundle or individual)
 
 **Entry:** `src/components/ArtifactsView.tsx`

--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -144,7 +144,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                 notes: notes || undefined,
             };
 
-            const { payload, warnings } = await generateMockup(prdContent, settings, structuredPRD);
+            const { payload, warnings, critique } = await generateMockup(prdContent, settings, structuredPRD);
 
             const title = payload.title?.trim()
                 || `Mockup — ${platform} / ${fidelity} / ${scope.replace('_', ' ')}`;
@@ -154,7 +154,15 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                 projectId,
                 artifactId,
                 JSON.stringify(payload),
-                { settings, format: MOCKUP_HTML_V1 },
+                {
+                    settings,
+                    format: MOCKUP_HTML_V1,
+                    alignmentCritique: {
+                        score: critique.alignmentScore,
+                        severity: critique.severity,
+                        missingConcepts: critique.missingConcepts,
+                    },
+                },
                 [{
                     id: uuidv4(),
                     sourceArtifactId: projectId,
@@ -187,13 +195,21 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
             const latestVersion = versions[versions.length - 1];
             const settings = latestVersion ? extractSettings(latestVersion) : DEFAULT_SETTINGS;
 
-            const { payload, warnings } = await generateMockup(prdContent, settings, structuredPRD);
+            const { payload, warnings, critique } = await generateMockup(prdContent, settings, structuredPRD);
 
             createArtifactVersion(
                 projectId,
                 artifactId,
                 JSON.stringify(payload),
-                { settings, format: MOCKUP_HTML_V1 },
+                {
+                    settings,
+                    format: MOCKUP_HTML_V1,
+                    alignmentCritique: {
+                        score: critique.alignmentScore,
+                        severity: critique.severity,
+                        missingConcepts: critique.missingConcepts,
+                    },
+                },
                 [{
                     id: uuidv4(),
                     sourceArtifactId: projectId,

--- a/src/lib/__tests__/mockupAlignmentCritique.test.ts
+++ b/src/lib/__tests__/mockupAlignmentCritique.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { MockupScreen, MockupSettings, StructuredPRD } from '../../types';
+import { critiqueMockupAlignment } from '../mockupAlignmentCritique';
+
+const settings: MockupSettings = {
+    platform: 'desktop',
+    fidelity: 'mid',
+    scope: 'multi_screen',
+};
+
+const structuredPRD: StructuredPRD = {
+    vision: 'Help warehouse managers reduce stockouts by coordinating replenishment workflows.',
+    coreProblem: 'Teams miss replenishment windows and cannot act on risk signals quickly.',
+    targetUsers: ['Warehouse manager', 'Inventory analyst'],
+    features: [
+        {
+            id: 'f1',
+            name: 'Replenishment Queue',
+            description: 'Prioritized restock tasks by SKU and facility risk.',
+            userValue: 'Prevents stockouts before they hit customers.',
+            complexity: 'medium',
+        },
+        {
+            id: 'f2',
+            name: 'Supplier Escalation',
+            description: 'Escalate delayed purchase orders and approve substitutions.',
+            userValue: 'Keeps fulfillment moving despite upstream delays.',
+            complexity: 'high',
+        },
+    ],
+    architecture: 'React web app with workflow service.',
+    risks: ['Supplier API lag'],
+};
+
+const prdContent = `${structuredPRD.vision}\n${structuredPRD.coreProblem}`;
+
+describe('mockupAlignmentCritique', () => {
+    it('flags generic outputs and missing PRD grounding', () => {
+        const genericScreens: MockupScreen[] = [
+            {
+                id: '1',
+                name: 'Overview Dashboard',
+                purpose: 'Track KPIs for teams.',
+                html: '<div class="min-h-screen"><header><h1>KPI Dashboard</h1></header><main><section>Revenue summary</section></main></div>',
+            },
+            {
+                id: '2',
+                name: 'Analytics Home',
+                purpose: 'Review trends and metrics.',
+                html: '<div class="min-h-screen"><main><section>Active users by month</section></main></div>',
+            },
+            {
+                id: '3',
+                name: 'Settings',
+                purpose: 'Configure account preferences.',
+                html: '<div class="min-h-screen"><main><section>Team workspace defaults</section></main></div>',
+            },
+        ];
+
+        const critique = critiqueMockupAlignment(genericScreens, settings, prdContent, structuredPRD);
+
+        expect(critique.severity).toBe('high');
+        expect(critique.alignmentScore).toBeLessThan(55);
+        expect(critique.issues.some(issue => issue.code === 'generic_dashboard_sludge')).toBe(true);
+        expect(critique.missingConcepts).toContain('main entities/objects');
+    });
+
+    it('accepts PRD-grounded screen sets', () => {
+        const alignedScreens: MockupScreen[] = [
+            {
+                id: '1',
+                name: 'Replenishment Queue',
+                purpose: 'Warehouse manager triages high-risk SKUs that need immediate restock action.',
+                html: '<div class="min-h-screen"><header><h1>Replenishment Queue</h1><button type="button">Create supplier escalation</button></header><main><section>SKU risk ladder</section><section>Facility restock tasks</section></main></div>',
+            },
+            {
+                id: '2',
+                name: 'Supplier Escalation',
+                purpose: 'Inventory analyst escalates delayed purchase orders and assigns substitution workflows.',
+                html: '<div class="min-h-screen"><header><h1>Supplier Escalation</h1></header><main><section>Delayed purchase orders</section><section>Substitution approvals</section></main></div>',
+            },
+            {
+                id: '3',
+                name: 'Restock Workflow Review',
+                purpose: 'Warehouse manager confirms replenishment completion and tracks stockout risk trend.',
+                html: '<div class="min-h-screen"><header><h1>Restock Workflow Review</h1></header><main><section>Workflow timeline</section><section>Risk trend</section></main></div>',
+            },
+        ];
+
+        const critique = critiqueMockupAlignment(alignedScreens, settings, prdContent, structuredPRD);
+
+        expect(critique.alignmentScore).toBeGreaterThanOrEqual(70);
+        expect(critique.severity).not.toBe('high');
+        expect(critique.missingConcepts.length).toBeLessThanOrEqual(3);
+    });
+});

--- a/src/lib/__tests__/mockupService.test.ts
+++ b/src/lib/__tests__/mockupService.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MockupSettings, StructuredPRD } from '../../types';
+
+const callGeminiMock = vi.fn();
+
+vi.mock('../geminiClient', () => ({
+    callGemini: (...args: unknown[]) => callGeminiMock(...args),
+}));
+
+import { generateMockup } from '../services/mockupService';
+
+const settings: MockupSettings = {
+    platform: 'desktop',
+    fidelity: 'mid',
+    scope: 'multi_screen',
+};
+
+const structuredPRD: StructuredPRD = {
+    vision: 'Coordinate clinic intake and triage decisions in one place.',
+    coreProblem: 'Care coordinators lose time jumping between intake notes and triage actions.',
+    targetUsers: ['Care coordinator'],
+    features: [
+        {
+            id: 'f1',
+            name: 'Triage queue',
+            description: 'Prioritize incoming patient cases by urgency and ownership.',
+            userValue: 'Respond to urgent patients faster.',
+            complexity: 'medium',
+        },
+    ],
+    architecture: 'Web app',
+    risks: ['Incomplete intake data'],
+};
+
+describe('mockupService alignment integration', () => {
+    it('returns structured critique alongside payload', async () => {
+        callGeminiMock.mockResolvedValueOnce(JSON.stringify({
+            version: 'mockup_html_v1',
+            title: 'Clinic Triage Concept',
+            summary: 'Queue-first layout for care coordinators.',
+            screens: [
+                {
+                    name: 'Triage Queue',
+                    purpose: 'Care coordinator reviews urgent patient cases and assigns triage owner.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Triage Queue</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Assign case owner</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><table class="w-full text-sm"><tbody><tr><td>Patient case</td><td>Urgency</td></tr></tbody></table></section><aside class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Triage actions</li></ul></aside></main></div>',
+                },
+                {
+                    name: 'Case Detail Review',
+                    purpose: 'Care coordinator validates intake details and logs triage recommendation.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Case Detail Review</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Submit triage recommendation</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Intake note summary</li><li>Risk indicators</li></ul></section><aside class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Escalation checklist</li></ul></aside></main></div>',
+                },
+                {
+                    name: 'Handoff Confirmation',
+                    purpose: 'Care coordinator confirms triage handoff and tracks pending follow-ups.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Handoff Confirmation</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Close handoff</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><table class="w-full text-sm"><tbody><tr><td>Assigned clinician</td><td>Status</td></tr></tbody></table></section><aside class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Follow-up tasks</li></ul></aside></main></div>',
+                },
+            ],
+        }));
+
+        const result = await generateMockup('Clinic triage PRD', settings, structuredPRD);
+
+        expect(result.payload.screens).toHaveLength(3);
+        expect(result.critique.alignmentScore).toBeGreaterThan(0);
+        expect(result.critique.screens).toHaveLength(3);
+    });
+
+    it('fails when alignment is critically poor', async () => {
+        callGeminiMock.mockResolvedValueOnce(JSON.stringify({
+            version: 'mockup_html_v1',
+            title: 'Generic App',
+            summary: 'Overview',
+            screens: [
+                {
+                    name: 'Overview Dashboard',
+                    purpose: 'Track KPIs for teams.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Overview Dashboard</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Create</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><table class="w-full text-sm"><tbody><tr><td>Revenue</td><td>Users</td></tr></tbody></table></section><aside class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Analytics panel</li></ul></aside></main></div>',
+                },
+                {
+                    name: 'Analytics Home',
+                    purpose: 'Review trends and metrics.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Analytics Home</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Export</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><table class="w-full text-sm"><tbody><tr><td>Active users</td><td>Conversion</td></tr></tbody></table></section><aside class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Team workspace summary</li></ul></aside></main></div>',
+                },
+                {
+                    name: 'Settings',
+                    purpose: 'Configure account preferences.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Settings</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Save</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Notification defaults</li></ul></section><aside class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Account settings</li></ul></aside></main></div>',
+                },
+            ],
+        }));
+
+        await expect(generateMockup('Clinic triage PRD', settings, structuredPRD))
+            .rejects
+            .toThrow(/PRD alignment critique/);
+    });
+});

--- a/src/lib/mockupAlignmentCritique.ts
+++ b/src/lib/mockupAlignmentCritique.ts
@@ -1,0 +1,284 @@
+import type { MockupScreen, MockupSettings, StructuredPRD } from '../types';
+
+export type AlignmentSeverity = 'low' | 'medium' | 'high';
+
+export interface MockupAlignmentIssue {
+    code:
+        | 'generic_dashboard_sludge'
+        | 'missing_prd_concepts'
+        | 'platform_mismatch'
+        | 'scope_mismatch'
+        | 'fidelity_mismatch'
+        | 'generic_naming'
+        | 'workflow_gap'
+        | 'prd_feature_gap';
+    severity: AlignmentSeverity;
+    reason: string;
+    recommendation: string;
+}
+
+export interface ScreenAlignmentCritique {
+    screenId?: string;
+    screenName: string;
+    score: number;
+    severity: AlignmentSeverity;
+    missingConcepts: string[];
+    mismatchReasons: string[];
+    recommendations: string[];
+    issues: MockupAlignmentIssue[];
+}
+
+export interface MockupAlignmentCritique {
+    alignmentScore: number;
+    severity: AlignmentSeverity;
+    missingConcepts: string[];
+    mismatchReasons: string[];
+    recommendations: string[];
+    issues: MockupAlignmentIssue[];
+    screens: ScreenAlignmentCritique[];
+}
+
+interface ProductConceptContext {
+    personaTerms: string[];
+    corePurposeTerms: string[];
+    entityTerms: string[];
+    workflowTerms: string[];
+    productTerms: string[];
+}
+
+const GENERIC_SLUDGE_PATTERNS: RegExp[] = [
+    /overview dashboard/i,
+    /kpi(?:s)?/i,
+    /revenue summary/i,
+    /active users/i,
+    /analytics panel/i,
+    /item [abc123]/i,
+    /team workspace/i,
+    /project alpha/i,
+    /generic/i,
+];
+
+const stripHtml = (value: string): string => value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const normalizeToken = (value: string): string => value.toLowerCase().replace(/[^a-z0-9\s-]/g, ' ').replace(/\s+/g, ' ').trim();
+
+const extractCandidateTerms = (value: string): string[] => {
+    const normalized = normalizeToken(value);
+    if (!normalized) return [];
+
+    const words = normalized.split(' ').filter(w => w.length >= 4);
+    const phrases = normalized
+        .split(/[.,;:()\n-]/)
+        .map(chunk => chunk.trim())
+        .filter(chunk => chunk.length >= 6)
+        .slice(0, 20);
+
+    return [...new Set([...words, ...phrases])];
+};
+
+const classifySeverity = (score: number): AlignmentSeverity => {
+    if (score >= 80) return 'low';
+    if (score >= 55) return 'medium';
+    return 'high';
+};
+
+const buildConceptContext = (prdContent: string, structuredPRD?: StructuredPRD): ProductConceptContext => {
+    if (!structuredPRD) {
+        const fallbackTerms = extractCandidateTerms(prdContent).slice(0, 30);
+        return {
+            personaTerms: fallbackTerms,
+            corePurposeTerms: fallbackTerms,
+            entityTerms: fallbackTerms,
+            workflowTerms: fallbackTerms,
+            productTerms: fallbackTerms,
+        };
+    }
+
+    const personaTerms = structuredPRD.targetUsers.flatMap(extractCandidateTerms).slice(0, 20);
+    const corePurposeTerms = [structuredPRD.vision, structuredPRD.coreProblem]
+        .flatMap(extractCandidateTerms)
+        .slice(0, 30);
+    const featureTerms = structuredPRD.features
+        .flatMap(feature => [feature.name, feature.description, feature.userValue])
+        .flatMap(extractCandidateTerms)
+        .slice(0, 80);
+
+    const entityTerms = featureTerms.filter(term => !/user|workflow|screen|feature/.test(term)).slice(0, 40);
+    const workflowTerms = featureTerms.filter(term => /(create|edit|review|submit|approve|track|configure|assign|flow|step|stage|sync|share)/.test(term)).slice(0, 30);
+
+    return {
+        personaTerms,
+        corePurposeTerms,
+        entityTerms,
+        workflowTerms,
+        productTerms: [...new Set([...personaTerms, ...corePurposeTerms, ...featureTerms])],
+    };
+};
+
+const countTermCoverage = (haystack: string, terms: string[]): number => {
+    if (!terms.length) return 0;
+    const normalizedHaystack = normalizeToken(haystack);
+    return terms.reduce((count, term) => (normalizedHaystack.includes(term) ? count + 1 : count), 0);
+};
+
+const critiqueScreen = (
+    screen: MockupScreen,
+    context: ProductConceptContext,
+    settings: MockupSettings,
+): ScreenAlignmentCritique => {
+    const issues: MockupAlignmentIssue[] = [];
+    const screenText = `${screen.name} ${screen.purpose} ${stripHtml(screen.html)} ${screen.notes ?? ''}`;
+
+    const personaCoverage = countTermCoverage(screenText, context.personaTerms.slice(0, 8));
+    const purposeCoverage = countTermCoverage(screenText, context.corePurposeTerms.slice(0, 12));
+    const entityCoverage = countTermCoverage(screenText, context.entityTerms.slice(0, 15));
+    const workflowCoverage = countTermCoverage(screenText, context.workflowTerms.slice(0, 12));
+
+    if (GENERIC_SLUDGE_PATTERNS.some(pattern => pattern.test(screenText))) {
+        issues.push({
+            code: 'generic_dashboard_sludge',
+            severity: 'high',
+            reason: 'Screen language looks like a generic dashboard instead of a product-specific concept.',
+            recommendation: 'Use PRD entities, workflows, and domain nouns in labels, table columns, and CTAs.',
+        });
+    }
+
+    const missingConcepts: string[] = [];
+    if (personaCoverage === 0) missingConcepts.push('primary user type');
+    if (purposeCoverage < 2) missingConcepts.push('core product purpose');
+    if (entityCoverage < 2) missingConcepts.push('main entities/objects');
+    if (workflowCoverage === 0) missingConcepts.push('primary user actions/workflows');
+
+    if (missingConcepts.length > 0) {
+        issues.push({
+            code: 'missing_prd_concepts',
+            severity: missingConcepts.length >= 3 ? 'high' : 'medium',
+            reason: `Screen is weakly grounded in PRD context: missing ${missingConcepts.join(', ')}.`,
+            recommendation: 'Tie title, purpose, and key UI regions directly to PRD persona, entities, and workflows.',
+        });
+    }
+
+    if (/dashboard|home|overview/i.test(screen.name) && context.productTerms.length > 0) {
+        const domainMentions = countTermCoverage(screen.name, context.productTerms.slice(0, 20));
+        if (domainMentions === 0) {
+            issues.push({
+                code: 'generic_naming',
+                severity: 'medium',
+                reason: 'Screen name is generic and does not include product-specific terminology.',
+                recommendation: 'Rename screen with domain language from the PRD (entity + workflow).',
+            });
+        }
+    }
+
+    const normalizedHtml = screen.html.toLowerCase();
+    if (settings.platform === 'mobile' && !/(max-w-\[420px\]|bottom tab|bottom-0|w-full)/.test(normalizedHtml)) {
+        issues.push({
+            code: 'platform_mismatch',
+            severity: 'medium',
+            reason: 'Mobile platform requested but mobile framing cues are weak.',
+            recommendation: 'Constrain width and include touch-native navigation patterns for mobile mockups.',
+        });
+    }
+    if (settings.platform === 'desktop' && /(bottom tab|fixed bottom-0)/.test(normalizedHtml)) {
+        issues.push({
+            code: 'platform_mismatch',
+            severity: 'medium',
+            reason: 'Desktop platform requested but screen uses mobile navigation assumptions.',
+            recommendation: 'Use desktop shell patterns (sidebar/topbar/grid) for desktop outputs.',
+        });
+    }
+
+    const styleClassCount = (screen.html.match(/class\s*=\s*['"][^'"]+['"]/g) ?? []).length;
+    if (settings.fidelity === 'high' && styleClassCount < 10) {
+        issues.push({
+            code: 'fidelity_mismatch',
+            severity: 'medium',
+            reason: 'High-fidelity requested, but visual density appears too sparse.',
+            recommendation: 'Add richer component hierarchy, realistic data blocks, and stronger visual polish.',
+        });
+    }
+
+    const penalties = issues.reduce((sum, issue) => sum + (issue.severity === 'high' ? 25 : issue.severity === 'medium' ? 12 : 6), 0);
+    const score = Math.max(0, 100 - penalties);
+
+    return {
+        screenId: screen.id,
+        screenName: screen.name,
+        score,
+        severity: classifySeverity(score),
+        missingConcepts,
+        mismatchReasons: issues.map(issue => issue.reason),
+        recommendations: [...new Set(issues.map(issue => issue.recommendation))],
+        issues,
+    };
+};
+
+export const critiqueMockupAlignment = (
+    screens: MockupScreen[],
+    settings: MockupSettings,
+    prdContent: string,
+    structuredPRD?: StructuredPRD,
+): MockupAlignmentCritique => {
+    const context = buildConceptContext(prdContent, structuredPRD);
+    const screenReports = screens.map(screen => critiqueScreen(screen, context, settings));
+
+    const issues: MockupAlignmentIssue[] = [...screenReports.flatMap(report => report.issues)];
+    const missingConcepts = [...new Set(screenReports.flatMap(report => report.missingConcepts))];
+
+    const scopeMismatch =
+        (settings.scope === 'single_screen' && screens.length !== 1)
+        || (settings.scope === 'multi_screen' && (screens.length < 3 || screens.length > 4))
+        || (settings.scope === 'key_workflow' && (screens.length < 3 || screens.length > 5));
+
+    if (scopeMismatch) {
+        issues.push({
+            code: 'scope_mismatch',
+            severity: 'medium',
+            reason: `Screen count (${screens.length}) does not match requested scope (${settings.scope}).`,
+            recommendation: 'Regenerate with scope-compliant number of screens and clearer sequencing.',
+        });
+    }
+
+    const lowWorkflowCoverage = screenReports.filter(report => report.missingConcepts.includes('primary user actions/workflows')).length;
+    if (settings.scope === 'key_workflow' && lowWorkflowCoverage > Math.floor(screens.length / 2)) {
+        issues.push({
+            code: 'workflow_gap',
+            severity: 'high',
+            reason: 'Most screens do not express a coherent end-to-end workflow.',
+            recommendation: 'Ensure each screen represents a sequential workflow step and uses continuation cues.',
+        });
+    }
+
+    const featureGapThreshold = Math.max(1, Math.floor(context.entityTerms.length * 0.15));
+    const totalEntityMentions = screens.reduce((sum, screen) => sum + countTermCoverage(
+        `${screen.name} ${screen.purpose} ${stripHtml(screen.html)} ${screen.notes ?? ''}`,
+        context.entityTerms,
+    ), 0);
+    if (context.entityTerms.length > 0 && totalEntityMentions <= featureGapThreshold) {
+        issues.push({
+            code: 'prd_feature_gap',
+            severity: 'high',
+            reason: 'Screens do not visibly represent key PRD entities/features.',
+            recommendation: 'Surface PRD features directly in navigation labels, sections, cards, and action buttons.',
+        });
+    }
+
+    const penalties = issues.reduce((sum, issue) => sum + (issue.severity === 'high' ? 18 : issue.severity === 'medium' ? 10 : 5), 0);
+    const avgScreenScore = screenReports.length
+        ? screenReports.reduce((sum, report) => sum + report.score, 0) / screenReports.length
+        : 0;
+    const alignmentScore = Math.max(0, Math.round(Math.max(0, avgScreenScore - penalties * 0.35)));
+
+    return {
+        alignmentScore,
+        severity: classifySeverity(alignmentScore),
+        missingConcepts,
+        mismatchReasons: issues.map(issue => issue.reason),
+        recommendations: [...new Set(issues.map(issue => issue.recommendation))],
+        issues,
+        screens: screenReports,
+    };
+};

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -9,6 +9,7 @@ import { callGemini } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
 import { mockupSchema } from '../schemas/mockupSchema';
 import { assessMockupHtmlQuality, normalizeMockupHtml } from '../mockupQuality';
+import { critiqueMockupAlignment, type MockupAlignmentCritique } from '../mockupAlignmentCritique';
 
 // ---- Instruction tables (rewritten for polished HTML/Tailwind output) ----
 
@@ -119,6 +120,7 @@ const MIN_HTML_LENGTH = 80;
 
 export interface ParseResult {
     payload: MockupPayload;
+    critique: MockupAlignmentCritique;
     /** Warnings for screens that were skipped (partial success). Empty when all
      *  screens parsed cleanly. */
     warnings: string[];
@@ -129,7 +131,12 @@ export interface ParseResult {
  * screens — skips them and reports warnings rather than throwing.  Only throws
  * when zero usable screens survive.
  */
-const parseMockupPayload = (raw: string): ParseResult => {
+const parseMockupPayload = (
+    raw: string,
+    prdContent: string,
+    settings: MockupSettings,
+    structuredPRD?: StructuredPRD,
+): ParseResult => {
     let parsed: unknown;
     try {
         parsed = JSON.parse(raw);
@@ -203,6 +210,29 @@ const parseMockupPayload = (raw: string): ParseResult => {
         );
     }
 
+    const critique = critiqueMockupAlignment(screens, settings, prdContent, structuredPRD);
+
+    if (critique.severity === 'high' && critique.alignmentScore < 45) {
+        const critiqueReason = critique.mismatchReasons.slice(0, 3).join(' ');
+        throw new Error(
+            `Mockup generation failed PRD alignment critique (${critique.alignmentScore}/100). ${critiqueReason}`
+        );
+    }
+
+    critique.screens
+        .filter(screen => screen.severity !== 'low')
+        .forEach(screen => {
+            warnings.push(
+                `Screen "${screen.screenName}": alignment ${screen.score}/100 (${screen.severity}). ${screen.mismatchReasons.slice(0, 2).join(' ')}`
+            );
+        });
+
+    if (critique.severity !== 'low') {
+        warnings.push(
+            `Set alignment ${critique.alignmentScore}/100 (${critique.severity}). Missing: ${critique.missingConcepts.join(', ') || 'none identified'}.`
+        );
+    }
+
     const title = typeof obj.title === 'string' && obj.title.trim()
         ? obj.title.trim()
         : 'Mockup concept';
@@ -215,6 +245,7 @@ const parseMockupPayload = (raw: string): ParseResult => {
             summary,
             screens,
         },
+        critique,
         warnings,
     };
 };
@@ -237,5 +268,5 @@ export const generateMockup = async (
         responseSchema: mockupSchema,
     });
 
-    return parseMockupPayload(raw);
+    return parseMockupPayload(raw, prdContent, settings, structuredPRD);
 };


### PR DESCRIPTION
### Motivation
- Prevent structurally valid but generic mockups from being accepted by checking whether generated screens are grounded in the upstream PRD (persona, purpose, entities, workflows, platform/scope/fidelity, and product terminology).
- Complement the existing heuristic HTML quality gate with a semantic alignment pass to make downstream regeneration decisions easier and more actionable.

### Description
- Add a new critique module `src/lib/mockupAlignmentCritique.ts` that produces a structured critique with `alignmentScore`, `severity`, `missingConcepts`, `mismatchReasons`, `recommendations`, and a per-screen breakdown of issues and scores.
- Integrate the critique into the mockup evaluation path in `src/lib/services/mockupService.ts` so it runs after `assessMockupHtmlQuality`, fails generation only on critically poor alignment, and emits structured warnings for non-low findings.
- Surface and persist a concise alignment summary into mockup artifact metadata (`alignmentCritique`) from `src/components/MockupsView.tsx` during generate/regenerate flows to support later refinement.
- Add unit tests for the critic heuristics and service-level integration (`src/lib/__tests__/mockupAlignmentCritique.test.ts`, `src/lib/__tests__/mockupService.test.ts`) and update documentation (`docs/artifact-flow.md`) to describe the dual-gate evaluation path.

### Testing
- Ran the targeted test suite: `npm test -- --run src/lib/__tests__/mockupQuality.test.ts src/lib/__tests__/mockupAlignmentCritique.test.ts src/lib/__tests__/mockupService.test.ts` and all tests passed. 
- Tests cover heuristic quality checks, PRD-grounded vs generic mockup detection, service integration behavior (successful critique return and hard-fail on critically poor alignment).
- No runtime failures observed in the mocked Gemini flows used by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0fb9b3e483218fe592b08e79bb44)