### PR TITLE
Add LinkedIn recruiter auth, activity capture, and admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,15 @@ graph TD
 ## Tech stack
 
 - **Frontend:** React 19, TypeScript, Vite 7, Tailwind CSS 3
+- **Backend:** Vercel serverless API routes + MongoDB (for recruiter auth analytics)
 - **State:** Zustand 5 with debounced `localStorage` persistence
 - **LLM:** Google Gemini 2.5 Pro / Flash (direct browser calls, streaming support)
 - **Markdown:** `react-markdown` + `remark-gfm` + `rehype-raw`
 - **Routing:** React Router v7
 - **Icons & animation:** `lucide-react`, `@formkit/auto-animate`
 
-No backend database, no serverless functions — everything runs in the
-browser against a user-supplied Gemini API key.
+The product workspace remains browser-first, while recruiter authentication
+and tracking run through API routes backed by MongoDB.
 
 ---
 
@@ -160,6 +161,8 @@ npm run build
   of one end-to-end pipeline run
 - [`docs/deployment.md`](docs/deployment.md) — commands, Vercel setup,
   self-hosting
+- [`docs/linkedin-auth.md`](docs/linkedin-auth.md) — LinkedIn OAuth setup,
+  recruiter capture fields, and compliance note
 - [`docs/archive/`](docs/archive/) — historical design notes and audits
   retained for context
 

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -1,0 +1,38 @@
+const API_VERSION = 'application/ejson';
+
+function getConfig() {
+  const url = process.env.MONGODB_DATA_API_URL;
+  const apiKey = process.env.MONGODB_DATA_API_KEY;
+  const dataSource = process.env.MONGODB_DATA_SOURCE;
+  const database = process.env.MONGODB_DB_NAME || 'synapse';
+
+  if (!url || !apiKey || !dataSource) {
+    throw new Error('Missing MongoDB Data API config. Set MONGODB_DATA_API_URL, MONGODB_DATA_API_KEY, MONGODB_DATA_SOURCE.');
+  }
+
+  return { url, apiKey, dataSource, database };
+}
+
+export async function runMongoAction(action, payload) {
+  const config = getConfig();
+  const response = await fetch(`${config.url}/action/${action}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: API_VERSION,
+      'api-key': config.apiKey,
+    },
+    body: JSON.stringify({
+      dataSource: config.dataSource,
+      database: config.database,
+      ...payload,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`MongoDB Data API ${action} failed (${response.status}): ${errorText}`);
+  }
+
+  return response.json();
+}

--- a/api/_lib/linkedin.js
+++ b/api/_lib/linkedin.js
@@ -1,0 +1,72 @@
+const LINKEDIN_AUTH_URL = 'https://www.linkedin.com/oauth/v2/authorization';
+const LINKEDIN_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
+const LINKEDIN_USERINFO_URL = 'https://api.linkedin.com/v2/userinfo';
+
+export function getLinkedInConfig(baseUrl) {
+  const clientId = process.env.LINKEDIN_CLIENT_ID;
+  const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
+  const redirectUri = process.env.LINKEDIN_REDIRECT_URI || `${baseUrl}/api/auth/linkedin/callback`;
+
+  if (!clientId || !clientSecret) {
+    throw new Error('LinkedIn auth is not configured. Missing LINKEDIN_CLIENT_ID or LINKEDIN_CLIENT_SECRET.');
+  }
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+    scopes: ['openid', 'profile', 'email'],
+  };
+}
+
+export function createLinkedInAuthUrl(config, state) {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: config.scopes.join(' '),
+    state,
+  });
+
+  return `${LINKEDIN_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForToken(config, code) {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: config.redirectUri,
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+  });
+
+  const response = await fetch(LINKEDIN_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`LinkedIn token exchange failed (${response.status}): ${errBody}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchLinkedInProfile(accessToken) {
+  const response = await fetch(LINKEDIN_USERINFO_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`LinkedIn profile fetch failed (${response.status}): ${errBody}`);
+  }
+
+  return response.json();
+}

--- a/api/_lib/response.js
+++ b/api/_lib/response.js
@@ -1,0 +1,15 @@
+export function json(res, status, body) {
+  res.status(status).setHeader('Content-Type', 'application/json');
+  res.send(JSON.stringify(body));
+}
+
+export function methodNotAllowed(res, allowed = ['GET']) {
+  res.setHeader('Allow', allowed.join(', '));
+  return json(res, 405, { error: `Method not allowed. Use ${allowed.join(', ')}` });
+}
+
+export function getBaseUrl(req) {
+  const proto = req.headers['x-forwarded-proto'] || 'http';
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  return `${proto}://${host}`;
+}

--- a/api/_lib/session.js
+++ b/api/_lib/session.js
@@ -1,0 +1,58 @@
+import crypto from 'crypto';
+
+const COOKIE_NAME = 'synapse_session';
+
+function base64Url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function sign(payload, secret) {
+  const h = crypto.createHmac('sha256', secret);
+  h.update(payload);
+  return h.digest('base64url');
+}
+
+export function createSessionToken(claims) {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) throw new Error('Missing SESSION_SECRET environment variable.');
+
+  const payload = base64Url(JSON.stringify(claims));
+  const signature = sign(payload, secret);
+  return `${payload}.${signature}`;
+}
+
+export function parseSessionCookie(req) {
+  const raw = req.headers.cookie || '';
+  const parts = raw.split(';').map((part) => part.trim());
+  const match = parts.find((part) => part.startsWith(`${COOKIE_NAME}=`));
+  if (!match) return null;
+  return decodeURIComponent(match.split('=')[1]);
+}
+
+export function verifySessionToken(token) {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret || !token || !token.includes('.')) return null;
+
+  const [payload, signature] = token.split('.');
+  const expected = sign(payload, secret);
+  if (expected !== signature) return null;
+
+  try {
+    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function setSessionCookie(res, token) {
+  const maxAge = 60 * 60 * 24 * 30;
+  const secure = process.env.NODE_ENV === 'production';
+  res.setHeader(
+    'Set-Cookie',
+    `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; Max-Age=${maxAge}; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
+  );
+}
+
+export function clearSessionCookie(res) {
+  res.setHeader('Set-Cookie', `${COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`);
+}

--- a/api/activity.js
+++ b/api/activity.js
@@ -1,0 +1,38 @@
+import { runMongoAction } from './_lib/db.js';
+import { json, methodNotAllowed } from './_lib/response.js';
+import { parseSessionCookie, verifySessionToken } from './_lib/session.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  const token = parseSessionCookie(req);
+  const claims = verifySessionToken(token);
+  if (!claims?.recruiterId) return json(res, 401, { error: 'Unauthorized' });
+
+  const { type, metadata } = req.body || {};
+  if (!type) return json(res, 400, { error: 'Missing activity type' });
+
+  try {
+    const now = new Date();
+    await runMongoAction('insertOne', {
+      collection: 'recruiter_activity',
+      document: {
+        recruiterId: claims.recruiterId,
+        type,
+        metadata: metadata || {},
+        createdAt: now,
+      },
+    });
+
+    await runMongoAction('updateOne', {
+      collection: 'recruiters',
+      filter: { linkedinId: claims.recruiterId },
+      update: { $set: { lastActiveAt: now } },
+    });
+
+    return json(res, 200, { ok: true });
+  } catch (error) {
+    console.error('[Activity logging failed]', error);
+    return json(res, 500, { error: 'Failed to track activity' });
+  }
+}

--- a/api/admin/recruiters.js
+++ b/api/admin/recruiters.js
@@ -1,0 +1,56 @@
+import { runMongoAction } from '../_lib/db.js';
+import { json, methodNotAllowed } from '../_lib/response.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  const adminKey = process.env.ADMIN_DASHBOARD_KEY;
+  if (!adminKey || req.headers['x-admin-key'] !== adminKey) return json(res, 401, { error: 'Unauthorized' });
+
+  try {
+    const result = await runMongoAction('aggregate', {
+      collection: 'recruiters',
+      pipeline: [
+        {
+          $lookup: {
+            from: 'recruiter_activity',
+            localField: 'linkedinId',
+            foreignField: 'recruiterId',
+            as: 'activity',
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            linkedinId: 1,
+            name: 1,
+            profileUrl: 1,
+            headline: 1,
+            company: 1,
+            avatarUrl: 1,
+            email: 1,
+            createdAt: 1,
+            lastActiveAt: 1,
+            loginCount: 1,
+            sessions: '$loginCount',
+            artifactGenerations: {
+              $size: { $filter: { input: '$activity', as: 'item', cond: { $eq: ['$$item.type', 'generated_artifact'] } } },
+            },
+            viewedMockups: {
+              $size: { $filter: { input: '$activity', as: 'item', cond: { $eq: ['$$item.type', 'viewed_mockups'] } } },
+            },
+            clickedSections: {
+              $size: { $filter: { input: '$activity', as: 'item', cond: { $eq: ['$$item.type', 'clicked_section'] } } },
+            },
+          },
+        },
+        { $sort: { lastActiveAt: -1 } },
+      ],
+    });
+
+    return json(res, 200, { recruiters: result.documents || [] });
+  } catch (error) {
+    console.error('[Recruiter dashboard query failed]', error);
+    return json(res, 500, { error: 'Failed to load recruiters' });
+  }
+}

--- a/api/auth/linkedin.js
+++ b/api/auth/linkedin.js
@@ -1,0 +1,21 @@
+import crypto from 'crypto';
+import { createLinkedInAuthUrl, getLinkedInConfig } from '../_lib/linkedin.js';
+import { getBaseUrl, methodNotAllowed } from '../_lib/response.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  try {
+    const baseUrl = getBaseUrl(req);
+    const config = getLinkedInConfig(baseUrl);
+    const state = crypto.randomBytes(16).toString('hex');
+    const authUrl = createLinkedInAuthUrl(config, state);
+
+    const secure = process.env.NODE_ENV === 'production';
+    res.setHeader('Set-Cookie', `synapse_linkedin_state=${state}; Path=/; Max-Age=600; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`);
+    return res.redirect(authUrl);
+  } catch (error) {
+    console.error('[LinkedIn auth init failed]', error);
+    return res.redirect('/?auth_error=linkedin_config');
+  }
+}

--- a/api/auth/linkedin/callback.js
+++ b/api/auth/linkedin/callback.js
@@ -1,0 +1,91 @@
+import { runMongoAction } from '../../_lib/db.js';
+import { createSessionToken, setSessionCookie } from '../../_lib/session.js';
+import { exchangeCodeForToken, fetchLinkedInProfile, getLinkedInConfig } from '../../_lib/linkedin.js';
+import { getBaseUrl, methodNotAllowed } from '../../_lib/response.js';
+
+function readCookie(req, name) {
+  const raw = req.headers.cookie || '';
+  const parts = raw.split(';').map((part) => part.trim());
+  const match = parts.find((part) => part.startsWith(`${name}=`));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}
+
+function parseCompany(profile) {
+  return profile.organization || profile.company || profile['https://www.linkedin.com/organization'];
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  const { code, state } = req.query;
+  if (!code || !state) return res.redirect('/?auth_error=missing_code');
+
+  const storedState = readCookie(req, 'synapse_linkedin_state');
+  if (!storedState || storedState !== state) return res.redirect('/?auth_error=invalid_state');
+
+  try {
+    const baseUrl = getBaseUrl(req);
+    const config = getLinkedInConfig(baseUrl);
+    const tokenResponse = await exchangeCodeForToken(config, String(code));
+    const profile = await fetchLinkedInProfile(tokenResponse.access_token);
+    const now = new Date();
+
+    const recruiterRecord = {
+      authProvider: 'linkedin',
+      linkedinId: profile.sub,
+      name: profile.name || `${profile.given_name || ''} ${profile.family_name || ''}`.trim(),
+      profileUrl: profile.profile || profile.profile_url || null,
+      headline: profile.headline || '',
+      company: parseCompany(profile) || null,
+      email: profile.email || null,
+      avatarUrl: profile.picture || null,
+      lastActiveAt: now,
+      updatedAt: now,
+    };
+
+    await runMongoAction('updateOne', {
+      collection: 'recruiters',
+      filter: { linkedinId: recruiterRecord.linkedinId },
+      update: {
+        $set: recruiterRecord,
+        $setOnInsert: {
+          createdAt: now,
+          firstLoginAt: now,
+          loginCount: 0,
+        },
+        $inc: { loginCount: 1 },
+      },
+      upsert: true,
+    });
+
+    await runMongoAction('insertOne', {
+      collection: 'recruiter_sessions',
+      document: {
+        recruiterId: recruiterRecord.linkedinId,
+        startedAt: now,
+        userAgent: req.headers['user-agent'] || null,
+        ip: req.headers['x-forwarded-for'] || req.socket.remoteAddress || null,
+      },
+    });
+
+    const sessionToken = createSessionToken({
+      recruiterId: recruiterRecord.linkedinId,
+      name: recruiterRecord.name,
+      profileUrl: recruiterRecord.profileUrl,
+      avatarUrl: recruiterRecord.avatarUrl,
+      email: recruiterRecord.email,
+      issuedAt: Date.now(),
+    });
+
+    setSessionCookie(res, sessionToken);
+    const sessionCookie = res.getHeader('Set-Cookie');
+    res.setHeader('Set-Cookie', [
+      `synapse_linkedin_state=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`,
+      ...(Array.isArray(sessionCookie) ? sessionCookie : [String(sessionCookie)]),
+    ]);
+    return res.redirect('/?auth=linkedin_success');
+  } catch (error) {
+    console.error('[LinkedIn callback failed]', error);
+    return res.redirect('/?auth_error=linkedin_callback_failed');
+  }
+}

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -1,0 +1,8 @@
+import { clearSessionCookie } from '../_lib/session.js';
+import { methodNotAllowed } from '../_lib/response.js';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+  clearSessionCookie(res);
+  return res.status(200).json({ ok: true });
+}

--- a/api/session.js
+++ b/api/session.js
@@ -1,0 +1,25 @@
+import { runMongoAction } from './_lib/db.js';
+import { json, methodNotAllowed } from './_lib/response.js';
+import { parseSessionCookie, verifySessionToken } from './_lib/session.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  try {
+    const token = parseSessionCookie(req);
+    const claims = verifySessionToken(token);
+    if (!claims?.recruiterId) return json(res, 200, { authenticated: false });
+
+    const result = await runMongoAction('findOne', {
+      collection: 'recruiters',
+      filter: { linkedinId: claims.recruiterId },
+      projection: { _id: 0, linkedinId: 1, name: 1, profileUrl: 1, headline: 1, company: 1, avatarUrl: 1, email: 1, lastActiveAt: 1 },
+    });
+
+    if (!result.document) return json(res, 200, { authenticated: false });
+    return json(res, 200, { authenticated: true, user: result.document });
+  } catch (error) {
+    console.error('[Session fetch failed]', error);
+    return json(res, 500, { authenticated: false, error: 'Failed to get session.' });
+  }
+}

--- a/docs/linkedin-auth.md
+++ b/docs/linkedin-auth.md
@@ -1,0 +1,51 @@
+# LinkedIn recruiter auth and follow-up pipeline
+
+## What data Synapse collects
+
+After a recruiter signs in with LinkedIn, Synapse stores:
+
+- LinkedIn member ID (`sub` from LinkedIn OIDC userinfo)
+- Name
+- LinkedIn profile URL (if returned)
+- Headline
+- Company (if returned)
+- Profile image URL
+- Email address (only when LinkedIn returns it)
+- First/last login timestamps and login count
+- Activity events in-product (e.g. viewed mockups, generated artifacts, clicked sections)
+
+Data is used to identify who evaluated Synapse and support direct, manual follow-up. No posting or automated outreach is performed.
+
+## Required environment variables
+
+```bash
+MONGODB_DATA_API_URL=
+MONGODB_DATA_API_KEY=
+MONGODB_DATA_SOURCE=
+MONGODB_DB_NAME=synapse
+SESSION_SECRET=change-me
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+# optional override
+LINKEDIN_REDIRECT_URI=
+# required for /admin/recruiters API access
+ADMIN_DASHBOARD_KEY=
+```
+
+## Endpoints
+
+- `GET /api/auth/linkedin` — begins OAuth redirect
+- `GET /api/auth/linkedin/callback` — exchanges code and upserts recruiter profile
+- `GET /api/session` — returns signed-in recruiter identity
+- `POST /api/activity` — logs recruiter actions for visibility
+- `GET /api/admin/recruiters` — admin dashboard data (requires `x-admin-key`)
+
+## LinkedIn scopes
+
+Synapse requests only:
+
+- `openid`
+- `profile`
+- `email`
+
+No posting, messaging, or write scopes are requested.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,20 @@
+import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { HomePage } from './components/HomePage';
 import { ProjectWorkspace } from './components/ProjectWorkspace';
 import { MeetSynapsePage } from './components/MeetSynapsePage';
+import { RecruiterAdminPage } from './components/RecruiterAdminPage';
 import { GlobalErrorBoundary } from './components/GlobalErrorBoundary';
 import { ToastContainer } from './components/ToastContainer';
+import { useAuthStore } from './store/authStore';
 
 function App() {
+  const refreshSession = useAuthStore((s) => s.refreshSession);
+
+  useEffect(() => {
+    refreshSession();
+  }, [refreshSession]);
+
   return (
     <GlobalErrorBoundary>
       <BrowserRouter>
@@ -13,6 +22,7 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/about" element={<MeetSynapsePage />} />
           <Route path="/p/:projectId" element={<ProjectWorkspace />} />
+          <Route path="/admin/recruiters" element={<RecruiterAdminPage />} />
         </Routes>
         <ToastContainer />
       </BrowserRouter>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -6,6 +6,7 @@ import { SettingsModal } from './SettingsModal';
 import { ProjectDrawer } from './ProjectDrawer';
 import { normalizeError, userMessage } from '../lib/errors';
 import type { ProjectPlatform } from '../types';
+import { useAuthStore } from '../store/authStore';
 
 const EXAMPLE_PROMPTS = [
     {
@@ -40,6 +41,7 @@ const MEET_DISMISSED_KEY = 'synapse-meet-dismissed';
 export function HomePage() {
     const { createProject } = useProjectStore();
     const navigate = useNavigate();
+    const user = useAuthStore((s) => s.user);
 
     const [projectName, setProjectName] = useState('');
     const [promptText, setPromptText] = useState('');
@@ -164,6 +166,18 @@ export function HomePage() {
                     <h1 className="text-2xl font-bold tracking-tight">Synapse</h1>
                 </div>
                 <div className="flex items-center gap-2">
+                    {user ? (
+                        <div className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-200 text-sm">
+                            Signed in as {user.name} via LinkedIn
+                        </div>
+                    ) : (
+                        <a
+                            href="/api/auth/linkedin"
+                            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-[#0a66c2]/50 bg-[#0a66c2]/15 text-[#9bc9f5] hover:bg-[#0a66c2]/25 transition text-sm font-medium"
+                        >
+                            Continue with LinkedIn
+                        </a>
+                    )}
                     <button
                         onClick={() => setIsSettingsOpen(true)}
                         className="p-2.5 text-neutral-400 hover:text-white hover:bg-white/10 rounded-xl transition-all border border-white/5 hover:border-white/10"
@@ -206,6 +220,9 @@ export function HomePage() {
                     <h2 className="text-4xl md:text-5xl font-bold text-center mb-8">
                         Welcome to Synapse
                     </h2>
+                    <p className="text-center text-sm text-neutral-400 mb-6">
+                        LinkedIn sign-in is used to identify visitors and improve Synapse. No posting or outreach is done automatically.
+                    </p>
 
                     {/* Example prompt pills */}
                     <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-hide">

--- a/src/components/RecruiterAdminPage.tsx
+++ b/src/components/RecruiterAdminPage.tsx
@@ -1,0 +1,89 @@
+import { useMemo, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import type { RecruiterDashboardItem } from '../lib/recruiterApi';
+import { fetchRecruiters } from '../lib/recruiterApi';
+
+type SortMode = 'recency' | 'engagement';
+
+export function RecruiterAdminPage() {
+  const [adminKey, setAdminKey] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sortMode, setSortMode] = useState<SortMode>('recency');
+  const [recruiters, setRecruiters] = useState<RecruiterDashboardItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const sorted = useMemo(() => {
+    const items = [...recruiters];
+    if (sortMode === 'engagement') {
+      return items.sort((a, b) => (b.artifactGenerations + b.clickedSections) - (a.artifactGenerations + a.clickedSections));
+    }
+    return items.sort((a, b) => new Date(b.lastActiveAt || 0).getTime() - new Date(a.lastActiveAt || 0).getTime());
+  }, [recruiters, sortMode]);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchRecruiters(adminKey);
+      setRecruiters(data);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen p-6 text-neutral-100">
+      <h1 className="text-2xl font-bold mb-4">Recruiter Dashboard</h1>
+      <div className="flex gap-2 mb-4">
+        <input
+          type="password"
+          placeholder="Admin key"
+          value={adminKey}
+          onChange={(e) => setAdminKey(e.target.value)}
+          className="px-3 py-2 rounded bg-neutral-800 border border-neutral-700"
+        />
+        <button onClick={load} className="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500">
+          {loading ? 'Loading...' : 'Load recruiters'}
+        </button>
+        <select value={sortMode} onChange={(e) => setSortMode(e.target.value as SortMode)} className="px-3 py-2 rounded bg-neutral-800 border border-neutral-700">
+          <option value="recency">Sort by recency</option>
+          <option value="engagement">Sort by engagement</option>
+        </select>
+      </div>
+
+      {error && <p className="text-rose-400 mb-3">{error}</p>}
+
+      <div className="grid gap-3">
+        {sorted.map((r) => {
+          const recentlyActive = r.lastActiveAt && (Date.now() - new Date(r.lastActiveAt).getTime()) < 1000 * 60 * 60 * 24;
+          const highEngagement = r.artifactGenerations + r.clickedSections >= 5;
+
+          return (
+            <div key={r.linkedinId} className={`rounded-xl border p-4 ${recentlyActive ? 'border-emerald-500/50' : 'border-neutral-700'} ${highEngagement ? 'bg-indigo-500/10' : 'bg-neutral-900/50'}`}>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold">{r.name}</p>
+                  <a href={r.profileUrl || '#'} target="_blank" rel="noreferrer" className="text-sky-300 hover:underline text-sm">
+                    LinkedIn profile
+                  </a>
+                  <p className="text-sm text-neutral-300 mt-1">{r.headline || 'No headline available'}</p>
+                  <p className="text-sm text-neutral-400">{r.company || 'Company unavailable'}</p>
+                </div>
+                <div className="text-right text-sm text-neutral-300">
+                  <p>Sessions: {r.sessions || 0}</p>
+                  <p>Artifacts: {r.artifactGenerations || 0}</p>
+                  <p>Mockup views: {r.viewedMockups || 0}</p>
+                </div>
+              </div>
+              <p className="text-xs text-neutral-400 mt-2">
+                Last active: {r.lastActiveAt ? formatDistanceToNow(new Date(r.lastActiveAt), { addSuffix: true }) : 'Unknown'}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/recruiterApi.ts
+++ b/src/lib/recruiterApi.ts
@@ -1,0 +1,49 @@
+export type RecruiterUser = {
+  linkedinId: string;
+  name: string;
+  profileUrl: string | null;
+  headline: string;
+  company: string | null;
+  avatarUrl: string | null;
+  email?: string | null;
+  lastActiveAt?: string;
+};
+
+export type RecruiterDashboardItem = RecruiterUser & {
+  sessions: number;
+  artifactGenerations: number;
+  viewedMockups: number;
+  clickedSections: number;
+};
+
+export async function fetchSession() {
+  const response = await fetch('/api/session', { credentials: 'include' });
+  return response.json();
+}
+
+export async function trackActivity(type: string, metadata: Record<string, unknown> = {}) {
+  try {
+    await fetch('/api/activity', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type, metadata }),
+    });
+  } catch {
+    // swallow tracking failures
+  }
+}
+
+export async function fetchRecruiters(adminKey: string): Promise<RecruiterDashboardItem[]> {
+  const response = await fetch('/api/admin/recruiters', {
+    headers: { 'x-admin-key': adminKey },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load recruiter dashboard data.');
+  }
+
+  const data = await response.json();
+  return data.recruiters;
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import type { RecruiterUser } from '../lib/recruiterApi';
+import { fetchSession } from '../lib/recruiterApi';
+
+type AuthState = {
+  user: RecruiterUser | null;
+  loading: boolean;
+  refreshSession: () => Promise<void>;
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  loading: true,
+  refreshSession: async () => {
+    set({ loading: true });
+    try {
+      const session = await fetchSession();
+      set({ user: session.authenticated ? session.user : null, loading: false });
+    } catch {
+      set({ user: null, loading: false });
+    }
+  },
+}));

--- a/src/store/slices/artifactSlice.ts
+++ b/src/store/slices/artifactSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
 import type { Artifact, ArtifactVersion, ArtifactType, CoreArtifactSubtype, SourceRef, HistoryEvent } from '../../types';
 import type { ProjectState } from '../types';
+import { trackActivity } from '../../lib/recruiterApi';
 
 export type ArtifactSlice = {
     artifacts: Record<string, Artifact[]>;
@@ -151,6 +152,12 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
                 [projectId]: [...(state.historyEvents[projectId] || []), historyEvent]
             },
         }));
+        void trackActivity('generated_artifact', {
+            projectId,
+            artifactId,
+            versionId,
+            type: artifact?.type || 'unknown',
+        });
 
         return { versionId };
     },

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
 import type { Project, HistoryEvent, PipelineStage, ProjectPlatform } from '../../types';
 import type { ProjectState } from '../types';
+import { trackActivity } from '../../lib/recruiterApi';
 
 export type ProjectSlice = {
     projects: Record<string, Project>;
@@ -51,6 +52,7 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             spineVersions: { ...state.spineVersions, [projectId]: [initialSpine] },
             historyEvents: { ...state.historyEvents, [projectId]: [initEvent] },
         }));
+        void trackActivity('clicked_section', { section: 'create_project', projectId });
 
         return { projectId, spineId: initialSpine.id };
     },
@@ -98,5 +100,6 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
                 [projectId]: { ...state.projects[projectId], currentStage: stage }
             }
         }));
+        void trackActivity(stage === 'mockups' ? 'viewed_mockups' : 'clicked_section', { section: stage, projectId });
     },
 });

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,6 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
### Motivation
- Provide a frictionless LinkedIn-based sign-in for recruiters so visitors can explore Synapse and be identified for manual follow-up. 
- Persist recruiter identity and in-product actions to enable discovery, prioritization, and contextual outreach while requesting only minimal scopes.
- Offer an internal view to surface recently active and high-engagement recruiters for follow-up.

### Description
- Implemented OAuth entry and callback routes at `GET /api/auth/linkedin` and `GET /api/auth/linkedin/callback` with CSRF state handling, token exchange, profile fetch, and upsert of recruiter identity. 
- Added signed session cookie utilities (`api/_lib/session.js`) and session lifecycle endpoints `GET /api/session` and `POST /api/auth/logout` to restore and clear recruiter sessions. 
- Added MongoDB Atlas Data API wrapper (`api/_lib/db.js`) and switched persistence to use the Data API for `recruiters`, `recruiter_sessions`, and `recruiter_activity` collections. 
- Added activity ingestion endpoint `POST /api/activity` and admin aggregation endpoint `GET /api/admin/recruiters` (guarded by `x-admin-key`) which returns engagement counters and sorts by recency. 
- Frontend changes include a `Continue with LinkedIn` CTA and signed-in indicator in `src/components/HomePage.tsx`, a lightweight auth store `src/store/authStore.ts`, recruiter API helpers `src/lib/recruiterApi.ts`, and a simple internal dashboard `src/components/RecruiterAdminPage.tsx` at `/admin/recruiters`. 
- Hooked activity tracking into product events by calling `trackActivity` from project creation / stage changes (`src/store/slices/projectSlice.ts`) and artifact generation (`src/store/slices/artifactSlice.ts`). 
- Documented setup, required env vars, scopes, and privacy note in `docs/linkedin-auth.md` and updated `README.md`. 
- Adjusted SPA rewrite so API routes are not intercepted (`vercel.json`).

### Testing
- Built the frontend with `npm run build`, which completed successfully (Vite build produced standard bundle warnings but completed). 
- Ran the test suite with `npm run test` (Vitest), where all tests passed (`4 files`, `23 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd130be5748321815e85accc1c91c7)