### PR TITLE
fix(artifacts): drive bundle progress from real state, honest concurrency copy

### DIFF
--- a/src/components/ArtifactsView.tsx
+++ b/src/components/ArtifactsView.tsx
@@ -10,7 +10,7 @@ import { ErrorBanner } from './ErrorBanner';
 import { StalenessBadge } from './StalenessBadge';
 import { FeedbackModal } from './FeedbackModal';
 import { GenerationProgress } from './GenerationProgress';
-import { STALE_REFRESH_STAGES, getArtifactStages } from './generationStages';
+import { STALE_REFRESH_STAGES, BUNDLE_GENERATION_STAGES, getArtifactStages } from './generationStages';
 import type { StructuredPRD, CoreArtifactSubtype } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -30,6 +30,8 @@ interface ArtifactsViewProps {
 // Display uses the user-facing order; generation uses dependency-layered order.
 const CORE_ARTIFACTS_DISPLAY = CORE_ARTIFACT_DISPLAY_ORDER;
 const TOTAL_CORE_ARTIFACTS = CORE_ARTIFACT_PIPELINE.length;
+// Max artifacts that can run in parallel within a single dependency layer.
+const MAX_PARALLEL_PER_LAYER = Math.max(...buildDependencyLayers().map(layer => layer.length));
 
 function isAbortError(reason: unknown): boolean {
     return reason instanceof DOMException && reason.name === 'AbortError';
@@ -418,20 +420,37 @@ export function ArtifactsView({ projectId, spineVersionId, prdContent, structure
             )}
 
             {/* Bundle / stale refresh progress */}
-            {generatingSubtype === 'bundle' && (
-                <GenerationProgress
-                    stages={staleCount > 0 ? STALE_REFRESH_STAGES : [
-                        { label: 'Preparing artifact pipeline...', minDuration: 2000 },
-                        { label: `Generating artifacts (${bundleDoneCount} of ${TOTAL_CORE_ARTIFACTS} complete)...`, minDuration: 3000 },
-                        { label: 'Structuring outputs...', minDuration: 4000 },
-                        { label: 'Validating artifact quality...', minDuration: 5000 },
-                    ]}
-
-                    variant="systematic"
-                    title={staleCount > 0 ? 'Refreshing Stale Artifacts' : 'Generating Artifact Bundle'}
-                    subtitle={`Processing ${staleCount > 0 ? staleCount : TOTAL_CORE_ARTIFACTS} artifacts concurrently (by dependency layer)`}
-                />
-            )}
+            {generatingSubtype === 'bundle' && (() => {
+                // Derive real progress from bundleStatus. Only artifacts that
+                // we actually queued for this run (bundleStatus has an entry)
+                // count toward the total — works for both the full bundle and
+                // the "Refresh N Stale" path.
+                const tracked = (Object.keys(bundleStatus) as CoreArtifactSubtype[])
+                    .map(subtype => getArtifactMeta(subtype));
+                const total = tracked.length;
+                const done = tracked.filter(m => bundleStatus[m.subtype] === 'done');
+                const active = tracked.filter(m => bundleStatus[m.subtype] === 'generating');
+                // Give in-flight artifacts partial credit so the bar advances
+                // smoothly within a layer instead of only at layer boundaries.
+                const progressPct = total === 0
+                    ? 0
+                    : Math.min(100, ((done.length + active.length * 0.5) / total) * 100);
+                const statusLabel = active.length > 0
+                    ? `Generating ${active.map(m => m.title).join(', ')} — ${done.length} of ${total} complete`
+                    : done.length === total && total > 0
+                        ? `Finalizing… ${done.length} of ${total} complete`
+                        : `Preparing next dependency layer… ${done.length} of ${total} complete`;
+                return (
+                    <GenerationProgress
+                        stages={staleCount > 0 ? STALE_REFRESH_STAGES : BUNDLE_GENERATION_STAGES}
+                        variant="systematic"
+                        title={staleCount > 0 ? 'Refreshing Stale Artifacts' : 'Generating Artifact Bundle'}
+                        subtitle={`Dependency-aware pipeline · up to ${MAX_PARALLEL_PER_LAYER} in parallel per layer`}
+                        progress={progressPct}
+                        statusLabel={statusLabel}
+                    />
+                );
+            })()}
 
             {/* Artifact Grid */}
             <div className="space-y-3">

--- a/src/components/GenerationProgress.tsx
+++ b/src/components/GenerationProgress.tsx
@@ -12,6 +12,17 @@ interface GenerationProgressProps {
     subtitle?: string;
     /** Compact inline mode (no card wrapper) */
     inline?: boolean;
+    /**
+     * 0-100 real completion percent. When provided, the component is
+     * state-driven: the bar width tracks this value directly and the
+     * timer-based stage rotation is disabled.
+     */
+    progress?: number;
+    /**
+     * Live status string shown instead of the rotating stage label when
+     * the component is state-driven (paired with `progress`).
+     */
+    statusLabel?: string;
 }
 
 const VARIANT_STYLES = {
@@ -67,13 +78,19 @@ export function GenerationProgress({
     title,
     subtitle,
     inline = false,
+    progress,
+    statusLabel,
 }: GenerationProgressProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isFading, setIsFading] = useState(false);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const style = VARIANT_STYLES[variant];
+    const isStateDriven = typeof progress === 'number';
 
     useEffect(() => {
+        // When a real progress value is supplied, skip time-based advancement
+        // entirely — the parent component owns stage progression.
+        if (isStateDriven) return;
         if (stages.length === 0) return;
 
         const advance = () => {
@@ -94,11 +111,26 @@ export function GenerationProgress({
             clearTimeout(id);
             if (timerRef.current) clearTimeout(timerRef.current);
         };
-    }, [currentIndex, stages]);
+    }, [currentIndex, stages, isStateDriven]);
 
     if (stages.length === 0) return null;
 
-    const currentLabel = stages[currentIndex]?.label ?? stages[stages.length - 1]?.label;
+    // Clamp/derive values for state-driven mode
+    const clampedProgress = isStateDriven ? Math.max(0, Math.min(100, progress!)) : 0;
+    const activeDotIndex = isStateDriven
+        ? Math.min(
+              stages.length - 1,
+              Math.floor((clampedProgress / 100) * stages.length),
+          )
+        : currentIndex;
+
+    const currentLabel = isStateDriven
+        ? (statusLabel ?? stages[activeDotIndex]?.label ?? stages[stages.length - 1]?.label)
+        : (stages[currentIndex]?.label ?? stages[stages.length - 1]?.label);
+
+    const barWidthPct = isStateDriven
+        ? clampedProgress
+        : Math.min(((currentIndex + 1) / stages.length) * 100, 95);
 
     if (inline) {
         return (
@@ -122,9 +154,7 @@ export function GenerationProgress({
             <div className="h-0.5 bg-white/60 overflow-hidden">
                 <div
                     className={`h-full ${style.barColor} transition-all duration-[2500ms] ease-linear`}
-                    style={{
-                        width: `${Math.min(((currentIndex + 1) / stages.length) * 100, 95)}%`,
-                    }}
+                    style={{ width: `${barWidthPct}%` }}
                 />
             </div>
 
@@ -156,9 +186,9 @@ export function GenerationProgress({
                             <div
                                 key={i}
                                 className={`h-1 rounded-full transition-all duration-500 ${
-                                    i < currentIndex
+                                    i < activeDotIndex
                                         ? `${style.barColor} w-3`
-                                        : i === currentIndex
+                                        : i === activeDotIndex
                                         ? `${style.barColor} w-5 opacity-80`
                                         : 'bg-neutral-300 w-1.5'
                                 }`}

--- a/src/components/generationStages.ts
+++ b/src/components/generationStages.ts
@@ -43,6 +43,17 @@ export const STALE_REFRESH_STAGES: ProgressStage[] = [
     { label: 'Validating updated outputs...', minDuration: 5000 },
 ];
 
+/**
+ * Visual scaffold for the artifact bundle progress panel.
+ * No `minDuration` — the panel is driven by real completion state, not timers.
+ */
+export const BUNDLE_GENERATION_STAGES: ProgressStage[] = [
+    { label: 'Preparing artifact pipeline...' },
+    { label: 'Generating foundational artifacts...' },
+    { label: 'Building dependent artifacts...' },
+    { label: 'Finalizing prompt pack...' },
+];
+
 /** Returns per-artifact-type stage labels for individual generation */
 export function getArtifactStages(subtype: string): ProgressStage[] {
     switch (subtype) {


### PR DESCRIPTION
The "Generating Artifact Bundle" panel was purely time-driven: it advanced
through four hard-coded stages on fixed setTimeouts (~14s total) and would
reach ~95% long before Gemini finished generating. The subtitle also claimed
"Processing 7 artifacts concurrently" when the dependency graph actually
produces 5 layers, only 2 of which contain >1 artifact.

Make GenerationProgress accept optional `progress` (0-100) and `statusLabel`
props. When supplied, timer-based stage rotation is disabled, the bar width
tracks real completion, and the label reflects what is currently generating.
ArtifactsView now derives progressPct and statusLabel from bundleStatus
(done + 0.5 * in-flight / total), and uses a truthful subtitle that names the
max parallelism per dependency layer. Works for both "Generate All" and
"Refresh N Stale" paths.