### PR TITLE
feat(auth): wire up email/password, Google, and GitHub sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ npm run build
   of one end-to-end pipeline run
 - [`docs/deployment.md`](docs/deployment.md) — commands, Vercel setup,
   self-hosting
+- [`docs/auth.md`](docs/auth.md) — multi-provider auth (email/password,
+  Google, GitHub, LinkedIn), user record schema, env vars, error codes
 - [`docs/linkedin-auth.md`](docs/linkedin-auth.md) — LinkedIn OAuth setup,
   recruiter capture fields, and compliance note
 - [`docs/archive/`](docs/archive/) — historical design notes and audits

--- a/api/_lib/github.js
+++ b/api/_lib/github.js
@@ -1,0 +1,114 @@
+const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GITHUB_USER_URL = 'https://api.github.com/user';
+const GITHUB_EMAILS_URL = 'https://api.github.com/user/emails';
+
+export function getGitHubConfig(baseUrl) {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  const redirectUri = process.env.GITHUB_REDIRECT_URI || `${baseUrl}/api/auth/github/callback`;
+
+  if (!clientId || !clientSecret) {
+    throw new Error('GitHub auth is not configured. Missing GITHUB_CLIENT_ID or GITHUB_CLIENT_SECRET.');
+  }
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+    scopes: ['read:user', 'user:email'],
+  };
+}
+
+export function createGitHubAuthUrl(config, state) {
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: config.scopes.join(' '),
+    state,
+    allow_signup: 'true',
+  });
+
+  return `${GITHUB_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForToken(config, code) {
+  const body = new URLSearchParams({
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    code,
+    redirect_uri: config.redirectUri,
+  });
+
+  const response = await fetch(GITHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`GitHub token exchange failed (${response.status}): ${errBody}`);
+  }
+
+  const tokenResponse = await response.json();
+  if (tokenResponse.error) {
+    throw new Error(`GitHub token exchange error: ${tokenResponse.error_description || tokenResponse.error}`);
+  }
+  return tokenResponse;
+}
+
+async function githubFetch(url, accessToken) {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'synapse-auth',
+    },
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`GitHub API ${url} failed (${response.status}): ${errBody}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchGitHubProfile(accessToken) {
+  const [user, emails] = await Promise.all([
+    githubFetch(GITHUB_USER_URL, accessToken),
+    githubFetch(GITHUB_EMAILS_URL, accessToken).catch((err) => {
+      // `user:email` scope may be denied; fall back to the public email on the
+      // user record if so.
+      console.warn('[GitHub emails fetch failed]', err);
+      return [];
+    }),
+  ]);
+
+  return { user, emails };
+}
+
+export function normalizeGitHubProfile({ user, emails }) {
+  const primary = Array.isArray(emails)
+    ? emails.find((entry) => entry.primary && entry.verified)
+      || emails.find((entry) => entry.verified)
+      || emails.find((entry) => entry.primary)
+    : null;
+
+  const email = primary?.email || user.email || null;
+  const name = user.name || user.login || '';
+
+  return {
+    providerUserId: String(user.id),
+    email,
+    name,
+    avatarUrl: user.avatar_url || null,
+    profileUrl: user.html_url || null,
+    headline: user.bio || '',
+    company: user.company || null,
+  };
+}

--- a/api/_lib/google.js
+++ b/api/_lib/google.js
@@ -1,0 +1,86 @@
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://openidconnect.googleapis.com/v1/userinfo';
+
+export function getGoogleConfig(baseUrl) {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const redirectUri = process.env.GOOGLE_REDIRECT_URI || `${baseUrl}/api/auth/google/callback`;
+
+  if (!clientId || !clientSecret) {
+    throw new Error('Google auth is not configured. Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET.');
+  }
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+    scopes: ['openid', 'email', 'profile'],
+  };
+}
+
+export function createGoogleAuthUrl(config, state) {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: config.scopes.join(' '),
+    state,
+    access_type: 'online',
+    prompt: 'select_account',
+  });
+
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForToken(config, code) {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: config.redirectUri,
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+  });
+
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`Google token exchange failed (${response.status}): ${errBody}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchGoogleProfile(accessToken) {
+  const response = await fetch(GOOGLE_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`Google profile fetch failed (${response.status}): ${errBody}`);
+  }
+
+  return response.json();
+}
+
+export function normalizeGoogleProfile(profile) {
+  const name = profile.name
+    || [profile.given_name, profile.family_name].filter(Boolean).join(' ').trim()
+    || profile.email
+    || '';
+  return {
+    providerUserId: profile.sub,
+    email: profile.email || null,
+    name,
+    avatarUrl: profile.picture || null,
+    profileUrl: null,
+    headline: '',
+    company: null,
+  };
+}

--- a/api/_lib/oauthCallback.js
+++ b/api/_lib/oauthCallback.js
@@ -1,0 +1,94 @@
+import {
+  upsertOAuthUser,
+  issueSessionForUser,
+  EmailInUseByOtherProviderError,
+} from './users.js';
+import { methodNotAllowed } from './response.js';
+
+function readCookie(req, name) {
+  const raw = req.headers.cookie || '';
+  const parts = raw.split(';').map((part) => part.trim());
+  const match = parts.find((part) => part.startsWith(`${name}=`));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}
+
+function clearStateCookie(res, name, existingSetCookie) {
+  const cleared = `${name}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`;
+  const header = existingSetCookie
+    ? Array.isArray(existingSetCookie)
+      ? [cleared, ...existingSetCookie]
+      : [cleared, String(existingSetCookie)]
+    : cleared;
+  res.setHeader('Set-Cookie', header);
+}
+
+/**
+ * Shared OAuth callback handler. Each provider supplies:
+ *   - provider: 'linkedin' | 'google' | 'github'
+ *   - stateCookieName: name of the state cookie set during the redirect
+ *   - successRedirect: path to redirect to on success (e.g. '/?auth=google_success')
+ *   - errorRedirectBase: path prefix for errors (e.g. '/?auth_error=google_')
+ *   - exchangeCode(code, baseUrl): returns { access_token, ... }
+ *   - fetchProfile(tokenResponse): returns raw profile object
+ *   - normalizeProfile(profile): returns {
+ *       providerUserId, email, name, avatarUrl, profileUrl, headline, company
+ *     }
+ */
+export async function handleOAuthCallback(req, res, opts) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  const {
+    provider,
+    stateCookieName,
+    successRedirect,
+    errorRedirectBase,
+    exchangeCode,
+    fetchProfile,
+    normalizeProfile,
+  } = opts;
+
+  const { code, state } = req.query;
+  if (!code || !state) {
+    return res.redirect(`${errorRedirectBase}missing_code`);
+  }
+
+  const storedState = readCookie(req, stateCookieName);
+  if (!storedState || storedState !== state) {
+    return res.redirect(`${errorRedirectBase}invalid_state`);
+  }
+
+  try {
+    const tokenResponse = await exchangeCode(String(code));
+    const profile = await fetchProfile(tokenResponse);
+    const normalized = normalizeProfile(profile);
+
+    if (!normalized.providerUserId) {
+      throw new Error(`${provider} profile missing providerUserId`);
+    }
+
+    const user = await upsertOAuthUser({
+      authProvider: provider,
+      providerUserId: String(normalized.providerUserId),
+      email: normalized.email || null,
+      name: normalized.name || '',
+      avatarUrl: normalized.avatarUrl || null,
+      profileUrl: normalized.profileUrl || null,
+      headline: normalized.headline || '',
+      company: normalized.company || null,
+    });
+
+    await issueSessionForUser(req, res, user);
+
+    // Clear the state cookie alongside the session cookie that was just set.
+    const existing = res.getHeader('Set-Cookie');
+    clearStateCookie(res, stateCookieName, existing);
+
+    return res.redirect(successRedirect);
+  } catch (error) {
+    if (error instanceof EmailInUseByOtherProviderError) {
+      return res.redirect('/?auth_error=email_in_use_other_provider');
+    }
+    console.error(`[${provider} callback failed]`, error);
+    return res.redirect(`${errorRedirectBase}callback_failed`);
+  }
+}

--- a/api/_lib/password.js
+++ b/api/_lib/password.js
@@ -1,0 +1,41 @@
+import crypto from 'crypto';
+
+const SCRYPT_KEY_LENGTH = 64;
+const SALT_BYTES = 16;
+const SCHEME = 'scrypt';
+
+/**
+ * Hash a plaintext password using Node's built-in scrypt.
+ * Returns `scrypt$<saltB64url>$<hashB64url>`.
+ */
+export function hashPassword(plain) {
+  if (typeof plain !== 'string' || plain.length === 0) {
+    throw new Error('hashPassword: plain password must be a non-empty string');
+  }
+  const salt = crypto.randomBytes(SALT_BYTES);
+  const hash = crypto.scryptSync(plain, salt, SCRYPT_KEY_LENGTH);
+  return `${SCHEME}$${salt.toString('base64url')}$${hash.toString('base64url')}`;
+}
+
+/**
+ * Constant-time verify of a plaintext password against a stored scrypt string.
+ * Returns false on any parse failure or mismatch.
+ */
+export function verifyPassword(plain, stored) {
+  if (typeof plain !== 'string' || typeof stored !== 'string') return false;
+
+  const parts = stored.split('$');
+  if (parts.length !== 3 || parts[0] !== SCHEME) return false;
+
+  try {
+    const salt = Buffer.from(parts[1], 'base64url');
+    const expected = Buffer.from(parts[2], 'base64url');
+    if (salt.length === 0 || expected.length === 0) return false;
+
+    const actual = crypto.scryptSync(plain, salt, expected.length);
+    if (actual.length !== expected.length) return false;
+    return crypto.timingSafeEqual(actual, expected);
+  } catch {
+    return false;
+  }
+}

--- a/api/_lib/users.js
+++ b/api/_lib/users.js
@@ -1,0 +1,292 @@
+import crypto from 'crypto';
+import { runMongoAction } from './db.js';
+import { createSessionToken, setSessionCookie } from './session.js';
+
+export const COLLECTION = 'recruiters';
+export const SESSIONS_COLLECTION = 'recruiter_sessions';
+
+export class EmailInUseError extends Error {
+  constructor(message = 'email_in_use') {
+    super(message);
+    this.name = 'EmailInUseError';
+    this.code = 'email_in_use';
+  }
+}
+
+export class EmailInUseByOtherProviderError extends Error {
+  constructor(existingProvider) {
+    super('email_in_use_other_provider');
+    this.name = 'EmailInUseByOtherProviderError';
+    this.code = 'email_in_use_other_provider';
+    this.existingProvider = existingProvider;
+  }
+}
+
+export function generateUserId() {
+  return crypto.randomUUID();
+}
+
+function normalizeEmail(email) {
+  if (typeof email !== 'string') return null;
+  const trimmed = email.trim().toLowerCase();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function publicUserProjection() {
+  return {
+    _id: 0,
+    userId: 1,
+    authProvider: 1,
+    linkedinId: 1,
+    name: 1,
+    profileUrl: 1,
+    headline: 1,
+    company: 1,
+    avatarUrl: 1,
+    email: 1,
+    emailVerified: 1,
+    lastActiveAt: 1,
+  };
+}
+
+async function findOne(filter) {
+  const result = await runMongoAction('findOne', {
+    collection: COLLECTION,
+    filter,
+    projection: publicUserProjection(),
+  });
+  return result.document || null;
+}
+
+async function findOneFull(filter) {
+  const result = await runMongoAction('findOne', {
+    collection: COLLECTION,
+    filter,
+  });
+  return result.document || null;
+}
+
+export function findUserByUserId(userId) {
+  return findOne({ userId });
+}
+
+export function findUserByLinkedinId(linkedinId) {
+  return findOne({ linkedinId });
+}
+
+export function findUserByProvider(authProvider, providerUserId) {
+  return findOne({ authProvider, providerUserId });
+}
+
+/**
+ * Returns the full (including passwordHash) document for an email-provider user.
+ * Used only inside the login endpoint for password comparison — never projected
+ * out to clients.
+ */
+export async function findEmailUserForLogin(email) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return null;
+  return findOneFull({ email: normalized, authProvider: 'email' });
+}
+
+export async function findAnyUserByEmail(email) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return null;
+  return findOne({ email: normalized });
+}
+
+/**
+ * Create a new email-provider user. Throws EmailInUseError if the email is
+ * already registered under ANY provider.
+ */
+export async function createEmailUser({ email, name, passwordHash }) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) throw new Error('createEmailUser: email is required');
+
+  const existing = await findAnyUserByEmail(normalized);
+  if (existing) throw new EmailInUseError();
+
+  const now = new Date();
+  const userId = generateUserId();
+  const doc = {
+    userId,
+    authProvider: 'email',
+    providerUserId: normalized,
+    email: normalized,
+    emailVerified: false,
+    name,
+    passwordHash,
+    profileUrl: null,
+    headline: '',
+    company: null,
+    avatarUrl: null,
+    createdAt: now,
+    firstLoginAt: now,
+    lastActiveAt: now,
+    updatedAt: now,
+    loginCount: 1,
+  };
+
+  await runMongoAction('insertOne', {
+    collection: COLLECTION,
+    document: doc,
+  });
+
+  return {
+    userId,
+    authProvider: 'email',
+    email: normalized,
+    emailVerified: false,
+    name,
+    profileUrl: null,
+    headline: '',
+    company: null,
+    avatarUrl: null,
+    lastActiveAt: now,
+  };
+}
+
+/**
+ * Upsert an OAuth-provider user. Throws EmailInUseByOtherProviderError if the
+ * email already belongs to a user under a different auth provider.
+ * Returns the public user projection.
+ */
+export async function upsertOAuthUser({
+  authProvider,
+  providerUserId,
+  email,
+  name,
+  avatarUrl = null,
+  profileUrl = null,
+  headline = '',
+  company = null,
+}) {
+  if (!authProvider || !providerUserId) {
+    throw new Error('upsertOAuthUser: authProvider and providerUserId are required');
+  }
+
+  const normalizedEmail = normalizeEmail(email);
+  const now = new Date();
+
+  // Is there already a record for this provider + providerUserId?
+  const existing = await findUserByProvider(authProvider, providerUserId);
+
+  // Cross-provider collision: email already used by a different provider.
+  if (!existing && normalizedEmail) {
+    const byEmail = await findAnyUserByEmail(normalizedEmail);
+    if (byEmail && byEmail.authProvider !== authProvider) {
+      throw new EmailInUseByOtherProviderError(byEmail.authProvider);
+    }
+  }
+
+  const userId = existing?.userId || generateUserId();
+
+  const setFields = {
+    userId,
+    authProvider,
+    providerUserId,
+    name,
+    profileUrl,
+    headline,
+    company,
+    avatarUrl,
+    email: normalizedEmail,
+    emailVerified: true,
+    lastActiveAt: now,
+    updatedAt: now,
+  };
+
+  // Keep legacy linkedinId in sync for existing code paths.
+  if (authProvider === 'linkedin') {
+    setFields.linkedinId = providerUserId;
+  }
+
+  await runMongoAction('updateOne', {
+    collection: COLLECTION,
+    filter: { authProvider, providerUserId },
+    update: {
+      $set: setFields,
+      $setOnInsert: {
+        createdAt: now,
+        firstLoginAt: now,
+        loginCount: 0,
+      },
+      $inc: { loginCount: 1 },
+    },
+    upsert: true,
+  });
+
+  return {
+    userId,
+    authProvider,
+    providerUserId,
+    name,
+    profileUrl,
+    headline,
+    company,
+    avatarUrl,
+    email: normalizedEmail,
+    emailVerified: true,
+    lastActiveAt: now,
+    linkedinId: authProvider === 'linkedin' ? providerUserId : undefined,
+  };
+}
+
+/**
+ * Build session claims, sign the cookie, set it on the response, and record a
+ * session row in `recruiter_sessions`. Shared by every successful auth path.
+ */
+export async function issueSessionForUser(req, res, user) {
+  const token = createSessionToken({
+    userId: user.userId,
+    authProvider: user.authProvider,
+    name: user.name,
+    email: user.email || null,
+    avatarUrl: user.avatarUrl || null,
+    profileUrl: user.profileUrl || null,
+    issuedAt: Date.now(),
+    // Back-compat: older code paths that inspect `recruiterId` keep working.
+    recruiterId: user.linkedinId || user.userId,
+  });
+
+  setSessionCookie(res, token);
+
+  try {
+    await runMongoAction('insertOne', {
+      collection: SESSIONS_COLLECTION,
+      document: {
+        userId: user.userId,
+        authProvider: user.authProvider,
+        recruiterId: user.linkedinId || user.userId,
+        startedAt: new Date(),
+        userAgent: req?.headers?.['user-agent'] || null,
+        ip: req?.headers?.['x-forwarded-for'] || req?.socket?.remoteAddress || null,
+      },
+    });
+  } catch (error) {
+    // Session-row insertion is best-effort analytics; don't block login.
+    console.error('[recruiter_sessions insert failed]', error);
+  }
+
+  return token;
+}
+
+/**
+ * Strip server-only fields before returning a user to a client.
+ */
+export function toPublicUser(user) {
+  if (!user) return null;
+  return {
+    userId: user.userId || null,
+    authProvider: user.authProvider || null,
+    linkedinId: user.linkedinId || null,
+    name: user.name || '',
+    profileUrl: user.profileUrl || null,
+    headline: user.headline || '',
+    company: user.company || null,
+    avatarUrl: user.avatarUrl || null,
+    email: user.email || null,
+    emailVerified: user.emailVerified ?? false,
+    lastActiveAt: user.lastActiveAt || null,
+  };
+}

--- a/api/_lib/validate.js
+++ b/api/_lib/validate.js
@@ -1,0 +1,66 @@
+// Lightweight, hand-rolled validators. Zero deps — avoids pulling zod for a few calls.
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LEN = 254;
+const MIN_PASSWORD_LEN = 8;
+const MAX_PASSWORD_LEN = 200;
+const MAX_NAME_LEN = 120;
+
+export function validateEmail(value) {
+  if (typeof value !== 'string') return { ok: false, error: 'Email is required.' };
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.length === 0) return { ok: false, error: 'Email is required.' };
+  if (trimmed.length > MAX_EMAIL_LEN) return { ok: false, error: 'Email is too long.' };
+  if (!EMAIL_RE.test(trimmed)) return { ok: false, error: 'Please enter a valid email address.' };
+  return { ok: true, value: trimmed };
+}
+
+export function validatePassword(value) {
+  if (typeof value !== 'string') return { ok: false, error: 'Password is required.' };
+  if (value.length < MIN_PASSWORD_LEN) {
+    return { ok: false, error: `Password must be at least ${MIN_PASSWORD_LEN} characters.` };
+  }
+  if (value.length > MAX_PASSWORD_LEN) {
+    return { ok: false, error: 'Password is too long.' };
+  }
+  return { ok: true, value };
+}
+
+export function validateName(value) {
+  if (typeof value !== 'string') return { ok: false, error: 'Name is required.' };
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return { ok: false, error: 'Name is required.' };
+  if (trimmed.length > MAX_NAME_LEN) return { ok: false, error: 'Name is too long.' };
+  return { ok: true, value: trimmed };
+}
+
+/**
+ * Read and JSON-parse the request body. Vercel Node functions sometimes deliver
+ * `req.body` already parsed, sometimes as a raw string, and sometimes as a
+ * stream depending on the content-type header. Handle all three.
+ */
+export async function parseJsonBody(req) {
+  if (req.body && typeof req.body === 'object' && !Buffer.isBuffer(req.body)) {
+    return req.body;
+  }
+  if (typeof req.body === 'string' && req.body.length > 0) {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) return {};
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}

--- a/api/activity.js
+++ b/api/activity.js
@@ -7,7 +7,8 @@ export default async function handler(req, res) {
 
   const token = parseSessionCookie(req);
   const claims = verifySessionToken(token);
-  if (!claims?.recruiterId) return json(res, 401, { error: 'Unauthorized' });
+  const subjectId = claims?.userId || claims?.recruiterId;
+  if (!subjectId) return json(res, 401, { error: 'Unauthorized' });
 
   const { type, metadata } = req.body || {};
   if (!type) return json(res, 400, { error: 'Missing activity type' });
@@ -17,16 +18,22 @@ export default async function handler(req, res) {
     await runMongoAction('insertOne', {
       collection: 'recruiter_activity',
       document: {
-        recruiterId: claims.recruiterId,
+        userId: claims?.userId || null,
+        recruiterId: claims?.recruiterId || subjectId,
         type,
         metadata: metadata || {},
         createdAt: now,
       },
     });
 
+    // Update lastActiveAt on the user record. Prefer userId (works for all
+    // providers); fall back to linkedinId for pre-migration tokens.
+    const userFilter = claims?.userId
+      ? { userId: claims.userId }
+      : { linkedinId: claims.recruiterId };
     await runMongoAction('updateOne', {
       collection: 'recruiters',
-      filter: { linkedinId: claims.recruiterId },
+      filter: userFilter,
       update: { $set: { lastActiveAt: now } },
     });
 

--- a/api/auth/github.js
+++ b/api/auth/github.js
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+import { createGitHubAuthUrl, getGitHubConfig } from '../_lib/github.js';
+import { getBaseUrl, methodNotAllowed } from '../_lib/response.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  try {
+    const baseUrl = getBaseUrl(req);
+    const config = getGitHubConfig(baseUrl);
+    const state = crypto.randomBytes(16).toString('hex');
+    const authUrl = createGitHubAuthUrl(config, state);
+
+    const secure = process.env.NODE_ENV === 'production';
+    res.setHeader(
+      'Set-Cookie',
+      `synapse_github_state=${state}; Path=/; Max-Age=600; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
+    );
+    return res.redirect(authUrl);
+  } catch (error) {
+    console.error('[GitHub auth init failed]', error);
+    return res.redirect('/?auth_error=github_config');
+  }
+}

--- a/api/auth/github/callback.js
+++ b/api/auth/github/callback.js
@@ -1,0 +1,23 @@
+import {
+  exchangeCodeForToken,
+  fetchGitHubProfile,
+  getGitHubConfig,
+  normalizeGitHubProfile,
+} from '../../_lib/github.js';
+import { handleOAuthCallback } from '../../_lib/oauthCallback.js';
+import { getBaseUrl } from '../../_lib/response.js';
+
+export default async function handler(req, res) {
+  const baseUrl = getBaseUrl(req);
+  const config = getGitHubConfig(baseUrl);
+
+  return handleOAuthCallback(req, res, {
+    provider: 'github',
+    stateCookieName: 'synapse_github_state',
+    successRedirect: '/?auth=github_success',
+    errorRedirectBase: '/?auth_error=github_',
+    exchangeCode: (code) => exchangeCodeForToken(config, code),
+    fetchProfile: (tokenResponse) => fetchGitHubProfile(tokenResponse.access_token),
+    normalizeProfile: normalizeGitHubProfile,
+  });
+}

--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+import { createGoogleAuthUrl, getGoogleConfig } from '../_lib/google.js';
+import { getBaseUrl, methodNotAllowed } from '../_lib/response.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res);
+
+  try {
+    const baseUrl = getBaseUrl(req);
+    const config = getGoogleConfig(baseUrl);
+    const state = crypto.randomBytes(16).toString('hex');
+    const authUrl = createGoogleAuthUrl(config, state);
+
+    const secure = process.env.NODE_ENV === 'production';
+    res.setHeader(
+      'Set-Cookie',
+      `synapse_google_state=${state}; Path=/; Max-Age=600; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
+    );
+    return res.redirect(authUrl);
+  } catch (error) {
+    console.error('[Google auth init failed]', error);
+    return res.redirect('/?auth_error=google_config');
+  }
+}

--- a/api/auth/google/callback.js
+++ b/api/auth/google/callback.js
@@ -1,0 +1,23 @@
+import {
+  exchangeCodeForToken,
+  fetchGoogleProfile,
+  getGoogleConfig,
+  normalizeGoogleProfile,
+} from '../../_lib/google.js';
+import { handleOAuthCallback } from '../../_lib/oauthCallback.js';
+import { getBaseUrl } from '../../_lib/response.js';
+
+export default async function handler(req, res) {
+  const baseUrl = getBaseUrl(req);
+  const config = getGoogleConfig(baseUrl);
+
+  return handleOAuthCallback(req, res, {
+    provider: 'google',
+    stateCookieName: 'synapse_google_state',
+    successRedirect: '/?auth=google_success',
+    errorRedirectBase: '/?auth_error=google_',
+    exchangeCode: (code) => exchangeCodeForToken(config, code),
+    fetchProfile: (tokenResponse) => fetchGoogleProfile(tokenResponse.access_token),
+    normalizeProfile: normalizeGoogleProfile,
+  });
+}

--- a/api/auth/linkedin/callback.js
+++ b/api/auth/linkedin/callback.js
@@ -1,91 +1,47 @@
-import { runMongoAction } from '../../_lib/db.js';
-import { createSessionToken, setSessionCookie } from '../../_lib/session.js';
-import { exchangeCodeForToken, fetchLinkedInProfile, getLinkedInConfig } from '../../_lib/linkedin.js';
-import { getBaseUrl, methodNotAllowed } from '../../_lib/response.js';
-
-function readCookie(req, name) {
-  const raw = req.headers.cookie || '';
-  const parts = raw.split(';').map((part) => part.trim());
-  const match = parts.find((part) => part.startsWith(`${name}=`));
-  return match ? decodeURIComponent(match.split('=')[1]) : null;
-}
+import {
+  exchangeCodeForToken,
+  fetchLinkedInProfile,
+  getLinkedInConfig,
+} from '../../_lib/linkedin.js';
+import { handleOAuthCallback } from '../../_lib/oauthCallback.js';
+import { getBaseUrl } from '../../_lib/response.js';
 
 function parseCompany(profile) {
-  return profile.organization || profile.company || profile['https://www.linkedin.com/organization'];
+  return (
+    profile.organization
+    || profile.company
+    || profile['https://www.linkedin.com/organization']
+    || null
+  );
+}
+
+function normalizeLinkedInProfile(profile) {
+  const name = profile.name
+    || `${profile.given_name || ''} ${profile.family_name || ''}`.trim()
+    || profile.email
+    || '';
+  return {
+    providerUserId: profile.sub,
+    email: profile.email || null,
+    name,
+    avatarUrl: profile.picture || null,
+    profileUrl: profile.profile || profile.profile_url || null,
+    headline: profile.headline || '',
+    company: parseCompany(profile),
+  };
 }
 
 export default async function handler(req, res) {
-  if (req.method !== 'GET') return methodNotAllowed(res);
+  const baseUrl = getBaseUrl(req);
+  const config = getLinkedInConfig(baseUrl);
 
-  const { code, state } = req.query;
-  if (!code || !state) return res.redirect('/?auth_error=missing_code');
-
-  const storedState = readCookie(req, 'synapse_linkedin_state');
-  if (!storedState || storedState !== state) return res.redirect('/?auth_error=invalid_state');
-
-  try {
-    const baseUrl = getBaseUrl(req);
-    const config = getLinkedInConfig(baseUrl);
-    const tokenResponse = await exchangeCodeForToken(config, String(code));
-    const profile = await fetchLinkedInProfile(tokenResponse.access_token);
-    const now = new Date();
-
-    const recruiterRecord = {
-      authProvider: 'linkedin',
-      linkedinId: profile.sub,
-      name: profile.name || `${profile.given_name || ''} ${profile.family_name || ''}`.trim(),
-      profileUrl: profile.profile || profile.profile_url || null,
-      headline: profile.headline || '',
-      company: parseCompany(profile) || null,
-      email: profile.email || null,
-      avatarUrl: profile.picture || null,
-      lastActiveAt: now,
-      updatedAt: now,
-    };
-
-    await runMongoAction('updateOne', {
-      collection: 'recruiters',
-      filter: { linkedinId: recruiterRecord.linkedinId },
-      update: {
-        $set: recruiterRecord,
-        $setOnInsert: {
-          createdAt: now,
-          firstLoginAt: now,
-          loginCount: 0,
-        },
-        $inc: { loginCount: 1 },
-      },
-      upsert: true,
-    });
-
-    await runMongoAction('insertOne', {
-      collection: 'recruiter_sessions',
-      document: {
-        recruiterId: recruiterRecord.linkedinId,
-        startedAt: now,
-        userAgent: req.headers['user-agent'] || null,
-        ip: req.headers['x-forwarded-for'] || req.socket.remoteAddress || null,
-      },
-    });
-
-    const sessionToken = createSessionToken({
-      recruiterId: recruiterRecord.linkedinId,
-      name: recruiterRecord.name,
-      profileUrl: recruiterRecord.profileUrl,
-      avatarUrl: recruiterRecord.avatarUrl,
-      email: recruiterRecord.email,
-      issuedAt: Date.now(),
-    });
-
-    setSessionCookie(res, sessionToken);
-    const sessionCookie = res.getHeader('Set-Cookie');
-    res.setHeader('Set-Cookie', [
-      `synapse_linkedin_state=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`,
-      ...(Array.isArray(sessionCookie) ? sessionCookie : [String(sessionCookie)]),
-    ]);
-    return res.redirect('/?auth=linkedin_success');
-  } catch (error) {
-    console.error('[LinkedIn callback failed]', error);
-    return res.redirect('/?auth_error=linkedin_callback_failed');
-  }
+  return handleOAuthCallback(req, res, {
+    provider: 'linkedin',
+    stateCookieName: 'synapse_linkedin_state',
+    successRedirect: '/?auth=linkedin_success',
+    errorRedirectBase: '/?auth_error=linkedin_',
+    exchangeCode: (code) => exchangeCodeForToken(config, code),
+    fetchProfile: (tokenResponse) => fetchLinkedInProfile(tokenResponse.access_token),
+    normalizeProfile: normalizeLinkedInProfile,
+  });
 }

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,0 +1,40 @@
+import { verifyPassword } from '../_lib/password.js';
+import { json, methodNotAllowed } from '../_lib/response.js';
+import { parseJsonBody, validateEmail } from '../_lib/validate.js';
+import {
+  findEmailUserForLogin,
+  issueSessionForUser,
+  toPublicUser,
+} from '../_lib/users.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  try {
+    const body = await parseJsonBody(req);
+
+    const emailCheck = validateEmail(body?.email);
+    if (!emailCheck.ok) {
+      return json(res, 401, { error: 'invalid_credentials' });
+    }
+    if (typeof body?.password !== 'string' || body.password.length === 0) {
+      return json(res, 401, { error: 'invalid_credentials' });
+    }
+
+    const user = await findEmailUserForLogin(emailCheck.value);
+    if (!user || !user.passwordHash) {
+      return json(res, 401, { error: 'invalid_credentials' });
+    }
+
+    const match = verifyPassword(body.password, user.passwordHash);
+    if (!match) {
+      return json(res, 401, { error: 'invalid_credentials' });
+    }
+
+    await issueSessionForUser(req, res, user);
+    return json(res, 200, { user: toPublicUser(user) });
+  } catch (error) {
+    console.error('[Login failed]', error);
+    return json(res, 500, { error: 'login_failed' });
+  }
+}

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -1,0 +1,53 @@
+import { hashPassword } from '../_lib/password.js';
+import { json, methodNotAllowed } from '../_lib/response.js';
+import {
+  parseJsonBody,
+  validateEmail,
+  validateName,
+  validatePassword,
+} from '../_lib/validate.js';
+import {
+  createEmailUser,
+  issueSessionForUser,
+  toPublicUser,
+  EmailInUseError,
+} from '../_lib/users.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  try {
+    const body = await parseJsonBody(req);
+
+    const emailCheck = validateEmail(body?.email);
+    if (!emailCheck.ok) return json(res, 400, { error: 'invalid_email', field: 'email', message: emailCheck.error });
+
+    const passwordCheck = validatePassword(body?.password);
+    if (!passwordCheck.ok) return json(res, 400, { error: 'weak_password', field: 'password', message: passwordCheck.error });
+
+    const nameCheck = validateName(body?.name);
+    if (!nameCheck.ok) return json(res, 400, { error: 'invalid_name', field: 'name', message: nameCheck.error });
+
+    const passwordHash = hashPassword(passwordCheck.value);
+
+    let user;
+    try {
+      user = await createEmailUser({
+        email: emailCheck.value,
+        name: nameCheck.value,
+        passwordHash,
+      });
+    } catch (error) {
+      if (error instanceof EmailInUseError) {
+        return json(res, 409, { error: 'email_in_use', field: 'email' });
+      }
+      throw error;
+    }
+
+    await issueSessionForUser(req, res, user);
+    return json(res, 201, { user: toPublicUser(user) });
+  } catch (error) {
+    console.error('[Signup failed]', error);
+    return json(res, 500, { error: 'signup_failed' });
+  }
+}

--- a/api/session.js
+++ b/api/session.js
@@ -1,6 +1,10 @@
-import { runMongoAction } from './_lib/db.js';
 import { json, methodNotAllowed } from './_lib/response.js';
 import { parseSessionCookie, verifySessionToken } from './_lib/session.js';
+import {
+  findUserByUserId,
+  findUserByLinkedinId,
+  toPublicUser,
+} from './_lib/users.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return methodNotAllowed(res);
@@ -8,16 +12,20 @@ export default async function handler(req, res) {
   try {
     const token = parseSessionCookie(req);
     const claims = verifySessionToken(token);
-    if (!claims?.recruiterId) return json(res, 200, { authenticated: false });
+    if (!claims) return json(res, 200, { authenticated: false });
 
-    const result = await runMongoAction('findOne', {
-      collection: 'recruiters',
-      filter: { linkedinId: claims.recruiterId },
-      projection: { _id: 0, linkedinId: 1, name: 1, profileUrl: 1, headline: 1, company: 1, avatarUrl: 1, email: 1, lastActiveAt: 1 },
-    });
+    // New tokens carry `userId`; legacy tokens only have `recruiterId` which
+    // was the LinkedIn sub. Try the new path first, fall back to legacy.
+    let user = null;
+    if (claims.userId) {
+      user = await findUserByUserId(claims.userId);
+    }
+    if (!user && claims.recruiterId) {
+      user = await findUserByLinkedinId(claims.recruiterId);
+    }
 
-    if (!result.document) return json(res, 200, { authenticated: false });
-    return json(res, 200, { authenticated: true, user: result.document });
+    if (!user) return json(res, 200, { authenticated: false });
+    return json(res, 200, { authenticated: true, user: toPublicUser(user) });
   } catch (error) {
     console.error('[Session fetch failed]', error);
     return json(res, 500, { authenticated: false, error: 'Failed to get session.' });

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,185 @@
+# Authentication
+
+Synapse supports four ways to sign in:
+
+| Provider | Flow | Notes |
+|---|---|---|
+| Email + password | `POST /api/auth/signup` / `POST /api/auth/login` | Password hashed with scrypt. |
+| Google | `GET /api/auth/google` → callback | OIDC userinfo. Email auto-verified. |
+| GitHub | `GET /api/auth/github` → callback | Primary verified email from `/user/emails`. |
+| LinkedIn | `GET /api/auth/linkedin` → callback | OIDC userinfo. Email auto-verified. |
+
+All four issue the same `synapse_session` HttpOnly cookie (30-day max-age,
+HMAC-SHA256 signed). `GET /api/session` reads the cookie and returns the
+canonical user record.
+
+## User record (`recruiters` collection)
+
+The collection name is retained from the LinkedIn-only era. New documents use
+these fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `userId` | string (UUID) | Primary identifier, stable across providers. |
+| `authProvider` | `'linkedin' \| 'email' \| 'google' \| 'github'` | Set on every record. |
+| `providerUserId` | string | LinkedIn `sub`, Google `sub`, GitHub `id`, or email address. |
+| `email` | string \| null | Always lowercased on write. |
+| `emailVerified` | boolean | `true` for OIDC providers, `false` for email signups. |
+| `passwordHash` | string \| null | `scrypt$<saltB64url>$<hashB64url>`. Only for `authProvider='email'`. |
+| `name`, `avatarUrl`, `profileUrl`, `headline`, `company` | | Unchanged. |
+| `linkedinId` | string | Retained on LinkedIn records for back-compat reads. |
+| `createdAt`, `firstLoginAt`, `lastActiveAt`, `updatedAt`, `loginCount` | | Unchanged. |
+
+### Recommended indexes
+
+```js
+db.recruiters.createIndex({ userId: 1 }, { unique: true });
+db.recruiters.createIndex(
+  { email: 1, authProvider: 1 },
+  { unique: true, partialFilterExpression: { email: { $type: 'string' } } }
+);
+```
+
+### One-time migration for existing LinkedIn records
+
+If you already have LinkedIn users in `recruiters`, run:
+
+```js
+db.recruiters.find({ userId: { $exists: false } }).forEach((doc) => {
+  db.recruiters.updateOne(
+    { _id: doc._id },
+    {
+      $set: {
+        userId: doc.linkedinId,
+        providerUserId: doc.linkedinId,
+        emailVerified: true,
+      },
+    }
+  );
+});
+```
+
+A read-only version of this lives in `scripts/migrate-recruiters-to-users.mjs`.
+Session tokens issued before the migration still resolve because
+`/api/session` falls back to `linkedinId` lookup when `userId` is absent from
+the token claims.
+
+## Session token
+
+HMAC-SHA256 over a base64url-encoded JSON payload. Current claim shape:
+
+```json
+{
+  "userId": "…uuid…",
+  "authProvider": "google",
+  "name": "Alex Example",
+  "email": "alex@example.com",
+  "avatarUrl": "https://…",
+  "profileUrl": null,
+  "issuedAt": 1712345678901,
+  "recruiterId": "…uuid or linkedinId…"
+}
+```
+
+`recruiterId` is preserved so legacy endpoints (`/api/activity`,
+`/api/admin/recruiters`) keep working.
+
+## Environment variables
+
+```bash
+# Session signing (required for all providers)
+SESSION_SECRET=change-me
+
+# MongoDB Data API (required)
+MONGODB_DATA_API_URL=
+MONGODB_DATA_API_KEY=
+MONGODB_DATA_SOURCE=
+MONGODB_DB_NAME=synapse
+
+# LinkedIn (optional)
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+LINKEDIN_REDIRECT_URI=   # optional; defaults to ${baseUrl}/api/auth/linkedin/callback
+
+# Google (optional)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=     # optional; defaults to ${baseUrl}/api/auth/google/callback
+
+# GitHub (optional)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_REDIRECT_URI=     # optional; defaults to ${baseUrl}/api/auth/github/callback
+
+# Admin dashboard
+ADMIN_DASHBOARD_KEY=
+```
+
+Add each OAuth app's redirect URI exactly as shown above to the provider's
+developer console:
+
+- Google Cloud Console → Credentials → OAuth 2.0 Client ID → Authorized
+  redirect URIs
+- GitHub → Settings → Developer settings → OAuth Apps → Authorization
+  callback URL
+- LinkedIn Developer Portal → App → Auth → Redirect URLs
+
+## Account-linking policy
+
+If a user signs up with email `alex@example.com` and later tries to sign in
+with Google using the same address, the callback **rejects** the attempt and
+redirects to `/?auth_error=email_in_use_other_provider`. The same applies to
+every cross-provider combination. Each email may only exist under one
+provider at a time.
+
+Automatic linking is intentionally out of scope — it requires careful
+trust-on-verification logic (only linking when the *new* provider asserts the
+email is verified) and dedicated UX affordances (e.g. "we found an existing
+account for alex@… — sign in first to link Google to it"). We'll add it in a
+follow-up PR.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/auth/signup` | Create email user, set session, return user. |
+| `POST` | `/api/auth/login` | Verify email password, set session, return user. |
+| `POST` | `/api/auth/logout` | Clear session cookie. |
+| `GET`  | `/api/auth/google` | Begin Google OAuth redirect. |
+| `GET`  | `/api/auth/google/callback` | Exchange code, upsert user, set session. |
+| `GET`  | `/api/auth/github` | Begin GitHub OAuth redirect. |
+| `GET`  | `/api/auth/github/callback` | Exchange code, upsert user, set session. |
+| `GET`  | `/api/auth/linkedin` | Begin LinkedIn OAuth redirect. |
+| `GET`  | `/api/auth/linkedin/callback` | Exchange code, upsert user, set session. |
+| `GET`  | `/api/session` | Return the current session user (or `authenticated: false`). |
+
+## Error codes
+
+Signup and login return `{ error, field?, message? }` on failure:
+
+| Code | Status | Meaning |
+|---|---|---|
+| `invalid_email` | 400 | Malformed or missing email. |
+| `weak_password` | 400 | Shorter than 8 characters. |
+| `invalid_name` | 400 | Missing or too long. |
+| `email_in_use` | 409 | Email already registered (any provider). |
+| `invalid_credentials` | 401 | Email or password mismatch (deliberately generic to avoid enumeration). |
+| `signup_failed` / `login_failed` | 500 | Unexpected server error — check logs. |
+
+OAuth redirects surface errors through the `?auth_error=…` query param on
+`/`. Common codes: `email_in_use_other_provider`, `{provider}_callback_failed`,
+`{provider}_invalid_state`, `{provider}_missing_code`, `{provider}_config`.
+
+## Not included (future work)
+
+- Email verification (new email users are created with `emailVerified: false`;
+  nothing currently enforces verification).
+- Password reset / "Forgot password?" flow (the UI affordance exists but is
+  disabled).
+- Account linking (see policy above).
+- Two-factor authentication.
+- Rate limiting on signup/login (Vercel has no built-in limiter; consider
+  Upstash Ratelimit).
+- The `/admin/recruiters` dashboard still filters via `linkedinId` and only
+  surfaces LinkedIn-provider users; email/Google/GitHub users will show up as
+  separate records once the projection is generalized.

--- a/docs/linkedin-auth.md
+++ b/docs/linkedin-auth.md
@@ -1,5 +1,9 @@
 # LinkedIn recruiter auth and follow-up pipeline
 
+> See [`docs/auth.md`](auth.md) for the complete multi-provider auth overview
+> (email/password, Google, GitHub, LinkedIn). This document covers only the
+> LinkedIn-specific setup and the recruiter capture pipeline.
+
 ## What data Synapse collects
 
 After a recruiter signs in with LinkedIn, Synapse stores:

--- a/scripts/migrate-recruiters-to-users.mjs
+++ b/scripts/migrate-recruiters-to-users.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * One-shot migration: backfill multi-provider fields on existing LinkedIn
+ * recruiter records so they work under the new `userId`-based auth system.
+ *
+ * Safe to re-run — the update is a no-op for already-migrated documents
+ * (records where `userId` is already set are skipped).
+ *
+ * Usage:
+ *   MONGODB_DATA_API_URL=... MONGODB_DATA_API_KEY=... \
+ *   MONGODB_DATA_SOURCE=... MONGODB_DB_NAME=synapse \
+ *   node scripts/migrate-recruiters-to-users.mjs [--dry-run]
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const {
+  MONGODB_DATA_API_URL,
+  MONGODB_DATA_API_KEY,
+  MONGODB_DATA_SOURCE,
+  MONGODB_DB_NAME = 'synapse',
+} = process.env;
+
+if (!MONGODB_DATA_API_URL || !MONGODB_DATA_API_KEY || !MONGODB_DATA_SOURCE) {
+  console.error(
+    'Missing MongoDB Data API env vars. Set MONGODB_DATA_API_URL, MONGODB_DATA_API_KEY, MONGODB_DATA_SOURCE.'
+  );
+  process.exit(1);
+}
+
+async function runMongoAction(action, payload) {
+  const response = await fetch(`${MONGODB_DATA_API_URL}/action/${action}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/ejson',
+      'api-key': MONGODB_DATA_API_KEY,
+    },
+    body: JSON.stringify({
+      dataSource: MONGODB_DATA_SOURCE,
+      database: MONGODB_DB_NAME,
+      ...payload,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Mongo ${action} failed (${response.status}): ${body}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  console.log(`[migrate] Scanning recruiters collection${DRY_RUN ? ' (dry-run)' : ''}…`);
+
+  const { documents: legacy = [] } = await runMongoAction('find', {
+    collection: 'recruiters',
+    filter: { userId: { $exists: false }, linkedinId: { $exists: true } },
+    projection: { _id: 0, linkedinId: 1, email: 1, name: 1 },
+    limit: 10000,
+  });
+
+  console.log(`[migrate] Found ${legacy.length} legacy LinkedIn records to migrate.`);
+  if (legacy.length === 0) {
+    console.log('[migrate] Nothing to do. Exiting.');
+    return;
+  }
+
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const doc of legacy) {
+    if (!doc.linkedinId) {
+      skipped += 1;
+      continue;
+    }
+    if (DRY_RUN) {
+      console.log(`[migrate] would update linkedinId=${doc.linkedinId} (${doc.email || 'no email'})`);
+      migrated += 1;
+      continue;
+    }
+
+    await runMongoAction('updateOne', {
+      collection: 'recruiters',
+      filter: { linkedinId: doc.linkedinId, userId: { $exists: false } },
+      update: {
+        $set: {
+          userId: doc.linkedinId,
+          authProvider: 'linkedin',
+          providerUserId: doc.linkedinId,
+          emailVerified: true,
+        },
+      },
+    });
+    migrated += 1;
+  }
+
+  console.log(
+    `[migrate] Done. Migrated: ${migrated}, skipped: ${skipped}${DRY_RUN ? ' (dry-run — nothing written)' : ''}.`
+  );
+  console.log(
+    '[migrate] Next: create unique indexes (see docs/auth.md → "Recommended indexes").'
+  );
+}
+
+main().catch((error) => {
+  console.error('[migrate] Failed:', error);
+  process.exit(1);
+});

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,17 +1,137 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Mail, Lock, Linkedin } from 'lucide-react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Github, Linkedin, Loader2, Lock, Mail, User as UserIcon } from 'lucide-react';
+import { useAuthStore } from '../store/authStore';
 
 type Tab = 'signin' | 'signup';
+type FieldName = 'email' | 'password' | 'name';
+
+const ERROR_COPY: Record<string, string> = {
+    email_in_use: 'An account with this email already exists.',
+    email_in_use_other_provider: 'This email is already registered with a different sign-in method.',
+    invalid_credentials: 'Email or password is incorrect.',
+    invalid_email: 'Please enter a valid email address.',
+    weak_password: 'Password must be at least 8 characters.',
+    invalid_name: 'Please enter your name.',
+    network_error: 'Network error. Please try again.',
+    signup_failed: 'Something went wrong creating your account. Please try again.',
+    login_failed: 'Something went wrong signing you in. Please try again.',
+    linkedin_callback_failed: 'LinkedIn sign-in failed. Please try again.',
+    linkedin_config: 'LinkedIn sign-in is not configured.',
+    linkedin_missing_code: 'LinkedIn sign-in was cancelled.',
+    linkedin_invalid_state: 'LinkedIn sign-in failed a security check.',
+    google_callback_failed: 'Google sign-in failed. Please try again.',
+    google_config: 'Google sign-in is not configured.',
+    google_missing_code: 'Google sign-in was cancelled.',
+    google_invalid_state: 'Google sign-in failed a security check.',
+    github_callback_failed: 'GitHub sign-in failed. Please try again.',
+    github_config: 'GitHub sign-in is not configured.',
+    github_missing_code: 'GitHub sign-in was cancelled.',
+    github_invalid_state: 'GitHub sign-in failed a security check.',
+};
+
+function friendlyError(code: string | undefined, message?: string): string {
+    if (!code) return message || 'Something went wrong. Please try again.';
+    return ERROR_COPY[code] || message || 'Something went wrong. Please try again.';
+}
+
+function GoogleIcon({ size = 16 }: { size?: number }) {
+    // Google "G" logo (brand colors). Inline SVG — lucide-react ships only a
+    // monochrome Chrome glyph, and we want the recognizable multi-color mark.
+    return (
+        <svg width={size} height={size} viewBox="0 0 48 48" aria-hidden="true">
+            <path
+                fill="#EA4335"
+                d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+            />
+            <path
+                fill="#4285F4"
+                d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+            />
+            <path
+                fill="#FBBC05"
+                d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+            />
+            <path
+                fill="#34A853"
+                d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+            />
+        </svg>
+    );
+}
 
 export function LoginPage() {
     const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const loginAction = useAuthStore((s) => s.loginWithEmail);
+    const signupAction = useAuthStore((s) => s.signupWithEmail);
+
     const [tab, setTab] = useState<Tab>('signin');
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [name, setName] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [banner, setBanner] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Partial<Record<FieldName, string>>>({});
+
+    // Surface auth errors passed back from OAuth redirects via `?auth_error=...`.
+    useEffect(() => {
+        const code = searchParams.get('auth_error');
+        if (code) {
+            setBanner(friendlyError(code));
+            const next = new URLSearchParams(searchParams);
+            next.delete('auth_error');
+            next.delete('auth');
+            setSearchParams(next, { replace: true });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const primaryLabel = tab === 'signin' ? 'Sign In' : 'Sign Up';
-    const comingSoonTitle = 'Email/password sign-in is coming soon — use LinkedIn for now';
+
+    const disabled = useMemo(() => submitting, [submitting]);
+
+    function clearErrors() {
+        setBanner(null);
+        setFieldErrors({});
+    }
+
+    function validateClient(): boolean {
+        const errors: Partial<Record<FieldName, string>> = {};
+        const trimmedEmail = email.trim();
+        if (!trimmedEmail) errors.email = 'Email is required.';
+        else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) errors.email = 'Please enter a valid email address.';
+        if (!password) errors.password = 'Password is required.';
+        else if (tab === 'signup' && password.length < 8) errors.password = 'Password must be at least 8 characters.';
+        if (tab === 'signup' && !name.trim()) errors.name = 'Name is required.';
+        setFieldErrors(errors);
+        return Object.keys(errors).length === 0;
+    }
+
+    async function handleSubmit(event: FormEvent) {
+        event.preventDefault();
+        clearErrors();
+        if (!validateClient()) return;
+
+        setSubmitting(true);
+        const result =
+            tab === 'signin'
+                ? await loginAction(email.trim(), password)
+                : await signupAction(email.trim(), password, name.trim());
+        setSubmitting(false);
+
+        if (!result.ok) {
+            if (result.field) {
+                setFieldErrors({ [result.field]: friendlyError(result.error, result.message) });
+            } else {
+                setBanner(friendlyError(result.error, result.message));
+            }
+            return;
+        }
+
+        // On success, `HomeRoute` will switch to HomePage automatically because
+        // the auth store now has a user.
+    }
 
     return (
         <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-neutral-900">
@@ -26,12 +146,19 @@ export function LoginPage() {
                 </div>
 
                 {/* Login card */}
-                <div className="rounded-3xl bg-neutral-900/80 backdrop-blur-xl border border-white/10 p-6 space-y-5">
+                <form
+                    onSubmit={handleSubmit}
+                    className="rounded-3xl bg-neutral-900/80 backdrop-blur-xl border border-white/10 p-6 space-y-5"
+                    noValidate
+                >
                     {/* Sign In / Sign Up tabs */}
                     <div className="grid grid-cols-2 gap-1 p-1 rounded-xl bg-black/40 border border-white/10">
                         <button
                             type="button"
-                            onClick={() => setTab('signin')}
+                            onClick={() => {
+                                setTab('signin');
+                                clearErrors();
+                            }}
                             className={`py-2 rounded-lg text-sm font-medium transition ${
                                 tab === 'signin'
                                     ? 'bg-white/10 text-white'
@@ -42,7 +169,10 @@ export function LoginPage() {
                         </button>
                         <button
                             type="button"
-                            onClick={() => setTab('signup')}
+                            onClick={() => {
+                                setTab('signup');
+                                clearErrors();
+                            }}
                             className={`py-2 rounded-lg text-sm font-medium transition ${
                                 tab === 'signup'
                                     ? 'bg-white/10 text-white'
@@ -53,55 +183,111 @@ export function LoginPage() {
                         </button>
                     </div>
 
+                    {/* Error banner */}
+                    {banner && (
+                        <div
+                            role="alert"
+                            aria-live="polite"
+                            className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+                        >
+                            {banner}
+                        </div>
+                    )}
+
+                    {/* Name (sign-up only) */}
+                    {tab === 'signup' && (
+                        <div>
+                            <div className="relative">
+                                <UserIcon
+                                    size={16}
+                                    className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+                                />
+                                <input
+                                    type="text"
+                                    value={name}
+                                    onChange={(e) => setName(e.target.value)}
+                                    placeholder="Name"
+                                    autoComplete="name"
+                                    className={`w-full bg-black/40 border rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 transition ${
+                                        fieldErrors.name
+                                            ? 'border-red-500/60 focus:ring-red-500/40 focus:border-red-500/60'
+                                            : 'border-white/10 focus:ring-indigo-500/50 focus:border-indigo-500/50'
+                                    }`}
+                                />
+                            </div>
+                            {fieldErrors.name && (
+                                <p className="mt-1.5 text-xs text-red-300">{fieldErrors.name}</p>
+                            )}
+                        </div>
+                    )}
+
                     {/* Email */}
-                    <div className="relative">
-                        <Mail
-                            size={16}
-                            className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
-                        />
-                        <input
-                            type="email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder="Email"
-                            className="w-full bg-black/40 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500/50 transition"
-                            autoComplete="email"
-                        />
+                    <div>
+                        <div className="relative">
+                            <Mail
+                                size={16}
+                                className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+                            />
+                            <input
+                                type="email"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                placeholder="Email"
+                                autoComplete="email"
+                                className={`w-full bg-black/40 border rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 transition ${
+                                    fieldErrors.email
+                                        ? 'border-red-500/60 focus:ring-red-500/40 focus:border-red-500/60'
+                                        : 'border-white/10 focus:ring-indigo-500/50 focus:border-indigo-500/50'
+                                }`}
+                            />
+                        </div>
+                        {fieldErrors.email && (
+                            <p className="mt-1.5 text-xs text-red-300">{fieldErrors.email}</p>
+                        )}
                     </div>
 
                     {/* Password */}
-                    <div className="relative">
-                        <Lock
-                            size={16}
-                            className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
-                        />
-                        <input
-                            type="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="Password"
-                            className="w-full bg-black/40 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500/50 transition"
-                            autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
-                        />
+                    <div>
+                        <div className="relative">
+                            <Lock
+                                size={16}
+                                className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+                            />
+                            <input
+                                type="password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                placeholder="Password"
+                                autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
+                                className={`w-full bg-black/40 border rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 transition ${
+                                    fieldErrors.password
+                                        ? 'border-red-500/60 focus:ring-red-500/40 focus:border-red-500/60'
+                                        : 'border-white/10 focus:ring-indigo-500/50 focus:border-indigo-500/50'
+                                }`}
+                            />
+                        </div>
+                        {fieldErrors.password && (
+                            <p className="mt-1.5 text-xs text-red-300">{fieldErrors.password}</p>
+                        )}
                     </div>
 
-                    {/* Primary button (disabled stub) */}
+                    {/* Primary button */}
                     <button
-                        type="button"
-                        disabled
-                        title={comingSoonTitle}
-                        className="w-full py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed font-semibold text-white transition"
+                        type="submit"
+                        disabled={disabled}
+                        className="w-full py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-60 disabled:cursor-not-allowed font-semibold text-white transition inline-flex items-center justify-center gap-2"
                     >
+                        {submitting && <Loader2 size={16} className="animate-spin" />}
                         {primaryLabel}
                     </button>
 
-                    {/* Forgot password */}
+                    {/* Forgot password (intentionally disabled — future work) */}
                     {tab === 'signin' && (
                         <div className="flex justify-end">
                             <button
                                 type="button"
                                 disabled
-                                title={comingSoonTitle}
+                                title="Password reset is coming soon"
                                 className="text-xs text-neutral-400 disabled:cursor-not-allowed hover:text-indigo-300 transition"
                             >
                                 Forgot password?
@@ -116,6 +302,24 @@ export function LoginPage() {
                         <div className="flex-1 h-px bg-white/10" />
                     </div>
 
+                    {/* Google */}
+                    <a
+                        href="/api/auth/google"
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-white/10 bg-white text-neutral-800 hover:bg-neutral-100 transition text-sm font-medium"
+                    >
+                        <GoogleIcon size={16} />
+                        Continue with Google
+                    </a>
+
+                    {/* GitHub */}
+                    <a
+                        href="/api/auth/github"
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-white/10 bg-neutral-800 text-white hover:bg-neutral-700 transition text-sm font-medium"
+                    >
+                        <Github size={16} />
+                        Continue with GitHub
+                    </a>
+
                     {/* LinkedIn */}
                     <a
                         href="/api/auth/linkedin"
@@ -124,7 +328,7 @@ export function LoginPage() {
                         <Linkedin size={16} />
                         Continue with LinkedIn
                     </a>
-                </div>
+                </form>
 
                 {/* Below-card actions */}
                 <div className="mt-6 flex flex-col items-center gap-2">

--- a/src/lib/recruiterApi.ts
+++ b/src/lib/recruiterApi.ts
@@ -1,13 +1,22 @@
+export type AuthProvider = 'linkedin' | 'email' | 'google' | 'github';
+
 export type RecruiterUser = {
-  linkedinId: string;
+  userId?: string;
+  authProvider?: AuthProvider;
+  /** Retained for legacy LinkedIn records; prefer `userId` for new code. */
+  linkedinId?: string;
   name: string;
   profileUrl: string | null;
   headline: string;
   company: string | null;
   avatarUrl: string | null;
   email?: string | null;
+  emailVerified?: boolean;
   lastActiveAt?: string;
 };
+
+/** Forward-looking alias — favor `User` in new code. */
+export type User = RecruiterUser;
 
 export type RecruiterDashboardItem = RecruiterUser & {
   sessions: number;
@@ -16,9 +25,90 @@ export type RecruiterDashboardItem = RecruiterUser & {
   clickedSections: number;
 };
 
+export type AuthResult =
+  | { ok: true; user: User }
+  | { ok: false; error: string; field?: 'email' | 'password' | 'name'; message?: string };
+
 export async function fetchSession() {
   const response = await fetch('/api/session', { credentials: 'include' });
   return response.json();
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<{ status: number; data: T }> {
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  let data: unknown = null;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+  return { status: response.status, data: data as T };
+}
+
+export async function signupWithEmail(payload: {
+  email: string;
+  password: string;
+  name: string;
+}): Promise<AuthResult> {
+  try {
+    const { status, data } = await postJson<{
+      user?: User;
+      error?: string;
+      field?: 'email' | 'password' | 'name';
+      message?: string;
+    }>('/api/auth/signup', payload);
+
+    if (status >= 200 && status < 300 && data?.user) {
+      return { ok: true, user: data.user };
+    }
+    return {
+      ok: false,
+      error: data?.error || 'signup_failed',
+      field: data?.field,
+      message: data?.message,
+    };
+  } catch {
+    return { ok: false, error: 'network_error' };
+  }
+}
+
+export async function loginWithEmail(payload: {
+  email: string;
+  password: string;
+}): Promise<AuthResult> {
+  try {
+    const { status, data } = await postJson<{
+      user?: User;
+      error?: string;
+      field?: 'email' | 'password' | 'name';
+      message?: string;
+    }>('/api/auth/login', payload);
+
+    if (status >= 200 && status < 300 && data?.user) {
+      return { ok: true, user: data.user };
+    }
+    return {
+      ok: false,
+      error: data?.error || 'invalid_credentials',
+      field: data?.field,
+      message: data?.message,
+    };
+  } catch {
+    return { ok: false, error: 'network_error' };
+  }
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+  } catch {
+    // swallow; the client store will be cleared by the caller
+  }
 }
 
 export async function trackActivity(type: string, metadata: Record<string, unknown> = {}) {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,11 +1,19 @@
 import { create } from 'zustand';
-import type { RecruiterUser } from '../lib/recruiterApi';
-import { fetchSession } from '../lib/recruiterApi';
+import type { AuthResult, RecruiterUser } from '../lib/recruiterApi';
+import {
+  fetchSession,
+  loginWithEmail,
+  logout as logoutRequest,
+  signupWithEmail,
+} from '../lib/recruiterApi';
 
 type AuthState = {
   user: RecruiterUser | null;
   loading: boolean;
   refreshSession: () => Promise<void>;
+  loginWithEmail: (email: string, password: string) => Promise<AuthResult>;
+  signupWithEmail: (email: string, password: string, name: string) => Promise<AuthResult>;
+  logout: () => Promise<void>;
 };
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -19,5 +27,23 @@ export const useAuthStore = create<AuthState>((set) => ({
     } catch {
       set({ user: null, loading: false });
     }
+  },
+  loginWithEmail: async (email, password) => {
+    const result = await loginWithEmail({ email, password });
+    if (result.ok) {
+      set({ user: result.user, loading: false });
+    }
+    return result;
+  },
+  signupWithEmail: async (email, password, name) => {
+    const result = await signupWithEmail({ email, password, name });
+    if (result.ok) {
+      set({ user: result.user, loading: false });
+    }
+    return result;
+  },
+  logout: async () => {
+    await logoutRequest();
+    set({ user: null, loading: false });
   },
 }));


### PR DESCRIPTION
The LoginPage's email/password form was a stub and Google/GitHub weren't
offered at all. Add the backend endpoints and OAuth flows, generalize the
user record to support multiple providers while staying compatible with
existing LinkedIn sessions, and wire the form to it.

- api/auth/signup + login: scrypt-hashed passwords (zero-dep via Node
  crypto), shared validators, 8-char minimum, generic invalid_credentials
  on mismatch to avoid user enumeration.
- api/auth/google + github: mirror the LinkedIn OAuth pattern; extract
  handleOAuthCallback helper so LinkedIn uses the same flow.
- api/_lib/users: userId-keyed repo with upsertOAuthUser,
  createEmailUser, and issueSessionForUser. Rejects cross-provider email
  collisions (EmailInUseByOtherProviderError) — no auto-linking.
- api/session: reads new userId claim; falls back to linkedinId so
  pre-migration session tokens still resolve.
- LoginPage: submit handler, inline field errors, banner, loading
  spinner, Google + GitHub buttons, surfaces ?auth_error= from OAuth
  redirects.
- docs/auth.md + migration script for existing LinkedIn records.

https://claude.ai/code/session_01CVRmh33Ldyg3GHjoP2WjvK