### PR TITLE
fix(login): tighten layout, surface tagline, promote demo actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Synapse is an AI-native product definition environment that transforms PRDs (Product Requirements Documents) into a dynamic pipeline: structured PRD generation, UI mockups, downstream artifacts, and visual annotations. It is a fully client-side React SPA with no backend database — all state persists in localStorage via Zustand.
+Synapse — "From plain-language to product blueprint" — is an AI-native product definition environment that transforms PRDs (Product Requirements Documents) into a dynamic pipeline: structured PRD generation, UI mockups, downstream artifacts, and visual annotations. It is a fully client-side React SPA with no backend database — all state persists in localStorage via Zustand.
 
 ## Commands
 

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -134,15 +134,33 @@ export function LoginPage() {
     }
 
     return (
-        <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-neutral-900">
-            <div className="w-full max-w-md">
-                {/* Logo + name + tagline */}
-                <div className="flex flex-col items-center mb-8">
-                    <img src="/icon.png" alt="Synapse" className="w-14 h-14 mb-4" />
+        <div className="min-h-screen flex flex-col items-center justify-center px-6 py-12 bg-neutral-900">
+            <div className="w-full max-w-sm space-y-6">
+                {/* Name + tagline */}
+                <div className="flex flex-col items-center">
                     <h1 className="text-3xl font-bold tracking-tight text-center">Synapse</h1>
                     <p className="text-sm text-neutral-400 text-center mt-2">
-                        AI-native product definition
+                        From plain-language to product blueprint
                     </p>
+                </div>
+
+                {/* Meet Synapse + Demo actions */}
+                <div className="flex items-center justify-center gap-3">
+                    <button
+                        type="button"
+                        onClick={() => navigate('/about')}
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 text-sm text-indigo-300 hover:border-indigo-400/60 hover:text-indigo-200 transition"
+                    >
+                        Meet Synapse
+                    </button>
+                    <button
+                        type="button"
+                        disabled
+                        title="Coming soon"
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-sm text-neutral-400 cursor-not-allowed"
+                    >
+                        Demo project (coming soon)
+                    </button>
                 </div>
 
                 {/* Login card */}
@@ -329,25 +347,6 @@ export function LoginPage() {
                         Continue with LinkedIn
                     </a>
                 </form>
-
-                {/* Below-card actions */}
-                <div className="mt-6 flex flex-col items-center gap-2">
-                    <button
-                        type="button"
-                        onClick={() => navigate('/about')}
-                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 text-sm text-indigo-300 hover:border-indigo-400/60 hover:text-indigo-200 transition"
-                    >
-                        Meet Synapse
-                    </button>
-                    <button
-                        type="button"
-                        disabled
-                        title="Coming soon"
-                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-sm text-neutral-400 cursor-not-allowed"
-                    >
-                        Demo project (coming soon)
-                    </button>
-                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- Remove redundant icon image from the login screen
- Replace generic "AI-native product definition" line with the official tagline **"From plain-language to product blueprint"** (and document it in `CLAUDE.md`'s Project Overview)
- Move the **Meet Synapse** and **Demo project** buttons above the sign-in card so unauthenticated visitors see them without scrolling
- Narrow container to `max-w-sm` for tighter visual density

## Test plan
- [ ] Visit `/` while signed out — confirm tagline reads "From plain-language to product blueprint" and no logo image renders
- [ ] Confirm Meet Synapse / Demo project pills sit above the sign-in card and center-align
- [ ] Click **Meet Synapse** → navigates to `/about`
- [ ] Sign In / Sign Up tabs, email/password validation, Google/GitHub/LinkedIn buttons still render and function
- [ ] Resize to mobile width — layout stays centered, buttons wrap gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
