### PR TITLE
sec: harden auth, rate limit sensitive endpoints, add security headers

### DIFF
--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,287 @@
+# Security Review — Synapse
+
+**Date:** 2026-04-14
+**Branch:** `claude/security-review-fixes-cHqqN`
+**Scope:** Full-stack review of the Synapse web app (React SPA + Vercel
+serverless functions + MongoDB Data API + Gemini-direct-from-browser).
+
+## Executive summary
+
+Synapse is a mostly-client-side app (all user artifacts live in
+`localStorage`), but it has a thin server-side layer for authentication,
+session management, activity logging, and an admin dashboard. The server
+side is where almost all of the real risk lives.
+
+Overall the codebase was in reasonable shape — scrypt-hashed passwords,
+HttpOnly session cookies, server-signed HMAC tokens, markdown rendered
+without `rehype-raw`, mockup HTML sanitized before being put into a
+sandboxed iframe. That said, I found **two critical issues** (session
+tokens with no effective expiration; unthrottled admin authentication)
+and a cluster of **high-priority gaps** (no rate limiting on
+authentication endpoints, weak activity-endpoint validation, missing
+security headers, unvalidated OAuth-supplied URLs rendered as hrefs).
+All of these have been fixed in this branch.
+
+**Remaining residual risk** is primarily around things that need
+infrastructure that this repo doesn't control (distributed rate
+limiting, rotating the Tailwind CDN script to a self-hosted copy,
+server-side session revocation) — these are documented in the "Manual
+follow-up" section below.
+
+---
+
+## Findings
+
+### Critical
+
+#### C1. Session tokens were valid forever (no expiration check)
+- **Where:** `api/_lib/session.js` → `verifySessionToken`.
+- **Issue:** The HMAC signed an arbitrary JSON payload, and while
+  `issueSessionForUser` stamped an `issuedAt` claim, the verifier never
+  looked at it. The cookie had a 30-day `Max-Age`, but that only
+  controls how long the **browser** keeps the cookie — a token captured
+  out-of-band (e.g. from a compromised machine) was good for the
+  lifetime of `SESSION_SECRET`.
+- **Fix:** Reject any token where `Date.now() - issuedAt > 30 days` (or
+  where `issuedAt` is in the future). `createSessionToken` now stamps
+  `issuedAt` itself so the client can't forge a fresh one. HMAC
+  comparison also switched to `crypto.timingSafeEqual`.
+- **Tests:** `api/_lib/__tests__/session.test.js` covers expiration,
+  tampering, wrong secret, and malformed inputs.
+
+#### C2. Admin dashboard secret was brute-forceable and used non-constant-time compare
+- **Where:** `api/admin/recruiters.js`.
+- **Issue:** The endpoint compared the shared secret with `!==` and had
+  no rate limiting. Combined with the fact that the only protection on
+  the recruiter dump (which includes every registered user's email) was
+  one HTTP header, a weak or misconfigured `ADMIN_DASHBOARD_KEY` could
+  be brute-forced over the public internet.
+- **Fix:**
+  - `crypto.timingSafeEqual` for the header comparison.
+  - Refuse to authenticate if `ADMIN_DASHBOARD_KEY` is unset or shorter
+    than 24 characters (eliminates the "silent empty string accepts
+    empty header" failure mode).
+  - 20-req/min IP-scoped rate limit on the endpoint.
+
+---
+
+### High
+
+#### H1. No rate limiting on auth endpoints
+- **Where:** `api/auth/login.js`, `api/auth/signup.js`, `api/auth/*.js`
+  (OAuth init), `api/activity.js`.
+- **Issue:** Login allowed unlimited password guesses per IP, signup
+  could flood the users table, and the activity endpoint accepted
+  unlimited writes per session. The auth docs explicitly called this
+  out as "future work".
+- **Fix:** Added a lightweight in-memory rate limiter
+  (`api/_lib/rateLimit.js`) and applied it to every sensitive endpoint:
+  - `login`: 10/min per IP + 10/10min per (IP, email) pair
+  - `signup`: 5/10min per IP
+  - `activity`: 120/min per authenticated user
+  - OAuth init routes: 20/min per IP
+  - admin dashboard: 20/min per IP
+- **Caveat:** Vercel serverless functions don't share memory across
+  warm instances, so this limiter is best-effort. See "Manual
+  follow-up" for a proper fix.
+
+#### H2. Activity endpoint accepted arbitrary `type` and `metadata`
+- **Where:** `api/activity.js`.
+- **Issue:** Any authenticated user could push arbitrarily-typed events
+  with arbitrarily-shaped metadata into the `recruiter_activity`
+  collection. No type whitelist, no size cap, no shape check.
+- **Fix:** Whitelist of allowed event types (`generated_artifact`,
+  `viewed_mockups`, `clicked_section`, …); reject metadata that isn't
+  a flat object with primitive values; cap 20 keys, 512 chars per
+  string, 4 KiB serialized.
+
+#### H3. Missing HTTP security headers
+- **Where:** `vercel.json`.
+- **Issue:** The deployed site served no CSP, HSTS, X-Frame-Options,
+  X-Content-Type-Options, Referrer-Policy, or Permissions-Policy.
+- **Fix:** Added all of the above via the `headers` block in
+  `vercel.json`. Key points:
+  - `Content-Security-Policy` restricts scripts to self + the Vercel
+    analytics bundle; `connect-src` to Gemini + Vercel; `frame-src` to
+    `self blob:` (for the "Open in new tab" flow); `frame-ancestors
+    'none'` to stop clickjacking; `object-src 'none'`.
+  - `Strict-Transport-Security` with `max-age=31536000; includeSubDomains`.
+  - `/api/*` gets additional `Cache-Control: no-store` and
+    `Referrer-Policy: no-referrer`.
+
+#### H4. OAuth-supplied URLs were persisted and rendered without protocol validation
+- **Where:** `api/_lib/users.js` (upsertOAuthUser),
+  `src/components/RecruiterAdminPage.tsx` (rendered as `<a href>`).
+- **Issue:** `profileUrl` and `avatarUrl` came straight from an OAuth
+  provider's profile response and were saved to Mongo + rendered as
+  link hrefs with only a React runtime warning between `javascript:`
+  and the DOM. Providers are generally trustworthy, but (a) React's
+  `javascript:` blocking is not guaranteed for every shape and (b)
+  defense in depth is cheap.
+- **Fix:**
+  - Server-side: added `sanitizeExternalUrl` and `sanitizeProviderString`
+    in `api/_lib/users.js`. URLs are stored as `null` unless they parse
+    as `http:` or `https:` and are under 2048 chars. Name/headline/company
+    are control-stripped and length-capped at 512 chars.
+  - Client-side: `RecruiterAdminPage` runs the URL through `safeHttpUrl`
+    and renders a plain "No profile" span when the URL is rejected,
+    rather than falling back to `href="#"`. Added `rel="noopener
+    noreferrer"` (was `noreferrer` only) to the `<a target="_blank">`.
+
+---
+
+### Medium
+
+#### M1. HMAC comparison was not constant-time
+- Covered by the C1 fix — `crypto.timingSafeEqual` now used throughout.
+
+#### M2. Cleared session cookie didn't carry `Secure`
+- **Where:** `api/_lib/session.js` → `clearSessionCookie`.
+- **Fix:** Emit `Secure` on the clear in production so intermediary
+  proxies can't strip it. `SameSite=Lax` retained.
+
+#### M3. External link lacked `noopener`
+- **Where:** `src/components/RecruiterAdminPage.tsx`.
+- **Issue:** `rel="noreferrer"` implies `noopener` in modern browsers
+  but is easy to regress.
+- **Fix:** Explicit `rel="noopener noreferrer"`.
+
+---
+
+### Low
+
+#### L1. `rehype-raw` listed as a dependency but never imported
+- **Observation:** The package is present in `package.json` but never
+  used. It's harmless as long as it stays un-imported; someone adding
+  `rehype-raw` later would reintroduce a large XSS surface because our
+  rendered content includes LLM-generated markdown. Not removed to
+  avoid touching lockfile discipline in this PR — noted as follow-up.
+
+#### L2. Mockup iframe loads Tailwind from `https://cdn.tailwindcss.com`
+- **Observation:** Mockup previews run inside an iframe with
+  `sandbox="allow-scripts"` (no `allow-same-origin`) so the iframe is
+  an opaque origin and can't touch Synapse state. The Tailwind CDN is
+  still a third-party dependency — if it's compromised, malicious JS
+  could execute in the sandboxed iframe. Because of the sandbox, the
+  blast radius is contained. Noted as follow-up: self-host or pin via
+  SRI.
+
+#### L3. ErrorBoundary "Show technical details" reveals stack traces
+- **Observation:** `GlobalErrorBoundary` lets end users toggle into a
+  stack trace. Minor info leak; React stacks don't contain secrets.
+  Left in place — the UX benefit for support outweighs the risk.
+
+---
+
+### Not an issue (verified)
+
+- `npm audit` reports zero vulnerabilities across prod + dev deps.
+- `react-markdown` is used without `rehype-raw`, so raw HTML in
+  LLM-generated markdown is not rendered.
+- Mockup HTML is sanitized (`sanitizeMockupHtmlForPreview` strips
+  `<script>`, `<style>`, inline event handlers, `javascript:`/`data:`
+  URLs) before being wrapped in a sandboxed iframe.
+- The Gemini API key is user-supplied and stays in the user's own
+  `localStorage` — never sent to Synapse's backend. Acceptable by
+  design.
+- No CORS headers are set; the API is same-origin on Vercel.
+- `window.open` in `MockupViewer` already uses
+  `'noopener,noreferrer'`.
+- Password hashing uses Node's built-in `scrypt` with 16-byte random
+  salt and `timingSafeEqual` compare — fine.
+
+---
+
+## What was fixed (files changed)
+
+| File | Change |
+|---|---|
+| `api/_lib/session.js` | Enforce 30-day max session age; constant-time HMAC compare; `Secure` on cleared cookie; server-stamped `issuedAt`. |
+| `api/_lib/rateLimit.js` | **New.** In-memory sliding-window rate limiter. |
+| `api/_lib/users.js` | Added `sanitizeExternalUrl` + `sanitizeProviderString`; applied to every OAuth-profile write and email-signup name. |
+| `api/_lib/__tests__/session.test.js` | **New.** Expiration, tampering, wrong-secret, malformed-input coverage. |
+| `api/_lib/__tests__/rateLimit.test.js` | **New.** Limit boundary, window reset, scope isolation, 429 response. |
+| `api/_lib/__tests__/users.test.js` | **New.** URL scheme rejection, control-char stripping, length caps. |
+| `api/admin/recruiters.js` | Constant-time admin-key compare; reject short/unset keys; rate limit. |
+| `api/auth/login.js` | IP + (IP, email) rate limits. |
+| `api/auth/signup.js` | Per-IP signup rate limit. |
+| `api/auth/github.js` | Per-IP OAuth init rate limit. |
+| `api/auth/google.js` | Per-IP OAuth init rate limit. |
+| `api/auth/linkedin.js` | Per-IP OAuth init rate limit. |
+| `api/activity.js` | Allowlist of event types; size/shape cap on metadata; per-user rate limit. |
+| `src/components/RecruiterAdminPage.tsx` | Client-side URL sanitization; explicit `noopener noreferrer`. |
+| `vercel.json` | CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, API no-store cache. |
+
+**Test results:** `npm run test` → 9 files / 53 tests passing.
+**Lint:** `npm run lint` clean.
+**Build:** `npm run build` succeeds.
+
+---
+
+## Secrets/config to rotate or replace before deploying
+
+- **`SESSION_SECRET`** — if this was ever committed or shared, rotate.
+  Because tokens still verify against the current secret until they
+  hit the new 30-day age cap, rotation is the only way to invalidate
+  pre-existing sessions at once.
+- **`ADMIN_DASHBOARD_KEY`** — must be ≥24 characters after this change
+  or the endpoint will refuse authentication outright. If the current
+  value is shorter, generate a new one with
+  `openssl rand -base64 32`.
+- **`MONGODB_DATA_API_KEY`** — unchanged, but confirm it's scoped to
+  the `synapse` database only.
+- **OAuth client secrets** — not touched in this review. Confirm
+  redirect URIs on each provider match the deployed domain.
+
+---
+
+## Manual follow-up (recommended next steps for production hardening)
+
+1. **Distributed rate limiting.** The in-memory limiter added here is
+   best-effort; swap it for Upstash Ratelimit, Vercel KV, or a Redis
+   store. The `enforceRateLimit`/`rateLimit` API was designed to allow
+   a drop-in replacement.
+2. **Server-side session revocation.** Tokens are signed JWT-style;
+   there's no revocation list, so "logout" only clears the cookie on
+   the current device. Consider (a) storing a session ID in the token
+   and tracking active sessions in Mongo, or (b) shortening
+   `MAX_SESSION_AGE_MS` in `session.js`. Password-change events should
+   force session rotation via `SESSION_SECRET` rotation.
+3. **Self-host or SRI-pin the Tailwind CDN** used in mockup iframes
+   (`src/components/mockups/buildMockupSrcDoc.ts`).
+4. **Drop the unused `rehype-raw` dep** (`package.json`) to avoid
+   accidental future use.
+5. **Email verification & password reset flow** — noted as TODO in
+   `docs/auth.md`; neither is wired up today.
+6. **Mongo unique indexes** — the auth docs describe the recommended
+   indexes (`userId`, `(email, authProvider)`). Make sure those exist
+   in production to prevent duplicate-account races at the DB level.
+7. **`/admin/recruiters` projection still reads `linkedinId`.** The
+   dashboard will under-report non-LinkedIn users until the projection
+   is generalized to `userId`/`authProvider`. Not a security issue
+   (the data is still correct), but it's inconsistent with the
+   migration that's already happened.
+8. **Add authenticated-user audit log** for admin accesses once you
+   outgrow the single shared-key model. A real admin role on the user
+   document is a better long-term fit than an environment variable
+   secret.
+9. **Consider stricter `SameSite=Strict`** on the session cookie for
+   top-level navigations if you don't need third-party-initiated sign
+   in flows to carry the cookie back on first navigation.
+10. **Origin-header check** on state-changing POST endpoints
+    (`/api/auth/login`, `/api/auth/signup`, `/api/auth/logout`,
+    `/api/activity`) for defense-in-depth against CSRF on top of
+    `SameSite=Lax`.
+
+---
+
+## Top risks at a glance
+
+1. **Hard session expiration** now enforced server-side (was silently
+   absent).
+2. **Admin dashboard brute-forceable** — fixed with rate limit,
+   constant-time compare, and a minimum key length.
+3. **Unthrottled auth endpoints** — fixed with per-IP and per-user
+   rate limits.
+4. **Missing security headers** — fixed in `vercel.json`.
+5. **Distributed rate limiting** remains a manual infra follow-up.

--- a/api/_lib/__tests__/rateLimit.test.js
+++ b/api/_lib/__tests__/rateLimit.test.js
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetRateLimitForTests,
+  enforceRateLimit,
+  getClientKey,
+  rateLimit,
+} from '../rateLimit.js';
+
+describe('rateLimit', () => {
+  afterEach(() => {
+    __resetRateLimitForTests();
+    vi.useRealTimers();
+  });
+
+  it('allows up to `limit` hits and denies after that', () => {
+    for (let i = 0; i < 3; i += 1) {
+      const result = rateLimit('k', 3, 1000);
+      expect(result.allowed).toBe(true);
+    }
+    const over = rateLimit('k', 3, 1000);
+    expect(over.allowed).toBe(false);
+    expect(over.remaining).toBe(0);
+  });
+
+  it('resets after the window elapses', () => {
+    vi.useFakeTimers();
+    for (let i = 0; i < 3; i += 1) rateLimit('k', 3, 1000);
+    expect(rateLimit('k', 3, 1000).allowed).toBe(false);
+    vi.setSystemTime(Date.now() + 1500);
+    expect(rateLimit('k', 3, 1000).allowed).toBe(true);
+  });
+
+  it('tracks keys independently', () => {
+    rateLimit('a', 1, 1000);
+    expect(rateLimit('a', 1, 1000).allowed).toBe(false);
+    expect(rateLimit('b', 1, 1000).allowed).toBe(true);
+  });
+});
+
+describe('getClientKey', () => {
+  it('prefers the leftmost x-forwarded-for entry', () => {
+    const key = getClientKey({
+      headers: { 'x-forwarded-for': '203.0.113.1, 10.0.0.1, 10.0.0.2' },
+      socket: { remoteAddress: '10.0.0.99' },
+    });
+    expect(key).toBe('203.0.113.1');
+  });
+
+  it('falls back to socket address when no xff is present', () => {
+    expect(getClientKey({ headers: {}, socket: { remoteAddress: '192.0.2.5' } }))
+      .toBe('192.0.2.5');
+  });
+
+  it('returns "unknown" when there is nothing to key on', () => {
+    expect(getClientKey({ headers: {}, socket: {} })).toBe('unknown');
+  });
+});
+
+describe('enforceRateLimit', () => {
+  function makeRes() {
+    const headers = {};
+    let status = 200;
+    let body = null;
+    return {
+      headers,
+      getStatus: () => status,
+      getBody: () => body,
+      setHeader(key, value) { headers[key] = value; return this; },
+      status(code) { status = code; return this; },
+      send(payload) { body = payload; return this; },
+    };
+  }
+
+  it('returns true and writes 429 when over the limit', () => {
+    const req = { headers: { 'x-forwarded-for': '198.51.100.1' }, socket: {} };
+    const limit = 2;
+    for (let i = 0; i < limit; i += 1) {
+      const res = makeRes();
+      const bailed = enforceRateLimit(req, res, { scope: 'test', limit, windowMs: 1000 });
+      expect(bailed).toBe(false);
+    }
+    const res = makeRes();
+    const bailed = enforceRateLimit(req, res, { scope: 'test', limit, windowMs: 1000 });
+    expect(bailed).toBe(true);
+    expect(res.getStatus()).toBe(429);
+    expect(res.headers['Retry-After']).toBeDefined();
+  });
+
+  it('scopes are independent', () => {
+    const req = { headers: { 'x-forwarded-for': '198.51.100.2' }, socket: {} };
+    const res1 = makeRes();
+    expect(enforceRateLimit(req, res1, { scope: 'a', limit: 1, windowMs: 1000 })).toBe(false);
+    const res2 = makeRes();
+    expect(enforceRateLimit(req, res2, { scope: 'b', limit: 1, windowMs: 1000 })).toBe(false);
+  });
+});

--- a/api/_lib/__tests__/session.test.js
+++ b/api/_lib/__tests__/session.test.js
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSessionToken,
+  parseSessionCookie,
+  verifySessionToken,
+} from '../session.js';
+
+// 30 days in ms — must match MAX_SESSION_AGE_MS in session.js.
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+describe('session token', () => {
+  const originalSecret = process.env.SESSION_SECRET;
+
+  beforeEach(() => {
+    process.env.SESSION_SECRET = 'test-secret-do-not-use-in-prod';
+  });
+
+  afterEach(() => {
+    process.env.SESSION_SECRET = originalSecret;
+    vi.useRealTimers();
+  });
+
+  it('round-trips claims and validates the signature', () => {
+    const token = createSessionToken({ userId: 'abc' });
+    const claims = verifySessionToken(token);
+    expect(claims).toBeTruthy();
+    expect(claims.userId).toBe('abc');
+    expect(typeof claims.issuedAt).toBe('number');
+  });
+
+  it('rejects tokens with a tampered payload', () => {
+    const token = createSessionToken({ userId: 'abc' });
+    const [, signature] = token.split('.');
+    const fakePayload = Buffer.from(JSON.stringify({ userId: 'evil', issuedAt: Date.now() })).toString('base64url');
+    expect(verifySessionToken(`${fakePayload}.${signature}`)).toBeNull();
+  });
+
+  it('rejects tokens signed with a different secret', () => {
+    const token = createSessionToken({ userId: 'abc' });
+    process.env.SESSION_SECRET = 'a-completely-different-secret';
+    expect(verifySessionToken(token)).toBeNull();
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(verifySessionToken(null)).toBeNull();
+    expect(verifySessionToken('')).toBeNull();
+    expect(verifySessionToken('no-dot-here')).toBeNull();
+    expect(verifySessionToken('.empty')).toBeNull();
+    expect(verifySessionToken('empty.')).toBeNull();
+  });
+
+  it('rejects tokens older than the maximum session age', () => {
+    const token = createSessionToken({ userId: 'abc' });
+    // Advance time beyond MAX_SESSION_AGE_MS.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + THIRTY_DAYS_MS + 60_000);
+    expect(verifySessionToken(token)).toBeNull();
+  });
+
+  it('rejects tokens with an issuedAt far in the future', () => {
+    // Manually craft a token with a future issuedAt, which a malicious client
+    // might try to extend validity. Since our sign() function uses the same
+    // secret, we can only exercise this branch by simulating a clock jump.
+    const token = createSessionToken({ userId: 'abc' });
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() - 10 * 60_000); // 10 minutes before issuedAt
+    expect(verifySessionToken(token)).toBeNull();
+  });
+
+  it('parseSessionCookie pulls the named cookie out of the header', () => {
+    const req = { headers: { cookie: 'foo=bar; synapse_session=xyz; other=baz' } };
+    expect(parseSessionCookie(req)).toBe('xyz');
+  });
+
+  it('parseSessionCookie returns null when no cookie header is present', () => {
+    expect(parseSessionCookie({ headers: {} })).toBeNull();
+  });
+});

--- a/api/_lib/__tests__/users.test.js
+++ b/api/_lib/__tests__/users.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeExternalUrl, sanitizeProviderString } from '../users.js';
+
+describe('sanitizeExternalUrl', () => {
+  it('accepts http/https URLs', () => {
+    expect(sanitizeExternalUrl('https://example.com/foo')).toBe('https://example.com/foo');
+    expect(sanitizeExternalUrl('http://example.com/')).toBe('http://example.com/');
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(sanitizeExternalUrl('javascript:alert(1)')).toBeNull();
+    expect(sanitizeExternalUrl('JAVASCRIPT:alert(1)')).toBeNull();
+  });
+
+  it('rejects data: URLs', () => {
+    expect(sanitizeExternalUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+  });
+
+  it('rejects other exotic protocols', () => {
+    expect(sanitizeExternalUrl('ftp://example.com')).toBeNull();
+    expect(sanitizeExternalUrl('file:///etc/passwd')).toBeNull();
+    expect(sanitizeExternalUrl('vbscript:msgbox')).toBeNull();
+  });
+
+  it('rejects obviously malformed input', () => {
+    expect(sanitizeExternalUrl('')).toBeNull();
+    expect(sanitizeExternalUrl(null)).toBeNull();
+    expect(sanitizeExternalUrl(undefined)).toBeNull();
+    expect(sanitizeExternalUrl(12345)).toBeNull();
+    expect(sanitizeExternalUrl('not-a-url')).toBeNull();
+  });
+
+  it('rejects overly long URLs', () => {
+    const huge = `https://example.com/${'a'.repeat(5000)}`;
+    expect(sanitizeExternalUrl(huge)).toBeNull();
+  });
+});
+
+describe('sanitizeProviderString', () => {
+  it('strips control characters', () => {
+    const raw = 'Alex\u0000\u0001 Example';
+    expect(sanitizeProviderString(raw)).toBe('Alex Example');
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizeProviderString('  hello  ')).toBe('hello');
+  });
+
+  it('caps length at 512 chars', () => {
+    const result = sanitizeProviderString('x'.repeat(2000));
+    expect(result.length).toBe(512);
+  });
+
+  it('returns empty string for non-strings', () => {
+    expect(sanitizeProviderString(null)).toBe('');
+    expect(sanitizeProviderString(undefined)).toBe('');
+    expect(sanitizeProviderString(42)).toBe('');
+  });
+});

--- a/api/_lib/rateLimit.js
+++ b/api/_lib/rateLimit.js
@@ -1,0 +1,116 @@
+// Lightweight in-memory sliding-window rate limiter.
+//
+// IMPORTANT: Vercel serverless functions are stateless across warm
+// instances, so this limiter is *best effort only* — counters live in
+// the process memory of whichever instance services the request. It
+// materially slows casual abuse and single-host brute-force attempts
+// but will not defend against a distributed attacker.
+//
+// For production-grade rate limiting, wire this module up to a shared
+// store (Upstash Ratelimit, Redis, Vercel KV). The public API here is
+// intentionally compatible with that kind of drop-in replacement.
+
+const BUCKETS = new Map();
+
+// Cap the bucket map so a flood of unique keys can't exhaust memory.
+// When we hit the cap, drop the oldest entries.
+const MAX_KEYS = 10_000;
+
+function prune(now) {
+  if (BUCKETS.size < MAX_KEYS) return;
+  // Evict any fully-expired entries first.
+  for (const [key, value] of BUCKETS) {
+    if (now - value.windowStart > value.windowMs * 2) BUCKETS.delete(key);
+    if (BUCKETS.size < MAX_KEYS * 0.9) return;
+  }
+  // Still too full — drop oldest insertions.
+  const overflow = BUCKETS.size - Math.floor(MAX_KEYS * 0.9);
+  const iter = BUCKETS.keys();
+  for (let i = 0; i < overflow; i += 1) {
+    const next = iter.next();
+    if (next.done) break;
+    BUCKETS.delete(next.value);
+  }
+}
+
+/**
+ * Extract a stable client identifier. Prefers the leftmost entry in
+ * x-forwarded-for (the client-facing value on Vercel), falling back to
+ * the raw socket address. Coerces to string; strips port if present.
+ */
+export function getClientKey(req) {
+  const xff = req.headers?.['x-forwarded-for'];
+  let ip = null;
+  if (typeof xff === 'string' && xff.length > 0) {
+    ip = xff.split(',')[0].trim();
+  } else if (Array.isArray(xff) && xff.length > 0) {
+    ip = String(xff[0]).trim();
+  } else {
+    ip = req.socket?.remoteAddress || 'unknown';
+  }
+  // Strip IPv6 zone / port
+  if (typeof ip === 'string' && ip.includes(']:')) {
+    ip = ip.split(']:')[0].replace('[', '');
+  } else if (typeof ip === 'string' && ip.match(/^\d+\.\d+\.\d+\.\d+:\d+$/)) {
+    ip = ip.split(':')[0];
+  }
+  return ip || 'unknown';
+}
+
+/**
+ * Allow or deny a request under a fixed-window counter.
+ *   key: stable per-client string (scope-prefix your usage).
+ *   limit: maximum requests per window.
+ *   windowMs: window size in milliseconds.
+ * Returns `{ allowed, remaining, resetMs }`.
+ */
+export function rateLimit(key, limit, windowMs) {
+  const now = Date.now();
+  prune(now);
+
+  const existing = BUCKETS.get(key);
+  if (!existing || now - existing.windowStart >= windowMs) {
+    BUCKETS.set(key, { count: 1, windowStart: now, windowMs });
+    return { allowed: true, remaining: limit - 1, resetMs: windowMs };
+  }
+
+  existing.count += 1;
+  const resetMs = windowMs - (now - existing.windowStart);
+  if (existing.count > limit) {
+    return { allowed: false, remaining: 0, resetMs };
+  }
+  return { allowed: true, remaining: Math.max(0, limit - existing.count), resetMs };
+}
+
+/**
+ * Convenience: enforce a rate limit on a Vercel-style (req, res) handler.
+ * Responds with 429 JSON and `Retry-After` if the caller exceeds it, and
+ * returns `true` in that case so the handler can bail out early.
+ */
+export function enforceRateLimit(req, res, options) {
+  const {
+    scope,
+    limit,
+    windowMs,
+    keyFn,
+    errorBody = { error: 'rate_limited' },
+  } = options;
+  const clientKey = keyFn ? keyFn(req) : getClientKey(req);
+  const bucketKey = `${scope}:${clientKey}`;
+  const result = rateLimit(bucketKey, limit, windowMs);
+  if (!result.allowed) {
+    const retryAfter = Math.max(1, Math.ceil(result.resetMs / 1000));
+    res.setHeader('Retry-After', String(retryAfter));
+    res.setHeader('X-RateLimit-Limit', String(limit));
+    res.setHeader('X-RateLimit-Remaining', '0');
+    res.status(429).setHeader('Content-Type', 'application/json');
+    res.send(JSON.stringify(errorBody));
+    return true;
+  }
+  return false;
+}
+
+// Test-only helper. Not exported through index; internal usage.
+export function __resetRateLimitForTests() {
+  BUCKETS.clear();
+}

--- a/api/_lib/session.js
+++ b/api/_lib/session.js
@@ -2,6 +2,11 @@ import crypto from 'crypto';
 
 const COOKIE_NAME = 'synapse_session';
 
+// Tokens older than this are considered expired even if the HMAC verifies,
+// so stolen/leaked tokens stop working. Kept in sync with the cookie Max-Age.
+const MAX_SESSION_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const SESSION_COOKIE_MAX_AGE_S = 30 * 24 * 60 * 60; // seconds
+
 function base64Url(value) {
   return Buffer.from(value).toString('base64url');
 }
@@ -16,7 +21,9 @@ export function createSessionToken(claims) {
   const secret = process.env.SESSION_SECRET;
   if (!secret) throw new Error('Missing SESSION_SECRET environment variable.');
 
-  const payload = base64Url(JSON.stringify(claims));
+  // Always stamp issuedAt on the server so clients can't forge a fresh timestamp.
+  const stamped = { ...claims, issuedAt: Date.now() };
+  const payload = base64Url(JSON.stringify(stamped));
   const signature = sign(payload, secret);
   return `${payload}.${signature}`;
 }
@@ -29,30 +36,62 @@ export function parseSessionCookie(req) {
   return decodeURIComponent(match.split('=')[1]);
 }
 
-export function verifySessionToken(token) {
-  const secret = process.env.SESSION_SECRET;
-  if (!secret || !token || !token.includes('.')) return null;
-
-  const [payload, signature] = token.split('.');
-  const expected = sign(payload, secret);
-  if (expected !== signature) return null;
-
+// Constant-time string compare for signatures to avoid any (mostly theoretical)
+// timing side channel. Falls back to false on length mismatch.
+function safeCompare(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
   try {
-    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    return crypto.timingSafeEqual(bufA, bufB);
   } catch {
-    return null;
+    return false;
   }
 }
 
+export function verifySessionToken(token) {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret || !token || typeof token !== 'string' || !token.includes('.')) return null;
+
+  const [payload, signature] = token.split('.');
+  if (!payload || !signature) return null;
+
+  const expected = sign(payload, secret);
+  if (!safeCompare(expected, signature)) return null;
+
+  let claims;
+  try {
+    claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+
+  // Reject tokens that don't have a valid issuedAt or are older than the
+  // configured max session age. This turns the signed cookie into an
+  // expiring credential even if the client never rotates it.
+  const issuedAt = typeof claims?.issuedAt === 'number' ? claims.issuedAt : null;
+  if (!issuedAt || issuedAt > Date.now() + 60_000 /* clock skew */) return null;
+  if (Date.now() - issuedAt > MAX_SESSION_AGE_MS) return null;
+
+  return claims;
+}
+
 export function setSessionCookie(res, token) {
-  const maxAge = 60 * 60 * 24 * 30;
   const secure = process.env.NODE_ENV === 'production';
+  // Prefer the __Host- prefix in production: requires Secure, Path=/, and no
+  // Domain attribute. This hardens the cookie against subdomain overrides.
+  // We keep the plain name in dev to avoid requiring HTTPS locally.
   res.setHeader(
     'Set-Cookie',
-    `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; Max-Age=${maxAge}; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
+    `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; Max-Age=${SESSION_COOKIE_MAX_AGE_S}; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
   );
 }
 
 export function clearSessionCookie(res) {
-  res.setHeader('Set-Cookie', `${COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`);
+  const secure = process.env.NODE_ENV === 'production';
+  res.setHeader(
+    'Set-Cookie',
+    `${COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
+  );
 }

--- a/api/_lib/users.js
+++ b/api/_lib/users.js
@@ -32,6 +32,35 @@ function normalizeEmail(email) {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+// OAuth providers hand us arbitrary URLs that end up rendered as <a href> and
+// <img src>. Only let http(s) URLs through so that even if a provider (or a
+// malicious actor via provider-side profile fields) tries to slip in a
+// javascript:/data: URL, it never reaches the DB or the DOM.
+const MAX_URL_LEN = 2048;
+export function sanitizeExternalUrl(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_URL_LEN) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+// Plain strings from OAuth providers (name, headline, company). Trims,
+// drops control characters that could affect log output, and caps length.
+const MAX_FIELD_LEN = 512;
+export function sanitizeProviderString(value) {
+  if (typeof value !== 'string') return '';
+  // Strip C0 control characters except tab/newline (the rendered text
+  // shouldn't contain them, and they confuse logs + some renderers).
+  const cleaned = value.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '').trim();
+  return cleaned.slice(0, MAX_FIELD_LEN);
+}
+
 function publicUserProjection() {
   return {
     _id: 0,
@@ -106,6 +135,7 @@ export async function createEmailUser({ email, name, passwordHash }) {
   const existing = await findAnyUserByEmail(normalized);
   if (existing) throw new EmailInUseError();
 
+  const safeName = sanitizeProviderString(name);
   const now = new Date();
   const userId = generateUserId();
   const doc = {
@@ -114,7 +144,7 @@ export async function createEmailUser({ email, name, passwordHash }) {
     providerUserId: normalized,
     email: normalized,
     emailVerified: false,
-    name,
+    name: safeName,
     passwordHash,
     profileUrl: null,
     headline: '',
@@ -137,7 +167,7 @@ export async function createEmailUser({ email, name, passwordHash }) {
     authProvider: 'email',
     email: normalized,
     emailVerified: false,
-    name,
+    name: safeName,
     profileUrl: null,
     headline: '',
     company: null,
@@ -166,6 +196,18 @@ export async function upsertOAuthUser({
   }
 
   const normalizedEmail = normalizeEmail(email);
+  // Sanitize anything provider-supplied that ends up on the client as markup.
+  // Only http(s) URLs survive; everything else stored as null.
+  const safeAvatarUrl = sanitizeExternalUrl(avatarUrl);
+  const safeProfileUrl = sanitizeExternalUrl(profileUrl);
+  const safeName = sanitizeProviderString(name);
+  const safeHeadline = sanitizeProviderString(headline);
+  const safeCompany = company ? sanitizeProviderString(company) : null;
+  avatarUrl = safeAvatarUrl;
+  profileUrl = safeProfileUrl;
+  name = safeName;
+  headline = safeHeadline;
+  company = safeCompany || null;
   const now = new Date();
 
   // Is there already a record for this provider + providerUserId?

--- a/api/activity.js
+++ b/api/activity.js
@@ -1,6 +1,56 @@
 import { runMongoAction } from './_lib/db.js';
 import { json, methodNotAllowed } from './_lib/response.js';
 import { parseSessionCookie, verifySessionToken } from './_lib/session.js';
+import { parseJsonBody } from './_lib/validate.js';
+import { enforceRateLimit } from './_lib/rateLimit.js';
+
+// Activity events are structured analytics we log for our own UI — reject
+// anything that isn't on this allowlist so clients can't dump arbitrary
+// strings into our database.
+const ALLOWED_TYPES = new Set([
+  'generated_artifact',
+  'viewed_mockups',
+  'clicked_section',
+  'opened_project',
+  'exported_project',
+  'created_branch',
+  'consolidated_branch',
+  'regenerated_spine',
+]);
+
+const MAX_TYPE_LEN = 64;
+const MAX_METADATA_BYTES = 4 * 1024; // 4 KiB
+const MAX_METADATA_KEYS = 20;
+
+function validateMetadata(metadata) {
+  if (metadata === undefined || metadata === null) return {};
+  if (typeof metadata !== 'object' || Array.isArray(metadata)) return null;
+
+  const keys = Object.keys(metadata);
+  if (keys.length > MAX_METADATA_KEYS) return null;
+
+  // Only permit primitive leaf values one level deep — reject nested objects
+  // and large string payloads so the collection can't be abused as blob storage.
+  for (const key of keys) {
+    if (typeof key !== 'string' || key.length === 0 || key.length > 64) return null;
+    const v = metadata[key];
+    if (v === null) continue;
+    const t = typeof v;
+    if (t === 'string') {
+      if (v.length > 512) return null;
+    } else if (t === 'number') {
+      if (!Number.isFinite(v)) return null;
+    } else if (t === 'boolean') {
+      // ok
+    } else {
+      return null;
+    }
+  }
+
+  const serialized = JSON.stringify(metadata);
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_METADATA_BYTES) return null;
+  return metadata;
+}
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
@@ -10,8 +60,32 @@ export default async function handler(req, res) {
   const subjectId = claims?.userId || claims?.recruiterId;
   if (!subjectId) return json(res, 401, { error: 'Unauthorized' });
 
-  const { type, metadata } = req.body || {};
-  if (!type) return json(res, 400, { error: 'Missing activity type' });
+  // Cap writes per authenticated client to prevent billing/DB abuse.
+  if (
+    enforceRateLimit(req, res, {
+      scope: 'activity_user',
+      limit: 120,
+      windowMs: 60_000,
+      keyFn: () => `u:${subjectId}`,
+      errorBody: { error: 'rate_limited' },
+    })
+  ) {
+    return;
+  }
+
+  const body = await parseJsonBody(req);
+  const rawType = body?.type;
+  if (typeof rawType !== 'string' || rawType.length === 0 || rawType.length > MAX_TYPE_LEN) {
+    return json(res, 400, { error: 'Missing activity type' });
+  }
+  if (!ALLOWED_TYPES.has(rawType)) {
+    return json(res, 400, { error: 'Invalid activity type' });
+  }
+
+  const metadata = validateMetadata(body?.metadata);
+  if (metadata === null) {
+    return json(res, 400, { error: 'Invalid metadata' });
+  }
 
   try {
     const now = new Date();
@@ -20,8 +94,8 @@ export default async function handler(req, res) {
       document: {
         userId: claims?.userId || null,
         recruiterId: claims?.recruiterId || subjectId,
-        type,
-        metadata: metadata || {},
+        type: rawType,
+        metadata,
         createdAt: now,
       },
     });

--- a/api/admin/recruiters.js
+++ b/api/admin/recruiters.js
@@ -1,11 +1,51 @@
+import crypto from 'crypto';
 import { runMongoAction } from '../_lib/db.js';
 import { json, methodNotAllowed } from '../_lib/response.js';
+import { enforceRateLimit } from '../_lib/rateLimit.js';
+
+// Minimum length for the admin shared secret so we never accept a trivially
+// guessable key. Enforced both on-reject (constant-time compare) and here.
+const MIN_ADMIN_KEY_LEN = 24;
+
+function constantTimeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  try {
+    return crypto.timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
+}
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return methodNotAllowed(res);
 
+  // Throttle failed admin-key attempts aggressively.
+  if (
+    enforceRateLimit(req, res, {
+      scope: 'admin_recruiters',
+      limit: 20,
+      windowMs: 60_000,
+      errorBody: { error: 'rate_limited' },
+    })
+  ) {
+    return;
+  }
+
   const adminKey = process.env.ADMIN_DASHBOARD_KEY;
-  if (!adminKey || req.headers['x-admin-key'] !== adminKey) return json(res, 401, { error: 'Unauthorized' });
+  const provided = req.headers['x-admin-key'];
+
+  // Refuse to authenticate if the server-side key is missing or too short —
+  // prevents an unset/empty env var from silently accepting a blank header.
+  if (!adminKey || adminKey.length < MIN_ADMIN_KEY_LEN) {
+    console.warn('[admin] ADMIN_DASHBOARD_KEY is unset or too short; rejecting admin request.');
+    return json(res, 401, { error: 'Unauthorized' });
+  }
+  if (typeof provided !== 'string' || !constantTimeEqual(provided, adminKey)) {
+    return json(res, 401, { error: 'Unauthorized' });
+  }
 
   try {
     const result = await runMongoAction('aggregate', {

--- a/api/auth/github.js
+++ b/api/auth/github.js
@@ -1,9 +1,12 @@
 import crypto from 'crypto';
 import { createGitHubAuthUrl, getGitHubConfig } from '../_lib/github.js';
 import { getBaseUrl, methodNotAllowed } from '../_lib/response.js';
+import { enforceRateLimit } from '../_lib/rateLimit.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return methodNotAllowed(res);
+
+  if (enforceRateLimit(req, res, { scope: 'oauth_init_github', limit: 20, windowMs: 60_000 })) return;
 
   try {
     const baseUrl = getBaseUrl(req);

--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -1,9 +1,12 @@
 import crypto from 'crypto';
 import { createGoogleAuthUrl, getGoogleConfig } from '../_lib/google.js';
 import { getBaseUrl, methodNotAllowed } from '../_lib/response.js';
+import { enforceRateLimit } from '../_lib/rateLimit.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return methodNotAllowed(res);
+
+  if (enforceRateLimit(req, res, { scope: 'oauth_init_google', limit: 20, windowMs: 60_000 })) return;
 
   try {
     const baseUrl = getBaseUrl(req);

--- a/api/auth/linkedin.js
+++ b/api/auth/linkedin.js
@@ -1,9 +1,12 @@
 import crypto from 'crypto';
 import { createLinkedInAuthUrl, getLinkedInConfig } from '../_lib/linkedin.js';
 import { getBaseUrl, methodNotAllowed } from '../_lib/response.js';
+import { enforceRateLimit } from '../_lib/rateLimit.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return methodNotAllowed(res);
+
+  if (enforceRateLimit(req, res, { scope: 'oauth_init_linkedin', limit: 20, windowMs: 60_000 })) return;
 
   try {
     const baseUrl = getBaseUrl(req);

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -6,9 +6,22 @@ import {
   issueSessionForUser,
   toPublicUser,
 } from '../_lib/users.js';
+import { enforceRateLimit, getClientKey } from '../_lib/rateLimit.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  // Per-IP throttle on login attempts to blunt online password brute force.
+  if (
+    enforceRateLimit(req, res, {
+      scope: 'auth_login_ip',
+      limit: 10,
+      windowMs: 60_000,
+      errorBody: { error: 'rate_limited' },
+    })
+  ) {
+    return;
+  }
 
   try {
     const body = await parseJsonBody(req);
@@ -19,6 +32,20 @@ export default async function handler(req, res) {
     }
     if (typeof body?.password !== 'string' || body.password.length === 0) {
       return json(res, 401, { error: 'invalid_credentials' });
+    }
+
+    // Extra per-email throttle to make targeted attacks harder even from
+    // rotating IPs (doesn't defeat distributed attackers but raises cost).
+    if (
+      enforceRateLimit(req, res, {
+        scope: 'auth_login_email',
+        limit: 10,
+        windowMs: 10 * 60_000,
+        keyFn: () => `${getClientKey(req)}|${emailCheck.value}`,
+        errorBody: { error: 'rate_limited' },
+      })
+    ) {
+      return;
     }
 
     const user = await findEmailUserForLogin(emailCheck.value);

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -12,9 +12,22 @@ import {
   toPublicUser,
   EmailInUseError,
 } from '../_lib/users.js';
+import { enforceRateLimit } from '../_lib/rateLimit.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  // Throttle account creation so a single host can't flood the user table.
+  if (
+    enforceRateLimit(req, res, {
+      scope: 'auth_signup_ip',
+      limit: 5,
+      windowMs: 10 * 60_000,
+      errorBody: { error: 'rate_limited' },
+    })
+  ) {
+    return;
+  }
 
   try {
     const body = await parseJsonBody(req);

--- a/src/components/RecruiterAdminPage.tsx
+++ b/src/components/RecruiterAdminPage.tsx
@@ -5,6 +5,22 @@ import { fetchRecruiters } from '../lib/recruiterApi';
 
 type SortMode = 'recency' | 'engagement';
 
+// Defense-in-depth: even though we sanitize provider URLs on write, still
+// only render http(s) URLs at render time so a legacy bad record in Mongo
+// can't turn into a javascript:/data: href at the browser.
+function safeHttpUrl(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+        const url = new URL(trimmed);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+        return url.toString();
+    } catch {
+        return null;
+    }
+}
+
 export function RecruiterAdminPage() {
   const [adminKey, setAdminKey] = useState('');
   const [loading, setLoading] = useState(false);
@@ -59,15 +75,20 @@ export function RecruiterAdminPage() {
         {sorted.map((r) => {
           const recentlyActive = r.lastActiveAt && (Date.now() - new Date(r.lastActiveAt).getTime()) < 1000 * 60 * 60 * 24;
           const highEngagement = r.artifactGenerations + r.clickedSections >= 5;
+          const safeProfileUrl = safeHttpUrl(r.profileUrl);
 
           return (
             <div key={r.linkedinId} className={`rounded-xl border p-4 ${recentlyActive ? 'border-emerald-500/50' : 'border-neutral-700'} ${highEngagement ? 'bg-indigo-500/10' : 'bg-neutral-900/50'}`}>
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="font-semibold">{r.name}</p>
-                  <a href={r.profileUrl || '#'} target="_blank" rel="noreferrer" className="text-sky-300 hover:underline text-sm">
-                    LinkedIn profile
-                  </a>
+                  {safeProfileUrl ? (
+                    <a href={safeProfileUrl} target="_blank" rel="noopener noreferrer" className="text-sky-300 hover:underline text-sm">
+                      LinkedIn profile
+                    </a>
+                  ) : (
+                    <span className="text-neutral-500 text-sm">No profile</span>
+                  )}
                   <p className="text-sm text-neutral-300 mt-1">{r.headline || 'No headline available'}</p>
                   <p className="text-sm text-neutral-400">{r.company || 'Company unavailable'}</p>
                 </div>

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,29 @@
   "outputDirectory": "dist",
   "rewrites": [
     { "source": "/((?!api/).*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://vitals.vercel-insights.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "no-referrer" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Security review fixes spanning session handling, admin authN, input
validation, and deployment config. Full writeup in SECURITY_REVIEW.md.

Critical:
- Enforce 30-day session expiration and constant-time HMAC compare in
  verifySessionToken; stamp issuedAt server-side
- Gate admin dashboard behind constant-time key compare, minimum key
  length, and a per-IP rate limit

High:
- Add an in-memory rate limiter (api/_lib/rateLimit.js) and apply it
  to login, signup, OAuth init, activity, and admin endpoints
- Allowlist activity event types and cap metadata shape/size
- Sanitize OAuth-supplied URLs (http(s) only) and strings before
  persisting; defense-in-depth client-side URL check in the admin UI
- Add CSP, HSTS, X-Frame-Options, X-Content-Type-Options,
  Referrer-Policy, and Permissions-Policy via vercel.json; no-store
  on /api/*

Tests: 3 new spec files (session/rateLimit/users), 53 total passing.