### PR TITLE
Disable authentication during development

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -7,6 +7,20 @@ import {
   signupWithEmail,
 } from '../lib/recruiterApi';
 
+// DEV BYPASS: set to false to re-enable real authentication
+const DEV_SKIP_AUTH = true;
+
+const DEV_USER: RecruiterUser = {
+  userId: 'dev-user',
+  authProvider: 'email',
+  name: 'Dev User',
+  email: 'dev@localhost',
+  profileUrl: null,
+  headline: '',
+  company: null,
+  avatarUrl: null,
+};
+
 type AuthState = {
   user: RecruiterUser | null;
   loading: boolean;
@@ -17,9 +31,13 @@ type AuthState = {
 };
 
 export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  loading: true,
+  user: DEV_SKIP_AUTH ? DEV_USER : null,
+  loading: DEV_SKIP_AUTH ? false : true,
   refreshSession: async () => {
+    if (DEV_SKIP_AUTH) {
+      set({ user: DEV_USER, loading: false });
+      return;
+    }
     set({ loading: true });
     try {
       const session = await fetchSession();
@@ -29,6 +47,10 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
   loginWithEmail: async (email, password) => {
+    if (DEV_SKIP_AUTH) {
+      set({ user: DEV_USER, loading: false });
+      return { ok: true as const, user: DEV_USER };
+    }
     const result = await loginWithEmail({ email, password });
     if (result.ok) {
       set({ user: result.user, loading: false });
@@ -36,6 +58,10 @@ export const useAuthStore = create<AuthState>((set) => ({
     return result;
   },
   signupWithEmail: async (email, password, name) => {
+    if (DEV_SKIP_AUTH) {
+      set({ user: DEV_USER, loading: false });
+      return { ok: true as const, user: DEV_USER };
+    }
     const result = await signupWithEmail({ email, password, name });
     if (result.ok) {
       set({ user: result.user, loading: false });
@@ -43,6 +69,9 @@ export const useAuthStore = create<AuthState>((set) => ({
     return result;
   },
   logout: async () => {
+    if (DEV_SKIP_AUTH) {
+      return; // no-op in dev mode
+    }
     await logoutRequest();
     set({ user: null, loading: false });
   },


### PR DESCRIPTION
Add DEV_SKIP_AUTH flag to authStore that bypasses all auth API calls
and uses a hardcoded dev user. Set the flag to false to re-enable
real authentication.

https://claude.ai/code/session_012X2UT6Gy9iVvZ2bTfhqRFA