### PR TITLE
Demo project prepopulation + Gemini 3 model support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ProjectWorkspace } from './components/ProjectWorkspace';
 import { MeetSynapsePage } from './components/MeetSynapsePage';
 import { PrivacyPolicyPage } from './components/PrivacyPolicyPage';
 import { RecruiterAdminPage } from './components/RecruiterAdminPage';
+import { AdminCaptureDemo } from './components/AdminCaptureDemo';
 import { GlobalErrorBoundary } from './components/GlobalErrorBoundary';
 import { ToastContainer } from './components/ToastContainer';
 import { useAuthStore } from './store/authStore';
@@ -27,10 +28,31 @@ function HomeRoute() {
   return user ? <HomePage /> : <LoginPage />;
 }
 
+/**
+ * One-shot migration: move anyone still on `gemini-2.5-flash` to the new
+ * default (`gemini-3-flash-preview`) which has better capacity headroom.
+ * Gated by a sentinel localStorage key so it only runs once — a user who
+ * deliberately re-selects 2.5 Flash afterward is respected.
+ */
+const GEMINI_MODEL_MIGRATION_KEY = 'GEMINI_MODEL_MIGRATED_2026_04';
+function migrateGeminiModel() {
+  try {
+    if (localStorage.getItem(GEMINI_MODEL_MIGRATION_KEY)) return;
+    const current = localStorage.getItem('GEMINI_MODEL');
+    if (current === 'gemini-2.5-flash') {
+      localStorage.setItem('GEMINI_MODEL', 'gemini-3-flash-preview');
+    }
+    localStorage.setItem(GEMINI_MODEL_MIGRATION_KEY, '1');
+  } catch {
+    // localStorage unavailable (private mode, etc.) — skip migration.
+  }
+}
+
 function App() {
   const refreshSession = useAuthStore((s) => s.refreshSession);
 
   useEffect(() => {
+    migrateGeminiModel();
     refreshSession();
   }, [refreshSession]);
 
@@ -43,6 +65,9 @@ function App() {
           <Route path="/p/:projectId" element={<ProjectWorkspace />} />
           <Route path="/privacy" element={<PrivacyPolicyPage />} />
           <Route path="/admin/recruiters" element={<RecruiterAdminPage />} />
+          {import.meta.env.DEV && (
+            <Route path="/admin/capture-demo" element={<AdminCaptureDemo />} />
+          )}
         </Routes>
         <ToastContainer />
       </BrowserRouter>

--- a/src/components/AdminCaptureDemo.tsx
+++ b/src/components/AdminCaptureDemo.tsx
@@ -1,0 +1,387 @@
+/**
+ * Dev-only capture helper: runs the full Synapse pipeline end-to-end using the
+ * caller's own Gemini key (already stored in localStorage) and downloads a
+ * freshly serialized `demoProject.ts` containing the result.
+ *
+ * The produced file replaces `src/data/demoProject.ts` and is committed. At
+ * runtime, `loadDemoProject()` hydrates the store from that fixture so any
+ * visitor can view a finished project without providing their own key.
+ *
+ * This route is tree-shaken out of production builds via the
+ * `import.meta.env.DEV` guard in App.tsx.
+ */
+
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Loader2, ChevronLeft, Download } from 'lucide-react';
+import { useProjectStore } from '../store/projectStore';
+import { generateStructuredPRD, structuredPRDToMarkdown, generateMockup, generateCoreArtifact } from '../lib/llmProvider';
+import { MOCKUP_HTML_V1, type MockupSettings } from '../types';
+import { CORE_ARTIFACT_PIPELINE, getArtifactMeta } from '../lib/coreArtifactPipeline';
+import { DEMO_PROJECT_ID } from '../data/demoProject';
+import type { StructuredPRD } from '../types';
+import { v4 as uuidv4 } from 'uuid';
+
+// Fitness-tracker prompt used as the demo seed. Matches the shape of the
+// existing EXAMPLE_PROMPTS entry in HomePage so users recognize it.
+const DEMO_PROMPT =
+    'A fitness tracking app with workout logging, progress photos, social challenges, leaderboards, AI-powered form analysis from video, and personalized training programs.';
+const DEMO_PROJECT_NAME = 'Demo: Fitness tracker';
+const DEMO_PLATFORM = 'app' as const;
+
+type Step = {
+    label: string;
+    status: 'pending' | 'running' | 'done' | 'error';
+    detail?: string;
+};
+
+const INITIAL_STEPS: Step[] = [
+    { label: 'Generate structured PRD', status: 'pending' },
+    { label: 'Mark PRD as final', status: 'pending' },
+    { label: 'Generate mockup (mobile / key workflow)', status: 'pending' },
+    ...CORE_ARTIFACT_PIPELINE.map((m) => ({
+        label: `Generate ${m.title}`,
+        status: 'pending' as const,
+    })),
+    { label: 'Serialize + download fixture', status: 'pending' },
+];
+
+export function AdminCaptureDemo() {
+    const navigate = useNavigate();
+    const [running, setRunning] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [steps, setSteps] = useState<Step[]>(INITIAL_STEPS);
+    const [downloadReady, setDownloadReady] = useState(false);
+
+    const patchStep = (index: number, patch: Partial<Step>) => {
+        setSteps((prev) => prev.map((s, i) => (i === index ? { ...s, ...patch } : s)));
+    };
+
+    const apiKey = typeof window !== 'undefined' ? localStorage.getItem('GEMINI_API_KEY') : null;
+
+    const run = async () => {
+        if (!apiKey) {
+            setError('No Gemini API key found in localStorage. Open Settings on the home page and add one before running capture.');
+            return;
+        }
+
+        setRunning(true);
+        setError(null);
+        setDownloadReady(false);
+        setSteps(INITIAL_STEPS.map((s) => ({ ...s })));
+
+        const store = useProjectStore.getState();
+
+        // Clean any prior demo project in the store so we start from zero.
+        store.deleteProject(DEMO_PROJECT_ID);
+
+        // 1) create project + generate PRD
+        let projectId: string;
+        let spineId: string;
+        let structuredPRD: StructuredPRD;
+        try {
+            patchStep(0, { status: 'running' });
+            const result = store.createProject(DEMO_PROJECT_NAME, DEMO_PROMPT, DEMO_PLATFORM);
+            projectId = result.projectId;
+            spineId = result.spineId;
+            structuredPRD = await generateStructuredPRD(DEMO_PROMPT, undefined, DEMO_PLATFORM);
+            const prdMarkdown = structuredPRDToMarkdown(structuredPRD);
+            useProjectStore.getState().updateSpineStructuredPRD(projectId, spineId, structuredPRD, prdMarkdown);
+            patchStep(0, { status: 'done' });
+        } catch (e) {
+            patchStep(0, { status: 'error', detail: e instanceof Error ? e.message : String(e) });
+            setError('PRD generation failed. See console for details.');
+            console.error(e);
+            setRunning(false);
+            return;
+        }
+
+        // 2) mark final
+        try {
+            patchStep(1, { status: 'running' });
+            useProjectStore.getState().markSpineFinal(projectId, spineId, true);
+            patchStep(1, { status: 'done' });
+        } catch (e) {
+            patchStep(1, { status: 'error', detail: e instanceof Error ? e.message : String(e) });
+            setRunning(false);
+            return;
+        }
+
+        const prdContent = structuredPRDToMarkdown(structuredPRD);
+
+        // 3) mockup
+        try {
+            patchStep(2, { status: 'running' });
+            const settings: MockupSettings = {
+                platform: 'mobile',
+                fidelity: 'mid',
+                scope: 'key_workflow',
+            };
+            const { payload } = await generateMockup(prdContent, settings, structuredPRD);
+            const { artifactId: mockupArtifactId } = useProjectStore
+                .getState()
+                .createArtifact(projectId, 'mockup', payload.title?.trim() || 'Fitness Tracker Workflow');
+            useProjectStore.getState().createArtifactVersion(
+                projectId,
+                mockupArtifactId,
+                JSON.stringify(payload),
+                { settings, format: MOCKUP_HTML_V1 },
+                [
+                    {
+                        id: uuidv4(),
+                        sourceArtifactId: projectId,
+                        sourceArtifactVersionId: spineId,
+                        sourceType: 'spine',
+                    },
+                ],
+                `Generate ${settings.fidelity} ${settings.platform} mockup for ${settings.scope.replace('_', ' ')}`,
+            );
+            patchStep(2, { status: 'done' });
+        } catch (e) {
+            patchStep(2, { status: 'error', detail: e instanceof Error ? e.message : String(e) });
+            setError('Mockup generation failed.');
+            console.error(e);
+            setRunning(false);
+            return;
+        }
+
+        // 4) 7 core artifacts, in dependency-valid order
+        const generatedArtifacts: Record<string, string> = {};
+        for (let i = 0; i < CORE_ARTIFACT_PIPELINE.length; i++) {
+            const meta = CORE_ARTIFACT_PIPELINE[i];
+            const stepIndex = 3 + i;
+            try {
+                patchStep(stepIndex, { status: 'running' });
+                const content = await generateCoreArtifact(meta.subtype, prdContent, structuredPRD, {
+                    generatedArtifacts,
+                });
+                generatedArtifacts[meta.subtype] = content;
+                const { artifactId } = useProjectStore
+                    .getState()
+                    .createArtifact(projectId, 'core_artifact', getArtifactMeta(meta.subtype).title, meta.subtype);
+                useProjectStore.getState().createArtifactVersion(
+                    projectId,
+                    artifactId,
+                    content,
+                    { subtype: meta.subtype },
+                    [
+                        {
+                            id: uuidv4(),
+                            sourceArtifactId: projectId,
+                            sourceArtifactVersionId: spineId,
+                            sourceType: 'spine',
+                        },
+                    ],
+                    `Generate ${getArtifactMeta(meta.subtype).title} from PRD`,
+                );
+                patchStep(stepIndex, { status: 'done' });
+            } catch (e) {
+                patchStep(stepIndex, {
+                    status: 'error',
+                    detail: e instanceof Error ? e.message : String(e),
+                });
+                setError(`Core artifact ${meta.subtype} failed.`);
+                console.error(e);
+                setRunning(false);
+                return;
+            }
+        }
+
+        // 5) serialize + download
+        const serializeStep = 3 + CORE_ARTIFACT_PIPELINE.length;
+        try {
+            patchStep(serializeStep, { status: 'running' });
+            const state = useProjectStore.getState();
+            const fileContent = buildFixtureFile({
+                projectId,
+                spineId,
+                project: state.projects[projectId]!,
+                spineVersions: state.spineVersions[projectId] ?? [],
+                artifacts: state.artifacts[projectId] ?? [],
+                artifactVersions: state.artifactVersions[projectId] ?? [],
+                historyEvents: state.historyEvents[projectId] ?? [],
+            });
+            triggerDownload('demoProject.ts', fileContent);
+            patchStep(serializeStep, { status: 'done' });
+            setDownloadReady(true);
+        } catch (e) {
+            patchStep(serializeStep, {
+                status: 'error',
+                detail: e instanceof Error ? e.message : String(e),
+            });
+            setError('Serialization failed.');
+            console.error(e);
+        } finally {
+            setRunning(false);
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-neutral-950 text-neutral-100 px-6 py-10">
+            <div className="max-w-2xl mx-auto">
+                <button
+                    onClick={() => navigate('/')}
+                    className="inline-flex items-center gap-1 text-sm text-neutral-400 hover:text-white mb-6"
+                >
+                    <ChevronLeft size={16} /> Back
+                </button>
+
+                <h1 className="text-2xl font-bold mb-1">Capture demo project</h1>
+                <p className="text-sm text-neutral-400 mb-6">
+                    Runs the full pipeline (PRD → mockup → 7 core artifacts) using your current Gemini API key,
+                    then downloads a <code className="text-xs">demoProject.ts</code> fixture file. Move the downloaded
+                    file to <code className="text-xs">src/data/demoProject.ts</code> and commit it.
+                </p>
+
+                {!apiKey && (
+                    <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200 mb-4">
+                        No Gemini API key found. Add one in Settings on the home page before running.
+                    </div>
+                )}
+
+                {error && (
+                    <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200 mb-4">
+                        {error}
+                    </div>
+                )}
+
+                <button
+                    onClick={run}
+                    disabled={running || !apiKey}
+                    className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-60 disabled:cursor-not-allowed font-semibold text-white transition"
+                >
+                    {running && <Loader2 size={16} className="animate-spin" />}
+                    {running ? 'Capturing...' : 'Generate demo project'}
+                </button>
+
+                {downloadReady && (
+                    <div className="mt-4 inline-flex items-center gap-2 text-sm text-emerald-300">
+                        <Download size={14} /> Fixture downloaded — move it to <code className="text-xs">src/data/demoProject.ts</code>.
+                    </div>
+                )}
+
+                <ol className="mt-8 space-y-2">
+                    {steps.map((s, i) => (
+                        <li
+                            key={i}
+                            className="flex items-start gap-3 rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2 text-sm"
+                        >
+                            <span className={`mt-0.5 inline-block h-2 w-2 rounded-full shrink-0 ${
+                                s.status === 'done'
+                                    ? 'bg-emerald-400'
+                                    : s.status === 'running'
+                                        ? 'bg-indigo-400 animate-pulse'
+                                        : s.status === 'error'
+                                            ? 'bg-red-400'
+                                            : 'bg-neutral-600'
+                            }`} />
+                            <div className="min-w-0">
+                                <div className="text-neutral-200">{s.label}</div>
+                                {s.detail && <div className="text-xs text-neutral-500 mt-0.5 break-words">{s.detail}</div>}
+                            </div>
+                        </li>
+                    ))}
+                </ol>
+            </div>
+        </div>
+    );
+}
+
+// ---- Serialization helpers ----
+
+function triggerDownload(filename: string, contents: string) {
+    const blob = new Blob([contents], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+interface CaptureSource {
+    projectId: string;
+    spineId: string;
+    project: import('../types').Project;
+    spineVersions: import('../types').SpineVersion[];
+    artifacts: import('../types').Artifact[];
+    artifactVersions: import('../types').ArtifactVersion[];
+    historyEvents: import('../types').HistoryEvent[];
+}
+
+/**
+ * Rewrite every reference to the freshly-created projectId so it points at the
+ * stable DEMO_PROJECT_ID. This keeps the fixture deterministic across
+ * re-captures and lets `loadDemoProject()` key on a stable id.
+ */
+function rewriteIds<T>(value: T, fromProjectId: string): T {
+    if (Array.isArray(value)) {
+        return value.map((v) => rewriteIds(v, fromProjectId)) as unknown as T;
+    }
+    if (value && typeof value === 'object') {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+            if (typeof v === 'string' && v === fromProjectId) {
+                out[k] = DEMO_PROJECT_ID;
+            } else {
+                out[k] = rewriteIds(v, fromProjectId);
+            }
+        }
+        return out as T;
+    }
+    if (typeof value === 'string' && value === fromProjectId) {
+        return DEMO_PROJECT_ID as unknown as T;
+    }
+    return value;
+}
+
+function buildFixtureFile(src: CaptureSource): string {
+    const projectRewritten = rewriteIds({ ...src.project, id: DEMO_PROJECT_ID, createdAt: 0, currentStage: 'artifacts' as const }, src.projectId);
+    const spinesRewritten = src.spineVersions.map((s) =>
+        rewriteIds({ ...s, projectId: DEMO_PROJECT_ID, createdAt: 0 }, src.projectId),
+    );
+    const artifactsRewritten = src.artifacts.map((a) =>
+        rewriteIds({ ...a, projectId: DEMO_PROJECT_ID, createdAt: 0, updatedAt: 0 }, src.projectId),
+    );
+    const versionsRewritten = src.artifactVersions.map((v) =>
+        rewriteIds({ ...v, createdAt: 0 }, src.projectId),
+    );
+    const historyRewritten = src.historyEvents.map((h) =>
+        rewriteIds({ ...h, projectId: DEMO_PROJECT_ID, createdAt: 0 }, src.projectId),
+    );
+
+    return `/**
+ * Static demo-project fixture.
+ *
+ * Auto-generated by the /admin/capture-demo helper. Do not hand-edit unless
+ * you know what you're doing — regenerate via the helper instead.
+ *
+ * The fixture hydrates a finished Synapse project ("Demo: Fitness tracker")
+ * so visitors can explore the end-to-end pipeline without a Gemini API key.
+ */
+
+import type {
+    Project,
+    SpineVersion,
+    Artifact,
+    ArtifactVersion,
+    HistoryEvent,
+} from '../types';
+
+export const DEMO_PROJECT_ID = ${JSON.stringify(DEMO_PROJECT_ID)};
+
+export const DEMO_PROJECT_CAPTURED = true;
+
+export const demoProject: Project = ${JSON.stringify(projectRewritten, null, 4)};
+
+export const demoSpineVersions: SpineVersion[] = ${JSON.stringify(spinesRewritten, null, 4)};
+
+export const demoArtifacts: Artifact[] = ${JSON.stringify(artifactsRewritten, null, 4)};
+
+export const demoArtifactVersions: ArtifactVersion[] = ${JSON.stringify(versionsRewritten, null, 4)};
+
+export const demoHistoryEvents: HistoryEvent[] = ${JSON.stringify(historyRewritten, null, 4)};
+`;
+}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -7,6 +7,8 @@ import { ProjectDrawer } from './ProjectDrawer';
 import { normalizeError, userMessage } from '../lib/errors';
 import type { ProjectPlatform } from '../types';
 import { useAuthStore } from '../store/authStore';
+import { useToastStore } from '../store/toastStore';
+import { DEMO_PROJECT_ID } from '../data/demoProject';
 
 const EXAMPLE_PROMPTS = [
     {
@@ -39,9 +41,22 @@ const EXAMPLE_PROMPTS = [
 const MEET_DISMISSED_KEY = 'synapse-meet-dismissed';
 
 export function HomePage() {
-    const { createProject } = useProjectStore();
+    const { createProject, loadDemoProject } = useProjectStore();
     const navigate = useNavigate();
     const user = useAuthStore((s) => s.user);
+
+    const handleOpenDemo = () => {
+        const { captured } = loadDemoProject();
+        if (!captured) {
+            useToastStore.getState().addToast({
+                type: 'warning',
+                title: 'Demo not available yet',
+                message: 'The demo fixture has not been captured. Run /admin/capture-demo in dev to generate it.',
+            });
+            return;
+        }
+        navigate(`/p/${DEMO_PROJECT_ID}`);
+    };
 
     const [projectName, setProjectName] = useState('');
     const [promptText, setPromptText] = useState('');
@@ -216,6 +231,14 @@ export function HomePage() {
 
                     {/* Example prompt pills */}
                     <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-hide">
+                        <button
+                            type="button"
+                            onClick={handleOpenDemo}
+                            className="shrink-0 px-4 py-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 text-sm text-indigo-300 hover:border-indigo-400/60 hover:text-indigo-200 transition whitespace-nowrap"
+                            title="Open the prepopulated demo project — no API key required"
+                        >
+                            View demo project
+                        </button>
                         {EXAMPLE_PROMPTS.map((example) => (
                             <button
                                 key={example.label}

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Github, Linkedin, Loader2, Lock, Mail, User as UserIcon } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
+import { useProjectStore } from '../store/projectStore';
+import { useToastStore } from '../store/toastStore';
+import { DEMO_PROJECT_ID } from '../data/demoProject';
 
 type Tab = 'signin' | 'signup';
 type FieldName = 'email' | 'password' | 'name';
@@ -155,11 +158,21 @@ export function LoginPage() {
                     </button>
                     <button
                         type="button"
-                        disabled
-                        title="Coming soon"
-                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-sm text-neutral-400 cursor-not-allowed"
+                        onClick={() => {
+                            const { captured } = useProjectStore.getState().loadDemoProject();
+                            if (!captured) {
+                                useToastStore.getState().addToast({
+                                    type: 'warning',
+                                    title: 'Demo not available yet',
+                                    message: 'The demo fixture has not been captured. A developer needs to run /admin/capture-demo and commit the result.',
+                                });
+                                return;
+                            }
+                            navigate(`/p/${DEMO_PROJECT_ID}`);
+                        }}
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 text-sm text-indigo-300 hover:border-indigo-400/60 hover:text-indigo-200 transition"
                     >
-                        Demo project (coming soon)
+                        Demo project
                     </button>
                 </div>
 

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -21,6 +21,7 @@ import { ExportModal } from './ExportModal';
 import { FeedbackItemsList } from './FeedbackItemsList';
 import { BranchCanvas } from './BranchCanvas';
 import type { Branch, PipelineStage, FeedbackItem } from '../types';
+import { DEMO_PROJECT_ID } from '../data/demoProject';
 
 export function ProjectWorkspace() {
     const { projectId } = useParams<{ projectId: string }>();
@@ -294,6 +295,17 @@ export function ProjectWorkspace() {
                     hasPRD={!!activeSpine?.isFinal}
                 />
             </div>
+
+            {/* Demo-mode banner: shown only for the prepopulated demo project.
+                Regenerate / refine buttons stay active; the existing no-key
+                error paths surface readable messages if the user clicks one. */}
+            {projectId === DEMO_PROJECT_ID && (
+                <div className="shrink-0 bg-indigo-500/10 border-b border-indigo-500/30 text-indigo-200 text-sm px-4 py-2 flex items-center justify-center gap-2 z-10">
+                    <span>
+                        You&apos;re viewing the demo project. Regenerating or refining requires your own Gemini API key — add one in Settings to customize.
+                    </span>
+                </div>
+            )}
 
             {/* Main Workspace Area — flex-1 fills remaining height */}
             <div className="flex-1 flex overflow-hidden">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,13 +1,103 @@
 import { useState } from 'react';
-import { X, Key, Cpu, Shield, ExternalLink, Activity } from 'lucide-react';
+import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown } from 'lucide-react';
+import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 
 interface SettingsModalProps {
     onClose: () => void;
 }
 
+/**
+ * Model catalog. Order within each tier = display order in the UI. `current`
+ * models render expanded; `legacy` models render inside a collapsed section.
+ * The `id` is passed straight into the Gemini REST URL, so it must match what
+ * Google's API accepts (see https://ai.google.dev/gemini-api/docs/models).
+ */
+type ModelTier = 'current' | 'legacy';
+interface ModelOption {
+    id: string;
+    name: string;
+    description: string;
+    tier: ModelTier;
+}
+
+const MODEL_CATALOG: ModelOption[] = [
+    {
+        id: 'gemini-3-flash-preview',
+        name: 'Gemini 3 Flash',
+        description: 'Recommended default. Frontier-class quality with capacity to spare.',
+        tier: 'current',
+    },
+    {
+        id: 'gemini-3.1-pro-preview',
+        name: 'Gemini 3.1 Pro',
+        description: 'Maximum reasoning power for the most complex PRDs.',
+        tier: 'current',
+    },
+    {
+        id: 'gemini-3.1-flash-lite-preview',
+        name: 'Gemini 3.1 Flash-Lite',
+        description: 'Cheapest option. Good for quick drafts and iteration.',
+        tier: 'current',
+    },
+    {
+        id: 'gemini-2.5-pro',
+        name: 'Gemini 2.5 Pro',
+        description: 'Previous-generation high-reasoning model.',
+        tier: 'legacy',
+    },
+    {
+        id: 'gemini-2.5-flash',
+        name: 'Gemini 2.5 Flash',
+        description: 'Previous-generation fast model. Often hits capacity limits — prefer 3 Flash.',
+        tier: 'legacy',
+    },
+];
+
+const CURRENT_MODELS = MODEL_CATALOG.filter((m) => m.tier === 'current');
+const LEGACY_MODELS = MODEL_CATALOG.filter((m) => m.tier === 'legacy');
+
+function ModelRadio({
+    option,
+    selected,
+    onSelect,
+}: {
+    option: ModelOption;
+    selected: boolean;
+    onSelect: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onSelect}
+            className={`flex items-start gap-4 p-4 rounded-2xl border transition-all text-left ${
+                selected
+                    ? 'bg-indigo-500/10 border-indigo-500/50 ring-1 ring-indigo-500/50'
+                    : 'bg-white/5 border-white/5 hover:bg-white/10'
+            }`}
+        >
+            <div
+                className={`mt-1 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                    selected ? 'border-indigo-500' : 'border-neutral-600'
+                }`}
+            >
+                {selected && <div className="w-2 h-2 rounded-full bg-indigo-400" />}
+            </div>
+            <div>
+                <h4 className="text-sm font-bold text-white mb-0.5">{option.name}</h4>
+                <p className="text-xs text-neutral-400">{option.description}</p>
+            </div>
+        </button>
+    );
+}
+
 export function SettingsModal({ onClose }: SettingsModalProps) {
     const [apiKey, setApiKey] = useState(() => localStorage.getItem('GEMINI_API_KEY') || '');
-    const [model, setModel] = useState(() => localStorage.getItem('GEMINI_MODEL') || 'gemini-2.5-flash');
+    const [model, setModel] = useState(() => localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL);
+
+    // Expand the legacy section automatically if the user is currently on a
+    // legacy model — otherwise keep it collapsed to reduce visual noise.
+    const currentIsLegacy = LEGACY_MODELS.some((m) => m.id === model);
+    const [legacyOpen, setLegacyOpen] = useState(currentIsLegacy);
 
     const handleSave = (e: React.FormEvent) => {
         e.preventDefault();
@@ -18,8 +108,8 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
 
     return (
         <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center p-4 z-50 animate-in fade-in duration-200" onClick={onClose}>
-            <div 
-                className="bg-neutral-900/90 backdrop-blur-xl rounded-3xl w-full max-w-lg shadow-[0_0_50px_-12px_rgba(0,0,0,0.5)] overflow-hidden border border-white/10 flex flex-col animate-in zoom-in-95 duration-200" 
+            <div
+                className="bg-neutral-900/90 backdrop-blur-xl rounded-3xl w-full max-w-lg shadow-[0_0_50px_-12px_rgba(0,0,0,0.5)] overflow-hidden border border-white/10 flex flex-col animate-in zoom-in-95 duration-200"
                 onClick={e => e.stopPropagation()}
             >
                 {/* Header */}
@@ -33,8 +123,8 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                             <p className="text-xs text-neutral-400 font-medium">Configure your AI intelligence</p>
                         </div>
                     </div>
-                    <button 
-                        onClick={onClose} 
+                    <button
+                        onClick={onClose}
                         className="w-8 h-8 rounded-full flex items-center justify-center text-neutral-500 hover:text-white hover:bg-white/5 transition-all"
                     >
                         <X size={20} />
@@ -49,10 +139,10 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                                 <Shield size={14} className="text-indigo-400" />
                                 Google Gemini API Key
                             </label>
-                            <a 
-                                href="https://aistudio.google.com/app/apikey" 
-                                target="_blank" 
-                                rel="noreferrer" 
+                            <a
+                                href="https://aistudio.google.com/app/apikey"
+                                target="_blank"
+                                rel="noreferrer"
                                 className="text-[11px] font-bold uppercase tracking-wider text-indigo-400 hover:text-indigo-300 transition flex items-center gap-1"
                             >
                                 Get Key <ExternalLink size={10} />
@@ -77,36 +167,45 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                             <Cpu size={14} className="text-indigo-400" />
                             Intelligence Level
                         </label>
-                        
+
                         <div className="grid grid-cols-1 gap-3">
+                            {CURRENT_MODELS.map((option) => (
+                                <ModelRadio
+                                    key={option.id}
+                                    option={option}
+                                    selected={model === option.id}
+                                    onSelect={() => setModel(option.id)}
+                                />
+                            ))}
+                        </div>
+
+                        {/* Legacy section — collapsed by default unless the user
+                            is on a legacy model. */}
+                        <div className="pt-2">
                             <button
                                 type="button"
-                                onClick={() => setModel('gemini-2.5-flash')}
-                                className={`flex items-start gap-4 p-4 rounded-2xl border transition-all text-left ${model === 'gemini-2.5-flash' ? 'bg-indigo-500/10 border-indigo-500/50 ring-1 ring-indigo-500/50' : 'bg-white/5 border-white/5 hover:bg-white/10'}`}
+                                onClick={() => setLegacyOpen((v) => !v)}
+                                className="w-full flex items-center justify-between text-[11px] font-bold uppercase tracking-wider text-neutral-500 hover:text-neutral-300 transition py-1"
+                                aria-expanded={legacyOpen}
                             >
-                                <div className={`mt-1 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${model === 'gemini-2.5-flash' ? 'border-indigo-500' : 'border-neutral-600'}`}>
-                                    {model === 'gemini-2.5-flash' && <div className="w-2 h-2 rounded-full bg-indigo-400" />}
-                                </div>
-                                <div>
-                                    <h4 className="text-sm font-bold text-white mb-0.5">Gemini 2.5 Flash</h4>
-                                    <p className="text-xs text-neutral-400">Extreme speed. Best for rapid brainstorming.</p>
-                                </div>
+                                <span>Legacy models</span>
+                                <ChevronDown
+                                    size={14}
+                                    className={`transition-transform ${legacyOpen ? 'rotate-180' : ''}`}
+                                />
                             </button>
-
-                            <button
-                                type="button"
-                                onClick={() => setModel('gemini-2.5-pro')}
-                                className={`flex items-start gap-4 p-4 rounded-2xl border transition-all text-left ${model === 'gemini-2.5-pro' ? 'bg-indigo-500/10 border-indigo-500/50 ring-1 ring-indigo-500/50' : 'bg-white/5 border-white/5 hover:bg-white/10'}`}
-                            >
-                                <div className={`mt-1 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${model === 'gemini-2.5-pro' ? 'border-indigo-500' : 'border-neutral-600'}`}>
-                                    {model === 'gemini-2.5-pro' && <div className="w-2 h-2 rounded-full bg-indigo-400" />}
+                            {legacyOpen && (
+                                <div className="grid grid-cols-1 gap-3 mt-3">
+                                    {LEGACY_MODELS.map((option) => (
+                                        <ModelRadio
+                                            key={option.id}
+                                            option={option}
+                                            selected={model === option.id}
+                                            onSelect={() => setModel(option.id)}
+                                        />
+                                    ))}
                                 </div>
-                                <div>
-                                    <h4 className="text-sm font-bold text-white mb-0.5">Gemini 2.5 Pro</h4>
-                                    <p className="text-xs text-neutral-400">Max reasoning power. Best for complex PRDs.</p>
-                                </div>
-                            </button>
-
+                            )}
                         </div>
                     </div>
 

--- a/src/data/demoProject.ts
+++ b/src/data/demoProject.ts
@@ -1,0 +1,46 @@
+/**
+ * Static demo-project fixture.
+ *
+ * This file ships a fully-finished Synapse project ("Demo: Fitness tracker")
+ * so any visitor can explore the end-to-end pipeline — finished PRD, a mockup
+ * with screens, and all 7 core artifacts — without providing a Gemini API key.
+ *
+ * The content is captured once by running the pipeline in /admin/capture-demo
+ * (see src/components/AdminCaptureDemo.tsx). That helper is only available in
+ * dev builds; it downloads a regenerated version of this file which is then
+ * committed over the top of the old one.
+ *
+ * IMPORTANT: keep `DEMO_PROJECT_ID` stable. The store's `loadDemoProject()`
+ * action keys on it for idempotency — if we changed the id, every prior
+ * visitor would get a duplicate copy on next visit.
+ */
+
+import type {
+    Project,
+    SpineVersion,
+    Artifact,
+    ArtifactVersion,
+    HistoryEvent,
+} from '../types';
+
+export const DEMO_PROJECT_ID = '00000000-0000-4000-8000-000000000d01';
+
+/**
+ * True when the fixture has real captured content. The capture helper flips
+ * this to `true` when it writes the file. Until then, `loadDemoProject()`
+ * surfaces a friendly error instead of hydrating an empty shell.
+ */
+export const DEMO_PROJECT_CAPTURED = false;
+
+export const demoProject: Project = {
+    id: DEMO_PROJECT_ID,
+    name: 'Demo: Fitness tracker',
+    createdAt: 0,
+    platform: 'app',
+    currentStage: 'artifacts',
+};
+
+export const demoSpineVersions: SpineVersion[] = [];
+export const demoArtifacts: Artifact[] = [];
+export const demoArtifactVersions: ArtifactVersion[] = [];
+export const demoHistoryEvents: HistoryEvent[] = [];

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -21,8 +21,16 @@ const getApiKey = () => {
     return key;
 };
 
+/**
+ * Default model. Gemini 3 Flash (preview) replaced 2.5 Flash as the recommended
+ * everyday model in early 2026 — it has more capacity headroom and better
+ * quality at a similar price. See SettingsModal for the full catalog + legacy
+ * migration flag.
+ */
+export const DEFAULT_GEMINI_MODEL = 'gemini-3-flash-preview';
+
 const getModel = () => {
-    return localStorage.getItem('GEMINI_MODEL') || 'gemini-2.5-flash';
+    return localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL;
 };
 
 export const callGemini = async (systemInstruction: string, promptText: string, jsonMode?: JsonModeConfig, signal?: AbortSignal) => {

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -3,6 +3,15 @@ import { v4 as uuidv4 } from 'uuid';
 import type { Project, HistoryEvent, PipelineStage, ProjectPlatform } from '../../types';
 import type { ProjectState } from '../types';
 import { trackActivity } from '../../lib/recruiterApi';
+import {
+    DEMO_PROJECT_ID,
+    DEMO_PROJECT_CAPTURED,
+    demoProject,
+    demoSpineVersions,
+    demoArtifacts,
+    demoArtifactVersions,
+    demoHistoryEvents,
+} from '../../data/demoProject';
 
 export type ProjectSlice = {
     projects: Record<string, Project>;
@@ -12,6 +21,7 @@ export type ProjectSlice = {
     getProject: ProjectState['getProject'];
     getHistoryEvents: ProjectState['getHistoryEvents'];
     setProjectStage: ProjectState['setProjectStage'];
+    loadDemoProject: ProjectState['loadDemoProject'];
 };
 
 export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice> = (set, get) => ({
@@ -101,5 +111,53 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             }
         }));
         void trackActivity(stage === 'mockups' ? 'viewed_mockups' : 'clicked_section', { section: stage, projectId });
+    },
+
+    // Hydrates the store with the pre-captured demo project. Idempotent: if
+    // the demo project already exists, no records are mutated (so a user's
+    // in-progress edits to the demo copy are preserved on re-click).
+    loadDemoProject: () => {
+        const existing = get().projects[DEMO_PROJECT_ID];
+        if (existing) {
+            return { projectId: DEMO_PROJECT_ID, captured: DEMO_PROJECT_CAPTURED };
+        }
+
+        if (!DEMO_PROJECT_CAPTURED) {
+            // Placeholder fixture is still in place — don't hydrate a hollow
+            // project. The caller surfaces this to the user.
+            return { projectId: DEMO_PROJECT_ID, captured: false };
+        }
+
+        set((state) => ({
+            projects: { ...state.projects, [DEMO_PROJECT_ID]: demoProject },
+            spineVersions: {
+                ...state.spineVersions,
+                [DEMO_PROJECT_ID]: demoSpineVersions,
+            },
+            artifacts: {
+                ...state.artifacts,
+                [DEMO_PROJECT_ID]: demoArtifacts,
+            },
+            artifactVersions: {
+                ...state.artifactVersions,
+                [DEMO_PROJECT_ID]: demoArtifactVersions,
+            },
+            historyEvents: {
+                ...state.historyEvents,
+                [DEMO_PROJECT_ID]: demoHistoryEvents,
+            },
+            // Branches and feedbackItems intentionally left empty — demo has
+            // none. Keep the maps shaped the same as other projects.
+            branches: {
+                ...state.branches,
+                [DEMO_PROJECT_ID]: state.branches[DEMO_PROJECT_ID] ?? [],
+            },
+            feedbackItems: {
+                ...state.feedbackItems,
+                [DEMO_PROJECT_ID]: state.feedbackItems[DEMO_PROJECT_ID] ?? [],
+            },
+        }));
+
+        return { projectId: DEMO_PROJECT_ID, captured: true };
     },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -35,6 +35,9 @@ export interface ProjectState {
     // Pipeline stage
     setProjectStage: (projectId: string, stage: PipelineStage) => void;
 
+    // Demo project hydration
+    loadDemoProject: () => { projectId: string; captured: boolean };
+
     // Structured PRD
     updateStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD) => void;
     updateSpineStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD, responseText: string) => void;


### PR DESCRIPTION
## Summary

- **Prepopulated demo project.** Adds a zero-API-key entry path into the product. A dev-only `/admin/capture-demo` route runs the real pipeline once against the maintainer's own Gemini key and serializes the result to `src/data/demoProject.ts`. Visitors click **Demo project** on the LoginPage (or **View demo project** on the HomePage) to hydrate the store from that fixture and walk a finished Fitness Tracker project end-to-end — PRD, mockup, all 7 core artifacts — without needing their own key.
- **Gemini 3 model support.** Settings now exposes `gemini-3-flash-preview` (new default), `gemini-3.1-pro-preview`, and `gemini-3.1-flash-lite-preview` as primary options. `gemini-2.5-pro` and `gemini-2.5-flash` moved under a collapsible "Legacy" section. A one-shot migration auto-upgrades existing `gemini-2.5-flash` users to `gemini-3-flash-preview` (gated by a sentinel key so a deliberate re-pick is preserved).

## Why

- New visitors currently see nothing until they sign up, enter a Gemini key, and wait through a generation. The LoginPage already had a placeholder *Demo project (coming soon)* button — this wires it up.
- `gemini-2.5-flash` is hitting capacity errors as Google shifts traffic to the Gemini 3 family. Paid-tier users still see throttling. `gemini-3-flash-preview` has more headroom at a similar price point.

## How to populate the demo fixture (maintainer only)

The committed `src/data/demoProject.ts` ships with `DEMO_PROJECT_CAPTURED = false` — clicking the demo button surfaces a "not captured yet" toast until a real fixture lands. To generate it:

1. `npm run dev`, enter your Gemini key in Settings on the home page.
2. Visit `http://localhost:5173/admin/capture-demo`.
3. Click **Generate demo project**. The full pipeline runs (PRD → mockup → 7 artifacts) with a live step log.
4. Browser downloads `demoProject.ts`. Move it to `src/data/demoProject.ts` and commit.

The capture route is guarded by `import.meta.env.DEV` so it's tree-shaken from production builds.

## Key files

- `src/data/demoProject.ts` — static fixture (empty placeholder until capture runs)
- `src/components/AdminCaptureDemo.tsx` — dev-only capture UI
- `src/store/slices/projectSlice.ts` — idempotent `loadDemoProject()` action
- `src/components/LoginPage.tsx`, `src/components/HomePage.tsx` — demo entry points
- `src/components/ProjectWorkspace.tsx` — demo banner
- `src/components/SettingsModal.tsx` — refactored to data-driven model catalog with Legacy collapse
- `src/lib/geminiClient.ts` — exports `DEFAULT_GEMINI_MODEL = 'gemini-3-flash-preview'`
- `src/App.tsx` — registers `/admin/capture-demo` route (DEV only) and runs the one-shot model migration

## Test plan

- [ ] Clear localStorage, open `/` → click **View demo project** → toast says *"Demo not available yet — Run /admin/capture-demo in dev to generate it."* (expected until capture runs)
- [ ] Visit `/admin/capture-demo` → 11 pipeline steps listed, **Generate demo project** button visible
- [ ] Open Settings on fresh install → **Gemini 3 Flash** pre-selected, legacy section collapsed
- [ ] Prime `GEMINI_MODEL = 'gemini-2.5-flash'`, clear the migration sentinel, reload → model auto-upgrades to `gemini-3-flash-preview`
- [ ] Re-pick 2.5 Flash after migration → preserved on next reload (sentinel respected)
- [ ] `npx tsc --noEmit`, `npm run lint`, `npm run build` all pass
- [ ] Once the capture has been run and the fixture committed: clicking **Demo project** navigates to `/p/<DEMO_PROJECT_ID>` with banner visible, full PRD/mockup/artifacts rendered, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)