### PR TITLE
fix(mockups): prevent oversized shell layouts from blanking the preview

### DIFF
--- a/src/components/mockups/buildMockupSrcDoc.ts
+++ b/src/components/mockups/buildMockupSrcDoc.ts
@@ -17,7 +17,16 @@ export const buildMockupSrcDoc = (fragment: string): string => {
   <style>
     :root { color-scheme: light; }
     html, body { margin: 0; padding: 0; background: #e5e7eb; }
+    html, body { overflow-y: auto; }
     body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+    /* Defensive overrides for LLM-emitted shells that trap content above
+       the iframe fold. The sandbox iframe is itself the scroll viewport,
+       so root shells should grow naturally instead of clipping. */
+    body > div.min-h-screen { min-height: 100vh; height: auto; }
+    body > div.min-h-screen.flex { min-height: 100vh; }
+    /* Belt-and-suspenders: even if the sanitizer misses a token, force any
+       main or flex column shell to release the overflow-hidden token. */
+    main.overflow-hidden, div.overflow-hidden.flex, div.overflow-hidden.flex-col { overflow: visible !important; }
   </style>
 </head>
 <body>

--- a/src/lib/mockupQuality.ts
+++ b/src/lib/mockupQuality.ts
@@ -45,6 +45,59 @@ const normalizeRootWrapper = (html: string): string => {
     return `<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">\n${trimmed}\n</div>`;
 };
 
+// Within a class="..." attribute, strip a specific Tailwind utility token
+// without disturbing surrounding classes.
+const stripClassToken = (classAttr: string, token: string): string =>
+    classAttr.replace(new RegExp(`(?:^|\\s)${token}(?=\\s|$)`, 'g'), ' ').replace(/\s+/g, ' ').trim();
+
+// Inject a Tailwind utility token into a class="..." attribute if it isn't
+// already present. Used to splice in `min-h-0` so flex children can actually
+// shrink and let `overflow-y-auto` activate inside the iframe.
+const ensureClassToken = (classAttr: string, token: string): string => {
+    if (new RegExp(`(?:^|\\s)${token}(?=\\s|$)`).test(classAttr)) return classAttr;
+    return `${classAttr.trim()} ${token}`.trim();
+};
+
+// Rewrite each class="..." attribute in the fragment so that:
+// 1. Shell containers don't trap their children with `overflow-hidden` — the
+//    sandbox iframe is already a scroll viewport, and nested `overflow-hidden`
+//    chains are how LLM-emitted dashboards end up showing nothing.
+// 2. Any `flex-1 overflow-y-auto` scroll container also carries `min-h-0` so
+//    the classic flexbox `min-height: auto` gotcha doesn't push content past
+//    the viewport.
+const fixOverflowScrollChains = (html: string): string => {
+    return html.replace(/class\s*=\s*("|')([^"']*)\1/gi, (match, quote, value) => {
+        let next = value as string;
+        const hasFlex = /(?:^|\s)flex(?=\s|$)/.test(next);
+        const hasFlexCol = /(?:^|\s)flex-col(?=\s|$)/.test(next);
+        const hasFlex1 = /(?:^|\s)flex-1(?=\s|$)/.test(next);
+        const hasOverflowHidden = /(?:^|\s)overflow-hidden(?=\s|$)/.test(next);
+        const hasOverflowYAuto = /(?:^|\s)overflow-y-auto(?=\s|$)/.test(next);
+
+        // Drop overflow-hidden from shell containers (anything that's also a
+        // flex container or already inside a flex-1 column). This is the
+        // pattern that traps content above the iframe fold.
+        if (hasOverflowHidden && (hasFlex || hasFlexCol || hasFlex1)) {
+            next = stripClassToken(next, 'overflow-hidden');
+        }
+
+        // Make sure flex-1 + overflow-y-auto chains can actually scroll.
+        if (hasFlex1 && hasOverflowYAuto) {
+            next = ensureClassToken(next, 'min-h-0');
+        }
+
+        // Make sure column-direction flex children can shrink so nested
+        // scroll containers behave correctly (`flex-col` parents need
+        // `min-h-0` for the same reason).
+        if (hasFlex1 && hasFlexCol) {
+            next = ensureClassToken(next, 'min-h-0');
+        }
+
+        if (next === value) return match;
+        return `class=${quote}${next}${quote}`;
+    });
+};
+
 export const sanitizeMockupHtmlForPreview = (html: string): string => {
     let out = html.length > MAX_FRAGMENT_LENGTH
         ? html.slice(0, MAX_FRAGMENT_LENGTH) + '\n<!-- truncated: exceeded maximum safe length -->'
@@ -67,6 +120,8 @@ export const sanitizeMockupHtmlForPreview = (html: string): string => {
     out = out.replace(/(href|src|action)\s*=\s*"\s*(javascript|data):[^"]*"/gi, '$1="#"');
     out = out.replace(/(href|src|action)\s*=\s*'\s*(javascript|data):[^']*'/gi, "$1='#'");
     out = out.replace(/(href|src|action)\s*=\s*(javascript|data):[^\s>]*/gi, '$1="#"');
+
+    out = fixOverflowScrollChains(out);
 
     return out;
 };
@@ -136,6 +191,21 @@ export const assessMockupHtmlQuality = (html: string): MockupQualityReport => {
             code: 'placeholder_copy',
             severity: 'high',
             message: 'Contains placeholder copy that reduces artifact credibility.',
+        });
+    }
+
+    // Layout-viability check: nested-scroll shells that don't fit the iframe
+    // viewport are the #1 cause of "preview is blank" reports. Both `flex-1
+    // overflow-y-auto` (without `min-h-0`) and `overflow-hidden` on a flex
+    // shell are normalized by `sanitizeMockupHtmlForPreview`, but we still
+    // surface a low-severity warning so authors can see what was rewritten.
+    const hasNestedScroll = /class\s*=\s*['"][^'"]*\bflex-1\b[^'"]*\boverflow-y-auto\b[^'"]*['"]|class\s*=\s*['"][^'"]*\boverflow-y-auto\b[^'"]*\bflex-1\b[^'"]*['"]/i.test(trimmed);
+    const hasShellOverflowHidden = /class\s*=\s*['"][^'"]*\b(?:flex|flex-col)\b[^'"]*\boverflow-hidden\b[^'"]*['"]|class\s*=\s*['"][^'"]*\boverflow-hidden\b[^'"]*\b(?:flex|flex-col)\b[^'"]*['"]/i.test(trimmed);
+    if (hasNestedScroll || hasShellOverflowHidden) {
+        issues.push({
+            code: 'fragile_scroll_shell',
+            severity: 'low',
+            message: 'Used a nested-scroll shell pattern (flex-1 overflow-y-auto / overflow-hidden); auto-rewritten for preview compatibility.',
         });
     }
 

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -58,6 +58,14 @@ const buildSystemPrompt = (settings: MockupSettings): string => {
 - Wrap EACH screen in a single top-level \`<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">\` so the sandbox renders a full-bleed surface.
 - Output must be valid HTML — every opening tag closed, attributes quoted.
 
+## Layout & scrolling rules (critical — preview will be blank if violated)
+- The render sandbox is a scrollable iframe. DO NOT build your own scroll containers inside it.
+- Do NOT put \`overflow-hidden\` on the root \`min-h-screen\` shell, on \`<main>\`, or on any flex column container. These trap content above the iframe fold and the user sees a blank preview.
+- Do NOT use \`flex-1 overflow-y-auto\` to create an internal scrolling content area. Let the page flow naturally; the iframe scrolls.
+- For sidebar shells: put \`flex\` on the root, \`<aside class="w-64 ...">\`, and \`<main class="flex-1 ...">\` (no \`overflow-hidden\`, no \`flex flex-col\` with internal scroll). Content inside main flows top-to-bottom.
+- Avoid \`h-screen\` (use \`min-h-screen\` only on the root). Do not pin inner sections to viewport height.
+- Keep total content density realistic for a single screen — if a section has 6+ KPI tiles plus 4+ panels plus a hero plus a leaderboard, split across screens instead of stuffing one shell.
+
 ## Required layout contract per screen
 - Every screen must include: (1) top-level app shell, (2) page header with title + primary action, (3) at least one primary content section, (4) at least one secondary/supporting section (filters, activity, details, etc.), and (5) at least one interactive control (button/input/select/tab).
 - Spacing rhythm must follow Tailwind scale 2/3/4/6/8. Avoid arbitrary values unless necessary for framing.


### PR DESCRIPTION
## Summary

- Sanitizer now rewrites the `flex-1 overflow-y-auto` + shell `overflow-hidden` patterns the LLM keeps emitting, so the preview iframe can actually scroll instead of clipping content into a blank panel.
- Defensive CSS in the iframe wrapper forces `min-h-screen` shells to grow naturally and overrides residual `overflow-hidden` on `<main>` / flex columns.
- Mockup system prompt gains an explicit **Layout & scrolling rules** section telling the model not to build internal scroll containers.

## Background

A high-fidelity dashboard mockup rendered as a blank preview because the LLM emitted:

```html
<div class="min-h-screen flex">
  <aside class="w-64 ...">…</aside>
  <main class="flex-1 flex flex-col overflow-hidden">
    <header class="h-16">…</header>
    <div class="flex-1 overflow-y-auto p-8 space-y-8">…dashboard…</div>
  </main>
</div>
```

Inside the 760px iframe this trips the flex `min-height: auto` gotcha — the inner `overflow-y-auto` never activates, content grows past the viewport, `<main>`'s `overflow-hidden` clips it, and the dark background hides the fold. The existing safeguards (`mockupQuality.ts`, `mockupAlignmentCritique.ts`) check structure and PRD alignment but had nothing for layout viability.

## Changes

- **`src/lib/mockupQuality.ts`**: new `fixOverflowScrollChains` runs as part of `sanitizeMockupHtmlForPreview`. Strips `overflow-hidden` from any element that's also a flex shell. Injects `min-h-0` into `flex-1 overflow-y-auto` and `flex-1 flex-col` chains. New low-severity `fragile_scroll_shell` quality warning surfaces when the rewrite fires.
- **`src/components/mockups/buildMockupSrcDoc.ts`**: iframe CSS gets `html, body { overflow-y: auto }`, `body > div.min-h-screen { height: auto }`, and a belt-and-suspenders override forcing `overflow: visible` on `<main>` / flex shells with `overflow-hidden`.
- **`src/lib/services/mockupService.ts`**: system prompt gains a **Layout & scrolling rules (critical — preview will be blank if violated)** section explicitly forbidding shell `overflow-hidden`, `flex-1 overflow-y-auto`, and `h-screen` on inner sections.

## Verification

- `npx tsc --noEmit` clean.
- All 53 vitest tests pass (no test changes needed).
- `npm run build` succeeds.
- Direct sanitizer run on the user's broken HTML rewrites `<main class="flex-1 flex flex-col overflow-hidden">` → `<main class="flex-1 flex flex-col min-h-0">` and appends `min-h-0` to the inner `flex-1 overflow-y-auto` div.

## Test plan

- [ ] Generate a desktop mockup with `fidelity=high`, `scope=single_screen` and confirm dense dashboards render with the iframe scrollable instead of going blank.
- [ ] Inspect a generated mockup's HTML in the Code tab and confirm shells no longer carry `overflow-hidden`.
- [ ] Confirm previously good mockups still render correctly (no regressions in simple/centered shells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)