### PR TITLE
Harden mockup generation with deterministic validation and safe fallback rendering

### DIFF
--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -177,6 +177,8 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                         severity: critique.severity,
                         missingConcepts: critique.missingConcepts,
                     },
+                    generationStrategy: 'mockup_strategy_v2',
+                    usedFallbackTemplate: warnings.some(w => w.includes('safe fallback')),
                 },
                 [{
                     id: uuidv4(),
@@ -190,7 +192,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
             setSelectedArtifactId(artifactId);
             setShowGeneratePanel(false);
             if (warnings.length > 0) {
-                setWarning(`Generated with ${warnings.length} skipped screen(s): ${warnings.join(' ')}`);
+                setWarning(`Generated with safeguards (${warnings.length} notices): ${warnings.join(' ')}`);
             }
         } catch (e) {
             const err = normalizeError(e);
@@ -224,6 +226,8 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                         severity: critique.severity,
                         missingConcepts: critique.missingConcepts,
                     },
+                    generationStrategy: 'mockup_strategy_v2',
+                    usedFallbackTemplate: warnings.some(w => w.includes('safe fallback')),
                 },
                 [{
                     id: uuidv4(),
@@ -235,14 +239,14 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                 latestVersion?.id,
             );
             if (warnings.length > 0) {
-                setWarning(`Regenerated with ${warnings.length} skipped screen(s): ${warnings.join(' ')}`);
+                setWarning(`Regenerated with safeguards (${warnings.length} notices): ${warnings.join(' ')}`);
             }
         } catch (e) {
             // On regeneration failure, the previous version is preserved — the
             // user still sees the last known good content.
             const err = normalizeError(e);
             console.error('[Mockup regeneration failed]', err.raw);
-            setError(userMessage(err));
+            setError(`Regeneration failed on ${new Date().toLocaleString()}. Showing the previous version. ${userMessage(err)}`);
         } finally {
             setIsGenerating(false);
         }

--- a/src/components/mockups/MockupHtmlPreview.tsx
+++ b/src/components/mockups/MockupHtmlPreview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { MockupPlatform } from '../../types';
 import { buildMockupSrcDoc } from './buildMockupSrcDoc';
 
@@ -13,6 +13,9 @@ type Props = {
 // `allow-same-origin` the iframe is treated as cross-origin and cannot touch
 // Synapse state.
 export function MockupHtmlPreview({ html, platform, className }: Props) {
+    const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+    const [retryCount, setRetryCount] = useState(0);
+    const frameKey = `${retryCount}-${html.length}`;
     const srcDoc = useMemo(() => {
         if (!html || !html.trim()) return null;
         try {
@@ -23,29 +26,51 @@ export function MockupHtmlPreview({ html, platform, className }: Props) {
         }
     }, [html]);
 
+    useEffect(() => {
+        window.setTimeout(() => setStatus(srcDoc ? 'loading' : 'error'), 0);
+        const timer = window.setTimeout(() => {
+            setStatus(current => (current === 'loading' ? 'error' : current));
+        }, 4500);
+        return () => window.clearTimeout(timer);
+    }, [srcDoc, retryCount]);
+
     const height = platform === 'mobile' ? 760 : platform === 'responsive' ? 720 : 760;
     const maxWidth = platform === 'mobile' ? 430 : undefined;
 
-    if (!srcDoc) {
+    if (!srcDoc || status === 'error') {
         return (
             <div
                 className={`w-full bg-neutral-50 rounded-lg border border-dashed border-neutral-300 flex flex-col items-center justify-center text-neutral-400 ${className ?? ''}`}
                 style={{ height: 240 }}
             >
                 <p className="text-sm font-medium text-neutral-500">Preview unavailable</p>
-                <p className="text-xs mt-1">This screen's content could not be rendered. Try regenerating.</p>
+                <p className="text-xs mt-1">This screen's content could not be rendered safely. Try regenerating.</p>
+                <button
+                    type="button"
+                    onClick={() => setRetryCount(v => v + 1)}
+                    className="mt-3 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-xs text-neutral-600 hover:bg-neutral-100"
+                >
+                    Retry preview
+                </button>
             </div>
         );
     }
 
     return (
         <div className="w-full rounded-xl border border-neutral-200 bg-gradient-to-b from-neutral-200 to-neutral-100 p-3">
+            {status === 'loading' && (
+                <div className="mb-2 rounded-md border border-neutral-200 bg-white/80 px-3 py-2 text-xs text-neutral-600">
+                    Rendering preview…
+                </div>
+            )}
             <iframe
+                key={frameKey}
                 title="Mockup preview"
                 srcDoc={srcDoc}
                 sandbox="allow-scripts"
                 referrerPolicy="no-referrer"
                 loading="lazy"
+                onLoad={() => setStatus('ready')}
                 className={`w-full bg-white rounded-lg border border-neutral-300 shadow-sm ${className ?? ''}`}
                 style={{ height, maxWidth, margin: '0 auto', display: 'block' }}
             />

--- a/src/lib/__tests__/mockupQuality.test.ts
+++ b/src/lib/__tests__/mockupQuality.test.ts
@@ -45,6 +45,13 @@ describe('mockupQuality', () => {
         </div>`;
         const report = assessMockupHtmlQuality(html);
         expect(report.reject).toBe(false);
-        expect(report.score).toBeGreaterThanOrEqual(55);
+        expect(report.score).toBeGreaterThanOrEqual(65);
+    });
+
+    it('rejects malformed structure missing required sections', () => {
+        const html = '<div class="min-h-screen"><section>Only one section</section></div>';
+        const report = assessMockupHtmlQuality(html);
+        expect(report.reject).toBe(true);
+        expect(report.issues.some(issue => issue.code === 'invalid_structure')).toBe(true);
     });
 });

--- a/src/lib/__tests__/mockupService.test.ts
+++ b/src/lib/__tests__/mockupService.test.ts
@@ -88,8 +88,28 @@ describe('mockupService alignment integration', () => {
             ],
         }));
 
-        await expect(generateMockup('Clinic triage PRD', settings, structuredPRD))
-            .rejects
-            .toThrow(/PRD alignment critique/);
+        const result = await generateMockup('Clinic triage PRD', settings, structuredPRD);
+        expect(result.usedFallback).toBe(true);
+        expect(result.payload.screens[0].name).toBe('Fallback Workspace');
+        expect(result.warnings.some(w => w.includes('safe fallback'))).toBe(true);
+    });
+
+    it('passes deterministic generation controls to Gemini JSON mode', async () => {
+        callGeminiMock.mockResolvedValueOnce(JSON.stringify({
+            version: 'mockup_html_v1',
+            title: 'Clinic Triage Concept',
+            summary: 'Queue-first layout for care coordinators.',
+            screens: [
+                {
+                    name: 'Triage Queue',
+                    purpose: 'Care coordinator reviews urgent patient cases and assigns triage owner.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Triage Queue</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Assign case owner</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><table class="w-full text-sm"><tbody><tr><td>Patient case</td><td>Urgency</td></tr></tbody></table></section><section class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Triage actions</li></ul></section></main></div>',
+                },
+            ],
+        }));
+
+        await generateMockup('Clinic triage PRD', settings, structuredPRD);
+        const call = callGeminiMock.mock.calls[0];
+        expect(call[2]).toMatchObject({ temperature: 0.2, topP: 0.8, topK: 32 });
     });
 });

--- a/src/lib/__tests__/mockupValidation.test.ts
+++ b/src/lib/__tests__/mockupValidation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { validateMockupHtmlStructure } from '../mockupValidation';
+
+describe('mockupValidation', () => {
+    it('passes canonical screen structure', () => {
+        const html = `
+        <div class="min-h-screen bg-neutral-50">
+          <header class="px-6 py-4 border-b border-neutral-200">
+            <button type="button" class="bg-indigo-600 text-white px-4 py-2">Create</button>
+          </header>
+          <main class="p-6">
+            <section class="rounded-xl border border-neutral-200 bg-white p-6">Primary</section>
+          </main>
+        </div>`;
+        const result = validateMockupHtmlStructure(html);
+        expect(result.isValid).toBe(true);
+        expect(result.score).toBeGreaterThanOrEqual(70);
+    });
+
+    it('flags missing required landmarks', () => {
+        const result = validateMockupHtmlStructure('<div class="min-h-screen"><article>Hi</article></div>');
+        expect(result.isValid).toBe(false);
+        expect(result.issues.some(issue => issue.includes('Missing required header'))).toBe(true);
+    });
+});

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -1,6 +1,9 @@
 export interface JsonModeConfig {
     responseMimeType: string;
     responseSchema: object;
+    temperature?: number;
+    topP?: number;
+    topK?: number;
 }
 
 export interface StreamCallbacks {
@@ -52,6 +55,9 @@ export const callGemini = async (systemInstruction: string, promptText: string, 
         body.generationConfig = {
             responseMimeType: jsonMode.responseMimeType,
             responseSchema: jsonMode.responseSchema,
+            ...(typeof jsonMode.temperature === 'number' ? { temperature: jsonMode.temperature } : {}),
+            ...(typeof jsonMode.topP === 'number' ? { topP: jsonMode.topP } : {}),
+            ...(typeof jsonMode.topK === 'number' ? { topK: jsonMode.topK } : {}),
         };
     }
 

--- a/src/lib/mockupQuality.ts
+++ b/src/lib/mockupQuality.ts
@@ -1,4 +1,5 @@
 import { expandPlaceholders } from './mockupPlaceholders';
+import { validateMockupHtmlStructure } from './mockupValidation';
 
 export type MockupQualitySeverity = 'low' | 'medium' | 'high';
 
@@ -194,6 +195,15 @@ export const assessMockupHtmlQuality = (html: string): MockupQualityReport => {
         });
     }
 
+    const structure = validateMockupHtmlStructure(trimmed);
+    if (!structure.isValid) {
+        issues.push({
+            code: 'invalid_structure',
+            severity: 'high',
+            message: `Failed structure validation (${structure.score}/100): ${structure.issues.slice(0, 2).join(' ')}`,
+        });
+    }
+
     // Layout-viability check: nested-scroll shells that don't fit the iframe
     // viewport are the #1 cause of "preview is blank" reports. Both `flex-1
     // overflow-y-auto` (without `min-h-0`) and `overflow-hidden` on a flex
@@ -215,8 +225,8 @@ export const assessMockupHtmlQuality = (html: string): MockupQualityReport => {
         return sum + 8;
     }, 0);
 
-    const score = Math.max(0, 100 - penalties);
-    const reject = score < 55 || issues.some(issue => issue.severity === 'high');
+    const score = Math.max(0, Math.round((100 - penalties) * 0.7 + structure.score * 0.3));
+    const reject = score < 65 || issues.some(issue => issue.severity === 'high');
 
     return { score, issues, reject };
 };

--- a/src/lib/mockupValidation.ts
+++ b/src/lib/mockupValidation.ts
@@ -1,0 +1,69 @@
+export interface MockupStructureValidationResult {
+    isValid: boolean;
+    score: number;
+    issues: string[];
+}
+
+const REQUIRED_SECTION_SELECTORS = [
+    /<header\b/i,
+    /<main\b/i,
+    /<section\b/i,
+    /<(button|input|select|textarea|a)\b/i,
+];
+
+const STYLE_TOKENS = [
+    /\btext-(xs|sm|base|lg|xl|2xl|3xl)\b/g,
+    /\bp-[23468]\b/g,
+    /\bpx-[23468]\b/g,
+    /\bpy-[23468]\b/g,
+    /\bg-(neutral-(50|100)|white|indigo-(50|100|600))\b/g,
+];
+
+const hasBalancedAngleBrackets = (html: string): boolean => {
+    const opens = (html.match(/</g) ?? []).length;
+    const closes = (html.match(/>/g) ?? []).length;
+    return opens > 0 && opens === closes;
+};
+
+export const validateMockupHtmlStructure = (html: string): MockupStructureValidationResult => {
+    const trimmed = html.trim();
+    const issues: string[] = [];
+
+    if (!trimmed) {
+        return { isValid: false, score: 0, issues: ['HTML is empty.'] };
+    }
+
+    if (!hasBalancedAngleBrackets(trimmed)) {
+        issues.push('HTML appears malformed (unbalanced tag delimiters).');
+    }
+
+    if (!/<div\b[^>]*\bmin-h-screen\b/i.test(trimmed)) {
+        issues.push('Missing required root shell with min-h-screen.');
+    }
+
+    REQUIRED_SECTION_SELECTORS.forEach((selector, index) => {
+        if (!selector.test(trimmed)) {
+            const labels = ['header', 'main content area', 'section block', 'interactive control'];
+            issues.push(`Missing required ${labels[index]}.`);
+        }
+    });
+
+    if (/<\/?(html|head|body|script|style|iframe|form)\b/i.test(trimmed)) {
+        issues.push('Contains forbidden document-level or unsafe tags.');
+    }
+
+    const styleTokenCount = STYLE_TOKENS.reduce((sum, token) => sum + (trimmed.match(token)?.length ?? 0), 0);
+    if (styleTokenCount < 6) {
+        issues.push('Styling token density is too low for a polished mockup.');
+    }
+
+    const penalty = issues.length * 14;
+    const score = Math.max(0, 100 - penalty);
+    const isValid = issues.length === 0 || score >= 70;
+
+    return {
+        isValid,
+        score,
+        issues,
+    };
+};

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -11,6 +11,7 @@ import { mockupSchema } from '../schemas/mockupSchema';
 import { assessMockupHtmlQuality, normalizeMockupHtml } from '../mockupQuality';
 import { critiqueMockupAlignment, type MockupAlignmentCritique } from '../mockupAlignmentCritique';
 import { PLACEHOLDER_PROMPT_CATALOG } from '../mockupPlaceholders';
+import { validateMockupHtmlStructure } from '../mockupValidation';
 
 // ---- Instruction tables (rewritten for polished HTML/Tailwind output) ----
 
@@ -32,12 +33,18 @@ const SCOPE_INSTRUCTIONS: Record<string, string> = {
     key_workflow: 'Scope: 3 to 5 screens forming a single linear workflow the primary persona would take end-to-end. Each screen should show the next logical step. Same shell, same style, same accent.',
 };
 
+const MOCKUP_PROMPT_TEMPLATE_VERSION = '2026-04-17.v2';
+const MOCKUP_GENERATION_STRATEGY_VERSION = 'mockup_strategy_v2';
+const MAX_GENERATION_ATTEMPTS = 3;
+const QUALITY_THRESHOLD = 70;
+
 // ---- Prompt construction ----
 
 const buildSystemPrompt = (settings: MockupSettings): string => {
     const styleLine = settings.style ? `\nStyle direction from the user: ${settings.style}` : '';
 
     return `You are a senior product designer at a top-tier SaaS company (think Linear, Notion, Vercel, Stripe). You generate high-fidelity UI *concepts* — not production code — for new products, grounded in a provided PRD. Your output MUST be valid JSON matching the provided response schema.
+Prompt template version: ${MOCKUP_PROMPT_TEMPLATE_VERSION}.
 
 ## Visual language
 - Modern SaaS aesthetic. Generous whitespace. Clear hierarchy. 8px spacing scale.
@@ -73,6 +80,22 @@ const buildSystemPrompt = (settings: MockupSettings): string => {
 - Avoid placeholder labels; every label should reflect the product domain.
 - If scope is workflow, each screen must represent a distinct step in that workflow with continuity in naming and entities.
 
+## Canonical output template (mandatory for each screen)
+Follow this section order in HTML:
+1) app shell root div with class min-h-screen
+2) header with title and one primary CTA button
+3) main containing:
+   - first section primary content panel
+   - second section supporting context (activity/filter/details)
+4) Optional aside for utilities; keep consistent placement across screens
+Do not emit additional root siblings. Keep exactly one app shell root.
+
+## Determinism contract (mandatory)
+- Use a single accent family throughout all screens.
+- Reuse the same shell and spacing scale unless the workflow step requires a clear state change.
+- Keep section names and entity labels consistent between screens.
+- Do not generate extra screens beyond the requested scope.
+
 ## Quality bar (fail these and regenerate internally before responding)
 - No malformed or partial tag structures.
 - No clipped/collapsed shells; content should fit inside intentional cards/sections.
@@ -91,6 +114,7 @@ If you generate multiple screens, they MUST feel like the same product:
 - \`notes\` (optional): 1–3 short assumptions or callouts the designer made.
 
 Also provide a top-level \`title\` (the overall concept name) and a \`summary\` (1–2 sentences framing the concept).
+Include \`version\` exactly as \`mockup_html_v1\`.
 
 ${FIDELITY_INSTRUCTIONS[settings.fidelity]}
 ${PLATFORM_INSTRUCTIONS[settings.platform]}
@@ -136,6 +160,8 @@ export interface ParseResult {
     /** Warnings for screens that were skipped (partial success). Empty when all
      *  screens parsed cleanly. */
     warnings: string[];
+    usedFallback?: boolean;
+    strategyVersion?: string;
 }
 
 /**
@@ -192,6 +218,11 @@ const parseMockupPayload = (
         }
 
         const normalizedHtml = normalizeMockupHtml(rawHtml);
+        const structure = validateMockupHtmlStructure(normalizedHtml);
+        if (!structure.isValid) {
+            warnings.push(`Screen ${i + 1} ("${name}"): skipped — failed structure validation (${structure.score}/100). ${structure.issues.slice(0, 2).join(' ')}`);
+            continue;
+        }
         const quality = assessMockupHtmlQuality(normalizedHtml);
         if (quality.reject) {
             const reason = quality.issues.map(issue => issue.message).join(' ');
@@ -259,6 +290,75 @@ const parseMockupPayload = (
         },
         critique,
         warnings,
+        usedFallback: false,
+        strategyVersion: MOCKUP_GENERATION_STRATEGY_VERSION,
+    };
+};
+
+const inferConceptName = (prdContent: string): string => {
+    const firstLine = prdContent.split('\n').map(line => line.trim()).find(Boolean) ?? 'Product';
+    return firstLine.replace(/[#*`]/g, '').slice(0, 56) || 'Product';
+};
+
+const buildSafeFallbackPayload = (
+    prdContent: string,
+    settings: MockupSettings,
+    warnings: string[],
+): ParseResult => {
+    const concept = inferConceptName(prdContent);
+    const action = settings.scope === 'key_workflow' ? 'Continue workflow' : 'Create item';
+    const html = normalizeMockupHtml(`
+<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">
+  <header class="border-b border-neutral-200 bg-white px-6 py-4 flex items-center justify-between">
+    <div>
+      <p class="text-xs uppercase tracking-wide text-neutral-500">Safe fallback</p>
+      <h1 class="text-xl font-semibold tracking-tight">${concept} Workspace</h1>
+    </div>
+    <button type="button" class="rounded-lg bg-indigo-600 text-white px-4 py-2 text-sm font-medium">${action}</button>
+  </header>
+  <main class="p-6 grid gap-4 md:grid-cols-3">
+    <section class="md:col-span-2 rounded-xl border border-neutral-200 bg-white p-5 space-y-3">
+      <h2 class="text-base font-semibold">Primary content</h2>
+      <p class="text-sm text-neutral-600">Generated fallback layout to keep the preview usable while regeneration is unavailable.</p>
+      <div class="rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-600">Use regenerate to request a richer PRD-grounded screen.</div>
+    </section>
+    <section class="rounded-xl border border-neutral-200 bg-white p-5 space-y-2">
+      <h3 class="text-sm font-semibold">Supporting context</h3>
+      <ul class="text-sm text-neutral-600 space-y-1">
+        <li>Stable shell and spacing system</li>
+        <li>Consistent typography and accent</li>
+        <li>Always-renderable safe template</li>
+      </ul>
+    </section>
+  </main>
+</div>`);
+
+    warnings.push('Generation failed quality gates repeatedly; rendered a deterministic safe fallback template.');
+    return {
+        payload: {
+            version: 'mockup_html_v1',
+            title: `${concept} — Safe Fallback Mockup`,
+            summary: 'Fallback mockup rendered to avoid blank or broken output. Regenerate for a richer PRD-grounded concept.',
+            screens: [{
+                id: uuidv4(),
+                name: 'Fallback Workspace',
+                purpose: 'Provides a safe, usable baseline when model output fails validation.',
+                html,
+                notes: 'Fallback template was used after repeated validation failures.',
+            }],
+        },
+        critique: {
+            alignmentScore: 55,
+            severity: 'medium',
+            missingConcepts: ['full PRD grounding'],
+            mismatchReasons: ['Fallback template used due to validation failures.'],
+            recommendations: ['Regenerate to recover full PRD-specific content.'],
+            issues: [],
+            screens: [],
+        },
+        warnings,
+        usedFallback: true,
+        strategyVersion: MOCKUP_GENERATION_STRATEGY_VERSION,
     };
 };
 
@@ -274,11 +374,43 @@ export const generateMockup = async (
 
     const system = buildSystemPrompt(settings);
     const user = buildUserPrompt(prdContent, structuredPRD);
+    const warnings: string[] = [];
+    let lastError: Error | null = null;
 
-    const raw = await callGemini(system, user, {
-        responseMimeType: 'application/json',
-        responseSchema: mockupSchema,
-    });
+    for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
+        options?.onStatus?.(`Generating mockup (attempt ${attempt}/${MAX_GENERATION_ATTEMPTS})...`);
+        try {
+            const raw = await callGemini(system, user, {
+                responseMimeType: 'application/json',
+                responseSchema: mockupSchema,
+                temperature: 0.2,
+                topP: 0.8,
+                topK: 32,
+            });
+            const parsed = parseMockupPayload(raw, prdContent, settings, structuredPRD);
+            const qualityAvg = parsed.payload.screens.length
+                ? Math.round(parsed.payload.screens
+                    .map(screen => assessMockupHtmlQuality(screen.html).score)
+                    .reduce((sum, score) => sum + score, 0) / parsed.payload.screens.length)
+                : 0;
+            if (qualityAvg < QUALITY_THRESHOLD) {
+                warnings.push(`Attempt ${attempt}: average quality ${qualityAvg}/100 below threshold ${QUALITY_THRESHOLD}.`);
+                lastError = new Error(`Quality threshold not met (${qualityAvg}/100).`);
+                continue;
+            }
+            return {
+                ...parsed,
+                warnings: [...warnings, ...parsed.warnings],
+                usedFallback: false,
+                strategyVersion: MOCKUP_GENERATION_STRATEGY_VERSION,
+            };
+        } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            lastError = err;
+            warnings.push(`Attempt ${attempt} failed: ${err.message}`);
+        }
+    }
 
-    return parseMockupPayload(raw, prdContent, settings, structuredPRD);
+    console.warn('[mockupService] returning safe fallback after repeated generation failures', lastError);
+    return buildSafeFallbackPayload(prdContent, settings, warnings);
 };


### PR DESCRIPTION
### Motivation
- Eliminate high-risk failure modes in the mockup pipeline (malformed-but-parseable HTML, blank/hidden previews, silent partial failures, and non-deterministic LLM variance) so mockups are reliable and trustworthy. 
- Add machine-enforced checks and deterministic controls because prompt-only constraints were non-deterministic and heuristics missed structural and rendering defects. 
- Provide a guaranteed, usable fallback so the system never returns a blank or broken preview to users. 

### Description
- Added a deterministic structural validator `validateMockupHtmlStructure` and integrated it into the parsing/quality gate so screens failing structural checks are rejected before persistence (`src/lib/mockupValidation.ts`, wired into `parseMockupPayload` in `src/lib/services/mockupService.ts`).
- Hardened prompts and generation strategy with a canonical prompt/template version, explicit canonical output ordering and determinism rules, capped retry + regenerate loop, average-quality thresholding, and strategy metadata tagging; deterministic generation knobs (`temperature`, `topP`, `topK`) are passed through JSON-mode calls (`src/lib/services/mockupService.ts`, `src/lib/geminiClient.ts`).
- Implemented a guaranteed safe fallback payload builder (`buildSafeFallbackPayload`) that returns a deterministic, always-renderable mockup when repeated attempts fail, and surfaced safeguard-aware metadata/warnings in the UI (`src/lib/services/mockupService.ts`, `src/components/MockupsView.tsx`).
- Improved rendering safeguards in the preview component with loading state, timeout-driven error fallback, retry button and iframe keying while preserving sandboxing, and tightened quality scoring by combining structure and stylistic checks (`src/components/mockups/MockupHtmlPreview.tsx`, `src/lib/mockupQuality.ts`).

### Testing
- Ran lint: `npm run lint` — passed. 
- Ran unit tests: `npm test` — all test files passed (10 files, 57 tests passed). 
- Built production bundle: `npm run build` — completed successfully. 
- Added and ran new unit tests for the validator and adjusted quality tests to assert the stricter gating; all new/updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e234f9d7bc8321879f78937925b0bb)