### PR TITLE
Add billing project ID support and improve Gemini error handling

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown } from 'lucide-react';
+import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase } from 'lucide-react';
 import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 
 interface SettingsModalProps {
@@ -92,7 +92,9 @@ function ModelRadio({
 
 export function SettingsModal({ onClose }: SettingsModalProps) {
     const [apiKey, setApiKey] = useState(() => localStorage.getItem('GEMINI_API_KEY') || '');
+    const [projectId, setProjectId] = useState(() => localStorage.getItem('GEMINI_PROJECT_ID') || '');
     const [model, setModel] = useState(() => localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL);
+    const selectedIsPreview = model.includes('preview');
 
     // Expand the legacy section automatically if the user is currently on a
     // legacy model — otherwise keep it collapsed to reduce visual noise.
@@ -103,6 +105,12 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         e.preventDefault();
         localStorage.setItem('GEMINI_API_KEY', apiKey.trim());
         localStorage.setItem('GEMINI_MODEL', model);
+        const trimmedProjectId = projectId.trim();
+        if (trimmedProjectId) {
+            localStorage.setItem('GEMINI_PROJECT_ID', trimmedProjectId);
+        } else {
+            localStorage.removeItem('GEMINI_PROJECT_ID');
+        }
         onClose();
     };
 
@@ -161,6 +169,28 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                         </p>
                     </div>
 
+                    {/* Billing Project ID — forces paid-tier quota */}
+                    <div className="space-y-3">
+                        <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
+                            <Briefcase size={14} className="text-indigo-400" />
+                            Billing Project ID
+                            <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Optional</span>
+                        </label>
+                        <input
+                            type="text"
+                            value={projectId}
+                            onChange={(e) => setProjectId(e.target.value)}
+                            className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
+                            placeholder="e.g. my-gcp-project-123"
+                        />
+                        <p className="text-[11px] text-neutral-500 leading-relaxed px-1">
+                            If you enabled billing on a specific Google Cloud project, paste its ID here.
+                            Synapse sends it as <code className="text-neutral-400">x-goog-user-project</code> so
+                            Gemini meters requests against that project — fixes the case where a key defaults
+                            to free-tier quota even after billing is on.
+                        </p>
+                    </div>
+
                     {/* Model Selection */}
                     <div className="space-y-4">
                         <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
@@ -178,6 +208,17 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                                 />
                             ))}
                         </div>
+
+                        {selectedIsPreview && (
+                            <div className="flex items-start gap-3 p-3 rounded-xl bg-amber-500/10 border border-amber-500/30 text-amber-200/90">
+                                <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                                <p className="text-[11px] leading-relaxed">
+                                    Preview models have reduced per-project quotas <em>even on paid tier</em>.
+                                    If you see persistent rate-limit / free-tier errors, switch to a stable model
+                                    (e.g. Gemini 2.5 Flash in Legacy models) until the Gemini 3 series exits preview.
+                                </p>
+                            </div>
+                        )}
 
                         {/* Legacy section — collapsed by default unless the user
                             is on a legacy model. */}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -9,6 +9,7 @@
 export type ErrorCategory =
     | 'api_key_missing'
     | 'rate_limited'
+    | 'free_tier_quota'
     | 'safety_blocked'
     | 'empty_response'
     | 'network'
@@ -24,6 +25,7 @@ export interface NormalizedError {
 
 const CATEGORY_PATTERNS: [ErrorCategory, RegExp][] = [
     ['api_key_missing', /missing gemini api key/i],
+    ['free_tier_quota', /free.?tier|freetier|-FreeTier/i],
     ['rate_limited', /429|resource exhausted|too many requests/i],
     ['safety_blocked', /safety filter/i],
     ['empty_response', /empty response/i],
@@ -53,6 +55,10 @@ export function normalizeError(e: unknown): NormalizedError {
 const USER_MESSAGES: Record<ErrorCategory, string> = {
     api_key_missing: 'API key not configured. Open Settings to add your Gemini API key.',
     rate_limited: 'Too many requests. Wait a moment and try again.',
+    free_tier_quota:
+        'Request hit the Gemini free-tier quota. Open Settings and set your Billing Project ID, ' +
+        'or recreate the API key on a project with billing enabled. Preview models also have ' +
+        'capped quotas — switch to a stable model if this keeps happening.',
     safety_blocked: 'Content was blocked by safety filters. Try adjusting your prompt.',
     empty_response: 'No content was generated. Please try again.',
     network: 'Network error. Check your internet connection and try again.',

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -36,6 +36,51 @@ const getModel = () => {
     return localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL;
 };
 
+/**
+ * Optional Google Cloud project ID. When present, we forward it as the
+ * `x-goog-user-project` header so Gemini bills and meters the request against
+ * that project. This is the fix for the common case where a user has enabled
+ * billing on one project but their AI Studio API key is still tied to a
+ * different (free-tier) project — without this header Google falls back to
+ * the key's home project and applies free-tier quotas.
+ */
+const getProjectId = () => {
+    return localStorage.getItem('GEMINI_PROJECT_ID')?.trim() || '';
+};
+
+const buildHeaders = (apiKey: string): HeadersInit => {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+    };
+    const projectId = getProjectId();
+    if (projectId) headers['x-goog-user-project'] = projectId;
+    return headers;
+};
+
+/**
+ * Turn a raw Gemini error payload into a more specific message when the
+ * failure is a quota/rate-limit hit. We surface free-tier hits explicitly so
+ * users know to check their billing project configuration rather than
+ * assuming they just need to wait.
+ */
+const formatGeminiError = (status: string, errorData: unknown): string => {
+    const raw = (errorData as { error?: { message?: string; status?: string } })?.error;
+    const message = raw?.message || 'Unknown error';
+    const isQuota = raw?.status === 'RESOURCE_EXHAUSTED' || /quota|resource.exhausted|rate.limit/i.test(message);
+    if (isQuota && /free.?tier|freetier|-FreeTier/i.test(message)) {
+        return (
+            'Gemini quota error — your request hit the FREE-TIER quota even though you expect paid tier. ' +
+            'Likely causes: (1) your API key is tied to a Google Cloud project without billing enabled — ' +
+            'recreate the key in AI Studio on the project that has billing; (2) set your billing project ID ' +
+            'in Settings so Synapse sends x-goog-user-project; (3) preview models (e.g. Gemini 3 Flash Preview) ' +
+            'have reduced quotas even on paid tier — switch to a stable model like gemini-2.5-flash. ' +
+            `Raw: ${message}`
+        );
+    }
+    return `Gemini API Error: ${status} - ${message}`;
+};
+
 export const callGemini = async (systemInstruction: string, promptText: string, jsonMode?: JsonModeConfig, signal?: AbortSignal) => {
     const startTime = performance.now();
     const apiKey = getApiKey();
@@ -63,17 +108,14 @@ export const callGemini = async (systemInstruction: string, promptText: string, 
 
     const response = await fetch(url, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'x-goog-api-key': apiKey,
-        },
+        headers: buildHeaders(apiKey),
         body: JSON.stringify(body),
         signal,
     });
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => null);
-        throw new Error(`Gemini API Error: ${response.statusText} - ${errorData?.error?.message || 'Unknown error'}`);
+        throw new Error(formatGeminiError(response.statusText, errorData));
     }
 
     const data = await response.json();
@@ -113,17 +155,14 @@ export const callGeminiStream = async (
 
     const response = await fetch(url, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'x-goog-api-key': apiKey,
-        },
+        headers: buildHeaders(apiKey),
         body: JSON.stringify(body),
         signal,
     });
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => null);
-        const err = new Error(`Gemini API Error: ${response.statusText} - ${errorData?.error?.message || 'Unknown error'}`);
+        const err = new Error(formatGeminiError(response.statusText, errorData));
         callbacks.onError(err);
         throw err;
     }


### PR DESCRIPTION
## Summary
This PR adds support for specifying a Google Cloud billing project ID to resolve free-tier quota issues when API keys are tied to non-billing projects. It also improves error messages to help users diagnose quota and rate-limit problems.

## Key Changes

- **Billing Project ID Configuration**: Added optional `GEMINI_PROJECT_ID` setting that users can configure in the Settings modal. When set, Synapse forwards it as the `x-goog-user-project` header so Gemini bills requests against the specified project instead of the API key's default (free-tier) project.

- **Improved Error Handling**: 
  - Created `formatGeminiError()` function that detects free-tier quota exhaustion and provides actionable guidance (check billing configuration, set project ID, or switch from preview models)
  - Added `buildHeaders()` helper to centralize header construction and conditionally include the project ID header
  - Updated both `callGemini()` and `callGeminiStream()` to use the new error formatting

- **Settings UI Enhancements**:
  - Added "Billing Project ID" input field with explanatory text about its purpose
  - Added warning banner when a preview model is selected, noting that preview models have reduced quotas even on paid tier
  - Properly handles saving/clearing the project ID from localStorage

- **Error Category Expansion**: Added `free_tier_quota` error category to `errors.ts` with pattern matching and user-friendly message to help users understand and resolve the issue

## Implementation Details

- The project ID is trimmed and optional — only sent as a header if explicitly configured
- Error detection uses both status code (`RESOURCE_EXHAUSTED`) and message pattern matching to identify quota issues
- Free-tier quota errors include specific troubleshooting steps and mention preview model limitations
- Settings modal now tracks three pieces of configuration: API key, project ID, and model selection

https://claude.ai/code/session_01K4PMHx8LRYaMrkKeh1YEV5