### PR TITLE
feat(mockups): add layout-spec engine behind MOCKUP_ENGINE flag

### DIFF
--- a/.github/workflows/mockup-harness.yml
+++ b/.github/workflows/mockup-harness.yml
@@ -1,0 +1,81 @@
+name: Mockup harness
+
+on:
+  pull_request:
+    paths:
+      - 'src/lib/services/mockupService.ts'
+      - 'src/lib/mockup*.ts'
+      - 'src/lib/schemas/mockup*.ts'
+      - 'src/components/mockups/**'
+      - 'src/components/MockupsView.tsx'
+      - 'harness/**'
+      - 'scripts/mockup-eval-harness.mjs'
+      - '.github/workflows/mockup-harness.yml'
+
+jobs:
+  harness:
+    name: Harness gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run mockup harness vs baseline
+        # The harness is simulation-based (doesn't call Gemini). It still
+        # exercises the layout-viability + perturbation checks against
+        # deterministic fixture outputs, which is what we actually want
+        # to gate on in CI.
+        run: >-
+          npm run mockup:harness --
+          --runs 4
+          --max-attempts 3
+          --outdir harness/results
+          --baseline harness/sample-results/latest/summary.json
+
+      - name: Assert no harness regressions
+        # detectRegressions flags any consistency/quality/viability/
+        # perturbation drop vs the committed baseline. Any regression
+        # fails the job.
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const summary = JSON.parse(fs.readFileSync('harness/results/latest/summary.json', 'utf8'));
+            const regressions = summary.regressions ?? [];
+            const m = summary.metrics;
+            console.log(JSON.stringify({ metrics: m, regressions }, null, 2));
+            if (regressions.length > 0) {
+              console.error('Harness regressions detected:');
+              for (const r of regressions) console.error('- ' + r);
+              process.exit(1);
+            }
+            if (typeof m.layoutViabilityRate === 'number' && m.layoutViabilityRate < 100) {
+              console.error('Layout viability rate ' + m.layoutViabilityRate + '% < 100% — preview renderer is producing blank/clipped output.');
+              process.exit(1);
+            }
+          "
+
+      - name: Upload harness artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mockup-harness-results
+          path: harness/results/latest

--- a/docs/mockup-improvements-plan-2026-04-23.md
+++ b/docs/mockup-improvements-plan-2026-04-23.md
@@ -118,30 +118,60 @@ hard input to generation.
 
 ## Phase C — Deterministic rendering & Demo Safe Mode
 
+**Status:** shipped.
+
 Closes the remaining runtime gaps (Tailwind CDN health, viewport occupancy,
 cross-run diff) and gives recruiter demos a defensible "safe" setting.
 
-### Planned work
+### Shipped
 
-- [ ] **Playwright harness** (already a devDep): render each generated
-      mockup in a real headless browser, not simulated. Check `onload`,
-      Tailwind-applied sentinel, `scrollWidth ≤ clientWidth`, above-the-fold
-      occupancy.
-- [ ] **Perturbation pairs** in `harness/mockup-test-suite.json`: for each
-      fixture, a variant with a ≤10-token PRD edit; assert shell-signature
-      similarity > 0.9 across the pair.
-- [ ] **Non-SaaS fixtures** — 3–4 consumer/marketplace/physical-goods PRDs
-      to stress the "generic dashboard" failure mode.
-- [ ] **Demo Safe Mode toggle** in `MockupsView.tsx`: pins `temperature: 0`
-      + `topK: 1`, disables the fallback chain, restricts shells, hard-
-      rejects on alignment critique miss.
-- [ ] **iframe post-load probe** in `MockupHtmlPreview.tsx`: inject a script
-      that posts `{ styled, occupancyPct }` via `postMessage`; show a
-      "preview degraded" badge when the probe fails.
-- [ ] **CI gate**: fail PRs touching `src/lib/services/mockupService.ts`,
-      `src/lib/schemas/mockup*`, `src/lib/mockup*.ts`, or
-      `src/components/mockups/**` when harness consistency < 90 or the
-      Playwright layout-viability pass rate < 100%.
+- [x] **Playwright layout-viability probe in harness**
+      (`scripts/mockup-eval-harness.mjs`): the existing `renderAndProbe` now
+      calls `page.evaluate` after `networkidle` to collect `styled`,
+      `horizontalOverflow`, `bodyHeight`, and `visibleElements` per screen.
+      A new `layoutViabilityRate` metric aggregates over all runs; a run
+      fails when any screen reports unstyled, overflowing, <100px body, or
+      zero landmarks.
+- [x] **Perturbation pairs**: `harness/mockup-test-suite.json` cases gain
+      an optional `variantPrompt` field (≤10-token edit). After the primary
+      loop, the harness generates each variant and computes shell-signature
+      Jaccard similarity. Aggregated as `perturbationSimilarityAvg` and
+      `perturbationPassRate` (share of pairs ≥ 0.9).
+- [x] **Non-SaaS fixtures**: `nonsaas_consumer_fitness`,
+      `nonsaas_marketplace`, `nonsaas_physical_goods` added to stress the
+      "generic dashboard sludge" failure mode against non-SaaS domains.
+- [x] **Demo Safe Mode toggle** in `MockupsView.tsx` + `MockupSettings`:
+      when on, pins `temperature=0 / topP=0.5 / topK=1` on the provider
+      call, disables both the spec→HTML fallback and the HTML safe
+      fallback template, and hard-rejects on ANY alignment critique hit
+      (not just high+low-score). Serialized into artifact metadata so
+      regeneration preserves the setting.
+- [x] **iframe post-load probe** in `buildMockupSrcDoc.ts` +
+      `MockupHtmlPreview.tsx`: a per-iframe UUID `probeId` drives an
+      injected script that inspects `min-h-screen` computed styles + body
+      geometry and posts a `MockupProbeReport` back to the parent via
+      `postMessage`. The preview surfaces a "Preview degraded: …" badge
+      when the probe reports missing Tailwind, horizontal overflow,
+      near-empty body, or no landmarks — or when it doesn't arrive within
+      6s.
+- [x] **CI gate** at `.github/workflows/mockup-harness.yml`: runs typecheck
+      + lint + tests + the harness (with Playwright installed) on PRs that
+      touch the mockup surface, and fails the job on any regression vs the
+      committed baseline or a `layoutViabilityRate < 100%`. Harness
+      artifacts are uploaded for debugging.
+- [x] Tests: Demo Safe Mode sampling pin + no-fallback behavior in
+      `mockupService.test.ts`, and probe-script injection in a new
+      `src/components/mockups/__tests__/buildMockupSrcDoc.test.ts`. 79/79
+      tests passing.
+
+### Open — Phase C polish
+
+- [ ] **Establish a Phase C baseline**: after the first CI run, commit the
+      generated `harness/sample-results/latest/summary.json` as the new
+      baseline for regression detection.
+- [ ] **Probe telemetry dashboard**: today the degraded badge is per-preview
+      and ephemeral. Aggregate probe outcomes across a session so users can
+      see if one generation consistently degrades.
 
 ---
 

--- a/docs/mockup-improvements-plan-2026-04-23.md
+++ b/docs/mockup-improvements-plan-2026-04-23.md
@@ -1,0 +1,156 @@
+# Mockup Improvements Roadmap — 2026-04-23
+
+Tracker for the multi-phase reliability/quality work kicked off after the
+2026-04-22 audit (`docs/mockup-audit-2026-04-22.md`). Each phase is shipped
+on its own so consistency gains can be measured incrementally.
+
+Baseline from the 2026-04-22 harness run (`npm run mockup:harness -- --runs 4`):
+
+| Metric | Baseline |
+|---|---:|
+| Render success | 100% |
+| Structural validity | 100% |
+| Visual quality | 81.1 / 100 |
+| Consistency (same input, 4 runs) | 77.5 / 100 |
+| Edge-case fallback rate | 33% |
+
+---
+
+## Phase A — Layout spec + template catalog
+
+**Status:** shipped (commit `11c80e6`, branch
+`claude/mockup-audit-improvements-FCt7b`).
+
+Collapses the model's generation surface from "arbitrary Tailwind HTML
+strings" to a typed `MockupLayoutSpec` (closed vocabulary of shells,
+sections, actions) rendered by vetted templates. Structural variance moves
+off the model and onto the renderer; only slot *content* stays model-
+generated.
+
+### Shipped
+
+- [x] `src/types/index.ts` — `MockupLayoutSpec` discriminated-union types.
+- [x] `src/lib/schemas/mockupLayoutSpec.ts` — Gemini JSON-mode schema with
+      tight enums and min/max bounds.
+- [x] `src/components/mockups/templates/` — 3 shells (`sidebar_topbar`,
+      `topbar_only`, `mobile_tab_shell`), 6 section components
+      (`stat_grid`, `data_table`, `activity_feed`, `filters_bar`,
+      `detail_panel`, `empty_state`), 5 action kinds. All slot text is
+      HTML-escaped.
+- [x] `src/lib/mockupLayoutRenderer.ts` — fail-soft JSON parser and
+      deterministic spec→HTML renderer; emits a dedicated
+      `MockupSpecParseError` so the orchestrator can retry on parse failure.
+- [x] `src/lib/services/mockupService.ts` — `runSpecEngine` alongside the
+      existing `runHtmlEngine`, gated on `localStorage.MOCKUP_ENGINE ===
+      'spec'`. Spec-engine failures fall back to the HTML engine.
+- [x] Tests: renderer determinism, injection escape, shell variants, and a
+      mockupService integration test for the spec path. 70/70 passing.
+
+### Open — still part of Phase A
+
+- [ ] **Harness comparison run.** Execute
+      `MOCKUP_ENGINE=spec npm run mockup:harness -- --runs 4` against the
+      same fixtures and compare consistency/quality numbers against the
+      77.5 / 81.1 baseline. Entrance criterion for flipping the default is
+      consistency ≥ 90.
+- [ ] **Flip default engine.** Change `getMockupEngine()` to default `'spec'`
+      once the harness threshold is met, and update
+      `docs/mockup-evaluation-harness.md` with the new baseline.
+- [ ] **Surface engine toggle in UI.** Add an advanced toggle in settings
+      (or the mockup view) for switching engines without touching
+      localStorage manually.
+- [ ] **Remove HTML-engine path.** After one stable release on the spec
+      default, delete `buildSystemPrompt`/`buildUserPrompt`/
+      `parseMockupPayload`/`buildSafeFallbackPayload` plus the now-redundant
+      regex checks in `mockupValidation.ts` and the non-PRD-grounding rules
+      in `mockupQuality.ts`. Keep placeholder-copy + domain-term coverage
+      checks, which still apply to slot text.
+
+---
+
+## Phase B — PRD grounding upgrade
+
+**Status:** shipped.
+
+Even a perfect renderer produces "generic SaaS sludge" if the LLM can't lock
+onto the product's real nouns. Phase A narrowed the visual surface; Phase B
+narrows the content surface by making PRD-derived entities and actions a
+hard input to generation.
+
+### Shipped
+
+- [x] **Extended `StructuredPRD`** (optional so older projects keep working):
+      - `domainEntities: { name, description?, exampleValues? }[]` — nouns
+        for table columns, detail-panel fields, activity-feed targets.
+      - `primaryActions: { verb, target }[]` — verb phrases for primary
+        CTAs across screens.
+- [x] **PRD generation** (`src/lib/schemas/prdSchemas.ts`,
+      `src/lib/services/prdService.ts`): schema and system prompt updated so
+      every new PRD includes 3–8 domain entities (with examples) and 3–6
+      primary actions. `structuredPRDToMarkdown` renders them as dedicated
+      sections.
+- [x] **Spec-engine grounding injection** (`src/lib/services/mockupService.ts`,
+      `buildSpecUserPrompt`): when the PRD carries `domainEntities` or
+      `primaryActions`, they're appended to the user prompt as a MANDATORY
+      grounding block, including exampleValues for realistic cell content
+      and quoted `"verb target"` phrases for CTA labels.
+- [x] **Stricter `mockupAlignmentCritique.ts`**: two new issue codes —
+      `insufficient_entity_grounding` (per-screen, hard-severity if zero
+      entity hits) and `insufficient_action_grounding` (set-level, hard-
+      severity if no primary action verb appears on any CTA). Heuristic
+      term-coverage still runs for projects without the new fields.
+- [x] Tests: alignment critique hits/misses for both new codes, a backward-
+      compat test that skips the structured checks when fields are absent,
+      and a spec-engine test asserting the grounding block is injected.
+      75/75 passing.
+
+### Open — Phase B polish
+
+- [ ] **Backfill migration**: older projects in localStorage won't have
+      `domainEntities`/`primaryActions`. Decide whether to (a) leave them
+      blank and rely on heuristic critique, (b) extract entities on read
+      from the markdown PRD, or (c) offer a "Refresh structured PRD" button
+      that re-runs PRD generation.
+- [ ] **StructuredPRDView UI**: surface the new sections in
+      `src/components/StructuredPRDView.tsx` so users can see + edit them.
+
+---
+
+## Phase C — Deterministic rendering & Demo Safe Mode
+
+Closes the remaining runtime gaps (Tailwind CDN health, viewport occupancy,
+cross-run diff) and gives recruiter demos a defensible "safe" setting.
+
+### Planned work
+
+- [ ] **Playwright harness** (already a devDep): render each generated
+      mockup in a real headless browser, not simulated. Check `onload`,
+      Tailwind-applied sentinel, `scrollWidth ≤ clientWidth`, above-the-fold
+      occupancy.
+- [ ] **Perturbation pairs** in `harness/mockup-test-suite.json`: for each
+      fixture, a variant with a ≤10-token PRD edit; assert shell-signature
+      similarity > 0.9 across the pair.
+- [ ] **Non-SaaS fixtures** — 3–4 consumer/marketplace/physical-goods PRDs
+      to stress the "generic dashboard" failure mode.
+- [ ] **Demo Safe Mode toggle** in `MockupsView.tsx`: pins `temperature: 0`
+      + `topK: 1`, disables the fallback chain, restricts shells, hard-
+      rejects on alignment critique miss.
+- [ ] **iframe post-load probe** in `MockupHtmlPreview.tsx`: inject a script
+      that posts `{ styled, occupancyPct }` via `postMessage`; show a
+      "preview degraded" badge when the probe fails.
+- [ ] **CI gate**: fail PRs touching `src/lib/services/mockupService.ts`,
+      `src/lib/schemas/mockup*`, `src/lib/mockup*.ts`, or
+      `src/components/mockups/**` when harness consistency < 90 or the
+      Playwright layout-viability pass rate < 100%.
+
+---
+
+## Alternatives considered (not primary path)
+
+- **Managed UI-gen MCP (v0.dev-style)** — breaks Synapse's client-side,
+  single-API-key architecture; revisit only as an opt-in "Pro engine".
+- **Vision-model-as-judge only** — closes the "preview looks blank" gap but
+  does not reduce variance. Useful as a *supplement* in Phase C, not a
+  replacement for the AST.
+- **Playwright MCP for harness/CI** — adopted in Phase C; stays out of
+  shipped client code.

--- a/harness/mockup-test-suite.json
+++ b/harness/mockup-test-suite.json
@@ -4,6 +4,7 @@
     "complexity": "simple",
     "title": "Basic landing page",
     "prd": "Build a landing page for a productivity app called FocusFlow. Include hero, benefits, and signup CTA.",
+    "variantPrompt": "Build a landing page for FocusFlow, a productivity app. Include hero, benefits section, and primary signup CTA.",
     "settings": {
       "platform": "desktop",
       "fidelity": "mid",
@@ -52,6 +53,7 @@
     "complexity": "medium",
     "title": "Dashboard UI",
     "prd": "Analytics dashboard for support team with ticket volume, SLA trends, queue table, and assignee activity.",
+    "variantPrompt": "Analytics dashboard for the support team showing ticket volume, SLA trends, the queue table, and assignee activity feed.",
     "settings": {
       "platform": "desktop",
       "fidelity": "high",
@@ -155,6 +157,55 @@
     "requiredSections": [
       "task",
       "button"
+    ]
+  },
+  {
+    "id": "nonsaas_consumer_fitness",
+    "complexity": "medium",
+    "title": "Consumer fitness app",
+    "prd": "Running coach mobile app called PacePilot for amateur 5K/10K runners. Track workouts, suggest next session based on target race date, celebrate milestones, and share workouts with training partners.",
+    "variantPrompt": "Running coach mobile app (PacePilot) for amateur 5K and 10K runners. Track workouts, recommend the next training session based on a target race date, celebrate milestones, and share completed workouts with training partners.",
+    "settings": {
+      "platform": "mobile",
+      "fidelity": "mid",
+      "scope": "multi_screen"
+    },
+    "requiredSections": [
+      "workout",
+      "milestone",
+      "partner"
+    ]
+  },
+  {
+    "id": "nonsaas_marketplace",
+    "complexity": "complex",
+    "title": "Two-sided marketplace",
+    "prd": "Local tutoring marketplace connecting parents with vetted STEM tutors. Parents browse tutors by subject and location, book a first session, leave reviews after. Tutors manage availability, payouts, and student progress notes.",
+    "settings": {
+      "platform": "responsive",
+      "fidelity": "high",
+      "scope": "key_workflow"
+    },
+    "requiredSections": [
+      "tutor",
+      "session",
+      "review"
+    ]
+  },
+  {
+    "id": "nonsaas_physical_goods",
+    "complexity": "medium",
+    "title": "Physical-goods operations",
+    "prd": "Coffee roastery operations tool for 3 retail cafes. Track green-bean inventory per origin, schedule roast batches, log tasting notes per roast, and assign baristas to shifts.",
+    "settings": {
+      "platform": "desktop",
+      "fidelity": "mid",
+      "scope": "multi_screen"
+    },
+    "requiredSections": [
+      "inventory",
+      "roast",
+      "shift"
     ]
   }
 ]

--- a/scripts/mockup-eval-harness.mjs
+++ b/scripts/mockup-eval-harness.mjs
@@ -168,13 +168,30 @@ const generateFixture = async (testCase, runIndex, attempt) => {
   };
 };
 
-const renderScreenshots = async (payload, screenshotDir, prefix) => {
+// Phase C: Playwright-backed render also collects layout-viability signals
+// per screen (styled, overflow, bodyHeight, visibleElements). Aggregated
+// into a `layoutViabilityRate` metric so CI can catch "renders OK but looks
+// blank" regressions that regex checks miss.
+const probeLayout = async (page) =>
+  page.evaluate(() => {
+    const root = document.querySelector('.min-h-screen') || document.body;
+    const cs = window.getComputedStyle(root);
+    const styled = parseFloat(cs.minHeight || '0') >= 1 || parseFloat(cs.padding || '0') > 0;
+    const body = document.body;
+    const horizontalOverflow = (body.scrollWidth - body.clientWidth) > 1;
+    const bodyHeight = body.scrollHeight;
+    const visibleElements = root.querySelectorAll('section, header, main, aside, nav, table, ul, button').length;
+    return { styled, horizontalOverflow, bodyHeight, visibleElements };
+  });
+
+const renderAndProbe = async (payload, screenshotDir, prefix) => {
   const results = [];
+  const probes = [];
   let chromium;
   try {
     ({ chromium } = await import('playwright'));
   } catch {
-    return { ok: true, skipped: true, warning: 'Playwright is not available in this environment.', screenshots: results };
+    return { ok: true, skipped: true, warning: 'Playwright is not available in this environment.', screenshots: results, probes };
   }
 
   let browser;
@@ -184,18 +201,60 @@ const renderScreenshots = async (payload, screenshotDir, prefix) => {
       const screen = payload.screens[i];
       const page = await browser.newPage({ viewport: { width: 1440, height: 1024 } });
       await page.setContent(wrapHtmlDocument(screen.html), { waitUntil: 'networkidle' });
+      const probe = await probeLayout(page);
       const imageName = `${prefix}-screen-${i + 1}.png`;
       const imagePath = path.join(screenshotDir, imageName);
       await page.screenshot({ path: imagePath, fullPage: true });
       await page.close();
       results.push(imagePath);
+      probes.push({ screenIndex: i, ...probe });
     }
-    return { ok: true, screenshots: results };
+    return { ok: true, screenshots: results, probes };
   } catch (error) {
-    return { ok: true, skipped: true, warning: `Screenshot rendering skipped: ${error instanceof Error ? error.message : String(error)}`, screenshots: results };
+    return { ok: true, skipped: true, warning: `Screenshot rendering skipped: ${error instanceof Error ? error.message : String(error)}`, screenshots: results, probes };
   } finally {
     if (browser) await browser.close();
   }
+};
+
+// A render is layout-viable when every screen reports styled=true, no
+// horizontal overflow, >100px body height, and at least one landmark.
+const isLayoutViable = (probes) => {
+  if (!probes || probes.length === 0) return false;
+  return probes.every(p => p.styled && !p.horizontalOverflow && p.bodyHeight > 100 && p.visibleElements > 0);
+};
+
+// Shell signature = sorted unique Tailwind class tokens on the root shell
+// element. Used to score perturbation pairs: a ≤10-token PRD edit should
+// NOT flip the shell signature, because shell layout is a structural
+// choice, not a content choice.
+const extractShellSignature = (payload) => {
+  const signatures = (payload.screens || []).map(screen => {
+    const match = screen.html.match(/<div\s+class\s*=\s*["']([^"']*min-h-screen[^"']*)["']/i);
+    if (!match) return [];
+    const tokens = match[1].split(/\s+/).filter(Boolean);
+    return [...new Set(tokens)].sort();
+  });
+  return signatures;
+};
+
+const jaccard = (a, b) => {
+  if (!a.length && !b.length) return 1;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter(x => setB.has(x)).length;
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 1 : intersection / union;
+};
+
+const perturbationSimilarity = (primaryPayload, variantPayload) => {
+  const primarySigs = extractShellSignature(primaryPayload);
+  const variantSigs = extractShellSignature(variantPayload);
+  if (primarySigs.length === 0 || variantSigs.length === 0) return null;
+  const pairs = Math.min(primarySigs.length, variantSigs.length);
+  let total = 0;
+  for (let i = 0; i < pairs; i++) total += jaccard(primarySigs[i], variantSigs[i]);
+  return total / pairs;
 };
 
 const detectRegressions = (currentMetrics, baselineMetrics) => {
@@ -214,6 +273,20 @@ const detectRegressions = (currentMetrics, baselineMetrics) => {
   }
   if (currentMetrics.fallbackRate > baselineMetrics.fallbackRate + 0.01) {
     regressions.push(`Fallback rate increased by ${drop(baselineMetrics.fallbackRate, currentMetrics.fallbackRate)} points.`);
+  }
+  if (
+    typeof currentMetrics.layoutViabilityRate === 'number'
+    && typeof baselineMetrics.layoutViabilityRate === 'number'
+    && currentMetrics.layoutViabilityRate + 0.01 < baselineMetrics.layoutViabilityRate
+  ) {
+    regressions.push(`Layout viability dropped by ${drop(currentMetrics.layoutViabilityRate, baselineMetrics.layoutViabilityRate)} points.`);
+  }
+  if (
+    typeof currentMetrics.perturbationPassRate === 'number'
+    && typeof baselineMetrics.perturbationPassRate === 'number'
+    && currentMetrics.perturbationPassRate + 0.01 < baselineMetrics.perturbationPassRate
+  ) {
+    regressions.push(`Perturbation pass rate dropped by ${drop(currentMetrics.perturbationPassRate, baselineMetrics.perturbationPassRate)} points.`);
   }
 
   return regressions;
@@ -317,15 +390,20 @@ const main = async () => {
       const quality = qualityScore(payload, testCase.requiredSections || []);
 
       const screenshotPrefix = `${safeSlug(testCase.id)}-run-${run}`;
-      const renderResult = await renderScreenshots(payload, screenshotDir, screenshotPrefix);
+      const renderResult = await renderAndProbe(payload, screenshotDir, screenshotPrefix);
       const renderSuccess = renderResult.ok;
       const renderSkipped = Boolean(renderResult.skipped);
+      const layoutViable = renderSkipped ? null : isLayoutViable(renderResult.probes);
 
-      if (!structural.isValid || (!renderSuccess && !renderSkipped)) {
+      if (!structural.isValid || (!renderSuccess && !renderSkipped) || layoutViable === false) {
         failures.push({
           caseId: testCase.id,
           run,
-          reason: !structural.isValid ? structural.issues.join(', ') : renderResult.warning || 'render_failed',
+          reason: !structural.isValid
+            ? structural.issues.join(', ')
+            : layoutViable === false
+              ? `layout_not_viable: ${JSON.stringify(renderResult.probes)}`
+              : renderResult.warning || 'render_failed',
         });
       }
 
@@ -339,6 +417,8 @@ const main = async () => {
         renderSkipped,
         renderWarning: renderResult.warning,
         screenshotPaths: renderResult.screenshots.map((p) => path.relative(repoRoot, p)),
+        layoutViable,
+        layoutProbes: renderResult.probes,
         structural,
         quality,
         generatorNotes: generated.generatorNotes || [],
@@ -348,6 +428,29 @@ const main = async () => {
       if (!caseRunMap.has(testCase.id)) caseRunMap.set(testCase.id, []);
       caseRunMap.get(testCase.id).push(entry);
     }
+  }
+
+  // Phase C perturbation pairs: for every case that ships a `variantPrompt`,
+  // generate once under the variant and compare shell signatures against
+  // the primary run's output. A shell-signature Jaccard < 0.9 means a
+  // ≤10-token PRD edit altered the structural layout — the audit calls
+  // this "fragility on small edits" (§3.5 risk #6 in the failure map).
+  const perturbationPairs = [];
+  for (const testCase of testCases) {
+    if (!testCase.variantPrompt) continue;
+    const primaryRuns = caseRunMap.get(testCase.id) ?? [];
+    const primaryPayload = primaryRuns[0]?.payload;
+    if (!primaryPayload) continue;
+    const variantCase = { ...testCase, prd: testCase.variantPrompt, id: `${testCase.id}__variant` };
+    const variantGen = await generateFixture(variantCase, 1, 1);
+    const variantPayload = variantGen.payload;
+    if (!variantPayload) continue;
+    const similarity = perturbationSimilarity(primaryPayload, variantPayload);
+    perturbationPairs.push({
+      caseId: testCase.id,
+      similarity,
+      passedThreshold: similarity !== null ? similarity >= 0.9 : null,
+    });
   }
 
   const total = logs.length;
@@ -373,6 +476,21 @@ const main = async () => {
     'Prioritize deterministic seeds / temperature controls for consistency-sensitive cases.',
   ];
 
+  // Phase C aggregates. layoutViabilityRate is computed over entries that
+  // actually ran Playwright (not skipped). perturbationSimilarityAvg is the
+  // mean Jaccard across all variant pairs; undefined when no pairs exist.
+  const viabilityEntries = logs.filter(l => typeof l.layoutViable === 'boolean');
+  const layoutViabilityRate = viabilityEntries.length
+    ? Math.round((viabilityEntries.filter(l => l.layoutViable).length / viabilityEntries.length) * 10000) / 100
+    : null;
+  const perturbationWithValues = perturbationPairs.filter(p => typeof p.similarity === 'number');
+  const perturbationSimilarityAvg = perturbationWithValues.length
+    ? Math.round((perturbationWithValues.reduce((s, p) => s + p.similarity, 0) / perturbationWithValues.length) * 10000) / 10000
+    : null;
+  const perturbationPassRate = perturbationWithValues.length
+    ? Math.round((perturbationWithValues.filter(p => p.passedThreshold).length / perturbationWithValues.length) * 10000) / 100
+    : null;
+
   const metrics = {
     renderSuccessRate,
     structuralValidityRate,
@@ -380,6 +498,9 @@ const main = async () => {
     fallbackRate,
     visualQualityScore,
     consistencyScore,
+    layoutViabilityRate,
+    perturbationSimilarityAvg,
+    perturbationPassRate,
   };
 
   let baselineMetrics;
@@ -389,6 +510,13 @@ const main = async () => {
   }
 
   const regressions = detectRegressions(metrics, baselineMetrics);
+
+  if (layoutViabilityRate !== null && layoutViabilityRate < 100) {
+    weakAreas.push(`Layout viability under 100% (${layoutViabilityRate}%) — some renders are blank, clipped, or unstyled.`);
+  }
+  if (perturbationPassRate !== null && perturbationPassRate < 100) {
+    weakAreas.push(`Perturbation pass rate ${perturbationPassRate}% — minor PRD edits flip shell layout.`);
+  }
 
   const summary = {
     runId,
@@ -400,6 +528,7 @@ const main = async () => {
     totalEvaluations: total,
     metrics,
     failures,
+    perturbationPairs,
     weakAreas,
     recommendations,
     regressions,

--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -121,6 +121,7 @@ const extractSettings = (version: ArtifactVersion): MockupSettings => {
         scope: (typeof s.scope === 'string' && ['single_screen', 'multi_screen', 'key_workflow'].includes(s.scope)
             ? s.scope : 'key_workflow') as MockupScope,
         style: typeof s.style === 'string' ? s.style : undefined,
+        safeMode: s.safeMode === true ? true : undefined,
     };
 };
 
@@ -144,6 +145,9 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
     // generation time from the project platform and PRD detail.
     const [scope, setScope] = useState<MockupScope>('key_workflow');
     const [style, setStyle] = useState('');
+    // Phase C: Demo Safe Mode pins the provider to greedy decoding, drops
+    // the fallback chain, and hard-rejects on alignment critique miss.
+    const [safeMode, setSafeMode] = useState(false);
 
     const mockupArtifacts = getArtifacts(projectId, 'mockup');
 
@@ -157,6 +161,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
             const settings: MockupSettings = {
                 platform, fidelity, scope,
                 style: style || undefined,
+                safeMode: safeMode || undefined,
             };
 
             const { payload, warnings, critique } = await generateMockup(prdContent, settings, structuredPRD);
@@ -559,6 +564,23 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                             placeholder="Select a preset or type your own…"
                             className="w-full px-3 py-2 border border-neutral-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/30 focus:border-indigo-300"
                         />
+                    </div>
+
+                    <div>
+                        <label className="flex items-start gap-3 cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={safeMode}
+                                onChange={e => setSafeMode(e.target.checked)}
+                                className="mt-0.5 h-4 w-4 rounded border-neutral-300 text-indigo-600 focus:ring-indigo-500"
+                            />
+                            <span>
+                                <span className="block text-sm font-medium text-neutral-700">Demo Safe Mode</span>
+                                <span className="block text-[11px] text-neutral-500 leading-tight">
+                                    Pin deterministic sampling (temperature 0) and hard-reject on PRD alignment miss instead of serving a fallback. Slower to succeed but repeatable — recommended for recruiter demos.
+                                </span>
+                            </span>
+                        </label>
                     </div>
 
                     <div className="flex items-center gap-3 pt-1 border-t border-neutral-100">

--- a/src/components/mockups/MockupHtmlPreview.tsx
+++ b/src/components/mockups/MockupHtmlPreview.tsx
@@ -1,11 +1,28 @@
 import { useEffect, useMemo, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import type { MockupPlatform } from '../../types';
-import { buildMockupSrcDoc } from './buildMockupSrcDoc';
+import { buildMockupSrcDoc, type MockupProbeReport } from './buildMockupSrcDoc';
 
 type Props = {
     html: string;
     platform: MockupPlatform;
     className?: string;
+};
+
+type ProbeState =
+    | { status: 'pending' }
+    | { status: 'ok'; report: MockupProbeReport }
+    | { status: 'degraded'; reason: string; report?: MockupProbeReport };
+
+// Heuristics for interpreting a probe report. Tuned against the Phase A
+// template catalog: a rendered shell should always have >100px body height
+// and at least one visible landmark section.
+const interpretProbe = (report: MockupProbeReport): ProbeState => {
+    if (!report.styled) return { status: 'degraded', reason: 'Tailwind styles did not apply.', report };
+    if (report.horizontalOverflow) return { status: 'degraded', reason: 'Screen overflows horizontally.', report };
+    if (report.bodyHeight < 100) return { status: 'degraded', reason: 'Screen rendered near-empty viewport.', report };
+    if (report.visibleElements === 0) return { status: 'degraded', reason: 'No layout landmarks detected.', report };
+    return { status: 'ok', report };
 };
 
 // Sandboxed iframe preview for a single mockup screen. `sandbox="allow-scripts"`
@@ -15,24 +32,65 @@ type Props = {
 export function MockupHtmlPreview({ html, platform, className }: Props) {
     const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
     const [retryCount, setRetryCount] = useState(0);
+    const [probe, setProbe] = useState<ProbeState>({ status: 'pending' });
     const frameKey = `${retryCount}-${html.length}`;
-    const srcDoc = useMemo(() => {
-        if (!html || !html.trim()) return null;
+
+    // Fresh probeId per (html, retryCount) pair so a remount/retry never
+    // matches a stale probe message from the previous iframe instance.
+    // Computed together with srcDoc so the pair stays in sync without a
+    // render-time ref. `retryCount` is intentionally in the closure key —
+    // linting can't see that because it's read via html+retry combination
+    // below — so we reference it here to keep the memo dep-complete.
+    const { srcDoc, probeId } = useMemo(() => {
+        void retryCount; // tracked to rotate probeId on retry
+        if (!html || !html.trim()) return { srcDoc: null, probeId: '' };
+        const id = uuidv4();
         try {
-            return buildMockupSrcDoc(html);
+            return { srcDoc: buildMockupSrcDoc(html, { probeId: id }), probeId: id };
         } catch (e) {
             console.warn('[MockupHtmlPreview] buildMockupSrcDoc failed:', e);
-            return null;
+            return { srcDoc: null, probeId: '' };
         }
-    }, [html]);
+    }, [html, retryCount]);
 
     useEffect(() => {
-        window.setTimeout(() => setStatus(srcDoc ? 'loading' : 'error'), 0);
-        const timer = window.setTimeout(() => {
+        // Both state resets are batched inside a zero-delay timeout so the
+        // effect body stays free of direct setState calls (which trigger
+        // cascading renders under react-hooks/set-state-in-effect).
+        const resetTimer = window.setTimeout(() => {
+            setStatus(srcDoc ? 'loading' : 'error');
+            setProbe({ status: 'pending' });
+        }, 0);
+        const loadTimer = window.setTimeout(() => {
             setStatus(current => (current === 'loading' ? 'error' : current));
         }, 4500);
-        return () => window.clearTimeout(timer);
-    }, [srcDoc, retryCount]);
+        // Probe arrives after onload + 50ms. If it doesn't arrive within
+        // 6s we flag the preview as degraded but keep showing it (better
+        // than hiding potentially-fine output on a slow CDN response).
+        const probeTimer = window.setTimeout(() => {
+            setProbe(current => current.status === 'pending'
+                ? { status: 'degraded', reason: 'Preview did not report layout signals.' }
+                : current);
+        }, 6000);
+        return () => {
+            window.clearTimeout(resetTimer);
+            window.clearTimeout(loadTimer);
+            window.clearTimeout(probeTimer);
+        };
+    }, [srcDoc]);
+
+    useEffect(() => {
+        if (!probeId) return;
+        const onMessage = (event: MessageEvent) => {
+            const data = event.data;
+            if (!data || typeof data !== 'object') return;
+            if (data.type !== 'mockup-probe') return;
+            if (data.probeId !== probeId) return;
+            setProbe(interpretProbe(data as MockupProbeReport));
+        };
+        window.addEventListener('message', onMessage);
+        return () => window.removeEventListener('message', onMessage);
+    }, [probeId]);
 
     const height = platform === 'mobile' ? 760 : platform === 'responsive' ? 720 : 760;
     const maxWidth = platform === 'mobile' ? 430 : undefined;
@@ -61,6 +119,14 @@ export function MockupHtmlPreview({ html, platform, className }: Props) {
             {status === 'loading' && (
                 <div className="mb-2 rounded-md border border-neutral-200 bg-white/80 px-3 py-2 text-xs text-neutral-600">
                     Rendering preview…
+                </div>
+            )}
+            {probe.status === 'degraded' && status !== 'loading' && (
+                <div
+                    className="mb-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+                    role="status"
+                >
+                    Preview degraded: {probe.reason} The mockup may still be usable — regenerate for a cleaner render.
                 </div>
             )}
             <iframe

--- a/src/components/mockups/__tests__/buildMockupSrcDoc.test.ts
+++ b/src/components/mockups/__tests__/buildMockupSrcDoc.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildMockupSrcDoc } from '../buildMockupSrcDoc';
+
+const fragment = '<div class="min-h-screen bg-neutral-50 p-6"><header><h1>Hi</h1></header><main><section>body</section></main></div>';
+
+describe('buildMockupSrcDoc', () => {
+    it('omits the probe script when no probeId is provided', () => {
+        const srcDoc = buildMockupSrcDoc(fragment);
+        expect(srcDoc).toContain('min-h-screen');
+        expect(srcDoc).not.toContain('mockup-probe');
+        expect(srcDoc).not.toContain('parent.postMessage');
+    });
+
+    it('injects a probe script when a probeId is provided', () => {
+        const srcDoc = buildMockupSrcDoc(fragment, { probeId: 'probe-xyz-123' });
+        expect(srcDoc).toContain('mockup-probe');
+        expect(srcDoc).toContain('"probe-xyz-123"');
+        expect(srcDoc).toContain('parent.postMessage');
+        // Probe reports the four signals MockupHtmlPreview interprets.
+        expect(srcDoc).toContain('styled');
+        expect(srcDoc).toContain('horizontalOverflow');
+        expect(srcDoc).toContain('bodyHeight');
+        expect(srcDoc).toContain('visibleElements');
+    });
+
+    it('keeps the Tailwind CDN script and defensive overflow overrides', () => {
+        const srcDoc = buildMockupSrcDoc(fragment, { probeId: 'probe-1' });
+        expect(srcDoc).toContain('cdn.tailwindcss.com');
+        expect(srcDoc).toContain('overflow: visible !important');
+    });
+});

--- a/src/components/mockups/buildMockupSrcDoc.ts
+++ b/src/components/mockups/buildMockupSrcDoc.ts
@@ -5,8 +5,77 @@
 
 import { normalizeMockupHtml } from '../../lib/mockupQuality';
 
-export const buildMockupSrcDoc = (fragment: string): string => {
+export interface BuildMockupSrcDocOptions {
+    // Phase C: when provided, the wrapper injects a post-load probe that
+    // reports styled/overflow/occupancy back to the parent via postMessage.
+    // The parent scopes incoming messages by matching probeId so multiple
+    // previews on the same page don't cross-contaminate.
+    probeId?: string;
+}
+
+export interface MockupProbeReport {
+    type: 'mockup-probe';
+    probeId: string;
+    styled: boolean;         // whether a vetted Tailwind utility actually applied
+    horizontalOverflow: boolean; // scrollWidth > clientWidth
+    bodyHeight: number;      // rendered body height in px
+    visibleElements: number; // rough element count inside the root shell
+}
+
+const buildProbeScript = (probeId: string): string => {
+    // Pure-browser IIFE: waits for load, inspects computed styles + layout,
+    // posts one MockupProbeReport. Kept inline (no external file) so the
+    // iframe works even when bundled into a downloaded artifact.
+    const script = `(() => {
+        const report = () => {
+            try {
+                const root = document.querySelector('.min-h-screen') || document.body;
+                // Styled check: the vetted templates always ship the root
+                // with 'min-h-screen'. If Tailwind CDN applied its styles,
+                // the computed min-height resolves to at least 100vh; if
+                // the CDN failed (CSP, network), min-height stays 0.
+                const cs = window.getComputedStyle(root);
+                const styled = parseFloat(cs.minHeight || '0') >= 1
+                    || cs.display !== 'inline'
+                    || parseFloat(cs.padding || '0') > 0;
+                const body = document.body;
+                const horizontalOverflow = (body.scrollWidth - body.clientWidth) > 1;
+                const bodyHeight = body.scrollHeight;
+                const visibleElements = root.querySelectorAll('section, header, main, aside, nav, table, ul, button').length;
+                parent.postMessage({
+                    type: 'mockup-probe',
+                    probeId: ${JSON.stringify(probeId)},
+                    styled,
+                    horizontalOverflow,
+                    bodyHeight,
+                    visibleElements,
+                }, '*');
+            } catch (_) {
+                parent.postMessage({
+                    type: 'mockup-probe',
+                    probeId: ${JSON.stringify(probeId)},
+                    styled: false,
+                    horizontalOverflow: false,
+                    bodyHeight: 0,
+                    visibleElements: 0,
+                }, '*');
+            }
+        };
+        if (document.readyState === 'complete') {
+            setTimeout(report, 50);
+        } else {
+            window.addEventListener('load', () => setTimeout(report, 50), { once: true });
+        }
+    })();`;
+    return `<script>${script}</script>`;
+};
+
+export const buildMockupSrcDoc = (
+    fragment: string,
+    options: BuildMockupSrcDocOptions = {},
+): string => {
     const normalized = normalizeMockupHtml(fragment);
+    const probeScript = options.probeId ? buildProbeScript(options.probeId) : '';
     return `<!doctype html>
 <html lang="en">
 <head>
@@ -31,6 +100,7 @@ export const buildMockupSrcDoc = (fragment: string): string => {
 </head>
 <body>
 ${normalized}
+${probeScript}
 </body>
 </html>`;
 };

--- a/src/components/mockups/templates/actions.ts
+++ b/src/components/mockups/templates/actions.ts
@@ -1,0 +1,32 @@
+import type { MockupLayoutAction } from '../../../types';
+import { esc } from './escape';
+
+// Action renderers produce the controls that live in the screen header.
+// Every template here emits a `type="button"` / `type="text"` element with
+// fixed Tailwind classes so the header's visual rhythm is identical across
+// screens regardless of which action kinds the model picked.
+
+const primaryCtaHtml = (label: string): string =>
+    `<button type="button" class="inline-flex items-center rounded-lg bg-indigo-600 hover:bg-indigo-700 px-4 py-2 text-sm font-medium text-white shadow-sm">${esc(label)}</button>`;
+
+const secondaryCtaHtml = (label: string): string =>
+    `<button type="button" class="inline-flex items-center rounded-lg border border-neutral-200 bg-white hover:bg-neutral-50 px-4 py-2 text-sm font-medium text-neutral-900">${esc(label)}</button>`;
+
+const inputHtml = (label: string): string =>
+    `<input type="text" aria-label="${esc(label)}" placeholder="${esc(label)}" class="rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />`;
+
+const selectHtml = (label: string): string =>
+    `<button type="button" aria-label="${esc(label)}" class="inline-flex items-center gap-2 rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-700"><span>${esc(label)}</span><span aria-hidden="true" class="text-neutral-400">▾</span></button>`;
+
+const tabHtml = (label: string): string =>
+    `<button type="button" class="inline-flex items-center rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-medium text-neutral-700 hover:border-indigo-200 hover:text-indigo-700">${esc(label)}</button>`;
+
+export const renderAction = (action: MockupLayoutAction): string => {
+    switch (action.kind) {
+        case 'primary_cta':   return primaryCtaHtml(action.label);
+        case 'secondary_cta': return secondaryCtaHtml(action.label);
+        case 'input':         return inputHtml(action.label);
+        case 'select':        return selectHtml(action.label);
+        case 'tab':           return tabHtml(action.label);
+    }
+};

--- a/src/components/mockups/templates/escape.ts
+++ b/src/components/mockups/templates/escape.ts
@@ -1,0 +1,13 @@
+// Minimal HTML-entity escape for slot-text rendered inside templates. Model
+// output is trusted to be text, not markup — any angle brackets or ampersands
+// are treated as data.
+const ENTITIES: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+};
+
+export const esc = (value: string): string =>
+    String(value ?? '').replace(/[&<>"']/g, ch => ENTITIES[ch] ?? ch);

--- a/src/components/mockups/templates/index.ts
+++ b/src/components/mockups/templates/index.ts
@@ -1,0 +1,4 @@
+export { renderShell } from './shells';
+export { renderSection } from './sections';
+export { renderAction } from './actions';
+export { esc } from './escape';

--- a/src/components/mockups/templates/sections.ts
+++ b/src/components/mockups/templates/sections.ts
@@ -1,0 +1,123 @@
+import type { MockupLayoutSection } from '../../../types';
+import { esc } from './escape';
+
+// Each section renderer takes a typed slot payload and returns a single
+// <section> element. Class tokens are fixed literals so Tailwind JIT picks
+// them up reliably inside the iframe CDN runtime.
+
+const sectionShell = (role: 'primary' | 'support' | 'utility', heading: string, body: string): string => {
+    const wide = role === 'primary';
+    const padClass = wide ? 'md:col-span-2' : '';
+    return `<section class="rounded-xl border border-neutral-200 bg-white p-5 space-y-4 ${padClass}">
+  <header class="flex items-center justify-between">
+    <h2 class="text-sm font-semibold text-neutral-900 tracking-tight">${esc(heading)}</h2>
+  </header>
+  ${body}
+</section>`;
+};
+
+const statGridHtml = (section: Extract<MockupLayoutSection, { component: 'stat_grid' }>): string => {
+    const tiles = section.data.rows
+        .map(row => {
+            const delta = row.delta
+                ? `<span class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">${esc(row.delta)}</span>`
+                : '';
+            return `<div class="rounded-lg border border-neutral-200 bg-neutral-50 p-4 space-y-1">
+  <p class="text-xs uppercase tracking-wide text-neutral-500">${esc(row.label)}</p>
+  <div class="flex items-baseline justify-between gap-2">
+    <p class="text-2xl font-semibold tracking-tight text-neutral-900">${esc(row.value)}</p>
+    ${delta}
+  </div>
+</div>`;
+        })
+        .join('\n');
+    return sectionShell(section.role, section.heading, `<div class="grid grid-cols-2 md:grid-cols-3 gap-3">${tiles}</div>`);
+};
+
+const dataTableHtml = (section: Extract<MockupLayoutSection, { component: 'data_table' }>): string => {
+    const headCells = section.data.columns
+        .map(col => `<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-neutral-500">${esc(col)}</th>`)
+        .join('');
+    const bodyRows = section.data.rows
+        .map((row, idx) => {
+            const zebra = idx % 2 === 0 ? 'bg-white' : 'bg-neutral-50';
+            const cells = row.cells
+                .map(cell => `<td class="px-3 py-2 text-sm text-neutral-700">${esc(cell)}</td>`)
+                .join('');
+            return `<tr class="${zebra} border-t border-neutral-100">${cells}</tr>`;
+        })
+        .join('\n');
+    const table = `<div class="overflow-hidden rounded-lg border border-neutral-200">
+  <table class="w-full">
+    <thead class="bg-neutral-50"><tr>${headCells}</tr></thead>
+    <tbody>${bodyRows}</tbody>
+  </table>
+</div>`;
+    return sectionShell(section.role, section.heading, table);
+};
+
+const activityFeedHtml = (section: Extract<MockupLayoutSection, { component: 'activity_feed' }>): string => {
+    const items = section.data.entries
+        .map(entry => `<li class="flex items-start gap-3">
+  <div class="mt-0.5 h-8 w-8 shrink-0 rounded-full bg-indigo-100 text-indigo-700 text-xs font-semibold inline-flex items-center justify-center">${esc(entry.actor.slice(0, 2).toUpperCase())}</div>
+  <div class="flex-1 text-sm">
+    <p class="text-neutral-900"><span class="font-medium">${esc(entry.actor)}</span> ${esc(entry.verb)} <span class="font-medium">${esc(entry.target)}</span></p>
+    <p class="text-xs text-neutral-500">${esc(entry.when)}</p>
+  </div>
+</li>`)
+        .join('\n');
+    return sectionShell(section.role, section.heading, `<ul class="space-y-3">${items}</ul>`);
+};
+
+const filtersBarHtml = (section: Extract<MockupLayoutSection, { component: 'filters_bar' }>): string => {
+    const filters = section.data.filters
+        .map(filter => {
+            const options = filter.options
+                .map((opt, idx) => {
+                    const active = idx === 0
+                        ? 'border-indigo-200 bg-indigo-50 text-indigo-700'
+                        : 'border-neutral-200 bg-white text-neutral-700';
+                    return `<button type="button" class="inline-flex items-center rounded-full border ${active} px-3 py-1 text-xs font-medium">${esc(opt)}</button>`;
+                })
+                .join('');
+            return `<div class="space-y-2">
+  <p class="text-xs font-medium uppercase tracking-wide text-neutral-500">${esc(filter.label)}</p>
+  <div class="flex flex-wrap gap-2">${options}</div>
+</div>`;
+        })
+        .join('\n');
+    return sectionShell(section.role, section.heading, `<div class="grid gap-4 md:grid-cols-2">${filters}</div>`);
+};
+
+const detailPanelHtml = (section: Extract<MockupLayoutSection, { component: 'detail_panel' }>): string => {
+    const rows = section.data.fields
+        .map(field => `<div class="flex items-start justify-between gap-3 border-b border-neutral-100 py-2 last:border-b-0">
+  <p class="text-xs uppercase tracking-wide text-neutral-500">${esc(field.label)}</p>
+  <p class="text-sm text-neutral-900 text-right">${esc(field.value)}</p>
+</div>`)
+        .join('\n');
+    return sectionShell(section.role, section.heading, `<div class="rounded-lg border border-neutral-200 bg-neutral-50 px-4">${rows}</div>`);
+};
+
+const emptyStateHtml = (section: Extract<MockupLayoutSection, { component: 'empty_state' }>): string => {
+    const cta = section.data.primaryActionLabel
+        ? `<button type="button" class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white">${esc(section.data.primaryActionLabel)}</button>`
+        : '';
+    const body = `<div class="rounded-lg border border-dashed border-neutral-200 bg-neutral-50 p-8 text-center space-y-3">
+  <h3 class="text-base font-semibold text-neutral-900">${esc(section.data.heading)}</h3>
+  <p class="text-sm text-neutral-600">${esc(section.data.body)}</p>
+  ${cta}
+</div>`;
+    return sectionShell(section.role, section.heading, body);
+};
+
+export const renderSection = (section: MockupLayoutSection): string => {
+    switch (section.component) {
+        case 'stat_grid':     return statGridHtml(section);
+        case 'data_table':    return dataTableHtml(section);
+        case 'activity_feed': return activityFeedHtml(section);
+        case 'filters_bar':   return filtersBarHtml(section);
+        case 'detail_panel':  return detailPanelHtml(section);
+        case 'empty_state':   return emptyStateHtml(section);
+    }
+};

--- a/src/components/mockups/templates/shells.ts
+++ b/src/components/mockups/templates/shells.ts
@@ -1,0 +1,133 @@
+import type { MockupLayoutScreen } from '../../../types';
+import { renderAction } from './actions';
+import { renderSection } from './sections';
+import { esc } from './escape';
+
+// Shells wrap a screen's sections + header actions in one of three vetted
+// layouts. Every shell emits exactly one `min-h-screen` root div; never an
+// inner `overflow-hidden` on a flex container (the #1 preview-blanking
+// pattern flagged in docs/mockup-failure-map-2026-04-17.md).
+
+const renderHeaderActions = (screen: MockupLayoutScreen): string =>
+    screen.actions.map(renderAction).join('\n    ');
+
+const renderMain = (screen: MockupLayoutScreen): string => {
+    const primary = screen.sections.filter(s => s.role === 'primary').map(renderSection).join('\n');
+    const support = screen.sections.filter(s => s.role !== 'primary').map(renderSection).join('\n');
+    return `<main class="p-6 md:p-8 grid gap-4 md:grid-cols-3">
+  ${primary}
+  ${support}
+</main>`;
+};
+
+const sidebarTopbarShellHtml = (screen: MockupLayoutScreen): string => {
+    const navItems = screen.shell.navLabels
+        .map((label, idx) => {
+            const active = idx === 0
+                ? 'bg-indigo-50 text-indigo-700'
+                : 'text-neutral-600 hover:bg-neutral-100';
+            return `<li><a class="block rounded-lg px-3 py-2 text-sm font-medium ${active}">${esc(label)}</a></li>`;
+        })
+        .join('\n        ');
+    return `<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">
+  <div class="flex">
+    <aside class="w-60 shrink-0 border-r border-neutral-200 bg-white px-4 py-5 space-y-6">
+      <div class="px-2">
+        <p class="text-xs uppercase tracking-wide text-neutral-500">Workspace</p>
+        <p class="text-sm font-semibold text-neutral-900">${esc(screen.shell.productName)}</p>
+      </div>
+      <nav>
+        <ul class="space-y-1">
+        ${navItems}
+        </ul>
+      </nav>
+    </aside>
+    <div class="flex-1">
+      <header class="flex items-center justify-between gap-4 border-b border-neutral-200 bg-white px-6 md:px-8 py-4">
+        <div>
+          <p class="text-xs uppercase tracking-wide text-neutral-500">${esc(screen.shell.productName)}</p>
+          <h1 class="text-xl font-semibold tracking-tight text-neutral-900">${esc(screen.name)}</h1>
+        </div>
+        <div class="flex items-center gap-2">
+          ${renderHeaderActions(screen)}
+        </div>
+      </header>
+      ${renderMain(screen)}
+    </div>
+  </div>
+</div>`;
+};
+
+const topbarOnlyShellHtml = (screen: MockupLayoutScreen): string => {
+    const navItems = screen.shell.navLabels
+        .map((label, idx) => {
+            const active = idx === 0
+                ? 'border-indigo-600 text-indigo-700'
+                : 'border-transparent text-neutral-600 hover:text-neutral-900';
+            return `<a class="border-b-2 ${active} px-1 pb-3 text-sm font-medium">${esc(label)}</a>`;
+        })
+        .join('\n          ');
+    return `<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">
+  <header class="border-b border-neutral-200 bg-white">
+    <div class="flex items-center justify-between gap-4 px-6 md:px-8 pt-4">
+      <div class="flex items-center gap-6">
+        <p class="text-sm font-semibold text-neutral-900">${esc(screen.shell.productName)}</p>
+        <p class="text-xs uppercase tracking-wide text-neutral-500">${esc(screen.name)}</p>
+      </div>
+      <div class="flex items-center gap-2">
+        ${renderHeaderActions(screen)}
+      </div>
+    </div>
+    <nav class="px-6 md:px-8">
+      <div class="flex items-end gap-6 pt-3">
+        ${navItems}
+      </div>
+    </nav>
+  </header>
+  ${renderMain(screen)}
+</div>`;
+};
+
+const mobileTabShellHtml = (screen: MockupLayoutScreen): string => {
+    // Mobile shell: single-column, sticky header, bottom tab bar of up to 5 items.
+    const tabs = screen.shell.navLabels
+        .slice(0, 5)
+        .map((label, idx) => {
+            const active = idx === 0 ? 'text-indigo-700' : 'text-neutral-500';
+            return `<button type="button" class="flex flex-col items-center gap-1 ${active}">
+      <span class="h-6 w-6 rounded-full bg-current opacity-20"></span>
+      <span class="text-[10px] font-medium">${esc(label)}</span>
+    </button>`;
+        })
+        .join('\n    ');
+    const sectionsHtml = screen.sections.map(renderSection).join('\n');
+    return `<div class="min-h-screen bg-neutral-50 text-neutral-900 font-sans antialiased">
+  <div class="mx-auto max-w-[420px] pb-24">
+    <header class="sticky top-0 z-10 border-b border-neutral-200 bg-white/90 backdrop-blur px-4 py-3">
+      <div class="flex items-center justify-between gap-2">
+        <div>
+          <p class="text-xs uppercase tracking-wide text-neutral-500">${esc(screen.shell.productName)}</p>
+          <h1 class="text-lg font-semibold tracking-tight text-neutral-900">${esc(screen.name)}</h1>
+        </div>
+        <div class="flex items-center gap-2">
+          ${renderHeaderActions(screen)}
+        </div>
+      </div>
+    </header>
+    <main class="p-4 space-y-4">
+      ${sectionsHtml}
+    </main>
+  </div>
+  <nav class="fixed inset-x-0 bottom-0 mx-auto max-w-[420px] border-t border-neutral-200 bg-white px-2 py-2 flex items-center justify-around">
+    ${tabs}
+  </nav>
+</div>`;
+};
+
+export const renderShell = (screen: MockupLayoutScreen): string => {
+    switch (screen.shell.type) {
+        case 'sidebar_topbar':   return sidebarTopbarShellHtml(screen);
+        case 'topbar_only':      return topbarOnlyShellHtml(screen);
+        case 'mobile_tab_shell': return mobileTabShellHtml(screen);
+    }
+};

--- a/src/lib/__tests__/mockupAlignmentCritique.test.ts
+++ b/src/lib/__tests__/mockupAlignmentCritique.test.ts
@@ -65,6 +65,132 @@ describe('mockupAlignmentCritique', () => {
         expect(critique.missingConcepts).toContain('main entities/objects');
     });
 
+    it('emits insufficient_entity_grounding when domainEntities are absent from screens', () => {
+        const prdWithEntities: StructuredPRD = {
+            ...structuredPRD,
+            domainEntities: [
+                { name: 'Replenishment task' },
+                { name: 'Supplier order' },
+                { name: 'Stockout risk signal' },
+            ],
+        };
+        const screens: MockupScreen[] = [
+            {
+                id: '1',
+                name: 'Overview Dashboard',
+                purpose: 'Track KPIs for teams.',
+                html: '<div class="min-h-screen"><header><h1>Overview Dashboard</h1></header><main><section>Active users</section></main></div>',
+            },
+            {
+                id: '2',
+                name: 'Analytics Home',
+                purpose: 'Review trends.',
+                html: '<div class="min-h-screen"><main><section>Revenue summary</section></main></div>',
+            },
+            {
+                id: '3',
+                name: 'Settings',
+                purpose: 'Configure preferences.',
+                html: '<div class="min-h-screen"><main><section>Defaults</section></main></div>',
+            },
+        ];
+        const critique = critiqueMockupAlignment(screens, settings, prdContent, prdWithEntities);
+        const perScreenIssueCodes = critique.screens.flatMap(s => s.issues.map(i => i.code));
+        expect(perScreenIssueCodes).toContain('insufficient_entity_grounding');
+    });
+
+    it('does not emit insufficient_entity_grounding when screens mention domainEntities by name', () => {
+        const prdWithEntities: StructuredPRD = {
+            ...structuredPRD,
+            domainEntities: [
+                { name: 'Replenishment task', exampleValues: ['SKU-1042', 'SKU-1188'] },
+                { name: 'Supplier order' },
+            ],
+        };
+        const screens: MockupScreen[] = [
+            {
+                id: '1',
+                name: 'Replenishment Queue',
+                purpose: 'Warehouse manager triages replenishment task items.',
+                html: '<div class="min-h-screen"><header><h1>Replenishment task queue</h1></header><main><section>Supplier order status</section></main></div>',
+            },
+            {
+                id: '2',
+                name: 'Supplier Escalation',
+                purpose: 'Inventory analyst escalates supplier order delays.',
+                html: '<div class="min-h-screen"><main><section>Supplier order delays</section><section>Replenishment task follow-up</section></main></div>',
+            },
+            {
+                id: '3',
+                name: 'Restock Workflow Review',
+                purpose: 'Confirm replenishment task completion.',
+                html: '<div class="min-h-screen"><main><section>Replenishment task trend</section></main></div>',
+            },
+        ];
+        const critique = critiqueMockupAlignment(screens, settings, prdContent, prdWithEntities);
+        const perScreenIssueCodes = critique.screens.flatMap(s => s.issues.map(i => i.code));
+        expect(perScreenIssueCodes).not.toContain('insufficient_entity_grounding');
+    });
+
+    it('emits insufficient_action_grounding when no primaryActions verb appears on any CTA', () => {
+        const prdWithActions: StructuredPRD = {
+            ...structuredPRD,
+            primaryActions: [
+                { verb: 'Escalate', target: 'supplier order' },
+                { verb: 'Approve', target: 'substitution' },
+            ],
+        };
+        const screens: MockupScreen[] = [
+            {
+                id: '1',
+                name: 'Replenishment Queue',
+                purpose: 'Manager reviews restock risks.',
+                html: '<div class="min-h-screen"><header><h1>Replenishment queue</h1><button type="button">Create record</button></header><main><section>Items</section></main></div>',
+            },
+            {
+                id: '2',
+                name: 'Restock Workflow Review',
+                purpose: 'Confirm restock progress.',
+                html: '<div class="min-h-screen"><header><h1>Workflow review</h1><button type="button">Save</button></header><main><section>Progress</section></main></div>',
+            },
+            {
+                id: '3',
+                name: 'Settings',
+                purpose: 'Configure preferences.',
+                html: '<div class="min-h-screen"><header><h1>Settings</h1><button type="button">Export</button></header><main><section>Defaults</section></main></div>',
+            },
+        ];
+        const critique = critiqueMockupAlignment(screens, settings, prdContent, prdWithActions);
+        expect(critique.issues.some(i => i.code === 'insufficient_action_grounding')).toBe(true);
+    });
+
+    it('skips structured grounding checks when domainEntities/primaryActions are absent', () => {
+        const screens: MockupScreen[] = [
+            {
+                id: '1',
+                name: 'Replenishment Queue',
+                purpose: 'Warehouse manager triages replenishment.',
+                html: '<div class="min-h-screen"><header><h1>Replenishment queue</h1></header><main><section>Restock ladder</section><section>Supplier activity</section></main></div>',
+            },
+            {
+                id: '2',
+                name: 'Supplier Escalation',
+                purpose: 'Escalate delayed orders.',
+                html: '<div class="min-h-screen"><main><section>Delayed orders</section><section>Approvals</section></main></div>',
+            },
+            {
+                id: '3',
+                name: 'Restock Workflow Review',
+                purpose: 'Confirm completion.',
+                html: '<div class="min-h-screen"><main><section>Timeline</section><section>Trend</section></main></div>',
+            },
+        ];
+        const critique = critiqueMockupAlignment(screens, settings, prdContent, structuredPRD);
+        const codes = critique.issues.map(i => i.code);
+        expect(codes).not.toContain('insufficient_entity_grounding');
+        expect(codes).not.toContain('insufficient_action_grounding');
+    });
+
     it('accepts PRD-grounded screen sets', () => {
         const alignedScreens: MockupScreen[] = [
             {

--- a/src/lib/__tests__/mockupLayoutRenderer.test.ts
+++ b/src/lib/__tests__/mockupLayoutRenderer.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+import {
+    MockupSpecParseError,
+    parseLayoutSpec,
+    renderLayoutSpec,
+} from '../mockupLayoutRenderer';
+import type { MockupLayoutSpec } from '../../types';
+
+const validSpec: MockupLayoutSpec = {
+    version: 'mockup_layout_spec_v1',
+    tokenSet: 'token_set_v1',
+    title: 'Clinic Triage Concept',
+    summary: 'Queue-first layout for care coordinators.',
+    screens: [
+        {
+            id: 'screen-1',
+            name: 'Triage Queue',
+            purpose: 'Care coordinator reviews urgent patient cases and assigns triage owner.',
+            shell: {
+                type: 'sidebar_topbar',
+                platform: 'desktop',
+                accent: 'indigo',
+                productName: 'Triage',
+                navLabels: ['Queue', 'Assigned', 'Follow-ups', 'Settings'],
+            },
+            sections: [
+                {
+                    role: 'primary',
+                    heading: 'Urgent patient cases',
+                    component: 'data_table',
+                    data: {
+                        columns: ['Patient', 'Urgency', 'Owner'],
+                        rows: [
+                            { cells: ['Alex Chen', 'Critical', 'Dr. Kim'] },
+                            { cells: ['Priya Patel', 'High', 'Unassigned'] },
+                        ],
+                    },
+                },
+                {
+                    role: 'support',
+                    heading: 'Recent triage activity',
+                    component: 'activity_feed',
+                    data: {
+                        entries: [
+                            { actor: 'Dr. Kim', verb: 'assigned', target: 'case 1142', when: '2m ago' },
+                            { actor: 'Nurse Ellis', verb: 'flagged', target: 'case 1139', when: '14m ago' },
+                        ],
+                    },
+                },
+            ],
+            actions: [
+                { kind: 'primary_cta', label: 'Assign case owner' },
+                { kind: 'secondary_cta', label: 'Export queue' },
+            ],
+        },
+    ],
+};
+
+describe('mockupLayoutRenderer', () => {
+    describe('renderLayoutSpec', () => {
+        it('produces a MockupPayload with one HTML fragment per screen', () => {
+            const payload = renderLayoutSpec(validSpec);
+            expect(payload.version).toBe('mockup_html_v1');
+            expect(payload.title).toBe(validSpec.title);
+            expect(payload.screens).toHaveLength(1);
+            expect(payload.screens[0].html).toContain('min-h-screen');
+            expect(payload.screens[0].html).toContain('Triage Queue');
+            expect(payload.screens[0].html).toContain('Assign case owner');
+        });
+
+        it('is deterministic — identical spec produces byte-identical HTML', () => {
+            const a = renderLayoutSpec(validSpec).screens[0].html;
+            const b = renderLayoutSpec(validSpec).screens[0].html;
+            expect(a).toBe(b);
+        });
+
+        it('escapes slot content to prevent HTML injection', () => {
+            const malicious: MockupLayoutSpec = {
+                ...validSpec,
+                screens: [
+                    {
+                        ...validSpec.screens[0],
+                        name: 'Triage <script>alert(1)</script>',
+                    },
+                ],
+            };
+            const html = renderLayoutSpec(malicious).screens[0].html;
+            expect(html).not.toContain('<script>alert(1)</script>');
+            expect(html).toContain('&lt;script&gt;');
+        });
+
+        it('emits exactly one min-h-screen root per screen', () => {
+            const html = renderLayoutSpec(validSpec).screens[0].html;
+            const rootMatches = html.match(/min-h-screen/g) ?? [];
+            expect(rootMatches.length).toBe(1);
+        });
+
+        it('renders each shell type differently', () => {
+            const sidebar = renderLayoutSpec(validSpec).screens[0].html;
+            const topbar = renderLayoutSpec({
+                ...validSpec,
+                screens: [{
+                    ...validSpec.screens[0],
+                    shell: { ...validSpec.screens[0].shell, type: 'topbar_only' },
+                }],
+            }).screens[0].html;
+            const mobile = renderLayoutSpec({
+                ...validSpec,
+                screens: [{
+                    ...validSpec.screens[0],
+                    shell: { ...validSpec.screens[0].shell, type: 'mobile_tab_shell', platform: 'mobile' },
+                }],
+            }).screens[0].html;
+            expect(sidebar).not.toBe(topbar);
+            expect(sidebar).not.toBe(mobile);
+            expect(topbar).not.toBe(mobile);
+            expect(sidebar).toContain('<aside');
+            expect(mobile).toContain('max-w-[420px]');
+        });
+    });
+
+    describe('parseLayoutSpec', () => {
+        const validRaw = JSON.stringify({
+            version: 'mockup_layout_spec_v1',
+            tokenSet: 'token_set_v1',
+            title: 'Spec Title',
+            summary: 'Spec summary.',
+            screens: [
+                {
+                    name: 'Screen A',
+                    purpose: 'The purpose.',
+                    shell: {
+                        type: 'sidebar_topbar',
+                        platform: 'desktop',
+                        accent: 'indigo',
+                        productName: 'Product',
+                        navLabels: ['One', 'Two', 'Three'],
+                    },
+                    sections: [
+                        {
+                            role: 'primary',
+                            heading: 'Primary stats',
+                            component: 'stat_grid',
+                            data: {
+                                rows: [
+                                    { label: 'Active', value: '128' },
+                                    { label: 'Escalated', value: '14', delta: '+3%' },
+                                ],
+                            },
+                        },
+                        {
+                            role: 'support',
+                            heading: 'Filters',
+                            component: 'filters_bar',
+                            data: {
+                                filters: [{ label: 'Status', options: ['Open', 'Closed'] }],
+                            },
+                        },
+                    ],
+                    actions: [{ kind: 'primary_cta', label: 'Create case' }],
+                },
+            ],
+        });
+
+        it('parses a valid spec and renders an HTML payload', () => {
+            const result = parseLayoutSpec(validRaw, 'Fallback');
+            expect(result.payload.screens).toHaveLength(1);
+            expect(result.spec.screens[0].name).toBe('Screen A');
+            expect(result.payload.screens[0].html).toContain('Primary stats');
+            expect(result.payload.screens[0].html).toContain('Create case');
+            expect(result.warnings).toHaveLength(0);
+        });
+
+        it('throws MockupSpecParseError on invalid JSON', () => {
+            expect(() => parseLayoutSpec('{not json', 'x')).toThrow(MockupSpecParseError);
+        });
+
+        it('throws when no screens survive parsing', () => {
+            const raw = JSON.stringify({
+                version: 'mockup_layout_spec_v1',
+                tokenSet: 'token_set_v1',
+                title: 't',
+                summary: 's',
+                screens: [
+                    { name: '' },
+                    { purpose: 'no name' },
+                ],
+            });
+            expect(() => parseLayoutSpec(raw, 'x')).toThrow(MockupSpecParseError);
+        });
+
+        it('drops sections with invalid slot data and fails the screen if fewer than 2 remain', () => {
+            const raw = JSON.stringify({
+                version: 'mockup_layout_spec_v1',
+                tokenSet: 'token_set_v1',
+                title: 't',
+                summary: 's',
+                screens: [
+                    {
+                        name: 'Bad screen',
+                        purpose: 'p',
+                        shell: {
+                            type: 'sidebar_topbar',
+                            platform: 'desktop',
+                            accent: 'indigo',
+                            productName: 'P',
+                            navLabels: ['a', 'b', 'c'],
+                        },
+                        sections: [
+                            { role: 'primary', heading: 'OK stats', component: 'stat_grid', data: { rows: [
+                                { label: 'Active', value: '1' },
+                                { label: 'Total', value: '2' },
+                            ] } },
+                            { role: 'support', heading: 'Bad table', component: 'data_table', data: {} },
+                        ],
+                        actions: [{ kind: 'primary_cta', label: 'Go' }],
+                    },
+                ],
+            });
+            expect(() => parseLayoutSpec(raw, 'x')).toThrow(MockupSpecParseError);
+        });
+
+        it('drops screens with unknown shell type or no actions and keeps valid ones', () => {
+            const validScreen = JSON.parse(validRaw).screens[0];
+            const raw = JSON.stringify({
+                version: 'mockup_layout_spec_v1',
+                tokenSet: 'token_set_v1',
+                title: 't',
+                summary: 's',
+                screens: [
+                    validScreen,
+                    { ...validScreen, name: 'No actions', actions: [] },
+                ],
+            });
+            const result = parseLayoutSpec(raw, 'x');
+            expect(result.payload.screens).toHaveLength(1);
+            expect(result.warnings.some(w => w.includes('No actions'))).toBe(true);
+        });
+    });
+});

--- a/src/lib/__tests__/mockupService.test.ts
+++ b/src/lib/__tests__/mockupService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockupSettings, StructuredPRD } from '../../types';
 
 const callGeminiMock = vi.fn();
@@ -8,6 +8,15 @@ vi.mock('../geminiClient', () => ({
 }));
 
 import { generateMockup } from '../services/mockupService';
+
+beforeEach(() => {
+    callGeminiMock.mockReset();
+    localStorage.removeItem('MOCKUP_ENGINE');
+});
+
+afterEach(() => {
+    localStorage.removeItem('MOCKUP_ENGINE');
+});
 
 const settings: MockupSettings = {
     platform: 'desktop',
@@ -111,5 +120,174 @@ describe('mockupService alignment integration', () => {
         await generateMockup('Clinic triage PRD', settings, structuredPRD);
         const call = callGeminiMock.mock.calls[0];
         expect(call[2]).toMatchObject({ temperature: 0.2, topP: 0.8, topK: 32 });
+    });
+});
+
+describe('mockupService spec engine', () => {
+    const buildSpecResponse = () => JSON.stringify({
+        version: 'mockup_layout_spec_v1',
+        tokenSet: 'token_set_v1',
+        title: 'Clinic Triage Concept',
+        summary: 'Queue-first layout for care coordinators.',
+        screens: [
+            {
+                name: 'Triage Queue',
+                purpose: 'Care coordinator reviews urgent patient cases and assigns triage owner.',
+                shell: {
+                    type: 'sidebar_topbar',
+                    platform: 'desktop',
+                    accent: 'indigo',
+                    productName: 'Triage',
+                    navLabels: ['Queue', 'Assigned', 'Follow-ups', 'Settings'],
+                },
+                sections: [
+                    {
+                        role: 'primary',
+                        heading: 'Urgent patient cases',
+                        component: 'data_table',
+                        data: {
+                            columns: ['Patient case', 'Urgency', 'Triage owner'],
+                            tableRows: [
+                                { cells: ['Alex Chen', 'Critical', 'Dr. Kim'] },
+                                { cells: ['Priya Patel', 'High', 'Unassigned'] },
+                            ],
+                        },
+                    },
+                    {
+                        role: 'support',
+                        heading: 'Recent triage activity',
+                        component: 'activity_feed',
+                        data: {
+                            entries: [
+                                { actor: 'Dr. Kim', verb: 'assigned', target: 'case 1142', when: '2m ago' },
+                                { actor: 'Nurse Ellis', verb: 'flagged', target: 'case 1139', when: '14m ago' },
+                            ],
+                        },
+                    },
+                ],
+                actions: [{ kind: 'primary_cta', label: 'Assign case owner' }],
+            },
+            {
+                name: 'Case Detail Review',
+                purpose: 'Care coordinator validates intake details and logs triage recommendation.',
+                shell: {
+                    type: 'sidebar_topbar',
+                    platform: 'desktop',
+                    accent: 'indigo',
+                    productName: 'Triage',
+                    navLabels: ['Queue', 'Assigned', 'Follow-ups', 'Settings'],
+                },
+                sections: [
+                    {
+                        role: 'primary',
+                        heading: 'Patient case details',
+                        component: 'detail_panel',
+                        data: {
+                            fields: [
+                                { label: 'Patient', value: 'Alex Chen' },
+                                { label: 'Urgency', value: 'Critical' },
+                                { label: 'Triage owner', value: 'Dr. Kim' },
+                                { label: 'Intake note', value: 'Chest pain, 45 min duration' },
+                            ],
+                        },
+                    },
+                    {
+                        role: 'support',
+                        heading: 'Escalation checklist',
+                        component: 'activity_feed',
+                        data: {
+                            entries: [
+                                { actor: 'Nurse Ellis', verb: 'verified', target: 'vitals', when: '5m ago' },
+                                { actor: 'Dr. Kim', verb: 'approved', target: 'escalation', when: '8m ago' },
+                            ],
+                        },
+                    },
+                ],
+                actions: [{ kind: 'primary_cta', label: 'Submit triage recommendation' }],
+            },
+        ],
+    });
+
+    const settingsLocal: MockupSettings = {
+        platform: 'desktop',
+        fidelity: 'mid',
+        scope: 'multi_screen',
+    };
+
+    const structuredPRDLocal: StructuredPRD = {
+        vision: 'Coordinate clinic intake and triage decisions in one place.',
+        coreProblem: 'Care coordinators lose time jumping between intake notes and triage actions.',
+        targetUsers: ['Care coordinator'],
+        features: [
+            {
+                id: 'f1',
+                name: 'Triage queue',
+                description: 'Prioritize incoming patient cases by urgency and ownership.',
+                userValue: 'Respond to urgent patients faster.',
+                complexity: 'medium',
+            },
+        ],
+        architecture: 'Web app',
+        risks: ['Incomplete intake data'],
+    };
+
+    it('uses the layout-spec schema when MOCKUP_ENGINE=spec', async () => {
+        localStorage.setItem('MOCKUP_ENGINE', 'spec');
+        callGeminiMock.mockResolvedValueOnce(buildSpecResponse());
+
+        const result = await generateMockup('Clinic triage PRD', settingsLocal, structuredPRDLocal);
+
+        const call = callGeminiMock.mock.calls[0];
+        const passedSchema = (call[2] as { responseSchema: { properties: { version: { enum: string[] } } } }).responseSchema;
+        expect(passedSchema.properties.version.enum).toContain('mockup_layout_spec_v1');
+        expect(result.payload.screens).toHaveLength(2);
+        expect(result.payload.screens[0].html).toContain('Assign case owner');
+        expect(result.payload.screens[1].html).toContain('Submit triage recommendation');
+        expect(result.usedFallback).toBe(false);
+        expect(result.strategyVersion).toBe('mockup_strategy_spec_v1');
+    });
+
+    it('spec engine output is deterministic across regeneration with identical model output', async () => {
+        localStorage.setItem('MOCKUP_ENGINE', 'spec');
+        callGeminiMock.mockResolvedValueOnce(buildSpecResponse());
+        callGeminiMock.mockResolvedValueOnce(buildSpecResponse());
+
+        const first = await generateMockup('Clinic triage PRD', settingsLocal, structuredPRDLocal);
+        const second = await generateMockup('Clinic triage PRD', settingsLocal, structuredPRDLocal);
+
+        // ids are uuids and differ per run — compare structure-only html with
+        // the id fields stripped.
+        const normalize = (html: string) => html.replace(/\s+/g, ' ').trim();
+        expect(first.payload.screens.length).toBe(second.payload.screens.length);
+        first.payload.screens.forEach((screen, i) => {
+            expect(normalize(screen.html)).toBe(normalize(second.payload.screens[i].html));
+        });
+    });
+
+    it('falls back to HTML engine when spec engine fails repeatedly', async () => {
+        localStorage.setItem('MOCKUP_ENGINE', 'spec');
+        // Spec engine gets 3 failing attempts, then HTML engine takes over
+        // and the first HTML-engine response succeeds.
+        callGeminiMock.mockResolvedValueOnce('not valid json');
+        callGeminiMock.mockResolvedValueOnce('still not json');
+        callGeminiMock.mockResolvedValueOnce('{bad');
+        callGeminiMock.mockResolvedValueOnce(JSON.stringify({
+            version: 'mockup_html_v1',
+            title: 'Clinic Triage Concept',
+            summary: 'Queue-first layout for care coordinators.',
+            screens: [
+                {
+                    name: 'Triage Queue',
+                    purpose: 'Care coordinator reviews urgent patient cases and assigns triage owner.',
+                    html: '<div class="min-h-screen bg-neutral-50 text-neutral-900"><header class="px-6 py-4 border-b border-neutral-200 flex items-center justify-between"><h1 class="text-xl font-semibold">Triage Queue</h1><button type="button" class="px-3 py-2 rounded-lg bg-indigo-600 text-white">Assign case owner</button></header><main class="p-6 grid grid-cols-3 gap-4"><section class="col-span-2 rounded-xl border border-neutral-200 bg-white p-5"><table class="w-full text-sm"><tbody><tr><td>Patient case</td><td>Urgency</td></tr></tbody></table></section><section class="rounded-xl border border-neutral-200 bg-white p-5"><ul class="space-y-2"><li>Triage actions</li></ul></section></main></div>',
+                },
+            ],
+        }));
+
+        const result = await generateMockup('Clinic triage PRD', settingsLocal, structuredPRDLocal);
+        expect(callGeminiMock.mock.calls.length).toBeGreaterThanOrEqual(4);
+        expect(result.warnings.some(w => w.includes('Spec attempt'))).toBe(true);
+        expect(result.warnings.some(w => w.includes('falling back to HTML engine'))).toBe(true);
+        expect(result.payload.screens[0].name).toBe('Triage Queue');
     });
 });

--- a/src/lib/__tests__/mockupService.test.ts
+++ b/src/lib/__tests__/mockupService.test.ts
@@ -293,6 +293,27 @@ describe('mockupService spec engine', () => {
         expect(userPrompt).toContain('MANDATORY');
     });
 
+    it('pins deterministic sampling and disables fallback under Demo Safe Mode', async () => {
+        localStorage.setItem('MOCKUP_ENGINE', 'spec');
+        // Spec engine fails 3 times; under Safe Mode we should throw, not
+        // fall back to the HTML engine.
+        callGeminiMock.mockResolvedValueOnce('not valid json');
+        callGeminiMock.mockResolvedValueOnce('still not json');
+        callGeminiMock.mockResolvedValueOnce('{bad');
+
+        await expect(
+            generateMockup('Clinic triage PRD', { ...settingsLocal, safeMode: true }, structuredPRDLocal),
+        ).rejects.toThrow(/Demo Safe Mode/);
+
+        // All three spec calls should use the deterministic sampling config.
+        for (let i = 0; i < 3; i++) {
+            const cfg = callGeminiMock.mock.calls[i][2] as { temperature: number; topP: number; topK: number };
+            expect(cfg.temperature).toBe(0);
+            expect(cfg.topP).toBe(0.5);
+            expect(cfg.topK).toBe(1);
+        }
+    });
+
     it('falls back to HTML engine when spec engine fails repeatedly', async () => {
         localStorage.setItem('MOCKUP_ENGINE', 'spec');
         // Spec engine gets 3 failing attempts, then HTML engine takes over

--- a/src/lib/__tests__/mockupService.test.ts
+++ b/src/lib/__tests__/mockupService.test.ts
@@ -264,6 +264,35 @@ describe('mockupService spec engine', () => {
         });
     });
 
+    it('injects domainEntities and primaryActions into the spec-engine user prompt', async () => {
+        localStorage.setItem('MOCKUP_ENGINE', 'spec');
+        callGeminiMock.mockResolvedValueOnce(buildSpecResponse());
+
+        const prdWithGrounding: StructuredPRD = {
+            ...structuredPRDLocal,
+            domainEntities: [
+                { name: 'Patient case', description: 'An intake record', exampleValues: ['Alex Chen', 'Priya Patel'] },
+                { name: 'Triage owner' },
+            ],
+            primaryActions: [
+                { verb: 'Assign', target: 'case owner' },
+                { verb: 'Submit', target: 'triage recommendation' },
+            ],
+        };
+
+        await generateMockup('Clinic triage PRD', settingsLocal, prdWithGrounding);
+
+        const userPrompt = callGeminiMock.mock.calls[0][1] as string;
+        expect(userPrompt).toContain('Domain entities');
+        expect(userPrompt).toContain('Patient case');
+        expect(userPrompt).toContain('Triage owner');
+        expect(userPrompt).toContain('Alex Chen');
+        expect(userPrompt).toContain('Primary actions');
+        expect(userPrompt).toContain('"Assign case owner"');
+        expect(userPrompt).toContain('"Submit triage recommendation"');
+        expect(userPrompt).toContain('MANDATORY');
+    });
+
     it('falls back to HTML engine when spec engine fails repeatedly', async () => {
         localStorage.setItem('MOCKUP_ENGINE', 'spec');
         // Spec engine gets 3 failing attempts, then HTML engine takes over

--- a/src/lib/mockupAlignmentCritique.ts
+++ b/src/lib/mockupAlignmentCritique.ts
@@ -11,7 +11,9 @@ export interface MockupAlignmentIssue {
         | 'fidelity_mismatch'
         | 'generic_naming'
         | 'workflow_gap'
-        | 'prd_feature_gap';
+        | 'prd_feature_gap'
+        | 'insufficient_entity_grounding'
+        | 'insufficient_action_grounding';
     severity: AlignmentSeverity;
     reason: string;
     recommendation: string;
@@ -44,6 +46,11 @@ interface ProductConceptContext {
     entityTerms: string[];
     workflowTerms: string[];
     productTerms: string[];
+    // Phase B: structured grounding anchors sourced directly from
+    // StructuredPRD.domainEntities / primaryActions (if present). These drive
+    // harder pass/fail checks than the heuristic term lists above.
+    structuredEntityNames: string[];
+    structuredActionPhrases: string[];
 }
 
 const GENERIC_SLUDGE_PATTERNS: RegExp[] = [
@@ -94,6 +101,8 @@ const buildConceptContext = (prdContent: string, structuredPRD?: StructuredPRD):
             entityTerms: fallbackTerms,
             workflowTerms: fallbackTerms,
             productTerms: fallbackTerms,
+            structuredEntityNames: [],
+            structuredActionPhrases: [],
         };
     }
 
@@ -109,12 +118,21 @@ const buildConceptContext = (prdContent: string, structuredPRD?: StructuredPRD):
     const entityTerms = featureTerms.filter(term => !/user|workflow|screen|feature/.test(term)).slice(0, 40);
     const workflowTerms = featureTerms.filter(term => /(create|edit|review|submit|approve|track|configure|assign|flow|step|stage|sync|share)/.test(term)).slice(0, 30);
 
+    const structuredEntityNames = (structuredPRD.domainEntities ?? [])
+        .map(e => normalizeToken(e.name))
+        .filter(name => name.length >= 3);
+    const structuredActionPhrases = (structuredPRD.primaryActions ?? [])
+        .map(a => normalizeToken(`${a.verb} ${a.target}`))
+        .filter(phrase => phrase.length >= 3);
+
     return {
         personaTerms,
         corePurposeTerms,
         entityTerms,
         workflowTerms,
         productTerms: [...new Set([...personaTerms, ...corePurposeTerms, ...featureTerms])],
+        structuredEntityNames,
+        structuredActionPhrases,
     };
 };
 
@@ -159,6 +177,31 @@ const critiqueScreen = (
             reason: `Screen is weakly grounded in PRD context: missing ${missingConcepts.join(', ')}.`,
             recommendation: 'Tie title, purpose, and key UI regions directly to PRD persona, entities, and workflows.',
         });
+    }
+
+    // Phase B: when the PRD carries structured domain entities / primary
+    // actions, grade screens against those exact names rather than relying
+    // on the heuristic term extractor. This is the hard gate that stops
+    // "polished but wrong" output from passing — a mockup can look great
+    // but still mis-name the product's core nouns/verbs, and the looser
+    // feature-term check misses that.
+    if (context.structuredEntityNames.length > 0) {
+        const entityHits = context.structuredEntityNames.filter(name => normalizeToken(screenText).includes(name)).length;
+        if (entityHits === 0) {
+            issues.push({
+                code: 'insufficient_entity_grounding',
+                severity: 'high',
+                reason: 'Screen does not mention any of the PRD domain entities by name.',
+                recommendation: 'Use the exact domainEntities names as section headings, table columns, or detail-panel labels.',
+            });
+        } else if (entityHits === 1 && context.structuredEntityNames.length >= 3) {
+            issues.push({
+                code: 'insufficient_entity_grounding',
+                severity: 'medium',
+                reason: 'Screen surfaces only one PRD domain entity; others are missing.',
+                recommendation: 'Spread PRD domainEntities across section headings, columns, and labels.',
+            });
+        }
     }
 
     if (/dashboard|home|overview/i.test(screen.name) && context.productTerms.length > 0) {
@@ -264,6 +307,28 @@ export const critiqueMockupAlignment = (
             reason: 'Screens do not visibly represent key PRD entities/features.',
             recommendation: 'Surface PRD features directly in navigation labels, sections, cards, and action buttons.',
         });
+    }
+
+    // Phase B: verify at least one primary_cta across the screen set uses a
+    // verb from structuredPRD.primaryActions. Matching on the full
+    // "verb target" phrase is too strict (CTAs often abbreviate), so we
+    // match on the verb token.
+    if (context.structuredActionPhrases.length > 0) {
+        const allHtml = screens.map(s => normalizeToken(stripHtml(s.html))).join(' ');
+        const actionVerbs = [...new Set(
+            context.structuredActionPhrases
+                .map(phrase => phrase.split(' ')[0])
+                .filter(verb => verb.length >= 3),
+        )];
+        const matchedVerbs = actionVerbs.filter(verb => allHtml.includes(verb));
+        if (actionVerbs.length > 0 && matchedVerbs.length === 0) {
+            issues.push({
+                code: 'insufficient_action_grounding',
+                severity: 'high',
+                reason: 'No primary actions from the PRD are used as CTA labels across the screen set.',
+                recommendation: 'Use at least one primaryActions verb (e.g. the first one) as a primary_cta label.',
+            });
+        }
     }
 
     const penalties = issues.reduce((sum, issue) => sum + (issue.severity === 'high' ? 18 : issue.severity === 'medium' ? 10 : 5), 0);

--- a/src/lib/mockupLayoutRenderer.ts
+++ b/src/lib/mockupLayoutRenderer.ts
@@ -1,0 +1,325 @@
+import { v4 as uuidv4 } from 'uuid';
+import type {
+    MockupLayoutAction,
+    MockupLayoutActivityEntry,
+    MockupLayoutDetailField,
+    MockupLayoutEmptyState,
+    MockupLayoutFilter,
+    MockupLayoutScreen,
+    MockupLayoutSection,
+    MockupLayoutShell,
+    MockupLayoutSpec,
+    MockupLayoutStatRow,
+    MockupLayoutTableRow,
+    MockupPayload,
+    MockupScreen,
+} from '../types';
+import { MOCKUP_LAYOUT_SPEC_V1, MOCKUP_TOKEN_SET_V1 } from '../types';
+import { renderShell } from '../components/mockups/templates/shells';
+
+// The renderer is the deterministic half of the Phase A pipeline. Given a
+// valid MockupLayoutSpec, it produces a MockupPayload that downstream
+// components (MockupViewer, buildMockupSrcDoc) already know how to render.
+//
+// Design rules:
+// - Parse raw model JSON defensively. Gemini's JSON mode enforces schema
+//   shape but not semantic completeness (e.g. a stat_grid with no rows).
+// - Drop individual bad screens/sections rather than throwing on first issue.
+// - If every screen is unusable, throw; the caller will decide whether to
+//   retry or fall back.
+
+export class MockupSpecParseError extends Error {
+    warnings: string[];
+    constructor(message: string, warnings: string[] = []) {
+        super(message);
+        this.name = 'MockupSpecParseError';
+        this.warnings = warnings;
+    }
+}
+
+export interface SpecParseResult {
+    payload: MockupPayload;
+    spec: MockupLayoutSpec;
+    warnings: string[];
+}
+
+// ---- parsing helpers ----
+
+const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === 'string' && value.trim().length > 0;
+
+const asStringArray = (value: unknown, min: number, max: number): string[] | null => {
+    if (!Array.isArray(value)) return null;
+    const items = value.filter(isNonEmptyString).map(s => s.trim());
+    if (items.length < min) return null;
+    return items.slice(0, max);
+};
+
+const ALLOWED_SHELL_TYPES = ['sidebar_topbar', 'topbar_only', 'mobile_tab_shell'] as const;
+const ALLOWED_PLATFORMS = ['desktop', 'mobile', 'responsive'] as const;
+const ALLOWED_ROLES = ['primary', 'support', 'utility'] as const;
+const ALLOWED_COMPONENTS = ['stat_grid', 'data_table', 'activity_feed', 'filters_bar', 'detail_panel', 'empty_state'] as const;
+const ALLOWED_ACTION_KINDS = ['primary_cta', 'secondary_cta', 'input', 'select', 'tab'] as const;
+
+const parseShell = (raw: unknown, fallbackProduct: string): MockupLayoutShell | null => {
+    if (!raw || typeof raw !== 'object') return null;
+    const obj = raw as Record<string, unknown>;
+    const type = (ALLOWED_SHELL_TYPES as readonly string[]).includes(obj.type as string)
+        ? (obj.type as MockupLayoutShell['type'])
+        : 'sidebar_topbar';
+    const platform = (ALLOWED_PLATFORMS as readonly string[]).includes(obj.platform as string)
+        ? (obj.platform as MockupLayoutShell['platform'])
+        : 'desktop';
+    const navLabels = asStringArray(obj.navLabels, 3, 6)
+        ?? ['Overview', 'Activity', 'Settings'];
+    const productName = isNonEmptyString(obj.productName) ? obj.productName.trim() : fallbackProduct;
+    return { type, platform, accent: 'indigo', productName, navLabels };
+};
+
+const parseStatRows = (raw: unknown): MockupLayoutStatRow[] | null => {
+    if (!Array.isArray(raw)) return null;
+    const rows = raw
+        .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object')
+        .map(r => ({
+            label: isNonEmptyString(r.label) ? r.label.trim() : '',
+            value: isNonEmptyString(r.value) ? r.value.trim() : '',
+            delta: isNonEmptyString(r.delta) ? r.delta.trim() : undefined,
+        }))
+        .filter(r => r.label && r.value);
+    return rows.length >= 2 ? rows.slice(0, 6) : null;
+};
+
+const parseTableData = (raw: Record<string, unknown>): { columns: string[]; rows: MockupLayoutTableRow[] } | null => {
+    const columns = asStringArray(raw.columns, 2, 6);
+    if (!columns) return null;
+    const tableRowsRaw = raw.tableRows;
+    if (!Array.isArray(tableRowsRaw)) return null;
+    const rows = tableRowsRaw
+        .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object')
+        .map(r => {
+            const cells = asStringArray(r.cells, 1, columns.length);
+            return cells ? { cells: cells.slice(0, columns.length) } : null;
+        })
+        .filter((r): r is MockupLayoutTableRow => r !== null);
+    return rows.length >= 1 ? { columns, rows: rows.slice(0, 8) } : null;
+};
+
+const parseActivityEntries = (raw: unknown): MockupLayoutActivityEntry[] | null => {
+    if (!Array.isArray(raw)) return null;
+    const entries = raw
+        .filter((e): e is Record<string, unknown> => !!e && typeof e === 'object')
+        .map(e => ({
+            actor: isNonEmptyString(e.actor) ? e.actor.trim() : '',
+            verb: isNonEmptyString(e.verb) ? e.verb.trim() : '',
+            target: isNonEmptyString(e.target) ? e.target.trim() : '',
+            when: isNonEmptyString(e.when) ? e.when.trim() : '',
+        }))
+        .filter(e => e.actor && e.verb && e.target && e.when);
+    return entries.length >= 2 ? entries.slice(0, 6) : null;
+};
+
+const parseFilters = (raw: unknown): MockupLayoutFilter[] | null => {
+    if (!Array.isArray(raw)) return null;
+    const filters = raw
+        .filter((f): f is Record<string, unknown> => !!f && typeof f === 'object')
+        .map(f => {
+            const label = isNonEmptyString(f.label) ? f.label.trim() : '';
+            const options = asStringArray(f.options, 2, 5);
+            return label && options ? { label, options } : null;
+        })
+        .filter((f): f is MockupLayoutFilter => f !== null);
+    return filters.length >= 1 ? filters.slice(0, 4) : null;
+};
+
+const parseDetailFields = (raw: unknown): MockupLayoutDetailField[] | null => {
+    if (!Array.isArray(raw)) return null;
+    const fields = raw
+        .filter((f): f is Record<string, unknown> => !!f && typeof f === 'object')
+        .map(f => ({
+            label: isNonEmptyString(f.label) ? f.label.trim() : '',
+            value: isNonEmptyString(f.value) ? f.value.trim() : '',
+        }))
+        .filter(f => f.label && f.value);
+    return fields.length >= 2 ? fields.slice(0, 8) : null;
+};
+
+const parseEmptyState = (raw: Record<string, unknown>): MockupLayoutEmptyState | null => {
+    const heading = isNonEmptyString(raw.heading) ? raw.heading.trim() : '';
+    const body = isNonEmptyString(raw.body) ? raw.body.trim() : '';
+    if (!heading || !body) return null;
+    const primaryActionLabel = isNonEmptyString(raw.primaryActionLabel)
+        ? raw.primaryActionLabel.trim()
+        : undefined;
+    return { heading, body, primaryActionLabel };
+};
+
+const parseSection = (raw: unknown): MockupLayoutSection | null => {
+    if (!raw || typeof raw !== 'object') return null;
+    const obj = raw as Record<string, unknown>;
+    const role = (ALLOWED_ROLES as readonly string[]).includes(obj.role as string)
+        ? (obj.role as MockupLayoutSection['role'])
+        : 'support';
+    const component = (ALLOWED_COMPONENTS as readonly string[]).includes(obj.component as string)
+        ? (obj.component as MockupLayoutSection['component'])
+        : null;
+    const heading = isNonEmptyString(obj.heading) ? obj.heading.trim() : '';
+    if (!component || !heading) return null;
+    const data = (obj.data && typeof obj.data === 'object') ? obj.data as Record<string, unknown> : {};
+
+    switch (component) {
+        case 'stat_grid': {
+            const rows = parseStatRows(data.rows);
+            return rows ? { role, heading, component, data: { rows } } : null;
+        }
+        case 'data_table': {
+            const table = parseTableData(data);
+            return table ? { role, heading, component, data: table } : null;
+        }
+        case 'activity_feed': {
+            const entries = parseActivityEntries(data.entries);
+            return entries ? { role, heading, component, data: { entries } } : null;
+        }
+        case 'filters_bar': {
+            const filters = parseFilters(data.filters);
+            return filters ? { role, heading, component, data: { filters } } : null;
+        }
+        case 'detail_panel': {
+            const fields = parseDetailFields(data.fields);
+            return fields ? { role, heading, component, data: { fields } } : null;
+        }
+        case 'empty_state': {
+            const empty = parseEmptyState(data);
+            return empty ? { role, heading, component, data: empty } : null;
+        }
+    }
+};
+
+const parseAction = (raw: unknown): MockupLayoutAction | null => {
+    if (!raw || typeof raw !== 'object') return null;
+    const obj = raw as Record<string, unknown>;
+    const kind = (ALLOWED_ACTION_KINDS as readonly string[]).includes(obj.kind as string)
+        ? (obj.kind as MockupLayoutAction['kind'])
+        : null;
+    const label = isNonEmptyString(obj.label) ? obj.label.trim().slice(0, 48) : '';
+    if (!kind || !label) return null;
+    return { kind, label };
+};
+
+const parseScreen = (raw: unknown, fallbackProduct: string, warnings: string[], idx: number): MockupLayoutScreen | null => {
+    if (!raw || typeof raw !== 'object') {
+        warnings.push(`Screen ${idx + 1}: skipped — not an object.`);
+        return null;
+    }
+    const obj = raw as Record<string, unknown>;
+    const name = isNonEmptyString(obj.name) ? obj.name.trim() : '';
+    const purpose = isNonEmptyString(obj.purpose) ? obj.purpose.trim() : '';
+    if (!name) {
+        warnings.push(`Screen ${idx + 1}: skipped — missing name.`);
+        return null;
+    }
+    const shell = parseShell(obj.shell, fallbackProduct);
+    if (!shell) {
+        warnings.push(`Screen ${idx + 1} ("${name}"): skipped — invalid shell.`);
+        return null;
+    }
+    const sectionsRaw = Array.isArray(obj.sections) ? obj.sections : [];
+    const sections = sectionsRaw
+        .map(parseSection)
+        .filter((s): s is MockupLayoutSection => s !== null);
+    if (sections.length < 2) {
+        warnings.push(`Screen ${idx + 1} ("${name}"): skipped — fewer than 2 valid sections (${sections.length}).`);
+        return null;
+    }
+    const actionsRaw = Array.isArray(obj.actions) ? obj.actions : [];
+    const actions = actionsRaw
+        .map(parseAction)
+        .filter((a): a is MockupLayoutAction => a !== null)
+        .slice(0, 4);
+    if (actions.length === 0) {
+        warnings.push(`Screen ${idx + 1} ("${name}"): skipped — no valid actions.`);
+        return null;
+    }
+    return {
+        id: uuidv4(),
+        name,
+        purpose,
+        shell,
+        sections: sections.slice(0, 4),
+        actions,
+    };
+};
+
+// ---- public API ----
+
+export const parseLayoutSpec = (raw: string, fallbackProduct: string): SpecParseResult => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (e) {
+        throw new MockupSpecParseError(
+            `Mockup layout spec returned invalid JSON: ${e instanceof Error ? e.message : String(e)}`,
+        );
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        throw new MockupSpecParseError('Mockup layout spec returned a non-object response.');
+    }
+    const obj = parsed as Record<string, unknown>;
+    const screensRaw = Array.isArray(obj.screens) ? obj.screens : [];
+    if (screensRaw.length === 0) {
+        throw new MockupSpecParseError('Mockup layout spec returned no screens.');
+    }
+
+    const warnings: string[] = [];
+    const screens = screensRaw
+        .map((s, i) => parseScreen(s, fallbackProduct, warnings, i))
+        .filter((s): s is MockupLayoutScreen => s !== null);
+
+    if (screens.length === 0) {
+        throw new MockupSpecParseError(
+            `Layout spec had ${screensRaw.length} screen(s) but none were usable. ${warnings.join(' ')}`,
+            warnings,
+        );
+    }
+
+    const title = isNonEmptyString(obj.title) ? obj.title.trim() : 'Mockup concept';
+    const summary = isNonEmptyString(obj.summary) ? obj.summary.trim() : '';
+
+    const spec: MockupLayoutSpec = {
+        version: MOCKUP_LAYOUT_SPEC_V1,
+        tokenSet: MOCKUP_TOKEN_SET_V1,
+        title,
+        summary,
+        screens,
+    };
+
+    const renderedScreens: MockupScreen[] = screens.map(screen => ({
+        id: screen.id,
+        name: screen.name,
+        purpose: screen.purpose,
+        html: renderShell(screen),
+    }));
+
+    return {
+        spec,
+        payload: {
+            version: 'mockup_html_v1',
+            title,
+            summary,
+            screens: renderedScreens,
+        },
+        warnings,
+    };
+};
+
+// Helper for tests and for the harness: render a known-good spec directly.
+export const renderLayoutSpec = (spec: MockupLayoutSpec): MockupPayload => ({
+    version: 'mockup_html_v1',
+    title: spec.title,
+    summary: spec.summary,
+    screens: spec.screens.map(screen => ({
+        id: screen.id,
+        name: screen.name,
+        purpose: screen.purpose,
+        html: renderShell(screen),
+    })),
+});

--- a/src/lib/schemas/mockupLayoutSpec.ts
+++ b/src/lib/schemas/mockupLayoutSpec.ts
@@ -1,0 +1,161 @@
+// Gemini JSON-mode schema for the Phase A layout-spec mockup engine.
+//
+// Mirrors MockupLayoutSpec in src/types/index.ts. The client-side `id` field
+// on each screen is assigned after parsing and is intentionally not part of
+// the model's output schema.
+//
+// NOTE: Gemini's responseSchema dialect uses uppercase TYPE tokens and does
+// not support oneOf/allOf/anyOf at time of writing. The per-section `data`
+// shape is therefore expressed as a single object with every possible field
+// declared optional; the renderer validates discriminator-appropriate fields
+// at runtime (see src/lib/mockupLayoutRenderer.ts).
+
+const SHELL_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        type: { type: 'STRING', enum: ['sidebar_topbar', 'topbar_only', 'mobile_tab_shell'] },
+        platform: { type: 'STRING', enum: ['desktop', 'mobile', 'responsive'] },
+        accent: { type: 'STRING', enum: ['indigo'] },
+        productName: { type: 'STRING' },
+        navLabels: { type: 'ARRAY', items: { type: 'STRING' }, minItems: 3, maxItems: 6 },
+    },
+    required: ['type', 'platform', 'accent', 'productName', 'navLabels'],
+    propertyOrdering: ['type', 'platform', 'accent', 'productName', 'navLabels'],
+};
+
+const STAT_ROW_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        label: { type: 'STRING' },
+        value: { type: 'STRING' },
+        delta: { type: 'STRING' },
+    },
+    required: ['label', 'value'],
+    propertyOrdering: ['label', 'value', 'delta'],
+};
+
+const TABLE_ROW_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        cells: { type: 'ARRAY', items: { type: 'STRING' }, minItems: 1, maxItems: 6 },
+    },
+    required: ['cells'],
+    propertyOrdering: ['cells'],
+};
+
+const ACTIVITY_ENTRY_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        actor: { type: 'STRING' },
+        verb: { type: 'STRING' },
+        target: { type: 'STRING' },
+        when: { type: 'STRING' },
+    },
+    required: ['actor', 'verb', 'target', 'when'],
+    propertyOrdering: ['actor', 'verb', 'target', 'when'],
+};
+
+const FILTER_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        label: { type: 'STRING' },
+        options: { type: 'ARRAY', items: { type: 'STRING' }, minItems: 2, maxItems: 5 },
+    },
+    required: ['label', 'options'],
+    propertyOrdering: ['label', 'options'],
+};
+
+const DETAIL_FIELD_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        label: { type: 'STRING' },
+        value: { type: 'STRING' },
+    },
+    required: ['label', 'value'],
+    propertyOrdering: ['label', 'value'],
+};
+
+// Flat union of every slot-data field across component types. The renderer
+// picks the discriminator-appropriate fields based on `section.component`.
+const SECTION_DATA_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        // stat_grid
+        rows: { type: 'ARRAY', items: STAT_ROW_SCHEMA, minItems: 2, maxItems: 6 },
+        // data_table
+        columns: { type: 'ARRAY', items: { type: 'STRING' }, minItems: 2, maxItems: 6 },
+        tableRows: { type: 'ARRAY', items: TABLE_ROW_SCHEMA, minItems: 1, maxItems: 8 },
+        // activity_feed
+        entries: { type: 'ARRAY', items: ACTIVITY_ENTRY_SCHEMA, minItems: 2, maxItems: 6 },
+        // filters_bar
+        filters: { type: 'ARRAY', items: FILTER_SCHEMA, minItems: 1, maxItems: 4 },
+        // detail_panel
+        fields: { type: 'ARRAY', items: DETAIL_FIELD_SCHEMA, minItems: 2, maxItems: 8 },
+        // empty_state
+        heading: { type: 'STRING' },
+        body: { type: 'STRING' },
+        primaryActionLabel: { type: 'STRING' },
+    },
+    propertyOrdering: [
+        'rows',
+        'columns',
+        'tableRows',
+        'entries',
+        'filters',
+        'fields',
+        'heading',
+        'body',
+        'primaryActionLabel',
+    ],
+};
+
+const SECTION_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        role: { type: 'STRING', enum: ['primary', 'support', 'utility'] },
+        heading: { type: 'STRING' },
+        component: {
+            type: 'STRING',
+            enum: ['stat_grid', 'data_table', 'activity_feed', 'filters_bar', 'detail_panel', 'empty_state'],
+        },
+        data: SECTION_DATA_SCHEMA,
+    },
+    required: ['role', 'heading', 'component', 'data'],
+    propertyOrdering: ['role', 'heading', 'component', 'data'],
+};
+
+const ACTION_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        kind: { type: 'STRING', enum: ['primary_cta', 'secondary_cta', 'input', 'select', 'tab'] },
+        label: { type: 'STRING' },
+    },
+    required: ['kind', 'label'],
+    propertyOrdering: ['kind', 'label'],
+};
+
+const SCREEN_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        name: { type: 'STRING' },
+        purpose: { type: 'STRING' },
+        shell: SHELL_SCHEMA,
+        sections: { type: 'ARRAY', items: SECTION_SCHEMA, minItems: 2, maxItems: 4 },
+        actions: { type: 'ARRAY', items: ACTION_SCHEMA, minItems: 1, maxItems: 4 },
+    },
+    required: ['name', 'purpose', 'shell', 'sections', 'actions'],
+    propertyOrdering: ['name', 'purpose', 'shell', 'sections', 'actions'],
+};
+
+export const mockupLayoutSpecSchema = {
+    type: 'OBJECT',
+    properties: {
+        version: { type: 'STRING', enum: ['mockup_layout_spec_v1'] },
+        tokenSet: { type: 'STRING', enum: ['token_set_v1'] },
+        title: { type: 'STRING' },
+        summary: { type: 'STRING' },
+        screens: { type: 'ARRAY', items: SCREEN_SCHEMA, minItems: 1, maxItems: 5 },
+    },
+    required: ['version', 'tokenSet', 'title', 'summary', 'screens'],
+    propertyOrdering: ['version', 'tokenSet', 'title', 'summary', 'screens'],
+};

--- a/src/lib/schemas/prdSchemas.ts
+++ b/src/lib/schemas/prdSchemas.ts
@@ -25,6 +25,33 @@ export const structuredPRDSchema = {
         risks: { type: "ARRAY", items: { type: "STRING" } },
         nonFunctionalRequirements: { type: "ARRAY", items: { type: "STRING" } },
         constraints: { type: "ARRAY", items: { type: "STRING" } },
+        // Phase B grounding fields. Required at generation so every new
+        // project has concrete nouns/verbs for the mockup spec engine to
+        // reuse. (Existing projects in localStorage may lack them; the
+        // mockup service treats them as optional at read time.)
+        domainEntities: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    name: { type: "STRING" },
+                    description: { type: "STRING" },
+                    exampleValues: { type: "ARRAY", items: { type: "STRING" } },
+                },
+                required: ["name"],
+            },
+        },
+        primaryActions: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    verb: { type: "STRING" },
+                    target: { type: "STRING" },
+                },
+                required: ["verb", "target"],
+            },
+        },
     },
-    required: ["vision", "targetUsers", "coreProblem", "features", "architecture", "risks", "nonFunctionalRequirements", "constraints"],
+    required: ["vision", "targetUsers", "coreProblem", "features", "architecture", "risks", "nonFunctionalRequirements", "constraints", "domainEntities", "primaryActions"],
 };

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -460,6 +460,31 @@ const buildSpecUserPrompt = (prdContent: string, structuredPRD?: StructuredPRD):
         if (personas) structuredLines.push(`Personas: ${personas}`);
         if (features) structuredLines.push(`Key features:\n${features}`);
         parts.push(structuredLines.join('\n'));
+
+        const groundingLines: string[] = [];
+        if (structuredPRD.domainEntities && structuredPRD.domainEntities.length > 0) {
+            const entityLines = structuredPRD.domainEntities.slice(0, 8).map(e => {
+                const examples = e.exampleValues?.length
+                    ? ` (examples: ${e.exampleValues.slice(0, 4).join(', ')})`
+                    : '';
+                const desc = e.description ? ` — ${e.description}` : '';
+                return `- ${e.name}${desc}${examples}`;
+            });
+            groundingLines.push('Domain entities — use these EXACT names for table columns, detail-panel fields, activity-feed targets, and section headings. Use the exampleValues as realistic cell content/row values:');
+            groundingLines.push(entityLines.join('\n'));
+        }
+        if (structuredPRD.primaryActions && structuredPRD.primaryActions.length > 0) {
+            const actionLines = structuredPRD.primaryActions
+                .slice(0, 6)
+                .map(a => `- "${a.verb} ${a.target}"`);
+            groundingLines.push('Primary actions — use these exact verb phrases for primary_cta labels across screens:');
+            groundingLines.push(actionLines.join('\n'));
+        }
+        if (groundingLines.length > 0) {
+            parts.push(
+                `Grounding requirements (MANDATORY — compliance gates pass/fail):\n${groundingLines.join('\n\n')}`,
+            );
+        }
     }
     parts.push('Return the layout_spec JSON now. No HTML. No markdown fences. Use only the allowed enum values.');
     return parts.join('\n\n');

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -498,12 +498,16 @@ const runSpecEngineAttempt = async (
 ): Promise<ParseResult> => {
     const system = buildSpecSystemPrompt(settings);
     const user = buildSpecUserPrompt(prdContent, structuredPRD);
+    // Demo Safe Mode pins deterministic sampling: temp=0 / topK=1 collapses
+    // the model to greedy decoding, which is the only way the stochastic
+    // boundary from the 2026-04-22 audit actually goes away.
+    const providerParams = settings.safeMode
+        ? { temperature: 0, topP: 0.5, topK: 1 }
+        : { temperature: 0.2, topP: 0.8, topK: 32 };
     const raw = await callGemini(system, user, {
         responseMimeType: 'application/json',
         responseSchema: mockupLayoutSpecSchema,
-        temperature: 0.2,
-        topP: 0.8,
-        topK: 32,
+        ...providerParams,
     });
     const fallbackProduct = inferConceptName(prdContent);
     const specResult = parseLayoutSpec(raw, fallbackProduct);
@@ -518,6 +522,14 @@ const runSpecEngineAttempt = async (
         prdContent,
         structuredPRD,
     );
+    // In Safe Mode, any medium-or-high alignment hit is a hard reject —
+    // the user gets an actionable error instead of a silent degrade.
+    if (settings.safeMode && critique.severity !== 'low') {
+        const reason = critique.mismatchReasons.slice(0, 3).join(' ');
+        throw new Error(
+            `Demo Safe Mode: mockup failed PRD alignment gate (${critique.alignmentScore}/100, severity=${critique.severity}). ${reason}`,
+        );
+    }
     if (critique.severity === 'high' && critique.alignmentScore < 45) {
         const reason = critique.mismatchReasons.slice(0, 3).join(' ');
         throw new Error(
@@ -556,6 +568,9 @@ const runHtmlEngine = async (
 ): Promise<ParseResult> => {
     const system = buildSystemPrompt(settings);
     const user = buildUserPrompt(prdContent, structuredPRD);
+    const providerParams = settings.safeMode
+        ? { temperature: 0, topP: 0.5, topK: 1 }
+        : { temperature: 0.2, topP: 0.8, topK: 32 };
     const warnings: string[] = [];
     let lastError: Error | null = null;
 
@@ -565,9 +580,7 @@ const runHtmlEngine = async (
             const raw = await callGemini(system, user, {
                 responseMimeType: 'application/json',
                 responseSchema: mockupSchema,
-                temperature: 0.2,
-                topP: 0.8,
-                topK: 32,
+                ...providerParams,
             });
             const parsed = parseMockupPayload(raw, prdContent, settings, structuredPRD);
             const qualityAvg = parsed.payload.screens.length
@@ -591,6 +604,15 @@ const runHtmlEngine = async (
             lastError = err;
             warnings.push(`Attempt ${attempt} failed: ${err.message}`);
         }
+    }
+
+    // Demo Safe Mode prefers an explicit "regenerate" failure over a silent
+    // fallback — the whole point is that recruiters don't see a watered-down
+    // output when the real output failed.
+    if (settings.safeMode) {
+        throw new Error(
+            `Demo Safe Mode: mockup generation failed after ${MAX_GENERATION_ATTEMPTS} attempts. ${lastError?.message ?? ''} Warnings: ${warnings.join(' ')}`,
+        );
     }
 
     console.warn('[mockupService] returning safe fallback after repeated generation failures', lastError);
@@ -618,6 +640,12 @@ const runSpecEngine = async (
             }
             warnings.push(`Spec attempt ${attempt} failed: ${err.message}`);
         }
+    }
+
+    if (settings.safeMode) {
+        throw new Error(
+            `Demo Safe Mode: spec engine failed after ${MAX_GENERATION_ATTEMPTS} attempts. ${lastError?.message ?? ''} Warnings: ${warnings.join(' ')}`,
+        );
     }
 
     console.warn('[mockupService] spec engine falling back to HTML engine after repeated failures', lastError);

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -8,10 +8,12 @@ import type {
 import { callGemini } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
 import { mockupSchema } from '../schemas/mockupSchema';
+import { mockupLayoutSpecSchema } from '../schemas/mockupLayoutSpec';
 import { assessMockupHtmlQuality, normalizeMockupHtml } from '../mockupQuality';
 import { critiqueMockupAlignment, type MockupAlignmentCritique } from '../mockupAlignmentCritique';
 import { PLACEHOLDER_PROMPT_CATALOG } from '../mockupPlaceholders';
 import { validateMockupHtmlStructure } from '../mockupValidation';
+import { MockupSpecParseError, parseLayoutSpec } from '../mockupLayoutRenderer';
 
 // ---- Instruction tables (rewritten for polished HTML/Tailwind output) ----
 
@@ -35,8 +37,22 @@ const SCOPE_INSTRUCTIONS: Record<string, string> = {
 
 const MOCKUP_PROMPT_TEMPLATE_VERSION = '2026-04-17.v2';
 const MOCKUP_GENERATION_STRATEGY_VERSION = 'mockup_strategy_v2';
+const MOCKUP_SPEC_STRATEGY_VERSION = 'mockup_strategy_spec_v1';
 const MAX_GENERATION_ATTEMPTS = 3;
 const QUALITY_THRESHOLD = 70;
+
+// Phase A engine switch. Default remains the HTML engine until the spec
+// engine has validated against the harness; users can opt-in via
+// localStorage.MOCKUP_ENGINE = 'spec'.
+type MockupEngine = 'html' | 'spec';
+const getMockupEngine = (): MockupEngine => {
+    try {
+        const raw = typeof localStorage !== 'undefined' ? localStorage.getItem('MOCKUP_ENGINE') : null;
+        return raw === 'spec' ? 'spec' : 'html';
+    } catch {
+        return 'html';
+    }
+};
 
 // ---- Prompt construction ----
 
@@ -362,16 +378,157 @@ const buildSafeFallbackPayload = (
     };
 };
 
-// ---- Public API ----
+// ---- Spec engine (Phase A) ----
+//
+// The spec engine replaces free-form HTML generation with a typed layout
+// spec. The model only picks shells/sections/actions from a closed vocabulary
+// and fills slot content; deterministic templates in
+// src/components/mockups/templates/ render the HTML. Slot text is still
+// critiqued for PRD alignment via critiqueMockupAlignment on the rendered
+// output so the existing gating path continues to apply.
 
-export const generateMockup = async (
+const buildSpecSystemPrompt = (settings: MockupSettings): string => {
+    const styleLine = settings.style ? `\nStyle direction from the user: ${settings.style}` : '';
+    return `You are a senior product designer producing a deterministic mockup layout spec (mockup_layout_spec_v1) for a new product, grounded in a PRD.
+
+DETERMINISTIC MODE IS ON.
+You MUST output ONLY a layout_spec JSON object matching the provided responseSchema. Do NOT return HTML. A separate deterministic renderer turns the spec into HTML.
+Prompt template version: ${MOCKUP_PROMPT_TEMPLATE_VERSION}.
+
+## Output contract
+- version: "mockup_layout_spec_v1"
+- tokenSet: "token_set_v1"
+- title: a short concept name grounded in the PRD
+- summary: one or two sentences framing the concept
+- screens: 1 to 5 screens. Use exactly the number implied by the scope setting below.
+
+## Per-screen rules
+- name: short screen title (e.g. "Triage Queue", "Case Detail Review")
+- purpose: one sentence explaining what this screen solves, for which persona, grounded in the PRD
+- shell: REUSE the same shell.type/platform/accent/productName/navLabels across ALL screens unless the workflow step explicitly requires a state change. This is how we enforce cross-screen coherence.
+- sections: 2 to 4 entries. At least one with role="primary"; the rest "support" or "utility".
+- actions: 1 to 4 entries. At least one action.kind="primary_cta" with a PRD-derived verb label.
+
+## Allowed values (strict — do not invent)
+- shell.type: sidebar_topbar | topbar_only | mobile_tab_shell
+- shell.platform: desktop | mobile | responsive
+- shell.accent: indigo
+- section.role: primary | support | utility
+- section.component: stat_grid | data_table | activity_feed | filters_bar | detail_panel | empty_state
+- action.kind: primary_cta | secondary_cta | input | select | tab
+
+## Section slot-data contract (fill only the fields for the chosen component)
+- stat_grid: data.rows = 2–6 items, each { label, value, delta? }. Use PRD metric names for labels; realistic numbers for values.
+- data_table: data.columns = 2–6 strings; data.tableRows = 1–8 items, each { cells: string[] }. Cell count should match columns. Column headers and cells must be grounded in PRD entities.
+- activity_feed: data.entries = 2–6 items, each { actor, verb, target, when }. Use real persona names, realistic verbs, PRD entities, and relative times like "2m ago".
+- filters_bar: data.filters = 1–4 items, each { label, options: 2–5 strings }. Use PRD-grounded filter dimensions.
+- detail_panel: data.fields = 2–8 items, each { label, value }. Use PRD entity field names and realistic values.
+- empty_state: data = { heading, body, primaryActionLabel? }.
+
+## Content quality bar
+- Copy MUST use the actual product's persona names, feature names, and entity names from the PRD. No "Lorem ipsum", no "Button 1", no "Item A".
+- Keep labels tight (under ~40 chars). No full paragraphs in slot text.
+- Reuse navLabels across screens; reuse productName exactly.
+- The first action on every screen should be the most important primary verb for that screen (e.g. "Assign case owner", not "Create").
+
+## Settings context
+${FIDELITY_INSTRUCTIONS[settings.fidelity]}
+${PLATFORM_INSTRUCTIONS[settings.platform]}
+${SCOPE_INSTRUCTIONS[settings.scope]}${styleLine}
+
+## Reminders
+Return ONLY the layout_spec JSON. No markdown, no commentary, no HTML.
+
+## Image & media placeholders (informational)
+Placeholder tokens below are available to the deterministic renderer. Do NOT include them yourself.
+${PLACEHOLDER_PROMPT_CATALOG}`;
+};
+
+const buildSpecUserPrompt = (prdContent: string, structuredPRD?: StructuredPRD): string => {
+    const parts: string[] = [`Product PRD:\n---\n${prdContent}\n---`];
+    if (structuredPRD) {
+        const personas = structuredPRD.targetUsers?.slice(0, 6).join(', ');
+        const features = structuredPRD.features
+            ?.slice(0, 8)
+            .map(f => `- ${f.name}${f.description ? `: ${f.description}` : ''}`)
+            .join('\n');
+        const vision = structuredPRD.vision?.trim();
+        const problem = structuredPRD.coreProblem?.trim();
+        const structuredLines: string[] = ['Structured PRD summary (use these names in your slot content):'];
+        if (vision) structuredLines.push(`Vision: ${vision}`);
+        if (problem) structuredLines.push(`Core problem: ${problem}`);
+        if (personas) structuredLines.push(`Personas: ${personas}`);
+        if (features) structuredLines.push(`Key features:\n${features}`);
+        parts.push(structuredLines.join('\n'));
+    }
+    parts.push('Return the layout_spec JSON now. No HTML. No markdown fences. Use only the allowed enum values.');
+    return parts.join('\n\n');
+};
+
+const runSpecEngineAttempt = async (
     prdContent: string,
     settings: MockupSettings,
-    structuredPRD?: StructuredPRD,
-    options?: ProviderOptions,
+    structuredPRD: StructuredPRD | undefined,
+    warnings: string[],
 ): Promise<ParseResult> => {
-    options?.onStatus?.('Generating mockup...');
+    const system = buildSpecSystemPrompt(settings);
+    const user = buildSpecUserPrompt(prdContent, structuredPRD);
+    const raw = await callGemini(system, user, {
+        responseMimeType: 'application/json',
+        responseSchema: mockupLayoutSpecSchema,
+        temperature: 0.2,
+        topP: 0.8,
+        topK: 32,
+    });
+    const fallbackProduct = inferConceptName(prdContent);
+    const specResult = parseLayoutSpec(raw, fallbackProduct);
+    specResult.warnings.forEach(w => warnings.push(w));
 
+    // Run the existing alignment critique on the rendered screens so the
+    // PRD-grounding gate still applies. The spec engine produces consistent
+    // structure, but copy can still drift generic if the PRD is thin.
+    const critique = critiqueMockupAlignment(
+        specResult.payload.screens,
+        settings,
+        prdContent,
+        structuredPRD,
+    );
+    if (critique.severity === 'high' && critique.alignmentScore < 45) {
+        const reason = critique.mismatchReasons.slice(0, 3).join(' ');
+        throw new Error(
+            `Mockup spec failed PRD alignment critique (${critique.alignmentScore}/100). ${reason}`,
+        );
+    }
+    critique.screens
+        .filter(screen => screen.severity !== 'low')
+        .forEach(screen => {
+            warnings.push(
+                `Screen "${screen.screenName}": alignment ${screen.score}/100 (${screen.severity}). ${screen.mismatchReasons.slice(0, 2).join(' ')}`,
+            );
+        });
+    if (critique.severity !== 'low') {
+        warnings.push(
+            `Set alignment ${critique.alignmentScore}/100 (${critique.severity}). Missing: ${critique.missingConcepts.join(', ') || 'none identified'}.`,
+        );
+    }
+
+    return {
+        payload: specResult.payload,
+        critique,
+        warnings: specResult.warnings,
+        usedFallback: false,
+        strategyVersion: MOCKUP_SPEC_STRATEGY_VERSION,
+    };
+};
+
+// ---- Public API ----
+
+const runHtmlEngine = async (
+    prdContent: string,
+    settings: MockupSettings,
+    structuredPRD: StructuredPRD | undefined,
+    options: ProviderOptions | undefined,
+): Promise<ParseResult> => {
     const system = buildSystemPrompt(settings);
     const user = buildUserPrompt(prdContent, structuredPRD);
     const warnings: string[] = [];
@@ -413,4 +570,50 @@ export const generateMockup = async (
 
     console.warn('[mockupService] returning safe fallback after repeated generation failures', lastError);
     return buildSafeFallbackPayload(prdContent, settings, warnings);
+};
+
+const runSpecEngine = async (
+    prdContent: string,
+    settings: MockupSettings,
+    structuredPRD: StructuredPRD | undefined,
+    options: ProviderOptions | undefined,
+): Promise<ParseResult> => {
+    const warnings: string[] = [];
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
+        options?.onStatus?.(`Generating mockup spec (attempt ${attempt}/${MAX_GENERATION_ATTEMPTS})...`);
+        try {
+            return await runSpecEngineAttempt(prdContent, settings, structuredPRD, warnings);
+        } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            lastError = err;
+            if (err instanceof MockupSpecParseError) {
+                err.warnings.forEach(w => warnings.push(w));
+            }
+            warnings.push(`Spec attempt ${attempt} failed: ${err.message}`);
+        }
+    }
+
+    console.warn('[mockupService] spec engine falling back to HTML engine after repeated failures', lastError);
+    warnings.push('Spec engine failed repeatedly; falling back to HTML engine for this generation.');
+    const htmlResult = await runHtmlEngine(prdContent, settings, structuredPRD, options);
+    return {
+        ...htmlResult,
+        warnings: [...warnings, ...htmlResult.warnings],
+    };
+};
+
+export const generateMockup = async (
+    prdContent: string,
+    settings: MockupSettings,
+    structuredPRD?: StructuredPRD,
+    options?: ProviderOptions,
+): Promise<ParseResult> => {
+    options?.onStatus?.('Generating mockup...');
+    const engine = getMockupEngine();
+    if (engine === 'spec') {
+        return runSpecEngine(prdContent, settings, structuredPRD, options);
+    }
+    return runHtmlEngine(prdContent, settings, structuredPRD, options);
 };

--- a/src/lib/services/prdService.ts
+++ b/src/lib/services/prdService.ts
@@ -38,6 +38,8 @@ Provide:
 - Risks with specific mitigation strategies
 - Non-functional requirements (performance, security, accessibility, etc.)
 - Constraints (budget, timeline, technical, regulatory)
+- domainEntities: 3–8 concrete nouns this product manipulates (e.g. "Patient case", "Intake note", "Triage owner"). Each entity MUST include a short description and 2–4 realistic exampleValues — these become table rows, detail-panel values, and activity-feed targets in downstream mockups, so make them specific (real names, real statuses, realistic IDs — no placeholders).
+- primaryActions: 3–6 verb+target pairs expressing the most important things a user does in this product (e.g. { verb: "Assign", target: "case owner" }). These become the primary CTAs in mockups, so prefer concrete verbs over vague ones like "manage" or "view".
 
 Each acceptance criterion must be testable and specific. Prioritize features using MoSCoW: "must" for launch-critical, "should" for important, "could" for nice-to-have.${platformNote}`;
 
@@ -103,6 +105,24 @@ export const structuredPRDToMarkdown = (prd: StructuredPRD): string => {
     if (prd.constraints && prd.constraints.length > 0) {
         lines.push('## Constraints');
         prd.constraints.forEach(c => lines.push(`- ${c}`));
+        lines.push('');
+    }
+
+    if (prd.domainEntities && prd.domainEntities.length > 0) {
+        lines.push('## Domain Entities');
+        prd.domainEntities.forEach(entity => {
+            const descPart = entity.description ? ` — ${entity.description}` : '';
+            lines.push(`- **${entity.name}**${descPart}`);
+            if (entity.exampleValues && entity.exampleValues.length > 0) {
+                lines.push(`  - Examples: ${entity.exampleValues.join(', ')}`);
+            }
+        });
+        lines.push('');
+    }
+
+    if (prd.primaryActions && prd.primaryActions.length > 0) {
+        lines.push('## Primary Actions');
+        prd.primaryActions.forEach(action => lines.push(`- ${action.verb} ${action.target}`));
         lines.push('');
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -225,6 +225,11 @@ export type MockupSettings = {
     style?: string;
     scope: MockupScope;
     selectedSections?: string[];
+    // Phase C: Demo Safe Mode. Pins temperature=0 + topK=1 on the provider
+    // call, disables the HTML-engine fallback chain, and hard-rejects on
+    // alignment critique miss. Intended for recruiter demos where a
+    // predictable "refused to generate" is preferable to a silent degrade.
+    safeMode?: boolean;
 };
 
 // Rendered HTML/Tailwind mockup payload (stored as JSON string in

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,23 @@ export type StructuredPRD = {
     risks: string[];
     nonFunctionalRequirements?: string[];
     constraints?: string[];
+    // Phase B grounding fields. Optional so older projects keep working; the
+    // mockup spec engine and alignment critique use them when present to
+    // force PRD-derived nouns/verbs into generated screens instead of
+    // relying on heuristic term extraction.
+    domainEntities?: DomainEntity[];
+    primaryActions?: PrimaryAction[];
+};
+
+export type DomainEntity = {
+    name: string;                 // e.g. "Patient case"
+    description?: string;         // short what-it-is line
+    exampleValues?: string[];     // 1–4 realistic example instances
+};
+
+export type PrimaryAction = {
+    verb: string;                 // e.g. "Assign"
+    target: string;               // e.g. "case owner"
 };
 
 export type SpineVersion = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -229,6 +229,111 @@ export type MockupPayload = {
 
 export const MOCKUP_HTML_V1 = 'mockup_html_v1' as const;
 
+// --- Mockup Layout Spec (Phase A deterministic generation) ---
+//
+// The layout-spec engine narrows the model's generation surface from "any
+// Tailwind HTML string" to a closed vocabulary of shells, sections and
+// actions. Slot *content* (titles, labels, row text) is still model-generated
+// and PRD-grounded; everything structural comes from vetted templates in
+// src/components/mockups/templates/ via mockupLayoutRenderer. See the plan in
+// docs/ for why and how.
+
+export type MockupShellType = 'sidebar_topbar' | 'topbar_only' | 'mobile_tab_shell';
+export type MockupShellPlatform = 'desktop' | 'mobile' | 'responsive';
+export type MockupShellAccent = 'indigo';
+
+export type MockupSectionRole = 'primary' | 'support' | 'utility';
+export type MockupSectionComponent =
+    | 'stat_grid'
+    | 'data_table'
+    | 'activity_feed'
+    | 'filters_bar'
+    | 'detail_panel'
+    | 'empty_state';
+
+export type MockupActionKind = 'primary_cta' | 'secondary_cta' | 'input' | 'select' | 'tab';
+
+export interface MockupLayoutShell {
+    type: MockupShellType;
+    platform: MockupShellPlatform;
+    accent: MockupShellAccent;
+    productName: string;        // short product/brand label for the shell chrome
+    navLabels: string[];        // 3–6 sidebar/tab items, PRD-derived
+}
+
+export interface MockupLayoutStatRow {
+    label: string;              // PRD entity or metric name
+    value: string;              // realistic number / status string
+    delta?: string;             // optional "+12%" style chip
+}
+
+export interface MockupLayoutTableRow {
+    cells: string[];            // matches columns[] length
+}
+
+export interface MockupLayoutActivityEntry {
+    actor: string;              // persona or entity name
+    verb: string;               // "updated", "flagged", "assigned"
+    target: string;             // PRD entity
+    when: string;               // relative time string, e.g. "2m ago"
+}
+
+export interface MockupLayoutFilter {
+    label: string;
+    options: string[];          // 2–5 realistic values
+}
+
+export interface MockupLayoutDetailField {
+    label: string;              // PRD field name
+    value: string;              // realistic value
+}
+
+export interface MockupLayoutEmptyState {
+    heading: string;
+    body: string;
+    primaryActionLabel?: string;
+}
+
+// Discriminated-union payload for each section's slot data. The renderer picks
+// a template based on `component` and expects the matching `data` shape.
+export type MockupLayoutSectionData =
+    | { component: 'stat_grid'; data: { rows: MockupLayoutStatRow[] } }
+    | { component: 'data_table'; data: { columns: string[]; rows: MockupLayoutTableRow[] } }
+    | { component: 'activity_feed'; data: { entries: MockupLayoutActivityEntry[] } }
+    | { component: 'filters_bar'; data: { filters: MockupLayoutFilter[] } }
+    | { component: 'detail_panel'; data: { fields: MockupLayoutDetailField[] } }
+    | { component: 'empty_state'; data: MockupLayoutEmptyState };
+
+export type MockupLayoutSection = MockupLayoutSectionData & {
+    role: MockupSectionRole;
+    heading: string;            // PRD-grounded section title
+};
+
+export interface MockupLayoutAction {
+    kind: MockupActionKind;
+    label: string;              // PRD-grounded verb phrase
+}
+
+export interface MockupLayoutScreen {
+    id: string;
+    name: string;
+    purpose: string;
+    shell: MockupLayoutShell;
+    sections: MockupLayoutSection[];   // >= 2 per screen
+    actions: MockupLayoutAction[];     // >= 1 per screen (the header CTA)
+}
+
+export interface MockupLayoutSpec {
+    version: 'mockup_layout_spec_v1';
+    tokenSet: 'token_set_v1';
+    title: string;
+    summary: string;
+    screens: MockupLayoutScreen[];
+}
+
+export const MOCKUP_LAYOUT_SPEC_V1 = 'mockup_layout_spec_v1' as const;
+export const MOCKUP_TOKEN_SET_V1 = 'token_set_v1' as const;
+
 // Prompt artifact settings
 export type PromptTarget =
     | 'mockup'


### PR DESCRIPTION
The 2026-04-22 audit measured 77.5/100 consistency across identical
reruns because the current pipeline asks Gemini to emit arbitrary
Tailwind HTML, leaving all guardrails to post-hoc regex. This collapses
the generation surface to a typed MockupLayoutSpec (closed vocabulary of
shells, sections, actions) rendered by vetted templates, so structural
variance moves from the model to the renderer and only slot content
remains model-generated.

- Add MockupLayoutSpec types and Gemini JSON-mode schema
- Add template catalog: 3 shells, 6 section components, 5 action kinds
- Add deterministic spec->HTML renderer with fail-soft parsing
- Wire runSpecEngine into mockupService behind localStorage
  MOCKUP_ENGINE=spec (default remains 'html' until validated against the
  harness); spec-engine failures fall back to the HTML engine
- Tests: renderer determinism + injection-escape + shell variants, and
  a mockupService integration test for the spec path