### PR TITLE
feat(mockups): phase follow-ups — engine toggle, grounding UI, probe telemetry

### DIFF
--- a/docs/mockup-improvements-plan-2026-04-23.md
+++ b/docs/mockup-improvements-plan-2026-04-23.md
@@ -56,9 +56,10 @@ generated.
 - [ ] **Flip default engine.** Change `getMockupEngine()` to default `'spec'`
       once the harness threshold is met, and update
       `docs/mockup-evaluation-harness.md` with the new baseline.
-- [ ] **Surface engine toggle in UI.** Add an advanced toggle in settings
-      (or the mockup view) for switching engines without touching
-      localStorage manually.
+- [x] **Surface engine toggle in UI** — added to `SettingsModal.tsx` as a
+      radio group next to the model selector; persists to
+      `localStorage.MOCKUP_ENGINE` (writes `'spec'` explicitly, clears the
+      key when on the default `'html'`).
 - [ ] **Remove HTML-engine path.** After one stable release on the spec
       default, delete `buildSystemPrompt`/`buildUserPrompt`/
       `parseMockupPayload`/`buildSafeFallbackPayload` plus the now-redundant
@@ -106,13 +107,16 @@ hard input to generation.
 
 ### Open — Phase B polish
 
-- [ ] **Backfill migration**: older projects in localStorage won't have
-      `domainEntities`/`primaryActions`. Decide whether to (a) leave them
-      blank and rely on heuristic critique, (b) extract entities on read
-      from the markdown PRD, or (c) offer a "Refresh structured PRD" button
-      that re-runs PRD generation.
-- [ ] **StructuredPRDView UI**: surface the new sections in
-      `src/components/StructuredPRDView.tsx` so users can see + edit them.
+- [x] **Backfill migration**: chose option (c). `StructuredPRDView` renders
+      a "Refresh grounding fields" amber CTA when either field is missing;
+      clicking re-runs `generateStructuredPRD` against a compact summary of
+      the existing structured PRD and merges only `domainEntities` and
+      `primaryActions` back — existing vision/features/risks untouched.
+- [x] **StructuredPRDView UI**: two new editable sections (domain entities
+      + primary actions) with inline edit using a one-per-line
+      pipe-delimited format (`Name | description | example1, example2` /
+      `verb | target`). Parse/serialize helpers extracted to
+      `src/lib/groundingFields.ts` with full round-trip tests.
 
 ---
 
@@ -169,9 +173,13 @@ cross-run diff) and gives recruiter demos a defensible "safe" setting.
 - [ ] **Establish a Phase C baseline**: after the first CI run, commit the
       generated `harness/sample-results/latest/summary.json` as the new
       baseline for regression detection.
-- [ ] **Probe telemetry dashboard**: today the degraded badge is per-preview
-      and ephemeral. Aggregate probe outcomes across a session so users can
-      see if one generation consistently degrades.
+- [x] **Probe telemetry dashboard**: session-scoped Zustand store
+      (`src/store/probeStore.ts`) aggregates probe outcomes per
+      `ArtifactVersion.id`. `MockupHtmlPreview` now takes an optional
+      `versionId` prop and records every interpreted probe report.
+      `MockupViewer` surfaces a per-version chip in the title strip —
+      green "Render OK (n/n)" or amber "Render degraded (d/n)" with the
+      last degradation reason as the tooltip.
 
 ---
 

--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -338,6 +338,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                         createdAt={version.createdAt}
                         sourceSpineVersionId={sourceSpineVersionId}
                         actions={actions}
+                        versionId={version.id}
                     />
                 </MockupErrorBoundary>
             );
@@ -387,6 +388,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
                             versionNumber={v.versionNumber}
                             createdAt={v.createdAt}
                             sourceSpineVersionId={v.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId}
+                            versionId={v.id}
                         />
                     </MockupErrorBoundary>
                 );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
-import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown } from 'lucide-react';
+import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, Layers } from 'lucide-react';
 import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 
 interface SettingsModalProps {
     onClose: () => void;
 }
+
+type MockupEngine = 'html' | 'spec';
+const readMockupEngine = (): MockupEngine =>
+    localStorage.getItem('MOCKUP_ENGINE') === 'spec' ? 'spec' : 'html';
 
 /**
  * Model catalog. Order within each tier = display order in the UI. `current`
@@ -93,6 +97,7 @@ function ModelRadio({
 export function SettingsModal({ onClose }: SettingsModalProps) {
     const [apiKey, setApiKey] = useState(() => localStorage.getItem('GEMINI_API_KEY') || '');
     const [model, setModel] = useState(() => localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL);
+    const [mockupEngine, setMockupEngine] = useState<MockupEngine>(() => readMockupEngine());
 
     // Expand the legacy section automatically if the user is currently on a
     // legacy model — otherwise keep it collapsed to reduce visual noise.
@@ -103,6 +108,14 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         e.preventDefault();
         localStorage.setItem('GEMINI_API_KEY', apiKey.trim());
         localStorage.setItem('GEMINI_MODEL', model);
+        // Persist engine choice. HTML is the default (legacy) path; only
+        // write 'spec' explicitly so clearing the default looks like "not
+        // set" in devtools.
+        if (mockupEngine === 'spec') {
+            localStorage.setItem('MOCKUP_ENGINE', 'spec');
+        } else {
+            localStorage.removeItem('MOCKUP_ENGINE');
+        }
         onClose();
     };
 
@@ -206,6 +219,50 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                                     ))}
                                 </div>
                             )}
+                        </div>
+                    </div>
+
+                    {/* Mockup engine */}
+                    <div className="space-y-3">
+                        <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
+                            <Layers size={14} className="text-indigo-400" />
+                            Mockup Engine
+                        </label>
+                        <div className="grid grid-cols-1 gap-3">
+                            <button
+                                type="button"
+                                onClick={() => setMockupEngine('html')}
+                                className={`flex items-start gap-4 p-4 rounded-2xl border transition-all text-left ${
+                                    mockupEngine === 'html'
+                                        ? 'bg-indigo-500/10 border-indigo-500/50 ring-1 ring-indigo-500/50'
+                                        : 'bg-white/5 border-white/5 hover:bg-white/10'
+                                }`}
+                            >
+                                <div className={`mt-1 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${mockupEngine === 'html' ? 'border-indigo-500' : 'border-neutral-600'}`}>
+                                    {mockupEngine === 'html' && <div className="w-2 h-2 rounded-full bg-indigo-400" />}
+                                </div>
+                                <div>
+                                    <h4 className="text-sm font-bold text-white mb-0.5">HTML engine (default)</h4>
+                                    <p className="text-xs text-neutral-400">Free-form Tailwind output with heuristic validation + safe fallback. Stable, slightly less consistent across reruns.</p>
+                                </div>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setMockupEngine('spec')}
+                                className={`flex items-start gap-4 p-4 rounded-2xl border transition-all text-left ${
+                                    mockupEngine === 'spec'
+                                        ? 'bg-indigo-500/10 border-indigo-500/50 ring-1 ring-indigo-500/50'
+                                        : 'bg-white/5 border-white/5 hover:bg-white/10'
+                                }`}
+                            >
+                                <div className={`mt-1 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${mockupEngine === 'spec' ? 'border-indigo-500' : 'border-neutral-600'}`}>
+                                    {mockupEngine === 'spec' && <div className="w-2 h-2 rounded-full bg-indigo-400" />}
+                                </div>
+                                <div>
+                                    <h4 className="text-sm font-bold text-white mb-0.5">Layout spec (experimental)</h4>
+                                    <p className="text-xs text-neutral-400">Typed shell + section + action vocabulary rendered deterministically. Better cross-run consistency; falls back to the HTML engine on failure.</p>
+                                </div>
+                            </button>
                         </div>
                     </div>
 

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
-import { Pencil, Check, X, Plus, Trash2 } from 'lucide-react';
+import { Pencil, Check, X, Plus, Trash2, Sparkles, Loader2 } from 'lucide-react';
 import Mark from 'mark.js';
 import { useProjectStore } from '../store/projectStore';
-import { structuredPRDToMarkdown, replyInBranch } from '../lib/llmProvider';
+import { structuredPRDToMarkdown, replyInBranch, generateStructuredPRD } from '../lib/llmProvider';
 import { FeatureCard } from './FeatureCard';
 import { v4 as uuidv4 } from 'uuid';
 import type { StructuredPRD, Feature } from '../types';
+import {
+    parseEntities,
+    parseActions,
+    serializeEntities,
+    serializeActions,
+} from '../lib/groundingFields';
 
 interface StructuredPRDViewProps {
     projectId: string;
@@ -14,7 +20,15 @@ interface StructuredPRDViewProps {
     readOnly: boolean;
 }
 
-type EditingSection = 'vision' | 'targetUsers' | 'coreProblem' | 'architecture' | 'risks' | null;
+type EditingSection =
+    | 'vision'
+    | 'targetUsers'
+    | 'coreProblem'
+    | 'architecture'
+    | 'risks'
+    | 'domainEntities'
+    | 'primaryActions'
+    | null;
 
 export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly }: StructuredPRDViewProps) {
     const { updateSpineStructuredPRD, createBranch, addBranchMessage, branches } = useProjectStore();
@@ -155,6 +169,61 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
         setEditingSection(null);
     };
 
+    const saveDomainEntities = () => {
+        const updated = { ...structuredPRD, domainEntities: parseEntities(editValue) };
+        savePRD(updated);
+        setEditingSection(null);
+    };
+
+    const savePrimaryActions = () => {
+        const updated = { ...structuredPRD, primaryActions: parseActions(editValue) };
+        savePRD(updated);
+        setEditingSection(null);
+    };
+
+    // Phase B backfill: older projects have no domainEntities / primaryActions
+    // because they were generated before those fields existed. This button
+    // re-runs the structured-PRD generator on a concise summary of the
+    // existing PRD and merges only the new grounding fields back in —
+    // existing vision / features / risks are left untouched.
+    const [isRefreshingGrounding, setIsRefreshingGrounding] = useState(false);
+    const [refreshError, setRefreshError] = useState<string | null>(null);
+    const groundingMissing =
+        !structuredPRD.domainEntities || structuredPRD.domainEntities.length === 0
+        || !structuredPRD.primaryActions || structuredPRD.primaryActions.length === 0;
+
+    const handleRefreshGrounding = async () => {
+        setRefreshError(null);
+        setIsRefreshingGrounding(true);
+        try {
+            // Synthesize a compact prompt from the existing structured PRD
+            // so the generator sees the same product context it originally
+            // produced, not a stale raw prompt.
+            const summaryLines: string[] = [];
+            if (structuredPRD.vision) summaryLines.push(`Vision: ${structuredPRD.vision}`);
+            if (structuredPRD.coreProblem) summaryLines.push(`Core problem: ${structuredPRD.coreProblem}`);
+            if (structuredPRD.targetUsers?.length) summaryLines.push(`Personas: ${structuredPRD.targetUsers.join(', ')}`);
+            if (structuredPRD.features?.length) {
+                summaryLines.push(`Features:\n${structuredPRD.features.slice(0, 8).map(f => `- ${f.name}: ${f.description}`).join('\n')}`);
+            }
+            const regenerated = await generateStructuredPRD(summaryLines.join('\n\n'));
+            const merged: StructuredPRD = {
+                ...structuredPRD,
+                domainEntities: regenerated.domainEntities?.length
+                    ? regenerated.domainEntities
+                    : structuredPRD.domainEntities,
+                primaryActions: regenerated.primaryActions?.length
+                    ? regenerated.primaryActions
+                    : structuredPRD.primaryActions,
+            };
+            savePRD(merged);
+        } catch (e) {
+            setRefreshError(e instanceof Error ? e.message : 'Failed to refresh grounding fields.');
+        } finally {
+            setIsRefreshingGrounding(false);
+        }
+    };
+
     const handleFeatureUpdate = (updatedFeature: Feature) => {
         const updated = {
             ...structuredPRD,
@@ -279,9 +348,157 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
         </div>
     );
 
+    const renderDomainEntities = () => {
+        const items = structuredPRD.domainEntities ?? [];
+        const editing = editingSection === 'domainEntities';
+        return (
+            <div className="mb-8">
+                <div className="flex items-center justify-between mb-3 border-b border-neutral-200 pb-2">
+                    <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight">Domain Entities</h3>
+                    {!readOnly && !editing && (
+                        <button
+                            onClick={() => startEditing('domainEntities', serializeEntities(items))}
+                            className="p-1 text-neutral-300 hover:text-neutral-500 transition"
+                            title="Edit domain entities"
+                            aria-label="Edit domain entities"
+                        >
+                            <Pencil size={14} />
+                        </button>
+                    )}
+                </div>
+                {editing ? (
+                    <div className="space-y-2">
+                        <textarea
+                            value={editValue}
+                            onChange={(e) => setEditValue(e.target.value)}
+                            className="w-full bg-neutral-50 border border-indigo-200 rounded-lg px-4 py-3 text-sm text-neutral-700 focus:outline-none focus:border-indigo-400 min-h-[140px] font-mono"
+                            placeholder={'Name | description | example1, example2\n(one entity per line; description and examples are optional)'}
+                            autoFocus
+                        />
+                        <div className="flex justify-end gap-2">
+                            <button onClick={cancelEditing} className="p-1.5 text-neutral-400 hover:text-neutral-600" title="Cancel" aria-label="Cancel editing">
+                                <X size={16} />
+                            </button>
+                            <button onClick={saveDomainEntities} className="p-1.5 text-indigo-500 hover:text-indigo-700" title="Save" aria-label="Save changes">
+                                <Check size={16} />
+                            </button>
+                        </div>
+                    </div>
+                ) : items.length === 0 ? (
+                    <div className="p-4 bg-neutral-50 border border-dashed border-neutral-200 rounded-lg text-xs text-neutral-500">
+                        No domain entities captured. These names drive table columns and labels in generated mockups — use "Refresh grounding fields" or edit to add them.
+                    </div>
+                ) : (
+                    <ul className="p-4 bg-neutral-50 border border-neutral-200 rounded-lg space-y-3">
+                        {items.map((entity, i) => (
+                            <li key={`${entity.name}-${i}`} className="text-sm text-neutral-700">
+                                <p className="font-semibold text-neutral-900">{entity.name}</p>
+                                {entity.description && (
+                                    <p className="text-xs text-neutral-600 mt-0.5">{entity.description}</p>
+                                )}
+                                {entity.exampleValues && entity.exampleValues.length > 0 && (
+                                    <p className="text-xs text-neutral-500 mt-1">
+                                        <span className="text-neutral-400">Examples:</span> {entity.exampleValues.join(', ')}
+                                    </p>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        );
+    };
+
+    const renderPrimaryActions = () => {
+        const items = structuredPRD.primaryActions ?? [];
+        const editing = editingSection === 'primaryActions';
+        return (
+            <div className="mb-8">
+                <div className="flex items-center justify-between mb-3 border-b border-neutral-200 pb-2">
+                    <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight">Primary Actions</h3>
+                    {!readOnly && !editing && (
+                        <button
+                            onClick={() => startEditing('primaryActions', serializeActions(items))}
+                            className="p-1 text-neutral-300 hover:text-neutral-500 transition"
+                            title="Edit primary actions"
+                            aria-label="Edit primary actions"
+                        >
+                            <Pencil size={14} />
+                        </button>
+                    )}
+                </div>
+                {editing ? (
+                    <div className="space-y-2">
+                        <textarea
+                            value={editValue}
+                            onChange={(e) => setEditValue(e.target.value)}
+                            className="w-full bg-neutral-50 border border-indigo-200 rounded-lg px-4 py-3 text-sm text-neutral-700 focus:outline-none focus:border-indigo-400 min-h-[120px] font-mono"
+                            placeholder={'Verb | target\n(one action per line; both parts required)'}
+                            autoFocus
+                        />
+                        <div className="flex justify-end gap-2">
+                            <button onClick={cancelEditing} className="p-1.5 text-neutral-400 hover:text-neutral-600" title="Cancel" aria-label="Cancel editing">
+                                <X size={16} />
+                            </button>
+                            <button onClick={savePrimaryActions} className="p-1.5 text-indigo-500 hover:text-indigo-700" title="Save" aria-label="Save changes">
+                                <Check size={16} />
+                            </button>
+                        </div>
+                    </div>
+                ) : items.length === 0 ? (
+                    <div className="p-4 bg-neutral-50 border border-dashed border-neutral-200 rounded-lg text-xs text-neutral-500">
+                        No primary actions captured. These become the primary CTAs across generated mockups.
+                    </div>
+                ) : (
+                    <ul className="p-4 bg-neutral-50 border border-neutral-200 rounded-lg space-y-1">
+                        {items.map((action, i) => (
+                            <li key={`${action.verb}-${action.target}-${i}`} className="text-sm text-neutral-700">
+                                <span className="font-semibold text-neutral-900">{action.verb}</span> {action.target}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        );
+    };
+
+    const renderGroundingBackfill = () => {
+        if (readOnly || !groundingMissing) return null;
+        return (
+            <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4">
+                <div className="flex items-start gap-3">
+                    <Sparkles size={16} className="text-amber-600 mt-0.5 shrink-0" />
+                    <div className="flex-1">
+                        <p className="text-sm font-semibold text-amber-900">Grounding fields missing</p>
+                        <p className="text-xs text-amber-800 mt-0.5 leading-relaxed">
+                            This project was created before domain entities and primary actions were captured.
+                            Refresh to let the PRD generator fill them in — used by the mockup engine to ground
+                            table columns, section labels, and primary CTAs.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={handleRefreshGrounding}
+                            disabled={isRefreshingGrounding}
+                            className="mt-3 inline-flex items-center gap-2 rounded-md border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
+                        >
+                            {isRefreshingGrounding
+                                ? <Loader2 size={12} className="animate-spin" />
+                                : <Sparkles size={12} />}
+                            {isRefreshingGrounding ? 'Refreshing…' : 'Refresh grounding fields'}
+                        </button>
+                        {refreshError && (
+                            <p className="mt-2 text-xs text-red-700">Refresh failed: {refreshError}</p>
+                        )}
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
     return (
         <div className="relative" onMouseUp={handleMouseUp}>
             <div ref={contentRef} className="space-y-2">
+                {renderGroundingBackfill()}
                 {renderTextSection('Vision', 'vision', structuredPRD.vision)}
                 {renderListSection('Target Users', 'targetUsers', structuredPRD.targetUsers)}
                 {renderTextSection('Core Problem', 'coreProblem', structuredPRD.coreProblem)}
@@ -329,6 +546,8 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
 
                 {renderTextSection('Architecture', 'architecture', structuredPRD.architecture)}
                 {renderListSection('Risks', 'risks', structuredPRD.risks)}
+                {renderDomainEntities()}
+                {renderPrimaryActions()}
             </div>
 
             {selection && (

--- a/src/components/mockups/MockupHtmlPreview.tsx
+++ b/src/components/mockups/MockupHtmlPreview.tsx
@@ -2,11 +2,16 @@ import { useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type { MockupPlatform } from '../../types';
 import { buildMockupSrcDoc, type MockupProbeReport } from './buildMockupSrcDoc';
+import { useProbeStore } from '../../store/probeStore';
 
 type Props = {
     html: string;
     platform: MockupPlatform;
     className?: string;
+    // Optional version id used to record probe outcomes into the session
+    // telemetry store. When absent (e.g. "Open in new tab"), probes still
+    // drive the degraded badge but aren't aggregated.
+    versionId?: string;
 };
 
 type ProbeState =
@@ -29,11 +34,12 @@ const interpretProbe = (report: MockupProbeReport): ProbeState => {
 // lets Tailwind CDN JIT-compile utility classes inside the iframe, but without
 // `allow-same-origin` the iframe is treated as cross-origin and cannot touch
 // Synapse state.
-export function MockupHtmlPreview({ html, platform, className }: Props) {
+export function MockupHtmlPreview({ html, platform, className, versionId }: Props) {
     const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
     const [retryCount, setRetryCount] = useState(0);
     const [probe, setProbe] = useState<ProbeState>({ status: 'pending' });
     const frameKey = `${retryCount}-${html.length}`;
+    const recordProbe = useProbeStore(s => s.recordProbe);
 
     // Fresh probeId per (html, retryCount) pair so a remount/retry never
     // matches a stale probe message from the previous iframe instance.
@@ -86,11 +92,20 @@ export function MockupHtmlPreview({ html, platform, className }: Props) {
             if (!data || typeof data !== 'object') return;
             if (data.type !== 'mockup-probe') return;
             if (data.probeId !== probeId) return;
-            setProbe(interpretProbe(data as MockupProbeReport));
+            const next = interpretProbe(data as MockupProbeReport);
+            setProbe(next);
+            // interpretProbe only ever returns 'ok' or 'degraded' — never
+            // 'pending' — but TypeScript can't see that from ProbeState, so
+            // we narrow explicitly instead of casting.
+            if (versionId && next.status === 'ok') {
+                recordProbe(versionId, { outcome: 'ok', at: Date.now() });
+            } else if (versionId && next.status === 'degraded') {
+                recordProbe(versionId, { outcome: 'degraded', reason: next.reason, at: Date.now() });
+            }
         };
         window.addEventListener('message', onMessage);
         return () => window.removeEventListener('message', onMessage);
-    }, [probeId]);
+    }, [probeId, versionId, recordProbe]);
 
     const height = platform === 'mobile' ? 760 : platform === 'responsive' ? 720 : 760;
     const maxWidth = platform === 'mobile' ? 430 : undefined;

--- a/src/components/mockups/MockupViewer.tsx
+++ b/src/components/mockups/MockupViewer.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Eye, Code2, ExternalLink, Copy, Check } from 'lucide-react';
+import { Eye, Code2, ExternalLink, Copy, Check, AlertTriangle, Activity } from 'lucide-react';
 import type { MockupPayload, MockupSettings, StalenessState } from '../../types';
 import { StalenessBadge } from '../StalenessBadge';
 import { MockupHtmlPreview } from './MockupHtmlPreview';
 import { buildMockupSrcDoc } from './buildMockupSrcDoc';
+import { useProbeStore } from '../../store/probeStore';
 
 type Props = {
     payload: MockupPayload;
@@ -13,6 +14,9 @@ type Props = {
     createdAt: number;
     sourceSpineVersionId?: string;
     actions?: React.ReactNode;
+    // Passed through to MockupHtmlPreview so iframe probe outcomes are
+    // aggregated per artifact version in the session telemetry store.
+    versionId?: string;
 };
 
 type Mode = 'preview' | 'code';
@@ -38,10 +42,16 @@ export function MockupViewer({
     createdAt,
     sourceSpineVersionId,
     actions,
+    versionId,
 }: Props) {
     const [activeIdx, setActiveIdx] = useState(0);
     const [mode, setMode] = useState<Mode>('preview');
     const [copied, setCopied] = useState(false);
+    // Session-scoped probe aggregate for this artifact version. Populated
+    // by MockupHtmlPreview every time a probe message arrives; surfaced
+    // here as a small health badge so reviewers can see whether the
+    // renders have been clean or degraded in this session.
+    const probeStats = useProbeStore(s => (versionId ? s.byVersion[versionId] : undefined));
 
     // Clamp in case of payload mutation.
     const safeIdx = Math.min(activeIdx, Math.max(0, payload.screens.length - 1));
@@ -126,6 +136,25 @@ export function MockupViewer({
                     <span className={CHIP}>{FIDELITY_LABELS[settings.fidelity] ?? settings.fidelity}</span>
                     <span className={CHIP}>{SCOPE_LABELS[settings.scope] ?? settings.scope}</span>
                     <StalenessBadge staleness={staleness} />
+                    {probeStats && probeStats.total > 0 && (
+                        probeStats.degraded === 0 ? (
+                            <span
+                                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-emerald-200 bg-emerald-50 text-emerald-700 font-medium"
+                                title={`All ${probeStats.total} iframe render(s) this session reported clean layout signals.`}
+                            >
+                                <Activity size={10} />
+                                Render OK ({probeStats.ok}/{probeStats.total})
+                            </span>
+                        ) : (
+                            <span
+                                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-amber-200 bg-amber-50 text-amber-700 font-medium"
+                                title={probeStats.lastReason ?? 'One or more renders reported degraded layout signals.'}
+                            >
+                                <AlertTriangle size={10} />
+                                Render degraded ({probeStats.degraded}/{probeStats.total})
+                            </span>
+                        )
+                    )}
                     <span className="text-[10px] text-neutral-400 ml-auto tabular-nums">
                         v{versionNumber} · {formatDate(createdAt)}
                     </span>
@@ -188,6 +217,7 @@ export function MockupViewer({
                         key={activeScreen.id}
                         html={activeScreen.html}
                         platform={settings.platform}
+                        versionId={versionId}
                     />
                 ) : (
                     <pre className="text-xs font-mono bg-neutral-900 text-neutral-100 rounded-lg p-4 overflow-auto max-h-[680px] whitespace-pre-wrap break-words">

--- a/src/lib/__tests__/groundingFields.test.ts
+++ b/src/lib/__tests__/groundingFields.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+    parseActions,
+    parseEntities,
+    serializeActions,
+    serializeEntities,
+} from '../groundingFields';
+
+describe('groundingFields', () => {
+    describe('entities', () => {
+        it('serialize + parse is a round-trip for full records', () => {
+            const input = [
+                { name: 'Patient case', description: 'Intake record', exampleValues: ['Alex Chen', 'Priya Patel'] },
+                { name: 'Triage owner', description: 'Clinician responsible', exampleValues: ['Dr. Kim'] },
+            ];
+            const raw = serializeEntities(input);
+            expect(parseEntities(raw)).toEqual(input);
+        });
+
+        it('handles name-only entities', () => {
+            expect(parseEntities('Patient case')).toEqual([{ name: 'Patient case' }]);
+            expect(serializeEntities([{ name: 'Patient case' }])).toBe('Patient case');
+        });
+
+        it('drops empty lines and lines without a name', () => {
+            const raw = '\n\n | no name |\nReal entity\n  \n| nothing | here';
+            expect(parseEntities(raw)).toEqual([{ name: 'Real entity' }]);
+        });
+
+        it('parses description without examples', () => {
+            expect(parseEntities('Order | A customer order')).toEqual([
+                { name: 'Order', description: 'A customer order' },
+            ]);
+        });
+
+        it('parses examples without description', () => {
+            expect(parseEntities('SKU |  | A-1, B-2, C-3')).toEqual([
+                { name: 'SKU', exampleValues: ['A-1', 'B-2', 'C-3'] },
+            ]);
+        });
+    });
+
+    describe('primaryActions', () => {
+        it('serialize + parse is a round-trip', () => {
+            const input = [
+                { verb: 'Assign', target: 'case owner' },
+                { verb: 'Submit', target: 'triage recommendation' },
+            ];
+            expect(parseActions(serializeActions(input))).toEqual(input);
+        });
+
+        it('drops lines missing a verb or target', () => {
+            const raw = 'Assign | case owner\nAlone\n| only target\nverb |';
+            expect(parseActions(raw)).toEqual([{ verb: 'Assign', target: 'case owner' }]);
+        });
+
+        it('handles multi-word verbs and targets', () => {
+            expect(parseActions('Bulk approve | pending orders')).toEqual([
+                { verb: 'Bulk approve', target: 'pending orders' },
+            ]);
+        });
+
+        it('produces empty string for empty input', () => {
+            expect(serializeActions([])).toBe('');
+            expect(serializeActions(undefined)).toBe('');
+            expect(parseActions('')).toEqual([]);
+        });
+    });
+});

--- a/src/lib/groundingFields.ts
+++ b/src/lib/groundingFields.ts
@@ -1,0 +1,51 @@
+import type { DomainEntity, PrimaryAction } from '../types';
+
+// Edit-format helpers for the Phase B grounding fields in StructuredPRDView.
+// Users edit one entity / action per line and these helpers parse back into
+// typed records. Kept in /lib so the UI module stays components-only (React
+// Fast Refresh requires pure-component exports from .tsx files).
+//
+// Entities format:  `Name | description | example1, example2`  (only Name required)
+// Actions format:   `verb | target`                            (both required)
+
+export const serializeEntities = (entities?: DomainEntity[]): string =>
+    (entities ?? [])
+        .map(e => {
+            const parts: string[] = [e.name];
+            if (e.description) parts.push(e.description);
+            if (e.exampleValues && e.exampleValues.length > 0) parts.push(e.exampleValues.join(', '));
+            return parts.join(' | ');
+        })
+        .join('\n');
+
+export const parseEntities = (raw: string): DomainEntity[] =>
+    raw
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+        .map(line => {
+            const parts = line.split('|').map(s => s.trim());
+            const entity: DomainEntity = { name: parts[0] };
+            if (parts[1]) entity.description = parts[1];
+            if (parts[2]) {
+                const values = parts[2].split(',').map(v => v.trim()).filter(Boolean);
+                if (values.length > 0) entity.exampleValues = values;
+            }
+            return entity;
+        })
+        .filter(e => e.name.length > 0);
+
+export const serializeActions = (actions?: PrimaryAction[]): string =>
+    (actions ?? []).map(a => `${a.verb} | ${a.target}`).join('\n');
+
+export const parseActions = (raw: string): PrimaryAction[] =>
+    raw
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+        .map(line => {
+            const parts = line.split('|').map(s => s.trim());
+            if (parts.length < 2 || !parts[0] || !parts[1]) return null;
+            return { verb: parts[0], target: parts[1] };
+        })
+        .filter((a): a is PrimaryAction => a !== null);

--- a/src/store/__tests__/probeStore.test.ts
+++ b/src/store/__tests__/probeStore.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useProbeStore } from '../probeStore';
+
+describe('probeStore', () => {
+    beforeEach(() => {
+        useProbeStore.getState().clear();
+    });
+
+    it('aggregates ok + degraded outcomes per version', () => {
+        const { recordProbe, getStats } = useProbeStore.getState();
+        recordProbe('v1', { outcome: 'ok', at: 1 });
+        recordProbe('v1', { outcome: 'degraded', reason: 'Tailwind styles did not apply.', at: 2 });
+        recordProbe('v1', { outcome: 'ok', at: 3 });
+
+        const stats = getStats('v1');
+        expect(stats).toBeDefined();
+        expect(stats?.ok).toBe(2);
+        expect(stats?.degraded).toBe(1);
+        expect(stats?.total).toBe(3);
+        expect(stats?.lastReason).toBe('Tailwind styles did not apply.');
+    });
+
+    it('isolates stats across versions', () => {
+        const { recordProbe, getStats } = useProbeStore.getState();
+        recordProbe('v1', { outcome: 'ok', at: 1 });
+        recordProbe('v2', { outcome: 'degraded', reason: 'overflow', at: 2 });
+        expect(getStats('v1')?.total).toBe(1);
+        expect(getStats('v2')?.total).toBe(1);
+        expect(getStats('v1')?.degraded).toBe(0);
+        expect(getStats('v2')?.degraded).toBe(1);
+    });
+
+    it('ignores records with no versionId', () => {
+        const before = useProbeStore.getState().byVersion;
+        useProbeStore.getState().recordProbe('', { outcome: 'ok', at: 1 });
+        expect(useProbeStore.getState().byVersion).toEqual(before);
+    });
+
+    it('clears stats for a single version without touching others', () => {
+        const { recordProbe, clear, getStats } = useProbeStore.getState();
+        recordProbe('v1', { outcome: 'ok', at: 1 });
+        recordProbe('v2', { outcome: 'ok', at: 1 });
+        clear('v1');
+        expect(getStats('v1')).toBeUndefined();
+        expect(getStats('v2')).toBeDefined();
+    });
+
+    it('preserves lastReason across subsequent ok probes', () => {
+        const { recordProbe, getStats } = useProbeStore.getState();
+        recordProbe('v1', { outcome: 'degraded', reason: 'horizontal overflow', at: 1 });
+        recordProbe('v1', { outcome: 'ok', at: 2 });
+        expect(getStats('v1')?.lastReason).toBe('horizontal overflow');
+    });
+});

--- a/src/store/probeStore.ts
+++ b/src/store/probeStore.ts
@@ -1,0 +1,68 @@
+/**
+ * Session-scoped probe telemetry store.
+ *
+ * MockupHtmlPreview reports every iframe post-load probe here so other parts
+ * of the UI (e.g. the mockup version header) can aggregate and surface
+ * whether a given artifact version's screens are rendering cleanly or
+ * degrading. Kept *out* of projectStore so reports never leak into
+ * localStorage — they describe this browser session's render health, not
+ * the artifact itself.
+ */
+
+import { create } from 'zustand';
+
+export type ProbeOutcome = 'ok' | 'degraded';
+
+export interface ProbeRecord {
+    outcome: ProbeOutcome;
+    reason?: string;          // populated when outcome === 'degraded'
+    at: number;               // Date.now() of the record
+}
+
+export interface VersionProbeStats {
+    ok: number;
+    degraded: number;
+    total: number;
+    lastReason?: string;
+    lastAt: number;
+}
+
+interface ProbeState {
+    byVersion: Record<string, VersionProbeStats>;
+    recordProbe: (versionId: string, record: ProbeRecord) => void;
+    getStats: (versionId: string) => VersionProbeStats | undefined;
+    clear: (versionId?: string) => void;
+}
+
+export const useProbeStore = create<ProbeState>((set, get) => ({
+    byVersion: {},
+
+    recordProbe: (versionId, record) => {
+        if (!versionId) return;
+        set(state => {
+            const prev = state.byVersion[versionId];
+            const next: VersionProbeStats = {
+                ok: (prev?.ok ?? 0) + (record.outcome === 'ok' ? 1 : 0),
+                degraded: (prev?.degraded ?? 0) + (record.outcome === 'degraded' ? 1 : 0),
+                total: (prev?.total ?? 0) + 1,
+                lastReason: record.outcome === 'degraded' ? record.reason : prev?.lastReason,
+                lastAt: record.at,
+            };
+            return { byVersion: { ...state.byVersion, [versionId]: next } };
+        });
+    },
+
+    getStats: (versionId) => get().byVersion[versionId],
+
+    clear: (versionId) => {
+        if (!versionId) {
+            set({ byVersion: {} });
+            return;
+        }
+        set(state => {
+            const { [versionId]: _removed, ...rest } = state.byVersion;
+            void _removed;
+            return { byVersion: rest };
+        });
+    },
+}));


### PR DESCRIPTION
Addresses the remaining post-Phase-C items called out in
docs/mockup-improvements-plan-2026-04-23.md. None of these required a
live Gemini run, so they're shipped together on a new branch.

Engine toggle (Phase A follow-up):
- SettingsModal grows a "Mockup Engine" radio group alongside the model
  selector. Persists MOCKUP_ENGINE in localStorage — writes "spec"
  explicitly and clears the key when on the default "html" so devtools
  inspection is obvious.

StructuredPRDView grounding UI + backfill (Phase B follow-up):
- Two new editable sections in StructuredPRDView: Domain Entities and
  Primary Actions. Inline edit via a one-per-line pipe-delimited format
  ("Name | description | example1, example2" / "verb | target").
- Parse/serialize helpers extracted to src/lib/groundingFields.ts so the
  .tsx stays components-only for React Fast Refresh, with full round-
  trip test coverage.
- "Refresh grounding fields" amber CTA appears when either field is
  missing — re-runs generateStructuredPRD against a compact summary of
  the existing PRD and merges only the new fields back, leaving vision/
  features/risks untouched. This is the backfill path for older
  projects that predate Phase B.

Probe telemetry dashboard (Phase C follow-up):
- New session-scoped Zustand store src/store/probeStore.ts aggregating
  probe outcomes per ArtifactVersion.id (ok count, degraded count,
  lastReason).
- MockupHtmlPreview takes an optional versionId prop and records every
  interpreted probe report. MockupViewer threads versionId through and
  renders a per-version chip in the title strip — green "Render OK
  (n/n)" or amber "Render degraded (d/n)" with the last degradation
  reason as the tooltip.

Tests: probe-store aggregation (5 cases) + entity/action parse-serialize
round-trip (9 cases). 93/93 passing (was 79); lint, typecheck, build all
clean.