### PR TITLE
perf(mockups): cut p95 generation latency on slow path

### DIFF
--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -155,10 +155,11 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
 
     /**
      * If the HTML pipeline fell through to its safe-fallback template, the
-     * structured mockup didn't really succeed — kick off a parallel
-     * gpt-image-2 draft (low quality) for each screen so the user has a
-     * second visual to compare against. Fire-and-forget; the per-screen
-     * panel surfaces its own errors.
+     * structured mockup didn't really succeed — kick off gpt-image-2 drafts
+     * (low quality) for each screen so the user has a second visual to
+     * compare against. Fire-and-forget at the call site; internally we cap
+     * concurrency to 2 to avoid rate-limit thrash on multi-screen scopes
+     * (gpt-image-2 is 30–60s per image and OpenAI penalises bursts).
      */
     const maybeAutoFireImages = (
         artifactId: string,
@@ -170,17 +171,28 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
         if (!usedFallback) return;
         if (!hasOpenAIKey()) return;
         const store = useMockupImageStore.getState();
-        for (const screen of payload.screens) {
-            void store.generate({
-                projectId,
-                artifactId,
-                versionId,
-                screen,
-                payload,
-                settings,
-                quality: 'low',
-            });
-        }
+        const screens = [...payload.screens];
+        const CONCURRENCY = 2;
+        const worker = async () => {
+            while (screens.length > 0) {
+                const screen = screens.shift();
+                if (!screen) return;
+                try {
+                    await store.generate({
+                        projectId,
+                        artifactId,
+                        versionId,
+                        screen,
+                        payload,
+                        settings,
+                        quality: 'low',
+                    });
+                } catch {
+                    // store.generate already records the error; continue draining.
+                }
+            }
+        };
+        for (let i = 0; i < CONCURRENCY; i++) void worker();
     };
 
     const handleGenerate = async () => {

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -4,6 +4,13 @@ export interface JsonModeConfig {
     temperature?: number;
     topP?: number;
     topK?: number;
+    /**
+     * Per-call model override. When set, this model is used instead of the
+     * user's configured default. Lets latency-sensitive paths (e.g. mockup
+     * generation) pin to a faster, higher-capacity stable model without
+     * changing the global default.
+     */
+    model?: string;
 }
 
 export interface StreamCallbacks {
@@ -84,7 +91,7 @@ const formatGeminiError = (status: string, errorData: unknown): string => {
 export const callGemini = async (systemInstruction: string, promptText: string, jsonMode?: JsonModeConfig, signal?: AbortSignal) => {
     const startTime = performance.now();
     const apiKey = getApiKey();
-    const model = getModel();
+    const model = jsonMode?.model || getModel();
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 
     const body: Record<string, unknown> = {

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -38,8 +38,18 @@ const SCOPE_INSTRUCTIONS: Record<string, string> = {
 const MOCKUP_PROMPT_TEMPLATE_VERSION = '2026-04-17.v2';
 const MOCKUP_GENERATION_STRATEGY_VERSION = 'mockup_strategy_v2';
 const MOCKUP_SPEC_STRATEGY_VERSION = 'mockup_strategy_spec_v1';
-const MAX_GENERATION_ATTEMPTS = 3;
-const QUALITY_THRESHOLD = 70;
+// Mockup generation is the slowest path in the app (sync structured-JSON
+// output, ~1.8k token system prompt, full PRD body). 3 attempts × ~25s on
+// a preview-tier model is the worst case users actually hit. Two attempts
+// at a softer quality bar trades the marginal third-attempt rescue for a
+// dramatically better p95 latency.
+const MAX_GENERATION_ATTEMPTS = 2;
+const QUALITY_THRESHOLD = 55;
+// Pin mockup generation to the stable Flash tier. The user's globally-
+// selected model (often a preview/Pro model) is reserved for paths where
+// reasoning quality matters; a mockup is structured HTML that 2.5 Flash
+// produces faster and with much higher capacity headroom.
+const MOCKUP_MODEL = 'gemini-2.5-flash';
 
 // Phase A engine switch. Default remains the HTML engine until the spec
 // engine has validated against the harness; users can opt-in via
@@ -507,6 +517,7 @@ const runSpecEngineAttempt = async (
     const raw = await callGemini(system, user, {
         responseMimeType: 'application/json',
         responseSchema: mockupLayoutSpecSchema,
+        model: MOCKUP_MODEL,
         ...providerParams,
     });
     const fallbackProduct = inferConceptName(prdContent);
@@ -580,6 +591,7 @@ const runHtmlEngine = async (
             const raw = await callGemini(system, user, {
                 responseMimeType: 'application/json',
                 responseSchema: mockupSchema,
+                model: MOCKUP_MODEL,
                 ...providerParams,
             });
             const parsed = parseMockupPayload(raw, prdContent, settings, structuredPRD);


### PR DESCRIPTION
Mockup generation was the slowest user-visible path: up to 3 sync calls
to a preview-tier model (~25s each) per request, with a strict 70/100
quality gate that frequently triggered the second and third attempts.
Add an unbounded image-fallback fan-out on top and a 5-screen mockup
fallback could spend 2–4 minutes waiting on gpt-image-2.

- Pin mockup generation to gemini-2.5-flash via a new per-call model
  override on JsonModeConfig. The user's chosen default (often a Pro or
  preview model) is preserved for paths where reasoning quality
  matters; mockups don't benefit from it and pay a steep latency tax.
- Drop MAX_GENERATION_ATTEMPTS 3 -> 2 and QUALITY_THRESHOLD 70 -> 55.
  The third attempt almost never rescued a prompt the first two
  rejected; the lower bar keeps obviously broken output out without
  wedging users in a retry loop.
- Cap gpt-image-2 fallback fan-out at 2 concurrent screens to stop
  rate-limit thrash on multi-screen scopes.

https://claude.ai/code/session_01UmPsRHi54f8aJW4EvzNVDo