### PR TITLE
fix(errors): surface real Gemini API errors so paid-tier failures are diagnosable on mobile

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -93,6 +93,7 @@ export function HomePage() {
                         message: userMessage(err),
                         category: err.category,
                         timestamp: err.timestamp,
+                        raw: err.raw,
                     });
                 });
         }).catch((e) => {
@@ -102,6 +103,7 @@ export function HomePage() {
                 message: 'Failed to load generation module. Try refreshing the page.',
                 category: err.category,
                 timestamp: err.timestamp,
+                raw: err.raw,
             });
         });
     };

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -181,6 +181,7 @@ export function ProjectWorkspace() {
                     message: userMessage(err),
                     category: err.category,
                     timestamp: err.timestamp,
+                    raw: err.raw,
                 });
             }
         } finally {
@@ -472,7 +473,20 @@ export function ProjectWorkspace() {
                                                     </div>
                                                     <div className="flex-1 min-w-0">
                                                         <p className="font-semibold text-red-800 mb-1">PRD generation could not be completed</p>
-                                                        <p className="text-sm text-red-700 mb-4">{activeSpine.generationError.message}</p>
+                                                        <p className="text-sm text-red-700 mb-4 whitespace-pre-wrap break-words">{activeSpine.generationError.message}</p>
+                                                        {activeSpine.generationError.raw && (
+                                                            <details className="mb-4 text-xs">
+                                                                <summary className="cursor-pointer font-medium text-red-700 hover:text-red-800 select-none">
+                                                                    Show technical details
+                                                                </summary>
+                                                                <div className="mt-2 p-3 rounded-lg bg-red-100/60 border border-red-200 text-red-900 font-mono whitespace-pre-wrap break-words">
+                                                                    <div className="text-[10px] uppercase tracking-wider text-red-700 mb-1">
+                                                                        Category: {activeSpine.generationError.category}
+                                                                    </div>
+                                                                    {activeSpine.generationError.raw}
+                                                                </div>
+                                                            </details>
+                                                        )}
                                                         <div className="flex items-center gap-3">
                                                             <button
                                                                 onClick={handleRegenerate}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -203,6 +203,11 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                             Gemini meters requests against that project — fixes the case where a key defaults
                             to free-tier quota even after billing is on.
                         </p>
+                        <p className="text-[11px] text-amber-300/80 leading-relaxed px-1">
+                            Use the Project <strong>ID</strong> (e.g. <code className="text-neutral-400">my-project-123</code>),
+                            not the Project Number. The <strong>Generative Language API</strong> must be
+                            enabled on this project (Google Cloud Console → APIs &amp; Services → Library).
+                        </p>
                     </div>
 
                     {/* OpenAI image preview (optional) */}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -8,6 +8,11 @@
 
 export type ErrorCategory =
     | 'api_key_missing'
+    | 'auth_failed'
+    | 'permission_denied'
+    | 'billing_disabled'
+    | 'model_not_found'
+    | 'bad_request'
     | 'rate_limited'
     | 'free_tier_quota'
     | 'safety_blocked'
@@ -23,10 +28,18 @@ export interface NormalizedError {
     timestamp: number;
 }
 
+// Order matters — first match wins. Specific paid-tier failures must come
+// before the broader `free_tier_quota` and `rate_limited` patterns so a 403
+// with a "billing disabled" message doesn't get mis-classified as a quota hit.
 const CATEGORY_PATTERNS: [ErrorCategory, RegExp][] = [
     ['api_key_missing', /missing gemini api key/i],
+    ['billing_disabled', /billing.*(not enabled|disabled)|enable billing|consumer.*not.*active|SERVICE_DISABLED/i],
+    ['auth_failed', /api key not valid|api[_ ]?key.*invalid|invalid.*api.*key|UNAUTHENTICATED|\b401\b/i],
+    ['permission_denied', /permission denied|PERMISSION_DENIED|forbidden|\b403\b/i],
+    ['model_not_found', /publisher model.*not found|model.*not.*found|NOT_FOUND.*model|\b404\b.*model|is not supported/i],
     ['free_tier_quota', /free.?tier|freetier|-FreeTier/i],
-    ['rate_limited', /429|resource exhausted|too many requests/i],
+    ['rate_limited', /\b429\b|resource exhausted|too many requests/i],
+    ['bad_request', /INVALID_ARGUMENT|\b400\b/i],
     ['safety_blocked', /safety filter/i],
     ['empty_response', /empty response/i],
     ['network', /failed to fetch|networkerror|load failed|net::/i],
@@ -52,8 +65,26 @@ export function normalizeError(e: unknown): NormalizedError {
     };
 }
 
-const USER_MESSAGES: Record<ErrorCategory, string> = {
+const USER_MESSAGES: Record<Exclude<ErrorCategory, 'unknown'>, string> = {
     api_key_missing: 'API key not configured. Open Settings to add your Gemini API key.',
+    auth_failed:
+        'Gemini rejected the API key as invalid. Open Settings and paste a fresh key from ' +
+        'https://aistudio.google.com/app/apikey — make sure you copy it from a project that has billing enabled.',
+    permission_denied:
+        'Gemini rejected the request: permission denied. Most common cause on paid tier: the ' +
+        '"Generative Language API" is not enabled on your billing project. In Google Cloud Console, ' +
+        'open APIs & Services → Library, search for "Generative Language API", and enable it on the ' +
+        'project whose ID is in Settings.',
+    billing_disabled:
+        'Billing is not enabled on the Google Cloud project tied to this API key. Enable billing on ' +
+        'that project (or switch to a key from a project that has billing enabled), then try again.',
+    model_not_found:
+        'The selected Gemini model is not available to your project. Open Settings and switch to a ' +
+        'stable model like Gemini 2.5 Flash — preview model IDs (e.g. Gemini 3 Flash Preview) are ' +
+        'sometimes renamed or restricted.',
+    bad_request:
+        'Gemini rejected the request as malformed. This usually means the selected model does not ' +
+        'support structured JSON output, or the prompt is too long. Try a different model in Settings.',
     rate_limited: 'Too many requests. Wait a moment and try again.',
     free_tier_quota:
         'Request hit the Gemini free-tier quota. Open Settings and set your Billing Project ID, ' +
@@ -63,10 +94,18 @@ const USER_MESSAGES: Record<ErrorCategory, string> = {
     empty_response: 'No content was generated. Please try again.',
     network: 'Network error. Check your internet connection and try again.',
     parse_failure: 'The response could not be processed. Please try again.',
-    unknown: 'Something went wrong. Please try again.',
 };
+
+const RAW_TRUNCATE = 400;
 
 /** Return a calm, human-readable message suitable for product UI. */
 export function userMessage(err: NormalizedError): string {
+    if (err.category === 'unknown') {
+        // No specific category matched — surface the raw API response so the
+        // user (especially on mobile, where DevTools is not available) has
+        // something actionable to act on or share.
+        const raw = err.raw.length > RAW_TRUNCATE ? `${err.raw.slice(0, RAW_TRUNCATE)}…` : err.raw;
+        return `Something went wrong. Raw error from Gemini: ${raw}`;
+    }
     return USER_MESSAGES[err.category];
 }

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -122,7 +122,7 @@ export const callGemini = async (systemInstruction: string, promptText: string, 
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => null);
-        throw new Error(formatGeminiError(response.statusText, errorData));
+        throw new Error(formatGeminiError(`${response.status} ${response.statusText}`.trim(), errorData));
     }
 
     const data = await response.json();
@@ -169,7 +169,7 @@ export const callGeminiStream = async (
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => null);
-        const err = new Error(formatGeminiError(response.statusText, errorData));
+        const err = new Error(formatGeminiError(`${response.status} ${response.statusText}`.trim(), errorData));
         callbacks.onError(err);
         throw err;
     }

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -110,7 +110,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
         });
     },
 
-    setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number } | null) => {
+    setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number; raw?: string } | null) => {
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const spine = projectSpines.find(s => s.id === spineId);

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -44,7 +44,7 @@ export interface ProjectState {
     updateSpineStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD, responseText: string) => void;
 
     // Error handling
-    setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number } | null) => void;
+    setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number; raw?: string } | null) => void;
 
     // --- Artifact System Actions ---
     createArtifact: (projectId: string, type: ArtifactType, title: string, subtype?: CoreArtifactSubtype) => { artifactId: string };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,7 @@ export type SpineVersion = {
         message: string;
         category: string;
         timestamp: number;
+        raw?: string;
     };
 };
 


### PR DESCRIPTION
Previously a 401/403/404 from Gemini fell through the regex categorizer
and rendered as a generic "Something went wrong. Please try again." —
the actual cause (bad key, missing API permission, wrong project ID,
unsupported model) was only logged to console, invisible on mobile.

- Classify auth_failed / permission_denied / billing_disabled /
  model_not_found / bad_request with paid-tier-aware user messages.
- When no category matches, append the raw API message instead of
  swallowing it.
- Persist err.raw on the spine and expose it via a "Show technical
  details" disclosure on the error banner.
- Pass the numeric HTTP status into formatGeminiError so the new
  patterns can reliably match.
- Nudge users in Settings to use a Project ID (not number) and to
  enable the Generative Language API on the billing project.