### PR TITLE
fix(workspace): clean up feature pills, unify queued/generating UI, and stream real progress

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
-    RefreshCcw, StopCircle, Clock,
+    RefreshCcw, StopCircle,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -51,8 +51,9 @@ function buildSlotMetas(): SlotMeta[] {
 
 function StatusDot({ status }: { status: GenerationStatus }) {
     if (status === 'done') return <CheckCircle2 size={14} className="text-green-500 shrink-0" />;
-    if (status === 'generating') return <Loader2 size={14} className="text-sky-500 animate-spin shrink-0" />;
-    if (status === 'queued') return <Clock size={14} className="text-neutral-400 shrink-0" />;
+    if (status === 'generating' || status === 'queued') {
+        return <Loader2 size={14} className="text-sky-500 animate-spin shrink-0" />;
+    }
     if (status === 'error') return <AlertTriangle size={14} className="text-red-500 shrink-0" />;
     if (status === 'interrupted') return <AlertTriangle size={14} className="text-amber-500 shrink-0" />;
     return <Circle size={14} className="text-neutral-300 shrink-0" />;
@@ -145,7 +146,12 @@ export function ArtifactWorkspace({
         if (status === 'queued' || status === 'generating') {
             const meta = selected === 'mockup' ? null : getArtifactMeta(selected);
             const stages = selected === 'mockup' ? MOCKUP_GENERATION_STAGES : getArtifactStages(selected);
-            const title = selected === 'mockup' ? 'Designing your product interface' : `Generating ${meta?.title ?? selected}`;
+            const displayName = selected === 'mockup' ? 'Mockup' : (meta?.title ?? selected);
+            const title = status === 'queued'
+                ? `Queued: ${displayName}`
+                : selected === 'mockup'
+                    ? 'Designing your product interface'
+                    : `Generating ${displayName}`;
             return (
                 <div className="max-w-2xl mx-auto">
                     <GenerationProgress
@@ -153,6 +159,7 @@ export function ArtifactWorkspace({
                         variant={selected === 'mockup' ? 'creative' : 'systematic'}
                         title={title}
                         subtitle={status === 'queued' ? 'Queued — will start as a generation slot frees up' : undefined}
+                        history={job?.slots[selected]?.progressLog ?? []}
                     />
                 </div>
             );

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -8,18 +8,11 @@ interface FeatureCardProps {
     readOnly: boolean;
 }
 
-const complexityColors = {
-    low: 'bg-green-100 text-green-700 border-green-200',
-    medium: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    high: 'bg-red-100 text-red-700 border-red-200',
-};
-
 export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(feature.name);
     const [editDescription, setEditDescription] = useState(feature.description);
     const [editUserValue, setEditUserValue] = useState(feature.userValue);
-    const [editComplexity, setEditComplexity] = useState(feature.complexity);
 
     const handleSave = () => {
         onUpdate({
@@ -27,7 +20,6 @@ export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
             name: editName,
             description: editDescription,
             userValue: editUserValue,
-            complexity: editComplexity,
         });
         setIsEditing(false);
     };
@@ -36,7 +28,6 @@ export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
         setEditName(feature.name);
         setEditDescription(feature.description);
         setEditUserValue(feature.userValue);
-        setEditComplexity(feature.complexity);
         setIsEditing(false);
     };
 
@@ -63,24 +54,13 @@ export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
                     className="w-full text-sm text-neutral-600 bg-neutral-50 border border-neutral-200 rounded px-3 py-1.5 mb-3 focus:outline-none focus:border-indigo-400"
                     placeholder="User value"
                 />
-                <div className="flex items-center justify-between">
-                    <select
-                        value={editComplexity}
-                        onChange={(e) => setEditComplexity(e.target.value as Feature['complexity'])}
-                        className="text-xs bg-neutral-50 border border-neutral-200 rounded px-2 py-1 focus:outline-none focus:border-indigo-400"
-                    >
-                        <option value="low">Low</option>
-                        <option value="medium">Medium</option>
-                        <option value="high">High</option>
-                    </select>
-                    <div className="flex items-center gap-2">
-                        <button onClick={handleCancel} className="p-1.5 text-neutral-400 hover:text-neutral-600 transition" title="Cancel" aria-label="Cancel editing">
-                            <X size={16} />
-                        </button>
-                        <button onClick={handleSave} className="p-1.5 text-indigo-500 hover:text-indigo-700 transition" title="Save" aria-label="Save changes">
-                            <Check size={16} />
-                        </button>
-                    </div>
+                <div className="flex items-center justify-end gap-2">
+                    <button onClick={handleCancel} className="p-1.5 text-neutral-400 hover:text-neutral-600 transition" title="Cancel" aria-label="Cancel editing">
+                        <X size={16} />
+                    </button>
+                    <button onClick={handleSave} className="p-1.5 text-indigo-500 hover:text-indigo-700 transition" title="Save" aria-label="Save changes">
+                        <Check size={16} />
+                    </button>
                 </div>
             </div>
         );
@@ -88,23 +68,18 @@ export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
 
     return (
         <div className="group p-4 bg-white border border-neutral-200 rounded-lg hover:border-neutral-300 transition">
-            <div className="flex items-start justify-between mb-2">
+            <div className="flex items-start justify-between mb-2 gap-2">
                 <h4 className="font-semibold text-neutral-800">{feature.name}</h4>
-                <div className="flex items-center gap-2">
-                    <span className={`text-xs px-2 py-0.5 rounded-full border ${complexityColors[feature.complexity]}`}>
-                        {feature.complexity}
-                    </span>
-                    {!readOnly && (
-                        <button
-                            onClick={() => setIsEditing(true)}
-                            className="p-1 text-neutral-300 hover:text-neutral-500 opacity-0 group-hover:opacity-100 transition"
-                            title="Edit feature"
-                            aria-label="Edit feature"
-                        >
-                            <Pencil size={14} />
-                        </button>
-                    )}
-                </div>
+                {!readOnly && (
+                    <button
+                        onClick={() => setIsEditing(true)}
+                        className="p-1 text-neutral-300 hover:text-neutral-500 opacity-0 group-hover:opacity-100 transition shrink-0"
+                        title="Edit feature"
+                        aria-label="Edit feature"
+                    >
+                        <Pencil size={14} />
+                    </button>
+                )}
             </div>
             <p className="text-sm text-neutral-600 mb-2">{feature.description}</p>
             <p className="text-xs text-neutral-500">

--- a/src/components/GenerationProgress.tsx
+++ b/src/components/GenerationProgress.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { Check } from 'lucide-react';
 import type { ProgressStage } from './generationStages';
 
 interface GenerationProgressProps {
@@ -23,7 +24,15 @@ interface GenerationProgressProps {
      * the component is state-driven (paired with `progress`).
      */
     statusLabel?: string;
+    /**
+     * Real progress events emitted by the operation, oldest first. When
+     * non-empty, the panel renders an accumulating list (✓ for past entries,
+     * pulsing dot for the active one) instead of cycling stage labels.
+     */
+    history?: string[];
 }
+
+const VISIBLE_HISTORY_CAP = 8;
 
 const VARIANT_STYLES = {
     default: {
@@ -80,17 +89,19 @@ export function GenerationProgress({
     inline = false,
     progress,
     statusLabel,
+    history,
 }: GenerationProgressProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isFading, setIsFading] = useState(false);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const style = VARIANT_STYLES[variant];
     const isStateDriven = typeof progress === 'number';
+    const hasHistory = !!history && history.length > 0;
 
     useEffect(() => {
-        // When a real progress value is supplied, skip time-based advancement
-        // entirely — the parent component owns stage progression.
-        if (isStateDriven) return;
+        // When a real progress value is supplied or history is being streamed
+        // in, skip time-based advancement — the parent owns stage progression.
+        if (isStateDriven || hasHistory) return;
         if (stages.length === 0) return;
 
         const advance = () => {
@@ -111,9 +122,9 @@ export function GenerationProgress({
             clearTimeout(id);
             if (timerRef.current) clearTimeout(timerRef.current);
         };
-    }, [currentIndex, stages, isStateDriven]);
+    }, [currentIndex, stages, isStateDriven, hasHistory]);
 
-    if (stages.length === 0) return null;
+    if (stages.length === 0 && !hasHistory) return null;
 
     // Clamp/derive values for state-driven mode
     const clampedProgress = isStateDriven ? Math.max(0, Math.min(100, progress!)) : 0;
@@ -132,6 +143,14 @@ export function GenerationProgress({
         ? clampedProgress
         : Math.min(((currentIndex + 1) / stages.length) * 100, 95);
 
+    // Dedupe consecutive identical entries (chunk-rate progress messages can
+    // round to the same string) and trim to the last N for display.
+    const dedupedHistory = hasHistory
+        ? history!.filter((msg, i, arr) => i === 0 || arr[i - 1] !== msg)
+        : [];
+    const visibleHistory = dedupedHistory.slice(-VISIBLE_HISTORY_CAP);
+    const hiddenCount = dedupedHistory.length - visibleHistory.length;
+
     if (inline) {
         return (
             <div className="flex items-center gap-3">
@@ -142,7 +161,7 @@ export function GenerationProgress({
                 <span
                     className={`text-sm ${style.accent} transition-opacity duration-300 ${isFading ? 'opacity-0' : 'opacity-100'}`}
                 >
-                    {currentLabel}
+                    {hasHistory ? dedupedHistory[dedupedHistory.length - 1] : currentLabel}
                 </span>
             </div>
         );
@@ -172,11 +191,35 @@ export function GenerationProgress({
                     <p className="text-xs text-neutral-500 mb-3 ml-[18px]">{subtitle}</p>
                 )}
                 <div className="ml-[18px]">
-                    <p
-                        className={`text-sm text-neutral-600 transition-opacity duration-300 ${isFading ? 'opacity-0' : 'opacity-100'}`}
-                    >
-                        {currentLabel}
-                    </p>
+                    {hasHistory ? (
+                        <ul className="space-y-1.5">
+                            {hiddenCount > 0 && (
+                                <li className="text-xs text-neutral-400 italic">+{hiddenCount} earlier…</li>
+                            )}
+                            {visibleHistory.map((msg, i) => {
+                                const isLast = i === visibleHistory.length - 1;
+                                return (
+                                    <li key={`${i}-${msg}`} className="flex items-center gap-2">
+                                        {isLast ? (
+                                            <span className="relative flex h-2 w-2 shrink-0">
+                                                <span className={`animate-ping absolute inline-flex h-full w-full rounded-full ${style.dotColor} opacity-75`} />
+                                                <span className={`relative inline-flex rounded-full h-2 w-2 ${style.dotColor}`} />
+                                            </span>
+                                        ) : (
+                                            <Check size={12} className={`${style.accent} shrink-0`} />
+                                        )}
+                                        <span className={`text-sm ${isLast ? style.accent : 'text-neutral-500'}`}>{msg}</span>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    ) : (
+                        <p
+                            className={`text-sm text-neutral-600 transition-opacity duration-300 ${isFading ? 'opacity-0' : 'opacity-100'}`}
+                        >
+                            {currentLabel}
+                        </p>
+                    )}
                 </div>
 
                 {/* Stage dots */}

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -107,10 +107,12 @@ async function runCoreArtifactSlot(
             status: 'generating',
             startedAt: Date.now(),
             attempt: (store.getSlot(projectId, subtype)?.attempt ?? 0) + 1,
+            progressLog: [],
         });
         content = await generateCoreArtifact(subtype, prdContent, structuredPRD, {
             generatedArtifacts,
             signal,
+            onProgress: (msg) => useProjectStore.getState().appendSlotProgress(projectId, subtype, msg),
         });
     } finally {
         semaphore.release();
@@ -125,6 +127,7 @@ async function runCoreArtifactSlot(
     const warnings = [...validation.warnings, ...consistencyWarnings];
 
     const writeStore = useProjectStore.getState();
+    writeStore.appendSlotProgress(projectId, subtype, 'Saving artifact…');
     const existing = writeStore.getArtifacts(projectId, 'core_artifact').find(a => a.subtype === subtype);
     let artifactId: string;
     if (existing) {
@@ -163,12 +166,15 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
             status: 'generating',
             startedAt: Date.now(),
             attempt: (store.getSlot(projectId, 'mockup')?.attempt ?? 0) + 1,
+            progressLog: [],
         });
+        store.appendSlotProgress(projectId, 'mockup', 'Sending request to model…');
         result = await generateMockup(prdContent, settings, structuredPRD);
     } finally {
         semaphore.release();
     }
     if (signal.aborted) throw new DOMException('aborted', 'AbortError');
+    useProjectStore.getState().appendSlotProgress(projectId, 'mockup', 'Saving artifact…');
 
     const { payload, warnings, critique } = result;
     const usedFallback = warnings.some(w => w.includes('safe fallback'));

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -1,5 +1,5 @@
 import type { StructuredPRD, CoreArtifactSubtype, ScreenInventoryContent, DataModelContent, ComponentInventoryContent } from '../../types';
-import { callGemini } from '../geminiClient';
+import { callGemini, callGeminiStream } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
 import { screenInventorySchema, dataModelSchema, componentInventorySchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
@@ -277,10 +277,11 @@ export const generateCoreArtifact = async (
         mockupContext?: string;
         generatedArtifacts?: Partial<Record<CoreArtifactSubtype, string>>;
         signal?: AbortSignal;
+        onProgress?: (message: string) => void;
     },
 ): Promise<string> => {
     const config = CORE_ARTIFACT_PROMPTS[subtype];
-    options?.onStatus?.(`Generating ${subtype.replace(/_/g, ' ')}...`);
+    const onProgress = options?.onProgress;
 
     const featureList = structuredPRD.features.map(f => {
         let line = `- [${f.id}] ${f.name} (${f.complexity}${f.priority ? `, ${f.priority}` : ''}): ${f.description}`;
@@ -327,12 +328,14 @@ Architecture: ${structuredPRD.architecture}${
     const schema = jsonSchemas[subtype];
     if (schema) {
         const jsonSystem = config.system + '\n\nReturn the result as structured JSON according to the provided schema.';
+        onProgress?.('Sending request to model…');
         const result = await callGemini(
             jsonSystem,
             `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`,
             { responseMimeType: 'application/json', responseSchema: schema },
             options?.signal,
         );
+        onProgress?.('Validating output…');
 
         try {
             const parsed = JSON.parse(result);
@@ -344,12 +347,30 @@ Architecture: ${structuredPRD.architecture}${
         }
     }
 
-    const result = await callGemini(
+    onProgress?.('Sending request to model…');
+    let chars = 0;
+    let lastEmittedChars = 0;
+    let lastEmittedAt = performance.now();
+    const result = await callGeminiStream(
         config.system,
         `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`,
-        undefined,
+        {
+            onChunk: (text) => {
+                chars += text.length;
+                const now = performance.now();
+                // Throttle to avoid hammering the Zustand store with chunk-rate updates.
+                if (chars - lastEmittedChars >= 500 || now - lastEmittedAt >= 750) {
+                    lastEmittedChars = chars;
+                    lastEmittedAt = now;
+                    onProgress?.(`Receiving response… (${chars.toLocaleString()} chars)`);
+                }
+            },
+            onComplete: () => {},
+            onError: () => {},
+        },
         options?.signal,
     );
+    onProgress?.('Validating output…');
     return normalizeArtifactMarkdown(result);
 };
 

--- a/src/store/slices/generationJobsSlice.ts
+++ b/src/store/slices/generationJobsSlice.ts
@@ -14,6 +14,7 @@ export type GenerationJobsSlice = {
         slot: ArtifactSlotKey,
         partial: Partial<SlotState>,
     ) => void;
+    appendSlotProgress: (projectId: string, slot: ArtifactSlotKey, message: string) => void;
     clearJob: (projectId: string) => void;
     getSlot: (projectId: string, slot: ArtifactSlotKey) => SlotState | undefined;
     getJob: (projectId: string) => ProjectJobState | undefined;
@@ -21,6 +22,8 @@ export type GenerationJobsSlice = {
 };
 
 const blankSlot = (): SlotState => ({ status: 'idle', attempt: 0 });
+
+const PROGRESS_LOG_CAP = 20;
 
 export const createGenerationJobsSlice: StateCreator<
     ProjectState,
@@ -33,7 +36,7 @@ export const createGenerationJobsSlice: StateCreator<
     initJob: (projectId, spineVersionId, slotKeys) => {
         const slots = {} as Record<ArtifactSlotKey, SlotState>;
         for (const key of slotKeys) {
-            slots[key] = { status: 'queued', attempt: 0 };
+            slots[key] = { status: 'queued', attempt: 0, progressLog: [] };
         }
         set((state) => ({
             jobs: {
@@ -60,6 +63,33 @@ export const createGenerationJobsSlice: StateCreator<
                         slots: {
                             ...job.slots,
                             [slot]: { ...current, ...partial },
+                        },
+                    },
+                },
+            };
+        });
+    },
+
+    appendSlotProgress: (projectId, slot, message) => {
+        set((state) => {
+            const job = state.jobs[projectId];
+            if (!job) return state;
+            const current = job.slots[slot] ?? blankSlot();
+            const log = current.progressLog ?? [];
+            // Dedupe consecutive identical messages so chunk-throttled emissions
+            // that round to the same string don't pile up.
+            if (log.length > 0 && log[log.length - 1] === message) return state;
+            const next = log.length >= PROGRESS_LOG_CAP
+                ? [...log.slice(log.length - PROGRESS_LOG_CAP + 1), message]
+                : [...log, message];
+            return {
+                jobs: {
+                    ...state.jobs,
+                    [projectId]: {
+                        ...job,
+                        slots: {
+                            ...job.slots,
+                            [slot]: { ...current, progressLog: next },
                         },
                     },
                 },

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -87,6 +87,7 @@ export interface ProjectState {
     jobs: Record<string, ProjectJobState | undefined>;
     initJob: (projectId: string, spineVersionId: string, slotKeys: ArtifactSlotKey[]) => void;
     setSlotStatus: (projectId: string, slot: ArtifactSlotKey, partial: Partial<SlotState>) => void;
+    appendSlotProgress: (projectId: string, slot: ArtifactSlotKey, message: string) => void;
     clearJob: (projectId: string) => void;
     getSlot: (projectId: string, slot: ArtifactSlotKey) => SlotState | undefined;
     getJob: (projectId: string) => ProjectJobState | undefined;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,6 +173,7 @@ export interface SlotState {
     finishedAt?: number;
     error?: { message: string; category: string; timestamp: number };
     attempt: number;
+    progressLog?: string[];
 }
 
 export interface ProjectJobState {


### PR DESCRIPTION
- Remove the high/medium/low complexity pill (and edit-mode selector) from FeatureCard. Users misread it as importance; the field stays on the Feature so downstream artifact prompts keep using it.
- Collapse 'queued' into the same spinner as 'generating' in the workspace sidebar so concurrent + queued slots are visually consistent. The detail-pane title now honestly reads 'Queued: <Title>' until generation actually starts.
- Add SlotState.progressLog and an appendSlotProgress action so per-slot progress events accumulate as a running history.
- Switch free-form core artifacts (user_flows, implementation_plan, design_system, prompt_pack) to callGeminiStream and emit real lifecycle events (Sending request / Receiving response / Validating output / Saving artifact) with chunk-rate throttling. JSON-mode artifacts keep callGemini and emit bookend events only.
- Wire onProgress through artifactJobController for both core artifacts and the mockup slot, and render the accumulating history in GenerationProgress (with checkmarks for past steps and a pulsing dot for the active one) when a 'history' prop is supplied.