### PR TITLE
fix(workspace): make AI image the primary mockup, stop auto-retry on reopen, unblock HTML mockups

### DIFF
--- a/src/components/MockupsView.tsx
+++ b/src/components/MockupsView.tsx
@@ -16,15 +16,13 @@ import type {
     StructuredPRD,
     MockupSettings,
     MockupScope,
-    MockupPayload,
     ArtifactVersion,
     StalenessState,
     ProjectPlatform,
 } from '../types';
 import { MOCKUP_HTML_V1 } from '../types';
 import { v4 as uuidv4 } from 'uuid';
-import { useMockupImageStore } from '../store/mockupImageStore';
-import { hasOpenAIKey } from '../lib/openaiClient';
+import { fireScreenImagesInBackground } from '../lib/services/mockupImageService';
 import { mapProjectPlatform, pickFidelity } from '../lib/mockupDefaults';
 import { tryParsePayload, extractMockupSettings, DEFAULT_MOCKUP_SETTINGS } from '../lib/mockupParsing';
 
@@ -80,48 +78,6 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
 
     const mockupArtifacts = getArtifacts(projectId, 'mockup');
 
-    /**
-     * If the HTML pipeline fell through to its safe-fallback template, the
-     * structured mockup didn't really succeed — kick off gpt-image-2 drafts
-     * (low quality) for each screen so the user has a second visual to
-     * compare against. Fire-and-forget at the call site; internally we cap
-     * concurrency to 2 to avoid rate-limit thrash on multi-screen scopes
-     * (gpt-image-2 is 30–60s per image and OpenAI penalises bursts).
-     */
-    const maybeAutoFireImages = (
-        artifactId: string,
-        versionId: string,
-        payload: MockupPayload,
-        settings: MockupSettings,
-        usedFallback: boolean,
-    ) => {
-        if (!usedFallback) return;
-        if (!hasOpenAIKey()) return;
-        const store = useMockupImageStore.getState();
-        const screens = [...payload.screens];
-        const CONCURRENCY = 2;
-        const worker = async () => {
-            while (screens.length > 0) {
-                const screen = screens.shift();
-                if (!screen) return;
-                try {
-                    await store.generate({
-                        projectId,
-                        artifactId,
-                        versionId,
-                        screen,
-                        payload,
-                        settings,
-                        quality: 'low',
-                    });
-                } catch {
-                    // store.generate already records the error; continue draining.
-                }
-            }
-        };
-        for (let i = 0; i < CONCURRENCY; i++) void worker();
-    };
-
     const handleGenerate = async () => {
         setError(null);
         setWarning(null);
@@ -171,7 +127,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
             if (warnings.length > 0) {
                 setWarning(`Generated with safeguards (${warnings.length} notices): ${warnings.join(' ')}`);
             }
-            maybeAutoFireImages(artifactId, versionId, payload, settings, usedFallback);
+            fireScreenImagesInBackground({ projectId, artifactId, versionId, payload, settings });
         } catch (e) {
             const err = normalizeError(e);
             console.error('[Mockup generation failed]', err.raw);
@@ -220,7 +176,7 @@ export function MockupsView({ projectId, spineVersionId, prdContent, structuredP
             if (warnings.length > 0) {
                 setWarning(`Regenerated with safeguards (${warnings.length} notices): ${warnings.join(' ')}`);
             }
-            maybeAutoFireImages(artifactId, versionId, payload, settings, usedFallback);
+            fireScreenImagesInBackground({ projectId, artifactId, versionId, payload, settings });
         } catch (e) {
             // On regeneration failure, the previous version is preserved — the
             // user still sees the last known good content.

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -87,27 +87,6 @@ export function ProjectWorkspace() {
         return () => document.removeEventListener('mousedown', handleClick);
     }, [showNavOverflow]);
 
-    // Auto-resume background generation when the user lands on a finalized
-    // project. Handles page refresh mid-job and tab return after navigation.
-    // Brief debounce so a fast spine regen doesn't trigger duplicate work.
-    useEffect(() => {
-        if (!projectId || projectId === DEMO_PROJECT_ID) return;
-        const timer = window.setTimeout(() => {
-            const store = useProjectStore.getState();
-            const latest = store.getLatestSpine(projectId);
-            if (!latest?.isFinal || !latest.structuredPRD) return;
-            const proj = store.getProject(projectId);
-            artifactJobController.resumeIfNeeded({
-                projectId,
-                spineVersionId: latest.id,
-                prdContent: latest.responseText,
-                structuredPRD: latest.structuredPRD,
-                projectPlatform: proj?.platform,
-            });
-        }, 2000);
-        return () => window.clearTimeout(timer);
-    }, [projectId]);
-
     if (!projectId) return <div>Invalid Project</div>;
 
     const project = getProject(projectId);

--- a/src/components/mockups/MockupViewer.tsx
+++ b/src/components/mockups/MockupViewer.tsx
@@ -54,7 +54,10 @@ export function MockupViewer({
 }: Props) {
     const aiImageEnabled = !!(projectId && artifactId && versionId);
     const [activeIdx, setActiveIdx] = useState(0);
-    const [mode, setMode] = useState<Mode>('preview');
+    // AI image is the primary mockup artifact — default to it when available,
+    // fall back to the HTML preview when no projectId/artifactId/versionId
+    // is threaded (e.g. comparison view).
+    const [mode, setMode] = useState<Mode>(aiImageEnabled ? 'image' : 'preview');
     const [copied, setCopied] = useState(false);
     // Session-scoped probe aggregate for this artifact version. Populated
     // by MockupHtmlPreview every time a probe message arrives; surfaced

--- a/src/lib/openaiClient.ts
+++ b/src/lib/openaiClient.ts
@@ -67,15 +67,32 @@ export const callOpenAIImage = async (
         n: 1,
     };
 
-    const response = await fetch(OPENAI_IMAGE_URL, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify(body),
-        signal: opts.signal,
-    });
+    let response: Response;
+    try {
+        response = await fetch(OPENAI_IMAGE_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(body),
+            signal: opts.signal,
+        });
+    } catch (err) {
+        // Bubble user-cancellation untouched.
+        if ((err as { name?: string })?.name === 'AbortError') throw err;
+        // Browser-level fetch failures arrive as TypeError with messages like
+        // Safari's "Load failed" or Chromium's "Failed to fetch". These don't
+        // carry HTTP status; surface a diagnostic that points at the actual
+        // suspects (network, content blocker, VPN/proxy, CORS extension).
+        const raw = err instanceof Error ? err.message : String(err);
+        if (/load failed|failed to fetch|networkerror/i.test(raw)) {
+            throw new Error(
+                `Could not reach api.openai.com. Common causes: no network, ad/content blocker, VPN or corporate proxy, or a CORS-blocking browser extension. Raw: ${raw}`
+            );
+        }
+        throw new Error(`OpenAI image request failed before a response was received. Raw: ${raw}`);
+    }
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => null);

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -19,6 +19,7 @@ import {
 import { isAbortError } from '../concurrency';
 import { buildAutoMockupSettings } from '../mockupDefaults';
 import { normalizeError } from '../errors';
+import { fireScreenImagesInBackground } from './mockupImageService';
 
 export interface StartArgs {
     projectId: string;
@@ -98,6 +99,7 @@ async function runCoreArtifactSlot(
 ): Promise<void> {
     const { projectId, spineVersionId, prdContent, structuredPRD } = args;
 
+    console.info(`[artifactJobController] ${subtype} starting`);
     await semaphore.acquire();
     let content: string;
     try {
@@ -189,7 +191,7 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
     const versions = writeStore.getArtifactVersions(projectId, artifactId);
     const parentVersionId = versions.length > 0 ? versions[versions.length - 1].id : null;
 
-    writeStore.createArtifactVersion(
+    const { versionId } = writeStore.createArtifactVersion(
         projectId,
         artifactId,
         JSON.stringify(payload),
@@ -211,6 +213,10 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
     );
 
     writeStore.setSlotStatus(projectId, 'mockup', { status: 'done', finishedAt: Date.now() });
+
+    // AI image previews are the primary mockup surface — fire low-quality
+    // gpt-image-2 jobs for every screen as soon as the HTML version lands.
+    fireScreenImagesInBackground({ projectId, artifactId, versionId, payload, settings });
 }
 
 async function executeJob(args: StartArgs, controller: AbortController, slotKeys: ArtifactSlotKey[]): Promise<void> {
@@ -268,6 +274,15 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
 
     if (signal.aborted) {
         useProjectStore.getState().markAllInterrupted(projectId);
+        return;
+    }
+
+    const job = useProjectStore.getState().getJob(projectId);
+    if (job) {
+        const summary = slotKeys
+            .map(k => `${k}=${job.slots[k]?.status ?? 'unknown'}`)
+            .join(' ');
+        console.info(`[artifactJobController] job complete — ${summary}`);
     }
 }
 

--- a/src/lib/services/mockupImageService.ts
+++ b/src/lib/services/mockupImageService.ts
@@ -3,6 +3,8 @@
 // store can stay thin.
 
 import type { MockupPayload, MockupScreen, MockupSettings, MockupPlatform } from '../../types';
+import { useMockupImageStore } from '../../store/mockupImageStore';
+import { hasOpenAIKey } from '../openaiClient';
 
 const FIDELITY_STYLE_HINTS: Record<string, string> = {
     low: 'low-fidelity wireframe sketch, neutral grey palette, simple boxes and labels, hand-drawn feel',
@@ -55,4 +57,46 @@ export const buildScreenImagePrompt = (
         `Avoid lorem ipsum — use realistic placeholder copy that fits the screen purpose.`,
         `No watermarks, no logos of real companies, no photographic people.`,
     ].join(' ');
+};
+
+interface AutoFireArgs {
+    projectId: string;
+    artifactId: string;
+    versionId: string;
+    payload: MockupPayload;
+    settings: MockupSettings;
+}
+
+/**
+ * Fire low-quality gpt-image-2 generation for every screen in a mockup
+ * payload, draining a 2-wide worker pool to avoid burst-rate-limit thrash.
+ * Returns immediately; per-screen errors are captured by the image store and
+ * surfaced in `MockupScreenImage`.
+ */
+export const fireScreenImagesInBackground = (args: AutoFireArgs): void => {
+    if (!hasOpenAIKey()) return;
+    const { projectId, artifactId, versionId, payload, settings } = args;
+    const store = useMockupImageStore.getState();
+    const queue = [...payload.screens];
+    const CONCURRENCY = 2;
+    const worker = async () => {
+        while (queue.length > 0) {
+            const screen = queue.shift();
+            if (!screen) return;
+            try {
+                await store.generate({
+                    projectId,
+                    artifactId,
+                    versionId,
+                    screen,
+                    payload,
+                    settings,
+                    quality: 'low',
+                });
+            } catch {
+                // store.generate captures errors per screen key; keep draining.
+            }
+        }
+    };
+    for (let i = 0; i < CONCURRENCY; i++) void worker();
 };

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -281,10 +281,15 @@ const parseMockupPayload = (
 
     const critique = critiqueMockupAlignment(screens, settings, prdContent, structuredPRD);
 
+    // Alignment critique is informational. Structure + quality validators above
+    // already gate unrenderable HTML; this layer adds a heuristic semantic
+    // signal (PRD term coverage, generic-sludge detection) that is useful as a
+    // warning but too noisy to use as a hard gate — it was the dominant reason
+    // good output was being discarded for the deterministic safe-fallback.
     if (critique.severity === 'high' && critique.alignmentScore < 45) {
         const critiqueReason = critique.mismatchReasons.slice(0, 3).join(' ');
-        throw new Error(
-            `Mockup generation failed PRD alignment critique (${critique.alignmentScore}/100). ${critiqueReason}`
+        warnings.push(
+            `Low PRD alignment (${critique.alignmentScore}/100): ${critiqueReason}`
         );
     }
 


### PR DESCRIPTION
Five regressions traced to commits 33bcc3e (auto-generate-on-final) and 952b40b (mockup perf):

1. AI image was only fired as a fallback after the HTML mockup hit the safe template. Now fires for every mockup version (auto-generated and manual) and defaults the MockupViewer to the AI Image tab when projectId/artifactId/versionId are available — making it the primary mockup surface as soon as the user finalises the PRD. Auto-fire helper extracted to mockupImageService so artifactJobController and MockupsView share the 2-wide worker.
2. "Load failed" was Safari's raw TypeError from fetch() leaking through. openaiClient now catches network-layer failures and surfaces an actionable diagnostic (network/blocker/VPN/proxy/CORS) with the raw cause appended.
3. HTML mockups were being discarded for the deterministic safe-fallback because the alignment critique threw whenever severity=high && score<45. Demoted the throw to a warning — structure and quality validators still gate unrenderable HTML; the alignment heuristic was the bloat the user flagged.
4. Added console.info traces at slot start and a one-line job summary so future bulk failures are diagnosable from the browser console.
5. ProjectWorkspace mounted a 2s-debounced effect that called artifactJobController.resumeIfNeeded on every project open, which re-queued any slot without a version. Removed; failed artifacts now stay failed until the user clicks Retry.

https://claude.ai/code/session_01GSiia2YhsXRWBarR1RNp3P