### PR TITLE
perf(prd): drop redundant markdown re-render from Pass B

### DIFF
--- a/src/lib/prompts/prdPrompts.ts
+++ b/src/lib/prompts/prdPrompts.ts
@@ -1,8 +1,8 @@
 // System instructions for the 3-pass PRD generation pipeline.
 //
 // Pass A — Strategy: produce the full extended StructuredPRD JSON.
-// Pass B — Render + Self-Score: render canonical premium markdown and rate
-//          the PRD against a 7-dimension rubric.
+// Pass B — Self-Score: rate the PRD against a 7-dimension rubric (markdown
+//          is rendered deterministically on the client).
 // Pass C — Revision (conditional): replace only weak sections when any
 //          rubric dimension scored below 4.
 
@@ -78,27 +78,14 @@ Output ONLY the JSON object, conforming to the supplied schema.`;
 
 // --- Pass B: Render + Self-Score ---
 
-export const buildRenderAndScoreInstruction = (): string => {
-    return `You are rendering a Product Requirements Document into premium, scannable markdown AND scoring it against a quality rubric.
+export const buildScoreInstruction = (): string => {
+    return `You are scoring a Product Requirements Document against a quality rubric. The markdown render is produced deterministically on the client — your job is critique, not formatting.
 
 Inputs: a JSON object containing the structured PRD.
 
-Output: a single JSON object with three fields:
-1. markdown — the canonical PRD markdown (see formatting rules below).
-2. qualityScores — your honest, calibrated scores against the rubric.
-3. weakestDimensions — a list of rubric dimension names (camelCase) where you scored 4 or lower, ordered worst first.
-
-Markdown formatting rules:
-- H1: the product name (or a generated title if productName is missing).
-- H2 sections in this exact order, each present only if the underlying data exists: Executive Summary, Product Thesis, Target Users & Jobs-to-be-Done, Core Problem, Product Principles, Core User Loops, UX Architecture, Feature Systems, Detailed Features, Data Model, State Machines, Permissions & Roles, Architecture, Non-Functional Requirements, Risks, MVP Scope, Success Metrics, Assumptions.
-- Use GitHub-flavored markdown tables wherever a section is tabular (JTBD, principles, loops, roles, risks, metrics, MVP scope columns).
-- Use \`> [!ASSUMPTION]\`, \`> [!RISK]\`, \`> [!DECISION]\`, \`> [!NOTE]\` blockquote callouts where appropriate.
-- Tag each detailed feature heading with \`[MVP]\`, \`[V1]\`, or \`[Later]\` based on its tier.
-- For each feature, render Functional Requirements, Acceptance Criteria (Success / Edge / Failure / UI as separate sub-bullet groups), Dependencies, Analytics Events.
-- For state machines, render a transitions table with columns: State, Trigger, Next States, User-visible, System behavior.
-- For architecture flows, render numbered ordered lists.
-- Keep paragraphs short. Use bold labels. Avoid long undifferentiated prose.
-- Do NOT include filler section bodies like "TBD" — omit the section if data is missing.
+Output: a single JSON object with two fields:
+1. qualityScores — your honest, calibrated scores against the rubric.
+2. weakestDimensions — a list of rubric dimension names (camelCase) where you scored 4 or lower, ordered worst first.
 
 ${RUBRIC_DEFINITION}
 

--- a/src/lib/schemas/prdSchemas.ts
+++ b/src/lib/schemas/prdSchemas.ts
@@ -288,8 +288,9 @@ export const structuredPRDSchema = {
 // --- Pass B: Render + Self-Score schema ---
 //
 // The model receives the StructuredPRD JSON from Pass A and returns a
-// premium-formatted markdown render plus a 7-dimension quality score and a
-// list of weakest dimensions (for use by the optional revision pass).
+// 7-dimension quality score and a list of weakest dimensions (for use by
+// the optional revision pass). Markdown is rendered deterministically on
+// the client from the structured JSON — no LLM round-trip needed for prose.
 
 const qualityScoresSchema = {
     type: "OBJECT",
@@ -316,14 +317,13 @@ const qualityScoresSchema = {
     ],
 };
 
-export const markdownAndScoreSchema = {
+export const scoreSchema = {
     type: "OBJECT",
     properties: {
-        markdown: { type: "STRING" },
         qualityScores: qualityScoresSchema,
         weakestDimensions: { type: "ARRAY", items: { type: "STRING" } },
     },
-    required: ["markdown", "qualityScores", "weakestDimensions"],
+    required: ["qualityScores", "weakestDimensions"],
 };
 
 // --- Pass C: Revision patch schema ---

--- a/src/lib/services/prdPipeline.ts
+++ b/src/lib/services/prdPipeline.ts
@@ -1,11 +1,13 @@
 // Multi-pass PRD generation orchestrator.
 //
 // Pass A — Strategy + Architecture (heavy lift, JSON, big schema, T=0.4)
-// Pass B — Render + Self-Score (medium, JSON, T=0.2)
+// Pass B — Self-Score (small, JSON, T=0.2) — markdown is rendered locally
 // Pass C — Conditional Revision (medium, JSON, T=0.3, only if min score < 4)
 //
-// Progressive render: the caller can read the Pass A output via onPartial
-// before Pass B finishes, so the UI can render a draft PRD immediately.
+// Markdown is always produced by the deterministic renderer in
+// prdMarkdownRenderer.ts; the LLM only contributes structured JSON and
+// rubric scores. Progressive render: the caller can read the Pass A output
+// via onPartial before Pass B finishes, so the UI can paint immediately.
 
 import {
     callGemini,
@@ -14,12 +16,12 @@ import {
 } from '../geminiClient';
 import {
     structuredPRDSchema,
-    markdownAndScoreSchema,
+    scoreSchema,
     revisionPatchSchema,
 } from '../schemas/prdSchemas';
 import {
     buildStrategySystemInstruction,
-    buildRenderAndScoreInstruction,
+    buildScoreInstruction,
     buildRevisionInstruction,
 } from '../prompts/prdPrompts';
 import { renderPremiumMarkdown } from './prdMarkdownRenderer';
@@ -118,38 +120,34 @@ export const runPrdPipeline = async (
     let markdown = renderPremiumMarkdown(structuredPRD);
     onPartial?.({ structuredPRD, markdown });
 
-    // --- Pass B: Render + Self-Score ---
+    // --- Pass B: Self-Score ---
     onStatus?.('Quality review…');
     const passBStart = performance.now();
     let qualityScores: QualityScores | undefined;
     let weakestDimensions: string[] = [];
     try {
         const result = await callGemini(
-            buildRenderAndScoreInstruction(),
+            buildScoreInstruction(),
             `PRD JSON:\n\n${JSON.stringify(structuredPRD)}`,
             {
                 responseMimeType: 'application/json',
-                responseSchema: markdownAndScoreSchema,
+                responseSchema: scoreSchema,
                 temperature: 0.2,
             },
             signal,
         );
         const parsed = JSON.parse(result) as {
-            markdown: string;
             qualityScores: QualityScores;
             weakestDimensions: string[];
         };
-        if (parsed.markdown && parsed.markdown.trim().length > 0) {
-            markdown = parsed.markdown;
-        }
         qualityScores = parsed.qualityScores;
         weakestDimensions = parsed.weakestDimensions || [];
         passes.push({ stage: 'render_score', ms: performance.now() - passBStart, ok: true });
     } catch (e) {
-        // Pass B failure is non-fatal — keep client-rendered markdown, no scores.
+        // Pass B failure is non-fatal — the PRD ships without scores.
         if ((e as { name?: string })?.name === 'AbortError') throw e;
         passes.push({ stage: 'render_score', ms: performance.now() - passBStart, ok: false });
-        console.warn('[PRD pipeline] Pass B failed; keeping client-rendered markdown without scores', e);
+        console.warn('[PRD pipeline] Pass B failed; shipping PRD without scores', e);
     }
 
     // --- Pass C: Conditional Revision ---


### PR DESCRIPTION
Pass B was producing both rubric scores and a model-rendered markdown
copy of the PRD, but the deterministic renderer in prdMarkdownRenderer.ts
already produces the same premium markdown from the StructuredPRD JSON
and was already used on the Pass A progressive-render path and the
Pass C post-revision path. The model-rendered markdown was only canonical
on the no-revision happy path — an asymmetry that paid for prose polish
on already-strong drafts.

Pass B is now score-only: smaller schema, less truncation risk, faster
round-trip, single source of truth for markdown. Pass A and Pass C are
unchanged.