### PR TITLE
feat(screen-inventory): copy-able image prompts + per-screen image uploads

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -74,7 +74,7 @@ export function ArtifactWorkspace({
     projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
 }: ArtifactWorkspaceProps) {
     const {
-        getArtifacts, getPreferredVersion, getArtifactStaleness, getJob,
+        getArtifacts, getPreferredVersion, getArtifactStaleness, getJob, getProject,
     } = useProjectStore();
 
     const slotMetas = useMemo(() => buildSlotMetas(), []);
@@ -252,9 +252,22 @@ export function ArtifactWorkspace({
         if (!artifact || !preferred) {
             return <EmptyState message="Not generated yet" />;
         }
+        const screenImageContext = subtype === 'screen_inventory'
+            ? {
+                projectId,
+                artifactId: artifact.id,
+                artifactVersionId: preferred.id,
+                productTitle: structuredPRD.productName ?? getProject(projectId)?.name ?? 'this product',
+                productSummary: structuredPRD.executiveSummary ?? structuredPRD.vision,
+            }
+            : undefined;
         return (
             <div className="max-w-3xl mx-auto bg-white rounded-xl border border-neutral-200 shadow-sm p-6 prose prose-sm prose-neutral max-w-none overflow-auto">
-                <ArtifactContentRenderer subtype={subtype} content={preferred.content} />
+                <ArtifactContentRenderer
+                    subtype={subtype}
+                    content={preferred.content}
+                    screenImageContext={screenImageContext}
+                />
             </div>
         );
     };

--- a/src/components/renderers/ScreenImageGallery.tsx
+++ b/src/components/renderers/ScreenImageGallery.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useState } from 'react';
+import { Copy, Check, Upload, Image as ImageIcon, X, AlertTriangle, Loader2 } from 'lucide-react';
+import type { ScreenItem } from '../../types';
+import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
+import { buildScreenInventoryImagePrompt } from '../../lib/services/screenInventoryImageService';
+import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
+
+export interface ScreenImageGalleryContext {
+    projectId: string;
+    artifactId: string;
+    artifactVersionId: string;
+    productTitle: string;
+    productSummary: string;
+}
+
+interface Props {
+    screen: ScreenItem;
+    context: ScreenImageGalleryContext;
+}
+
+export function ScreenImageGallery({ screen, context }: Props) {
+    const { projectId, artifactId, artifactVersionId, productTitle, productSummary } = context;
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [copied, setCopied] = useState(false);
+    const [lightboxKey, setLightboxKey] = useState<string | null>(null);
+
+    const versions = useScreenInventoryImageStore(s => s.listForScreen(artifactVersionId, screen.name));
+    const bucketKey = `${artifactVersionId}:${slugifyScreenName(screen.name)}`;
+    const isUploading = useScreenInventoryImageStore(s => Boolean(s.uploading[bucketKey]));
+    const error = useScreenInventoryImageStore(s => s.errors[bucketKey]);
+    const upload = useScreenInventoryImageStore(s => s.upload);
+    const setPreferred = useScreenInventoryImageStore(s => s.setPreferred);
+    const clearError = useScreenInventoryImageStore(s => s.clearError);
+
+    const prompt = buildScreenInventoryImagePrompt(screen, { productTitle, productSummary });
+    const preferred = versions.find(v => v.isPreferred);
+    const lightboxRecord = lightboxKey ? versions.find(v => v.key === lightboxKey) : null;
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(prompt).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        });
+    };
+
+    const handleFile = (file: File | null | undefined) => {
+        if (!file) return;
+        if (error) clearError(artifactVersionId, screen.name);
+        void upload({ projectId, artifactId, artifactVersionId, screenName: screen.name, file, prompt });
+    };
+
+    return (
+        <div className="pt-2 mt-1 border-t border-neutral-100 space-y-2">
+            <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    onClick={handleCopy}
+                    title="Copy an image-generation prompt for this screen"
+                    className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded bg-neutral-100 text-neutral-700 hover:bg-neutral-200 transition"
+                >
+                    {copied ? <Check size={12} className="text-green-600" /> : <Copy size={12} />}
+                    {copied ? 'Copied' : 'Copy image prompt'}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isUploading}
+                    className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded bg-indigo-50 text-indigo-700 hover:bg-indigo-100 disabled:opacity-60 disabled:cursor-not-allowed transition"
+                >
+                    {isUploading ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
+                    {isUploading ? 'Uploading…' : versions.length === 0 ? 'Upload image' : 'Upload new'}
+                </button>
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={(e) => {
+                        handleFile(e.target.files?.[0]);
+                        // Reset so re-uploading the same filename still triggers onChange.
+                        if (fileInputRef.current) fileInputRef.current.value = '';
+                    }}
+                />
+            </div>
+
+            {error && (
+                <div className="flex items-center gap-1.5 text-[11px] text-red-600">
+                    <AlertTriangle size={11} /> {error}
+                </div>
+            )}
+
+            {versions.length > 0 && (
+                <div className="space-y-1.5">
+                    {preferred && (
+                        <button
+                            type="button"
+                            onClick={() => setLightboxKey(preferred.key)}
+                            className="block w-full"
+                            title="Click to view full size"
+                        >
+                            <img
+                                src={preferred.dataUrl}
+                                alt={`${screen.name} (v${preferred.versionNumber})`}
+                                className="w-full rounded border border-neutral-200 bg-neutral-50 object-cover max-h-48"
+                            />
+                        </button>
+                    )}
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                        <span className="text-[10px] uppercase tracking-wide text-neutral-400 mr-1">
+                            <ImageIcon size={10} className="inline -mt-0.5 mr-0.5" />
+                            history
+                        </span>
+                        {versions.map(v => {
+                            const isActive = v.isPreferred;
+                            return (
+                                <button
+                                    key={v.key}
+                                    type="button"
+                                    onClick={() => {
+                                        if (isActive) setLightboxKey(v.key);
+                                        else void setPreferred(artifactVersionId, screen.name, v.versionNumber);
+                                    }}
+                                    title={isActive ? `v${v.versionNumber} (active) — click to enlarge` : `Switch to v${v.versionNumber}`}
+                                    className={`relative w-10 h-10 rounded overflow-hidden border transition ${
+                                        isActive
+                                            ? 'border-indigo-500 ring-2 ring-indigo-200'
+                                            : 'border-neutral-200 hover:border-neutral-400'
+                                    }`}
+                                >
+                                    <img src={v.dataUrl} alt={`v${v.versionNumber}`} className="w-full h-full object-cover" />
+                                    <span className={`absolute bottom-0 left-0 right-0 text-[9px] font-bold text-center leading-tight ${
+                                        isActive ? 'bg-indigo-600 text-white' : 'bg-black/50 text-white'
+                                    }`}>
+                                        v{v.versionNumber}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+
+            {lightboxRecord && (
+                <Lightbox record={lightboxRecord} onClose={() => setLightboxKey(null)} />
+            )}
+        </div>
+    );
+}
+
+function Lightbox({
+    record,
+    onClose,
+}: {
+    record: { dataUrl: string; screenName: string; versionNumber: number };
+    onClose: () => void;
+}) {
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [onClose]);
+
+    return (
+        <div
+            className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-6"
+            onClick={onClose}
+        >
+            <div className="relative max-w-5xl max-h-full" onClick={(e) => e.stopPropagation()}>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="absolute -top-3 -right-3 bg-white rounded-full p-1.5 shadow-lg hover:bg-neutral-100"
+                    aria-label="Close"
+                >
+                    <X size={16} />
+                </button>
+                <img
+                    src={record.dataUrl}
+                    alt={`${record.screenName} v${record.versionNumber}`}
+                    className="max-w-full max-h-[85vh] rounded-lg shadow-2xl bg-white"
+                />
+                <div className="mt-2 text-center text-xs text-white/80">
+                    {record.screenName} · v{record.versionNumber}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/renderers/ScreenInventoryRenderer.tsx
+++ b/src/components/renderers/ScreenInventoryRenderer.tsx
@@ -1,7 +1,12 @@
+import { useEffect } from 'react';
 import type { ScreenInventoryContent } from '../../types';
+import { ScreenImageGallery, type ScreenImageGalleryContext } from './ScreenImageGallery';
+import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
 
 interface Props {
     content: string;
+    /** When supplied, each screen card gets a copy-prompt + image-upload gallery. */
+    imageContext?: ScreenImageGalleryContext;
 }
 
 function tryParseScreenInventory(content: string): ScreenInventoryContent | null {
@@ -15,8 +20,14 @@ function tryParseScreenInventory(content: string): ScreenInventoryContent | null
     return null;
 }
 
-export function ScreenInventoryRenderer({ content }: Props) {
+export function ScreenInventoryRenderer({ content, imageContext }: Props) {
     const structured = tryParseScreenInventory(content);
+
+    const loadForArtifactVersion = useScreenInventoryImageStore(s => s.loadForArtifactVersion);
+    const artifactVersionId = imageContext?.artifactVersionId;
+    useEffect(() => {
+        if (artifactVersionId) void loadForArtifactVersion(artifactVersionId);
+    }, [artifactVersionId, loadForArtifactVersion]);
 
     // If we can't parse structured content, return null to fall back to markdown
     if (!structured) return null;
@@ -54,6 +65,9 @@ export function ScreenInventoryRenderer({ content }: Props) {
                                         {screen.navigationFrom?.join(', ') || '?'} → here → {screen.navigationTo?.join(', ') || '?'}
                                     </p>
                                 ) : null}
+                                {imageContext && (
+                                    <ScreenImageGallery screen={screen} context={imageContext} />
+                                )}
                             </div>
                         ))}
                     </div>

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -1,21 +1,17 @@
 import type { CoreArtifactSubtype } from '../../types';
 import { ScreenInventoryRenderer } from './ScreenInventoryRenderer';
+import type { ScreenImageGalleryContext } from './ScreenImageGallery';
 import { DataModelRenderer } from './DataModelRenderer';
 import { ComponentInventoryRenderer } from './ComponentInventoryRenderer';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-interface RendererProps {
+interface DispatchProps {
+    subtype: CoreArtifactSubtype;
     content: string;
+    /** Only consumed by `screen_inventory` today. Other subtypes ignore it. */
+    screenImageContext?: ScreenImageGalleryContext;
 }
-
-type RendererComponent = React.ComponentType<RendererProps>;
-
-const STRUCTURED_RENDERERS: Partial<Record<CoreArtifactSubtype, RendererComponent>> = {
-    screen_inventory: ScreenInventoryRenderer,
-    data_model: DataModelRenderer,
-    component_inventory: ComponentInventoryRenderer,
-};
 
 /**
  * Render artifact content using a type-specific renderer if available,
@@ -35,11 +31,15 @@ function isJsonString(str: string): boolean {
     }
 }
 
-export function ArtifactContentRenderer({ subtype, content }: { subtype: CoreArtifactSubtype; content: string }) {
-    const StructuredRenderer = STRUCTURED_RENDERERS[subtype];
-    if (StructuredRenderer && isJsonString(content)) {
-        return <StructuredRenderer content={content} />;
+export function ArtifactContentRenderer({ subtype, content, screenImageContext }: DispatchProps) {
+    if (subtype === 'screen_inventory' && isJsonString(content)) {
+        return <ScreenInventoryRenderer content={content} imageContext={screenImageContext} />;
     }
-
+    if (subtype === 'data_model' && isJsonString(content)) {
+        return <DataModelRenderer content={content} />;
+    }
+    if (subtype === 'component_inventory' && isJsonString(content)) {
+        return <ComponentInventoryRenderer content={content} />;
+    }
     return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;
 }

--- a/src/lib/screenInventoryImageStore.ts
+++ b/src/lib/screenInventoryImageStore.ts
@@ -1,0 +1,149 @@
+// IndexedDB wrapper for user-uploaded screen-inventory images. Lives outside
+// Zustand/localStorage because PNG/JPG data URLs would blow past the ~5 MB
+// origin quota for localStorage. Records are looked up either by their
+// composite primary key `${artifactVersionId}:${screenSlug}:${versionNumber}`
+// or via the `artifactVersionId` index for hydration on artifact open.
+//
+// Mirrors the shape of `src/lib/mockupImageStore.ts` — same fallback story,
+// same logging, just a different schema and store name so the two never
+// collide.
+
+import type { ScreenInventoryImageRecord } from '../types';
+
+const DB_NAME = 'synapse-screen-inventory-images';
+const DB_VERSION = 1;
+const STORE_NAME = 'images';
+const VERSION_INDEX = 'artifactVersionId';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+const memoryFallback: Map<string, ScreenInventoryImageRecord> = new Map();
+let memoryFallbackWarned = false;
+
+const noteFallback = (reason: string) => {
+    if (!memoryFallbackWarned) {
+        memoryFallbackWarned = true;
+        console.warn(`[screen-inventory-image-store] IndexedDB unavailable (${reason}); using in-memory fallback. Uploads will be lost on reload.`);
+    }
+};
+
+const openDb = (): Promise<IDBDatabase> => {
+    if (dbPromise) return dbPromise;
+    if (typeof indexedDB === 'undefined') {
+        noteFallback('indexedDB undefined');
+        return Promise.reject(new Error('IndexedDB unavailable'));
+    }
+
+    dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                const store = db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+                store.createIndex(VERSION_INDEX, 'artifactVersionId', { unique: false });
+            }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('Failed to open IndexedDB'));
+        req.onblocked = () => reject(new Error('IndexedDB open blocked'));
+    }).catch((err) => {
+        dbPromise = null;
+        noteFallback(String(err?.message ?? err));
+        throw err;
+    });
+
+    return dbPromise;
+};
+
+export const slugifyScreenName = (name: string): string =>
+    name
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[^\w\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-') || 'screen';
+
+export const buildScreenImageKey = (
+    artifactVersionId: string,
+    screenSlug: string,
+    versionNumber: number,
+): string => `${artifactVersionId}:${screenSlug}:${versionNumber}`;
+
+export const putScreenImage = async (record: ScreenInventoryImageRecord): Promise<void> => {
+    try {
+        const db = await openDb();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            tx.objectStore(STORE_NAME).put(record);
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error ?? new Error('IDB put failed'));
+            tx.onabort = () => reject(tx.error ?? new Error('IDB put aborted'));
+        });
+    } catch {
+        memoryFallback.set(record.key, record);
+    }
+};
+
+export const listScreenImagesForArtifactVersion = async (
+    artifactVersionId: string,
+): Promise<ScreenInventoryImageRecord[]> => {
+    try {
+        const db = await openDb();
+        return await new Promise<ScreenInventoryImageRecord[]>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly');
+            const idx = tx.objectStore(STORE_NAME).index(VERSION_INDEX);
+            const req = idx.getAll(artifactVersionId);
+            req.onsuccess = () => resolve((req.result as ScreenInventoryImageRecord[]) ?? []);
+            req.onerror = () => reject(req.error ?? new Error('IDB index getAll failed'));
+        });
+    } catch {
+        return Array.from(memoryFallback.values()).filter(r => r.artifactVersionId === artifactVersionId);
+    }
+};
+
+// Transactional preferred-flip: clears `isPreferred` on every record in the
+// `(artifactVersionId, screenSlug)` bucket, then sets it on the target.
+// Returns the updated set so callers can reflect it in their reactive cache
+// without re-querying.
+export const setPreferredScreenImage = async (
+    artifactVersionId: string,
+    screenSlug: string,
+    targetVersionNumber: number,
+): Promise<ScreenInventoryImageRecord[]> => {
+    try {
+        const db = await openDb();
+        return await new Promise<ScreenInventoryImageRecord[]>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const store = tx.objectStore(STORE_NAME);
+            const idx = store.index(VERSION_INDEX);
+            const updated: ScreenInventoryImageRecord[] = [];
+            const cursorReq = idx.openCursor(IDBKeyRange.only(artifactVersionId));
+            cursorReq.onsuccess = () => {
+                const cursor = cursorReq.result;
+                if (!cursor) return;
+                const record = cursor.value as ScreenInventoryImageRecord;
+                if (record.screenSlug === screenSlug) {
+                    const next = { ...record, isPreferred: record.versionNumber === targetVersionNumber };
+                    if (next.isPreferred !== record.isPreferred) {
+                        cursor.update(next);
+                    }
+                    updated.push(next);
+                }
+                cursor.continue();
+            };
+            tx.oncomplete = () => resolve(updated);
+            tx.onerror = () => reject(tx.error ?? new Error('IDB preferred flip failed'));
+            tx.onabort = () => reject(tx.error ?? new Error('IDB preferred flip aborted'));
+        });
+    } catch {
+        const updated: ScreenInventoryImageRecord[] = [];
+        for (const [k, r] of memoryFallback.entries()) {
+            if (r.artifactVersionId === artifactVersionId && r.screenSlug === screenSlug) {
+                const next = { ...r, isPreferred: r.versionNumber === targetVersionNumber };
+                memoryFallback.set(k, next);
+                updated.push(next);
+            }
+        }
+        return updated;
+    }
+};

--- a/src/lib/services/screenInventoryImageService.ts
+++ b/src/lib/services/screenInventoryImageService.ts
@@ -1,0 +1,61 @@
+// Pure helpers for the user-driven Screen Inventory image flow. The user
+// copies the prompt below into an external image tool (Nano Banana, GPT
+// image, etc.), generates outside the app, then uploads the result back
+// onto the screen card. No API calls happen in here — this module is
+// strictly prompt assembly so the renderer / store stay thin.
+
+import type { ScreenItem } from '../../types';
+
+interface ScreenImagePromptContext {
+    /** Product title for grounding the mockup. */
+    productTitle: string;
+    /** 1–2 sentence product framing. Pass `structuredPRD.vision` or similar. */
+    productSummary: string;
+    /** Optional platform hint — defaults to "responsive web app screen". */
+    platformHint?: 'mobile' | 'desktop' | 'responsive';
+}
+
+const PLATFORM_HINTS: Record<NonNullable<ScreenImagePromptContext['platformHint']>, string> = {
+    mobile: 'mobile app screen, portrait orientation',
+    desktop: 'desktop web app screen, landscape orientation',
+    responsive: 'responsive web app screen',
+};
+
+/**
+ * Build a copy-pasteable image-generation prompt for one screen-inventory
+ * row. Tool-agnostic — the same string works in any modern image model
+ * (Nano Banana / Gemini Imagen, GPT image, Midjourney, etc.).
+ *
+ * The structure mirrors `buildScreenImagePrompt` in `mockupImageService.ts`
+ * but works from the screen-inventory data shape (which has no
+ * `MockupSettings`), so we use sensible defaults for fidelity and platform.
+ */
+export const buildScreenInventoryImagePrompt = (
+    screen: ScreenItem,
+    context: ScreenImagePromptContext,
+): string => {
+    const platform = PLATFORM_HINTS[context.platformHint ?? 'responsive'];
+    const componentsLine = screen.components && screen.components.length > 0
+        ? `Key UI components on this screen: ${screen.components.join(', ')}.`
+        : '';
+    const navParts: string[] = [];
+    if (screen.navigationFrom && screen.navigationFrom.length > 0) {
+        navParts.push(`reachable from ${screen.navigationFrom.join(', ')}`);
+    }
+    if (screen.navigationTo && screen.navigationTo.length > 0) {
+        navParts.push(`navigates to ${screen.navigationTo.join(', ')}`);
+    }
+    const navLine = navParts.length > 0 ? `Navigation context: ${navParts.join('; ')}.` : '';
+
+    return [
+        `UI mockup of "${screen.name}" for the product "${context.productTitle}".`,
+        `Screen purpose: ${screen.purpose}`,
+        `Product context: ${context.productSummary}`,
+        componentsLine,
+        navLine,
+        `Render as a ${platform}.`,
+        `Style: mid-fidelity flat UI mockup, structured layout with clear hierarchy, neutral palette with one accent color, no decorative imagery.`,
+        `Avoid lorem ipsum — use realistic placeholder copy that fits the screen purpose.`,
+        `No watermarks, no logos of real companies, no photographic people.`,
+    ].filter(Boolean).join(' ');
+};

--- a/src/store/screenInventoryImageStore.ts
+++ b/src/store/screenInventoryImageStore.ts
@@ -1,0 +1,184 @@
+/**
+ * Session-scoped Zustand store for user-uploaded Screen Inventory images.
+ * Holds an in-memory cache of ScreenInventoryImageRecord rows hydrated from
+ * IndexedDB so React components can subscribe and re-render on upload /
+ * preferred-version flips. Persistence (the source of truth) lives in
+ * src/lib/screenInventoryImageStore.ts (IndexedDB).
+ *
+ * Mirrors the shape of src/store/mockupImageStore.ts so the two image flows
+ * read the same way to anyone scanning the codebase.
+ */
+
+import { create } from 'zustand';
+import type { ScreenInventoryImageRecord } from '../types';
+import {
+    buildScreenImageKey,
+    listScreenImagesForArtifactVersion as idbListImages,
+    putScreenImage as idbPutImage,
+    setPreferredScreenImage as idbSetPreferred,
+    slugifyScreenName,
+} from '../lib/screenInventoryImageStore';
+
+interface UploadArgs {
+    projectId: string;
+    artifactId: string;
+    artifactVersionId: string;
+    screenName: string;
+    file: File;
+    prompt: string;
+}
+
+interface ImageStoreState {
+    images: Record<string, ScreenInventoryImageRecord>;
+    hydrated: Record<string, boolean>;
+    uploading: Record<string, boolean>;
+    errors: Record<string, string>;
+
+    /** Hydrate this artifact version's uploads from IndexedDB. Idempotent. */
+    loadForArtifactVersion: (artifactVersionId: string) => Promise<void>;
+
+    /** All records for one screen, sorted by versionNumber ascending. */
+    listForScreen: (artifactVersionId: string, screenName: string) => ScreenInventoryImageRecord[];
+
+    /** The preferred record for one screen, or undefined. */
+    peekPreferred: (artifactVersionId: string, screenName: string) => ScreenInventoryImageRecord | undefined;
+
+    /** Read a file as a data URL and persist it as the new preferred upload. */
+    upload: (args: UploadArgs) => Promise<void>;
+
+    /** Promote an existing version to preferred for its screen. */
+    setPreferred: (artifactVersionId: string, screenName: string, versionNumber: number) => Promise<void>;
+
+    /** Clear an upload error for one screen bucket (e.g. on retry). */
+    clearError: (artifactVersionId: string, screenName: string) => void;
+}
+
+const bucketKey = (artifactVersionId: string, screenSlug: string): string =>
+    `${artifactVersionId}:${screenSlug}`;
+
+const readFileAsDataUrl = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            if (typeof reader.result === 'string') resolve(reader.result);
+            else reject(new Error('FileReader returned non-string result'));
+        };
+        reader.onerror = () => reject(reader.error ?? new Error('FileReader failed'));
+        reader.readAsDataURL(file);
+    });
+
+export const useScreenInventoryImageStore = create<ImageStoreState>((set, get) => ({
+    images: {},
+    hydrated: {},
+    uploading: {},
+    errors: {},
+
+    loadForArtifactVersion: async (artifactVersionId) => {
+        if (get().hydrated[artifactVersionId]) return;
+        const records = await idbListImages(artifactVersionId);
+        set((state) => {
+            const next = { ...state.images };
+            for (const r of records) next[r.key] = r;
+            return {
+                images: next,
+                hydrated: { ...state.hydrated, [artifactVersionId]: true },
+            };
+        });
+    },
+
+    listForScreen: (artifactVersionId, screenName) => {
+        const slug = slugifyScreenName(screenName);
+        return Object.values(get().images)
+            .filter(r => r.artifactVersionId === artifactVersionId && r.screenSlug === slug)
+            .sort((a, b) => a.versionNumber - b.versionNumber);
+    },
+
+    peekPreferred: (artifactVersionId, screenName) => {
+        const slug = slugifyScreenName(screenName);
+        return Object.values(get().images).find(
+            r => r.artifactVersionId === artifactVersionId && r.screenSlug === slug && r.isPreferred,
+        );
+    },
+
+    upload: async ({ projectId, artifactId, artifactVersionId, screenName, file, prompt }) => {
+        const slug = slugifyScreenName(screenName);
+        const bucket = bucketKey(artifactVersionId, slug);
+        if (get().uploading[bucket]) return;
+
+        set((state) => ({
+            uploading: { ...state.uploading, [bucket]: true },
+            errors: { ...state.errors, [bucket]: '' },
+        }));
+
+        try {
+            const dataUrl = await readFileAsDataUrl(file);
+            const siblings = get().listForScreen(artifactVersionId, screenName);
+            const versionNumber = siblings.length === 0
+                ? 1
+                : Math.max(...siblings.map(r => r.versionNumber)) + 1;
+            const record: ScreenInventoryImageRecord = {
+                key: buildScreenImageKey(artifactVersionId, slug, versionNumber),
+                projectId,
+                artifactId,
+                artifactVersionId,
+                screenSlug: slug,
+                screenName,
+                versionNumber,
+                isPreferred: true,
+                dataUrl,
+                mimeType: file.type || 'image/png',
+                prompt,
+                generatedAt: Date.now(),
+            };
+            await idbPutImage(record);
+            // Flip siblings to non-preferred (cheap when there are zero, common
+            // case). Skip the IDB roundtrip if there are no siblings to demote.
+            if (siblings.length > 0) {
+                await idbSetPreferred(artifactVersionId, slug, versionNumber);
+            }
+            set((state) => {
+                const nextImages = { ...state.images };
+                // Demote previously-preferred siblings in cache.
+                for (const s of siblings) {
+                    if (s.isPreferred) nextImages[s.key] = { ...s, isPreferred: false };
+                }
+                nextImages[record.key] = record;
+                const nextUploading = { ...state.uploading };
+                delete nextUploading[bucket];
+                return { images: nextImages, uploading: nextUploading };
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Upload failed.';
+            set((state) => {
+                const nextUploading = { ...state.uploading };
+                delete nextUploading[bucket];
+                return {
+                    uploading: nextUploading,
+                    errors: { ...state.errors, [bucket]: message },
+                };
+            });
+        }
+    },
+
+    setPreferred: async (artifactVersionId, screenName, versionNumber) => {
+        const slug = slugifyScreenName(screenName);
+        const updated = await idbSetPreferred(artifactVersionId, slug, versionNumber);
+        if (updated.length === 0) return;
+        set((state) => {
+            const nextImages = { ...state.images };
+            for (const r of updated) nextImages[r.key] = r;
+            return { images: nextImages };
+        });
+    },
+
+    clearError: (artifactVersionId, screenName) => {
+        const slug = slugifyScreenName(screenName);
+        const bucket = bucketKey(artifactVersionId, slug);
+        set((state) => {
+            if (!state.errors[bucket]) return state;
+            const next = { ...state.errors };
+            delete next[bucket];
+            return { errors: next };
+        });
+    },
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -495,6 +495,30 @@ export type MockupImageRecord = {
     generatedAt: number;
 };
 
+// --- Screen Inventory user-uploaded images ---
+//
+// Per-screen image history attached to a Screen Inventory artifact. Users
+// copy a generated prompt into an external image tool (Nano Banana, GPT
+// image, etc.), then upload the result back to the screen card. Each
+// upload is a new immutable record with an incrementing `versionNumber`;
+// `isPreferred` mirrors the same semantics as `ArtifactVersion.isPreferred`
+// — exactly one preferred record per `(artifactVersionId, screenSlug)`
+// bucket. Records live in IndexedDB to stay out of the localStorage quota.
+export type ScreenInventoryImageRecord = {
+    key: string;              // `${artifactVersionId}:${screenSlug}:${versionNumber}`
+    projectId: string;
+    artifactId: string;
+    artifactVersionId: string;
+    screenSlug: string;       // slug of ScreenItem.name
+    screenName: string;       // original name (for display / debugging)
+    versionNumber: number;
+    isPreferred: boolean;
+    dataUrl: string;          // `data:<mime>;base64,...`
+    mimeType: string;
+    prompt: string;           // prompt that was offered for copy at upload time
+    generatedAt: number;
+};
+
 // Prompt artifact settings
 export type PromptTarget =
     | 'mockup'


### PR DESCRIPTION
Each screen card in the Screen Inventory artifact now exposes a "Copy
image prompt" button (tool-agnostic prompt assembled from the screen's
purpose/components/navigation plus PRD context) and an "Upload image"
button. Uploaded images are persisted in a dedicated IndexedDB store
(synapse-screen-inventory-images) and tracked with versionNumber +
isPreferred semantics that mirror ArtifactVersion — users can switch
back to an earlier upload, and history is scoped to the
artifact-version the upload was taken against, the same way mockup
images are scoped today.