### PR TITLE
fix(mockup): stop iPhone "Could not reach api.openai.com" error

### DIFF
--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -124,11 +124,13 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
             <div className="w-12 h-12 rounded-full bg-indigo-50 flex items-center justify-center mb-3">
                 <ImageIcon size={20} className="text-indigo-500" />
             </div>
-            <div className="text-sm font-medium text-neutral-800">No AI image yet</div>
+            <div className="text-sm font-medium text-neutral-800">
+                {error ? 'AI image preview unavailable' : 'No AI image yet'}
+            </div>
             <div className="text-xs text-neutral-500 mt-1 max-w-sm">
-                Generate a quick draft image of this screen via OpenAI gpt-image-2.
-                Use it as a sanity check when the HTML mockup feels off — you can
-                regenerate at high quality once you like the draft.
+                {error
+                    ? 'The mockup rendered above — this is the optional AI screenshot. Tap retry below to try again.'
+                    : 'Generate a quick draft image of this screen via OpenAI gpt-image-2. Use it as a sanity check when the HTML mockup feels off — you can regenerate at high quality once you like the draft.'}
             </div>
             {error && (
                 <div className="mt-3 inline-flex items-start gap-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2 py-1.5 max-w-md">

--- a/src/lib/openaiClient.ts
+++ b/src/lib/openaiClient.ts
@@ -39,6 +39,10 @@ export const hasOpenAIKey = (): boolean => {
 const MAX_FETCH_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 
+// gpt-image-2 high-quality p99 sits around 60s; 75s gives headroom without
+// leaving doomed sockets open on cellular eating retry budget.
+const REQUEST_TIMEOUT_MS = 75_000;
+
 const sleepWithAbort = (ms: number, signal?: AbortSignal): Promise<void> =>
     new Promise((resolve, reject) => {
         if (signal?.aborted) return reject(new DOMException('Aborted', 'AbortError'));
@@ -103,6 +107,19 @@ export const callOpenAIImage = async (
         n: 1,
     };
 
+    // Combine the caller-cancel signal with a hard request timeout. We track
+    // `timedOut` separately so the error path can distinguish "we gave up"
+    // from "the user clicked Cancel" — both surface as AbortError otherwise.
+    const composite = new AbortController();
+    let timedOut = false;
+    const timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        composite.abort();
+    }, REQUEST_TIMEOUT_MS);
+    const onCallerAbort = () => composite.abort();
+    opts.signal?.addEventListener('abort', onCallerAbort, { once: true });
+    if (opts.signal?.aborted) composite.abort();
+
     let response: Response;
     try {
         response = await fetchWithRetry(OPENAI_IMAGE_URL, {
@@ -112,22 +129,34 @@ export const callOpenAIImage = async (
                 'Authorization': `Bearer ${apiKey}`,
             },
             body: JSON.stringify(body),
-            signal: opts.signal,
+            signal: composite.signal,
         });
     } catch (err) {
-        // Bubble user-cancellation untouched.
-        if ((err as { name?: string })?.name === 'AbortError') throw err;
+        // Bubble user-cancellation untouched, but rewrap timeout-driven aborts
+        // so the UI can show "took too long" instead of swallowing silently.
+        if ((err as { name?: string })?.name === 'AbortError') {
+            if (timedOut) {
+                throw new Error(
+                    `Image preview took longer than ${Math.round(REQUEST_TIMEOUT_MS / 1000)}s. The mockup itself rendered above — this is just the optional AI screenshot. Try again on Wi-Fi.`
+                );
+            }
+            throw err;
+        }
         // Browser-level fetch failures arrive as TypeError with messages like
         // Safari's "Load failed" or Chromium's "Failed to fetch". These don't
-        // carry HTTP status; surface a diagnostic that points at the actual
-        // suspects (network, content blocker, VPN/proxy, CORS extension).
+        // carry HTTP status. Be specific that this is the optional image
+        // preview, not the (already-rendered) HTML mockup the user is staring
+        // at — otherwise users read "mockup generation failed."
         const raw = err instanceof Error ? err.message : String(err);
         if (/load failed|failed to fetch|networkerror/i.test(raw)) {
             throw new Error(
-                `Could not reach api.openai.com after retrying. Common causes: flaky mobile network, no network, ad/content blocker, VPN or corporate proxy, or a CORS-blocking browser extension. Raw: ${raw}`
+                `Image preview couldn't reach OpenAI. The mockup itself rendered above — this is just the optional AI screenshot. Tap retry, or switch to Wi-Fi. Raw: ${raw}`
             );
         }
         throw new Error(`OpenAI image request failed before a response was received. Raw: ${raw}`);
+    } finally {
+        clearTimeout(timeoutHandle);
+        opts.signal?.removeEventListener('abort', onCallerAbort);
     }
 
     if (!response.ok) {

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -19,7 +19,6 @@ import {
 import { isAbortError } from '../concurrency';
 import { buildAutoMockupSettings } from '../mockupDefaults';
 import { normalizeError } from '../errors';
-import { fireScreenImagesInBackground } from './mockupImageService';
 
 export interface StartArgs {
     projectId: string;
@@ -228,7 +227,7 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
     const versions = writeStore.getArtifactVersions(projectId, artifactId);
     const parentVersionId = versions.length > 0 ? versions[versions.length - 1].id : null;
 
-    const { versionId } = writeStore.createArtifactVersion(
+    writeStore.createArtifactVersion(
         projectId,
         artifactId,
         JSON.stringify(payload),
@@ -250,10 +249,6 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
     );
 
     writeStore.setSlotStatus(projectId, 'mockup', { status: 'done', finishedAt: Date.now() });
-
-    // AI image previews are the primary mockup surface — fire low-quality
-    // gpt-image-2 jobs for every screen as soon as the HTML version lands.
-    fireScreenImagesInBackground({ projectId, artifactId, versionId, payload, settings });
 }
 
 async function executeJob(args: StartArgs, controller: AbortController, slotKeys: ArtifactSlotKey[]): Promise<void> {

--- a/src/lib/services/mockupImageService.ts
+++ b/src/lib/services/mockupImageService.ts
@@ -3,8 +3,6 @@
 // store can stay thin.
 
 import type { MockupPayload, MockupScreen, MockupSettings, MockupPlatform } from '../../types';
-import { useMockupImageStore } from '../../store/mockupImageStore';
-import { hasOpenAIKey } from '../openaiClient';
 
 const FIDELITY_STYLE_HINTS: Record<string, string> = {
     low: 'low-fidelity wireframe sketch, neutral grey palette, simple boxes and labels, hand-drawn feel',
@@ -57,46 +55,4 @@ export const buildScreenImagePrompt = (
         `Avoid lorem ipsum — use realistic placeholder copy that fits the screen purpose.`,
         `No watermarks, no logos of real companies, no photographic people.`,
     ].join(' ');
-};
-
-interface AutoFireArgs {
-    projectId: string;
-    artifactId: string;
-    versionId: string;
-    payload: MockupPayload;
-    settings: MockupSettings;
-}
-
-/**
- * Fire low-quality gpt-image-2 generation for every screen in a mockup
- * payload, draining a 2-wide worker pool to avoid burst-rate-limit thrash.
- * Returns immediately; per-screen errors are captured by the image store and
- * surfaced in `MockupScreenImage`.
- */
-export const fireScreenImagesInBackground = (args: AutoFireArgs): void => {
-    if (!hasOpenAIKey()) return;
-    const { projectId, artifactId, versionId, payload, settings } = args;
-    const store = useMockupImageStore.getState();
-    const queue = [...payload.screens];
-    const CONCURRENCY = 2;
-    const worker = async () => {
-        while (queue.length > 0) {
-            const screen = queue.shift();
-            if (!screen) return;
-            try {
-                await store.generate({
-                    projectId,
-                    artifactId,
-                    versionId,
-                    screen,
-                    payload,
-                    settings,
-                    quality: 'low',
-                });
-            } catch {
-                // store.generate captures errors per screen key; keep draining.
-            }
-        }
-    };
-    for (let i = 0; i < CONCURRENCY; i++) void worker();
 };

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://vitals.vercel-insights.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://vitals.vercel-insights.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
         }
       ]
     },


### PR DESCRIPTION
The error users reported on iPhone was the optional gpt-image-2 image
preview failing, not the Gemini-backed HTML mockup itself. Two root
causes:

1. CSP `connect-src` whitelisted Gemini but not OpenAI, so on iOS
   WebKit every image-preview fetch failed with `TypeError: Load
   failed` (no console diagnostic in production).
2. After every mockup HTML version landed we auto-fired up to 2
   concurrent gpt-image-2 calls per screen — each a 5–60s blocking
   fetch returning 1–3 MB of base64 over cellular. Even with retries,
   a flaky link guaranteed eventual failure, and the resulting amber
   error badge sat next to the (succeeded) mockup, leading users to
   read "mockup generation failed."

Changes:
- vercel.json: add api.openai.com to CSP connect-src.
- artifactJobController + mockupImageService: drop the auto-fire path
  entirely. Image previews now only run when the user clicks
  "Generate AI image" on a specific screen.
- openaiClient: add a 75s per-request timeout (separate from user
  cancel), and rewrite the failure copy so it names the optional
  image preview and points users at the working HTML mockup above.
- MockupScreenImage: error state now reads "AI image preview
  unavailable" with a one-liner clarifying the mockup itself
  rendered.

https://claude.ai/code/session_01EaNDsQ5A5R4eSnNBXBYQHx