### PR TITLE
feat(artifact-viewer): fix state-machine degenerate output, add Implementation Summary, ship structured renderers for the four markdown-only artifacts, and polish viewer layout

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
-    RefreshCcw, StopCircle, Menu, X,
+    RefreshCcw, StopCircle, Menu, X, ChevronLeft, ChevronRight,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -375,51 +375,137 @@ export function ArtifactWorkspace({
                 </div>
             </main>
 
-            {/* Right rail — Generation Status (hidden below xl; on smaller
-                screens status is visible inline via the StatusDots in the
-                left rail / mobile header) */}
-            <aside className="hidden xl:flex flex-col w-72 shrink-0 border-l border-neutral-200 bg-white overflow-y-auto">
-                <div className="p-4 border-b border-neutral-200">
+            {/* Right rail — Generation Status. Collapses to a slim strip
+                once all artifacts are ready; auto-expands while anything
+                is in flight or has errored. The user can also toggle
+                manually via the chevron. Hidden below xl; status remains
+                visible inline through the left-rail StatusDots and mobile
+                header. */}
+            <RightRail
+                slotMetas={slotMetas}
+                slotStatusFor={slotStatusFor}
+                doneCount={doneCount}
+                totalSlots={totalSlots}
+                generatingCount={generatingCount}
+                errorCount={errorCount}
+                interruptedCount={interruptedCount}
+                isActive={isActive}
+                onCancelAll={handleCancelAll}
+                onResumeAll={handleResumeAll}
+            />
+        </div>
+    );
+}
+
+interface RightRailProps {
+    slotMetas: SlotMeta[];
+    slotStatusFor: (key: WorkspaceSelection) => GenerationStatus;
+    doneCount: number;
+    totalSlots: number;
+    generatingCount: number;
+    errorCount: number;
+    interruptedCount: number;
+    isActive: boolean;
+    onCancelAll: () => void;
+    onResumeAll: () => void;
+}
+
+function RightRail({
+    slotMetas,
+    slotStatusFor,
+    doneCount,
+    totalSlots,
+    generatingCount,
+    errorCount,
+    interruptedCount,
+    isActive,
+    onCancelAll,
+    onResumeAll,
+}: RightRailProps) {
+    const allReady = doneCount === totalSlots && generatingCount === 0 && errorCount === 0 && interruptedCount === 0;
+    // User-controlled override; defaults to expanded except when all-ready,
+    // in which case it auto-collapses. The collapse chevron only appears
+    // when allReady, so userToggled === 'closed' can only be set in that
+    // state; while work is in flight !allReady forces expanded back open
+    // without us needing a setState-in-effect dance.
+    const [userToggled, setUserToggled] = useState<null | 'open' | 'closed'>(null);
+    const expanded = !allReady || userToggled === 'open';
+
+    if (!expanded) {
+        return (
+            <aside className="hidden xl:flex flex-col w-12 shrink-0 border-l border-neutral-200 bg-white">
+                <button
+                    type="button"
+                    onClick={() => setUserToggled('open')}
+                    title="Expand generation status"
+                    aria-label="Expand generation status"
+                    className="h-full flex flex-col items-center justify-start gap-3 pt-4 pb-4 text-neutral-500 hover:text-neutral-900 hover:bg-neutral-50"
+                >
+                    <ChevronLeft size={16} />
+                    <CheckCircle2 size={16} className="text-emerald-600" />
+                    <span className="[writing-mode:vertical-rl] rotate-180 text-[11px] font-semibold uppercase tracking-wider text-emerald-700">
+                        All ready · {doneCount}/{totalSlots}
+                    </span>
+                </button>
+            </aside>
+        );
+    }
+
+    return (
+        <aside className="hidden xl:flex flex-col w-72 shrink-0 border-l border-neutral-200 bg-white overflow-y-auto">
+            <div className="p-4 border-b border-neutral-200 flex items-start justify-between gap-2">
+                <div>
                     <h3 className="text-xs font-bold text-neutral-500 uppercase tracking-wider">Generation Status</h3>
                     <p className="text-sm text-neutral-700 mt-1">
                         {doneCount} of {totalSlots} ready
                         {generatingCount > 0 && <span className="text-neutral-500"> · {generatingCount} generating</span>}
                     </p>
                 </div>
-                <ul className="py-2">
-                    {slotMetas.map(slot => {
-                        const status = slotStatusFor(slot.key);
-                        return (
-                            <li key={slot.key} className="px-4 py-2 flex items-center gap-3">
-                                <StatusDot status={status} />
-                                <span className="text-sm text-neutral-700 flex-1 truncate">{slot.title}</span>
-                                <span className="text-[11px] text-neutral-400">{statusLabel(status)}</span>
-                            </li>
-                        );
-                    })}
-                </ul>
-                <div className="px-4 py-3 border-t border-neutral-200 space-y-2">
-                    {isActive && (
-                        <button
-                            type="button"
-                            onClick={handleCancelAll}
-                            className="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-xs bg-red-50 text-red-700 border border-red-200 rounded-md hover:bg-red-100 transition"
-                        >
-                            <StopCircle size={12} /> Cancel All
-                        </button>
-                    )}
-                    {(errorCount > 0 || interruptedCount > 0) && !isActive && (
-                        <button
-                            type="button"
-                            onClick={handleResumeAll}
-                            className="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-xs bg-indigo-50 text-indigo-700 border border-indigo-200 rounded-md hover:bg-indigo-100 transition"
-                        >
-                            <RefreshCcw size={12} /> Resume {errorCount + interruptedCount}
-                        </button>
-                    )}
-                </div>
-            </aside>
-        </div>
+                {allReady && (
+                    <button
+                        type="button"
+                        onClick={() => setUserToggled('closed')}
+                        title="Collapse generation status"
+                        aria-label="Collapse generation status"
+                        className="shrink-0 p-1 -mr-1 text-neutral-400 hover:text-neutral-700"
+                    >
+                        <ChevronRight size={16} />
+                    </button>
+                )}
+            </div>
+            <ul className="py-2">
+                {slotMetas.map(slot => {
+                    const status = slotStatusFor(slot.key);
+                    return (
+                        <li key={slot.key} className="px-4 py-2 flex items-center gap-3">
+                            <StatusDot status={status} />
+                            <span className="text-sm text-neutral-700 flex-1 truncate">{slot.title}</span>
+                            <span className="text-[11px] text-neutral-400">{statusLabel(status)}</span>
+                        </li>
+                    );
+                })}
+            </ul>
+            <div className="px-4 py-3 border-t border-neutral-200 space-y-2">
+                {isActive && (
+                    <button
+                        type="button"
+                        onClick={onCancelAll}
+                        className="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-xs bg-red-50 text-red-700 border border-red-200 rounded-md hover:bg-red-100 transition"
+                    >
+                        <StopCircle size={12} /> Cancel All
+                    </button>
+                )}
+                {(errorCount > 0 || interruptedCount > 0) && !isActive && (
+                    <button
+                        type="button"
+                        onClick={onResumeAll}
+                        className="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-xs bg-indigo-50 text-indigo-700 border border-indigo-200 rounded-md hover:bg-indigo-100 transition"
+                    >
+                        <RefreshCcw size={12} /> Resume {errorCount + interruptedCount}
+                    </button>
+                )}
+            </div>
+        </aside>
     );
 }
 

--- a/src/components/SectionTabs.tsx
+++ b/src/components/SectionTabs.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+// Sticky in-page section nav for long artifacts. Sits at the top of the
+// artifact main pane (which is the scroll container) and tracks the
+// currently-visible section via IntersectionObserver. Click a pill to
+// scroll to the matching anchor.
+//
+// Items must point to elements that exist in the DOM at render time and
+// carry the `scroll-mt-24` class so the sticky header doesn't cover the
+// jump target.
+
+export type SectionTabItem = {
+    id: string;
+    label: string;
+};
+
+interface Props {
+    items: SectionTabItem[];
+}
+
+export function SectionTabs({ items }: Props) {
+    const [activeId, setActiveId] = useState<string | null>(items[0]?.id ?? null);
+
+    useEffect(() => {
+        if (items.length === 0) return;
+        const elements = items
+            .map(item => document.getElementById(item.id))
+            .filter((el): el is HTMLElement => el != null);
+        if (elements.length === 0) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                // Choose the topmost intersecting entry.
+                const visible = entries
+                    .filter(e => e.isIntersecting)
+                    .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+                if (visible.length > 0) {
+                    setActiveId(visible[0].target.id);
+                }
+            },
+            { rootMargin: '-100px 0px -60% 0px', threshold: 0 },
+        );
+        elements.forEach(el => observer.observe(el));
+        return () => observer.disconnect();
+    }, [items]);
+
+    if (items.length <= 1) return null;
+
+    return (
+        <nav
+            aria-label="Artifact sections"
+            className="sticky top-0 z-20 -mx-4 md:-mx-8 px-4 md:px-8 py-2 bg-neutral-50/95 backdrop-blur border-b border-neutral-200 mb-4"
+        >
+            <div className="flex flex-wrap gap-1.5 overflow-x-auto">
+                {items.map(item => {
+                    const active = item.id === activeId;
+                    return (
+                        <a
+                            key={item.id}
+                            href={`#${item.id}`}
+                            onClick={(e) => {
+                                const el = document.getElementById(item.id);
+                                if (el) {
+                                    e.preventDefault();
+                                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                                    setActiveId(item.id);
+                                }
+                            }}
+                            className={`shrink-0 px-2.5 py-1 text-xs font-medium rounded-full transition ${
+                                active
+                                    ? 'bg-indigo-600 text-white'
+                                    : 'bg-white text-neutral-700 border border-neutral-200 hover:border-indigo-300 hover:text-indigo-700'
+                            }`}
+                        >
+                            {item.label}
+                        </a>
+                    );
+                })}
+            </div>
+        </nav>
+    );
+}

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -12,6 +12,7 @@ import {
     serializeEntities,
     serializeActions,
 } from '../lib/groundingFields';
+import { ImplementationSummarySection } from './prd/ImplementationSummarySection';
 import {
     ExecutiveSummarySection,
     ProductThesisSection,
@@ -521,6 +522,11 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                 {structuredPRD.executiveSummary && (
                     <ExecutiveSummarySection summary={structuredPRD.executiveSummary} />
                 )}
+
+                {/* Implementation summary — synthesized from existing fields so a
+                    reader can answer "what should I build first?" without scrolling
+                    the entire document. Hidden if the PRD has no actionable signal. */}
+                <ImplementationSummarySection prd={structuredPRD} />
 
                 {renderTextSection('Vision', 'vision', structuredPRD.vision)}
 

--- a/src/components/prd/ImplementationSummarySection.tsx
+++ b/src/components/prd/ImplementationSummarySection.tsx
@@ -1,0 +1,195 @@
+import { AlertTriangle, ArrowRight, ListChecks, Pause, ShieldQuestion } from 'lucide-react';
+import type { StructuredPRD } from '../../types';
+import {
+    deriveImplementationSummary,
+    isImplementationSummaryEmpty,
+    type SummaryFeature,
+} from '../../lib/derive/implementationSummary';
+
+// Synthesized "what to build first / next / defer / risks / decisions" view.
+// Pure derivation — no LLM call. Renders at the top of the PRD so a reader
+// can answer "what would I do Monday morning?" without scrolling 30 pages.
+
+function FeatureCard({ feature, accent }: { feature: SummaryFeature; accent: 'green' | 'blue' | 'neutral' }) {
+    const accentClasses = {
+        green: 'bg-green-50/60 border-green-200',
+        blue: 'bg-blue-50/60 border-blue-200',
+        neutral: 'bg-neutral-50 border-neutral-200',
+    }[accent];
+    const idClasses = {
+        green: 'text-green-700',
+        blue: 'text-blue-700',
+        neutral: 'text-neutral-500',
+    }[accent];
+    return (
+        <a
+            href={`#prd-features`}
+            className={`block rounded-md border ${accentClasses} px-3 py-2 hover:shadow-sm transition`}
+        >
+            <div className="flex items-baseline gap-2">
+                <span className={`text-[11px] font-mono font-bold ${idClasses}`}>{feature.id}</span>
+                <span className="text-sm font-semibold text-neutral-900 truncate">{feature.name}</span>
+            </div>
+            {feature.reason && (
+                <p className="text-[11px] text-neutral-600 mt-0.5 line-clamp-2">{feature.reason}</p>
+            )}
+        </a>
+    );
+}
+
+function FeatureBucket({
+    title,
+    icon: Icon,
+    accent,
+    features,
+    emptyHint,
+}: {
+    title: string;
+    icon: typeof ListChecks;
+    accent: 'green' | 'blue' | 'neutral';
+    features: SummaryFeature[];
+    emptyHint: string;
+}) {
+    const headerClasses = {
+        green: 'text-green-700',
+        blue: 'text-blue-700',
+        neutral: 'text-neutral-500',
+    }[accent];
+    return (
+        <div>
+            <div className="flex items-center gap-2 mb-2">
+                <Icon size={14} className={headerClasses} />
+                <h4 className={`text-[11px] font-bold uppercase tracking-wider ${headerClasses}`}>
+                    {title}
+                </h4>
+                <span className="text-[11px] text-neutral-400">{features.length}</span>
+            </div>
+            {features.length === 0 ? (
+                <p className="text-[11px] text-neutral-400 italic">{emptyHint}</p>
+            ) : (
+                <div className="space-y-1.5">
+                    {features.map(f => (
+                        <FeatureCard key={f.id} feature={f} accent={accent} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
+    const summary = deriveImplementationSummary(prd);
+    if (isImplementationSummaryEmpty(summary)) return null;
+
+    return (
+        <div id="prd-implementation-summary" className="mb-8 scroll-mt-24">
+            <div className="flex items-center justify-between mb-3 border-b border-neutral-200 pb-2">
+                <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight">
+                    Implementation Summary
+                </h3>
+                <span className="text-[11px] text-neutral-400">
+                    Derived from features, risks, assumptions
+                </span>
+            </div>
+
+            <div className="bg-gradient-to-br from-indigo-50/40 to-white border border-indigo-100 rounded-xl p-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                    <FeatureBucket
+                        title="Build First"
+                        icon={ListChecks}
+                        accent="green"
+                        features={summary.buildFirst}
+                        emptyHint="No MVP features tagged."
+                    />
+                    <FeatureBucket
+                        title="Build Next"
+                        icon={ArrowRight}
+                        accent="blue"
+                        features={summary.buildNext}
+                        emptyHint="No V1 features tagged."
+                    />
+                    <FeatureBucket
+                        title="Defer"
+                        icon={Pause}
+                        accent="neutral"
+                        features={summary.defer}
+                        emptyHint="No deferred features."
+                    />
+                </div>
+
+                {(summary.highestRisks.length > 0 || summary.openDecisions.length > 0) && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t border-indigo-100">
+                        {summary.highestRisks.length > 0 && (
+                            <div>
+                                <div className="flex items-center gap-2 mb-2">
+                                    <AlertTriangle size={14} className="text-red-600" />
+                                    <h4 className="text-[11px] font-bold uppercase tracking-wider text-red-700">
+                                        Highest Risks
+                                    </h4>
+                                    <span className="text-[11px] text-neutral-400">{summary.highestRisks.length}</span>
+                                </div>
+                                <ul className="space-y-1.5">
+                                    {summary.highestRisks.map((r, i) => (
+                                        <li
+                                            key={i}
+                                            className="rounded-md border border-red-100 bg-red-50/40 px-3 py-2"
+                                        >
+                                            <div className="flex items-start gap-2">
+                                                <span
+                                                    className={`shrink-0 mt-0.5 inline-block text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                                                        r.likelihood === 'high'
+                                                            ? 'bg-red-200 text-red-900'
+                                                            : r.likelihood === 'med'
+                                                                ? 'bg-amber-200 text-amber-900'
+                                                                : 'bg-neutral-200 text-neutral-700'
+                                                    }`}
+                                                >
+                                                    {r.likelihood}
+                                                </span>
+                                                <div className="min-w-0">
+                                                    <p className="text-sm text-neutral-900">{r.risk}</p>
+                                                    {r.impact && (
+                                                        <p className="text-[11px] text-neutral-600 mt-0.5">
+                                                            {r.impact}
+                                                        </p>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        {summary.openDecisions.length > 0 && (
+                            <div>
+                                <div className="flex items-center gap-2 mb-2">
+                                    <ShieldQuestion size={14} className="text-amber-700" />
+                                    <h4 className="text-[11px] font-bold uppercase tracking-wider text-amber-700">
+                                        Open Decisions
+                                    </h4>
+                                    <span className="text-[11px] text-neutral-400">{summary.openDecisions.length}</span>
+                                </div>
+                                <ul className="space-y-1.5">
+                                    {summary.openDecisions.map(d => (
+                                        <li
+                                            key={d.id}
+                                            className="rounded-md border border-amber-100 bg-amber-50/40 px-3 py-2"
+                                        >
+                                            <div className="flex items-start gap-2">
+                                                <span className="shrink-0 mt-0.5 text-[10px] font-mono font-bold text-amber-700">
+                                                    {d.id}
+                                                </span>
+                                                <p className="text-sm text-neutral-900">{d.statement}</p>
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/prd/PremiumSections.tsx
+++ b/src/components/prd/PremiumSections.tsx
@@ -3,6 +3,7 @@ import type {
     StateMachine, RolePermission, ArchFlow, RiskDetailed, MvpScope,
     SuccessMetric, Assumption, ProductThesis,
 } from '../../types';
+import { coerceToBulletList, looksDegenerate } from '../../lib/textCleanup';
 
 // Shared section wrapper. Mirrors the heading style used in StructuredPRDView
 // for visual consistency.
@@ -297,35 +298,100 @@ export function DataModelSection({ model }: { model: PrdDataModel }) {
 }
 
 export function StateMachinesSection({ machines }: { machines: StateMachine[] }) {
+    // Card-per-state layout. The previous wide table overflowed catastrophically
+    // when a single cell carried a long degenerate string from the model. Cards
+    // wrap naturally and the bullet lists are easier to scan than dense prose.
+    const hasQualityIssue = machines.some(m =>
+        m.states.some(s => looksDegenerate(s.userVisible) || looksDegenerate(s.systemBehavior)),
+    );
     return (
         <Section title="State Machines" id="prd-state-machines">
-            <div className="space-y-4">
+            {hasQualityIssue && (
+                <div className="mb-3 flex items-center gap-2 px-3 py-2 bg-amber-50 border border-amber-200 rounded-md">
+                    <span className="text-[11px] font-bold uppercase tracking-wider text-amber-700">
+                        Quality issue
+                    </span>
+                    <span className="text-xs text-amber-800">
+                        Some cells looked repetitive and were auto-cleaned. Consider regenerating for cleaner output.
+                    </span>
+                </div>
+            )}
+            <div className="space-y-6">
                 {machines.map((m, idx) => (
-                    <div key={idx}>
-                        <p className="text-sm font-bold text-neutral-900 mb-2">{m.entity}</p>
-                        <div className="overflow-x-auto rounded-lg border border-neutral-200">
-                            <table className="w-full text-xs">
-                                <thead className="bg-neutral-50 text-neutral-500 uppercase tracking-wider">
-                                    <tr>
-                                        <th className="px-2 py-1.5 text-left">State</th>
-                                        <th className="px-2 py-1.5 text-left">Trigger</th>
-                                        <th className="px-2 py-1.5 text-left">Next States</th>
-                                        <th className="px-2 py-1.5 text-left">User-visible</th>
-                                        <th className="px-2 py-1.5 text-left">System behavior</th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-neutral-100">
-                                    {m.states.map((s, k) => (
-                                        <tr key={k}>
-                                            <td className="px-2 py-1.5 font-mono text-neutral-800">{s.name}</td>
-                                            <td className="px-2 py-1.5 text-neutral-700">{s.trigger || '—'}</td>
-                                            <td className="px-2 py-1.5 text-neutral-700">{(s.nextStates || []).join(', ') || '—'}</td>
-                                            <td className="px-2 py-1.5 text-neutral-700">{s.userVisible || '—'}</td>
-                                            <td className="px-2 py-1.5 text-neutral-700">{s.systemBehavior || '—'}</td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
+                    <div key={idx} className="space-y-3">
+                        <div className="flex items-baseline gap-2">
+                            <h4 className="text-sm font-bold text-neutral-900 font-mono">{m.entity}</h4>
+                            <span className="text-[11px] text-neutral-500">
+                                {m.states.length} state{m.states.length === 1 ? '' : 's'}
+                            </span>
+                        </div>
+                        <div className="space-y-2">
+                            {m.states.map((s, k) => {
+                                const userVisible = coerceToBulletList(s.userVisible, { max: 6 });
+                                const systemBehavior = coerceToBulletList(s.systemBehavior, { max: 6 });
+                                return (
+                                    <div
+                                        key={k}
+                                        className="bg-white rounded-lg border border-neutral-200 p-4"
+                                    >
+                                        <div className="flex flex-wrap items-center gap-2 mb-2">
+                                            <span className="font-mono text-sm font-semibold text-neutral-900">
+                                                {s.name}
+                                            </span>
+                                            {s.trigger && (
+                                                <span className="text-[11px] text-neutral-500">
+                                                    <span className="font-semibold uppercase tracking-wider">Trigger</span>
+                                                    {' '}
+                                                    {s.trigger}
+                                                </span>
+                                            )}
+                                            {s.nextStates && s.nextStates.length > 0 && (
+                                                <span className="flex flex-wrap items-center gap-1">
+                                                    <span className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                                                        →
+                                                    </span>
+                                                    {s.nextStates.map((ns, i) => (
+                                                        <span
+                                                            key={i}
+                                                            className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-mono bg-neutral-100 text-neutral-700 rounded"
+                                                        >
+                                                            {ns}
+                                                        </span>
+                                                    ))}
+                                                </span>
+                                            )}
+                                        </div>
+                                        {(userVisible.length > 0 || systemBehavior.length > 0) && (
+                                            <div className="grid sm:grid-cols-2 gap-3 mt-2">
+                                                {userVisible.length > 0 && (
+                                                    <div>
+                                                        <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-700 mb-1">
+                                                            User-visible
+                                                        </p>
+                                                        <ul className="list-disc pl-4 text-xs text-neutral-700 space-y-0.5">
+                                                            {userVisible.map((b, i) => (
+                                                                <li key={i}>{b}</li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                )}
+                                                {systemBehavior.length > 0 && (
+                                                    <div>
+                                                        <p className="text-[11px] font-semibold uppercase tracking-wider text-emerald-700 mb-1">
+                                                            System behavior
+                                                        </p>
+                                                        <ul className="list-disc pl-4 text-xs text-neutral-700 space-y-0.5">
+                                                            {systemBehavior.map((b, i) => (
+                                                                <li key={i}>{b}</li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
                         </div>
                     </div>
                 ))}

--- a/src/components/renderers/DesignSystemRenderer.tsx
+++ b/src/components/renderers/DesignSystemRenderer.tsx
@@ -1,0 +1,348 @@
+import { useMemo } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+
+// Render a `design_system` artifact with first-class visual tokens:
+//  • inline color swatches for every hex code
+//  • a "live preview" cell next to each typography table row
+//  • horizontal bars for spacing-scale list items
+//
+// We don't change the artifact schema — the artifact is still markdown.
+// Instead we split the markdown on `### ` boundaries and dispatch each
+// section to a specialty sub-renderer where it pays off, then fall
+// back to ReactMarkdown for everything else with a small text-level
+// enhancement that turns standalone `#RRGGBB` tokens into swatches.
+
+interface Props {
+    content: string;
+}
+
+const HEX_RE = /#[0-9a-fA-F]{6}\b/g;
+const HEX_TEST = /^#[0-9a-fA-F]{6}$/;
+
+// Pre-replace hex codes with a span carrying a data attribute, so the
+// span override below can render them as a swatch + label without us
+// having to walk every text node by hand.
+function annotateHexes(markdown: string): string {
+    return markdown.replace(HEX_RE, hex => `<span data-hex="${hex}">${hex}</span>`);
+}
+
+function HexSwatch({ hex }: { hex: string }) {
+    return (
+        <span className="inline-flex items-center gap-1.5 align-middle">
+            <span
+                className="inline-block w-3.5 h-3.5 rounded border border-neutral-300 align-middle"
+                style={{ background: hex }}
+                aria-hidden="true"
+            />
+            <code className="font-mono text-[11px] text-neutral-700">{hex}</code>
+        </span>
+    );
+}
+
+const baseComponents: Components = {
+    span(props) {
+        // rehype-raw lifts the data-hex attribute into props.
+        const dataHex = (props as Record<string, unknown>)['data-hex'] as string | undefined;
+        if (dataHex && HEX_TEST.test(dataHex)) return <HexSwatch hex={dataHex} />;
+        const { children, ...rest } = props;
+        return <span {...rest}>{children}</span>;
+    },
+};
+
+type Section = { title: string; body: string };
+
+function splitByH3(markdown: string): Section[] {
+    const lines = markdown.split('\n');
+    const sections: Section[] = [];
+    let current: Section | null = null;
+    const preamble: string[] = [];
+    for (const line of lines) {
+        const m = line.match(/^### \s*(.+?)\s*$/);
+        if (m) {
+            if (current) sections.push(current);
+            current = { title: m[1], body: '' };
+            continue;
+        }
+        if (current) {
+            current.body += line + '\n';
+        } else {
+            preamble.push(line);
+        }
+    }
+    if (current) sections.push(current);
+    if (preamble.join('').trim().length > 0) {
+        sections.unshift({ title: '', body: preamble.join('\n') });
+    }
+    return sections;
+}
+
+// ─── Color Palette ──────────────────────────────────────────────────────────
+
+type ColorRow = { label: string; hex: string; description: string };
+
+function parseColorPalette(body: string): { rows: ColorRow[]; rest: string } {
+    const rows: ColorRow[] = [];
+    const restLines: string[] = [];
+    for (const line of body.split('\n')) {
+        // **Label:** #RRGGBB optional description
+        const m = line.match(/^\s*[-*]?\s*\*?\*?\s*([^*:]+?)\s*\*?\*?\s*[:-]\s*(#[0-9a-fA-F]{6})\b\s*(.*)$/);
+        if (m) {
+            const [, label, hex, description] = m;
+            rows.push({
+                label: label.trim().replace(/[*_]/g, ''),
+                hex,
+                description: description.trim().replace(/^[—–-]\s*/, ''),
+            });
+        } else {
+            restLines.push(line);
+        }
+    }
+    return { rows, rest: restLines.join('\n').trim() };
+}
+
+function ColorPaletteSection({ body }: { body: string }) {
+    const { rows, rest } = useMemo(() => parseColorPalette(body), [body]);
+    if (rows.length === 0) return <FallbackMarkdown body={body} />;
+    return (
+        <div className="space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {rows.map((row, i) => (
+                    <div
+                        key={i}
+                        className="flex items-start gap-3 bg-white rounded-lg border border-neutral-200 p-3"
+                    >
+                        <span
+                            className="shrink-0 w-12 h-12 rounded-md border border-neutral-200"
+                            style={{ background: row.hex }}
+                            aria-hidden="true"
+                        />
+                        <div className="min-w-0">
+                            <div className="flex flex-wrap items-baseline gap-2">
+                                <span className="text-sm font-semibold text-neutral-900">{row.label}</span>
+                                <code className="font-mono text-[11px] text-neutral-500">{row.hex}</code>
+                            </div>
+                            {row.description && (
+                                <p className="text-xs text-neutral-600 mt-0.5">{row.description}</p>
+                            )}
+                        </div>
+                    </div>
+                ))}
+            </div>
+            {rest && <FallbackMarkdown body={rest} />}
+        </div>
+    );
+}
+
+// ─── Typography ─────────────────────────────────────────────────────────────
+
+type TypographyRow = {
+    role: string;
+    font: string;
+    size: string;
+    weight: string;
+    lineHeight: string;
+    application: string;
+};
+
+function parseTypographyTable(body: string): TypographyRow[] | null {
+    const lines = body.split('\n').map(l => l.trim()).filter(Boolean);
+    let headerIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+        const l = lines[i].toLowerCase();
+        if (l.includes('role') && l.includes('font') && l.includes('size') && l.includes('weight')) {
+            headerIdx = i;
+            break;
+        }
+    }
+    if (headerIdx === -1) return null;
+    // Rows start two lines after the header (header + separator).
+    const rows: TypographyRow[] = [];
+    for (let i = headerIdx + 2; i < lines.length; i++) {
+        const cells = lines[i]
+            .split('|')
+            .map(c => c.trim())
+            .filter((c, idx, arr) => !(idx === 0 && c === '') && !(idx === arr.length - 1 && c === ''));
+        if (cells.length < 5) break;
+        rows.push({
+            role: cells[0],
+            font: cells[1],
+            size: cells[2],
+            weight: cells[3],
+            lineHeight: cells[4],
+            application: cells[5] || '',
+        });
+    }
+    return rows.length > 0 ? rows : null;
+}
+
+function parseSize(size: string): number {
+    const m = size.match(/(\d+(?:\.\d+)?)/);
+    return m ? Number(m[1]) : 16;
+}
+
+function TypographySection({ body }: { body: string }) {
+    const rows = useMemo(() => parseTypographyTable(body), [body]);
+    if (!rows) return <FallbackMarkdown body={body} />;
+    return (
+        <div className="space-y-2">
+            {rows.map((row, i) => {
+                const px = parseSize(row.size);
+                const previewSize = Math.min(Math.max(px, 12), 36);
+                return (
+                    <div
+                        key={i}
+                        className="grid grid-cols-[auto,1fr] gap-4 items-center bg-white rounded-lg border border-neutral-200 p-3"
+                    >
+                        <div className="min-w-[140px]">
+                            <p className="text-[11px] font-bold uppercase tracking-wider text-neutral-500">
+                                {row.role}
+                            </p>
+                            <p className="text-[11px] text-neutral-500 mt-0.5">
+                                {row.font} · {row.size} · {row.weight}
+                                {row.lineHeight ? ` · LH ${row.lineHeight}` : ''}
+                            </p>
+                        </div>
+                        <div className="min-w-0">
+                            <p
+                                className="text-neutral-900 truncate"
+                                style={{
+                                    fontFamily: row.font,
+                                    fontSize: `${previewSize}px`,
+                                    fontWeight: parseInt(row.weight, 10) || 400,
+                                    lineHeight: row.lineHeight || 1.3,
+                                }}
+                            >
+                                The quick brown fox
+                            </p>
+                            {row.application && (
+                                <p className="text-[11px] text-neutral-500 mt-0.5">{row.application}</p>
+                            )}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+// ─── Spacing Scale ──────────────────────────────────────────────────────────
+
+type SpacingRow = { px: number; label: string; description: string };
+
+function parseSpacing(body: string): SpacingRow[] {
+    const rows: SpacingRow[] = [];
+    for (const line of body.split('\n')) {
+        // - 4px (xs): description
+        // - 4px: description
+        const m = line.match(/^\s*[-*]\s*(\d+)px\s*(?:\(([^)]+)\))?\s*[:\-—]?\s*(.*)$/);
+        if (m) {
+            rows.push({
+                px: Number(m[1]),
+                label: (m[2] || '').trim(),
+                description: m[3].trim(),
+            });
+        }
+    }
+    return rows;
+}
+
+function SpacingSection({ body }: { body: string }) {
+    const rows = useMemo(() => parseSpacing(body), [body]);
+    if (rows.length === 0) return <FallbackMarkdown body={body} />;
+    const max = Math.max(...rows.map(r => r.px));
+    // Match the existing markdown list closely while adding a visual bar.
+    return (
+        <div>
+            {body.split('\n').filter(l => /^[A-Za-z]/.test(l.trim())).map((line, i) => (
+                <p key={`p-${i}`} className="text-sm text-neutral-700 mb-2">
+                    {line.trim()}
+                </p>
+            ))}
+            <div className="space-y-1.5">
+                {rows.map((row, i) => (
+                    <div
+                        key={i}
+                        className="flex items-center gap-3 bg-white rounded-md border border-neutral-200 px-3 py-2"
+                    >
+                        <code className="font-mono text-xs text-neutral-700 shrink-0 w-12">
+                            {row.px}px
+                        </code>
+                        {row.label && (
+                            <span className="text-[11px] font-medium uppercase tracking-wider text-indigo-600 shrink-0 w-10">
+                                {row.label}
+                            </span>
+                        )}
+                        <div className="shrink-0 h-3 bg-indigo-200 rounded-sm" style={{ width: `${(row.px / max) * 200}px` }} />
+                        <span className="text-xs text-neutral-600 truncate">{row.description}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// ─── Generic fallback with hex enhancement ─────────────────────────────────
+
+function FallbackMarkdown({ body }: { body: string }) {
+    const annotated = useMemo(() => annotateHexes(body), [body]);
+    return (
+        <div className="prose prose-sm prose-neutral max-w-none">
+            <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={baseComponents}
+            >
+                {annotated}
+            </ReactMarkdown>
+        </div>
+    );
+}
+
+// ─── Top-level dispatcher ──────────────────────────────────────────────────
+
+export function DesignSystemRenderer({ content }: Props) {
+    const sections = useMemo(() => splitByH3(content), [content]);
+    const tabs: SectionTabItem[] = sections
+        .filter(s => s.title)
+        .map(s => ({ id: `ds-${slug(s.title)}`, label: s.title }));
+
+    return (
+        <div className="space-y-6">
+            <SectionTabs items={tabs} />
+            {sections.map((section, i) => {
+                const title = section.title.toLowerCase();
+                let body: React.ReactNode;
+                if (title.includes('color') || title.includes('palette')) {
+                    body = <ColorPaletteSection body={section.body} />;
+                } else if (title.includes('typograph')) {
+                    body = <TypographySection body={section.body} />;
+                } else if (title.includes('spacing')) {
+                    body = <SpacingSection body={section.body} />;
+                } else {
+                    body = <FallbackMarkdown body={section.body} />;
+                }
+                return (
+                    <section
+                        key={i}
+                        id={section.title ? `ds-${slug(section.title)}` : undefined}
+                        className="scroll-mt-24"
+                    >
+                        {section.title && (
+                            <h3 className="text-base font-bold text-neutral-900 mb-3 pb-2 border-b border-neutral-200">
+                                {section.title}
+                            </h3>
+                        )}
+                        {body}
+                    </section>
+                );
+            })}
+        </div>
+    );
+}
+
+function slug(s: string): string {
+    return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}

--- a/src/components/renderers/ImplementationPlanRenderer.tsx
+++ b/src/components/renderers/ImplementationPlanRenderer.tsx
@@ -1,0 +1,266 @@
+import { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Calendar, ChevronRight, Flag, Layers, Target, Users } from 'lucide-react';
+import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+
+// Render an `implementation_plan` artifact as a vertical timeline of
+// `### Milestone N: …` cards with each milestone's checklist surfaced
+// as actual checkboxes (read-only). Anything after the milestones (the
+// horizontal rule + "Critical Path Summary" / "Team Size Recommendation"
+// / "Traceability Map" sections) is rendered as plain markdown so we
+// don't lose any content.
+
+interface Props {
+    content: string;
+}
+
+type Milestone = {
+    id: number;
+    title: string;
+    timeframe?: string;
+    body: string;
+};
+
+type ParsedPlan = {
+    preamble: string;
+    milestones: Milestone[];
+    appendix: string;
+};
+
+const MILESTONE_HEADING = /^###\s+Milestone\s+(\d+)\s*[:\-—]?\s*(.+?)\s*(\(([^)]*)\))?\s*$/i;
+
+function parsePlan(markdown: string): ParsedPlan {
+    const lines = markdown.split('\n');
+    const preamble: string[] = [];
+    const milestones: Milestone[] = [];
+    let inMilestones = false;
+    let appendixStart = -1;
+    let current: Milestone | null = null;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const m = line.match(MILESTONE_HEADING);
+        if (m) {
+            if (current) milestones.push(current);
+            inMilestones = true;
+            const id = Number(m[1]);
+            const baseTitle = m[2].trim();
+            const timeframe = m[4]?.trim();
+            current = {
+                id,
+                title: timeframe ? baseTitle : baseTitle.replace(/\s*\([^)]*\)\s*$/, ''),
+                timeframe: timeframe ?? extractTimeframe(baseTitle),
+                body: '',
+            };
+            continue;
+        }
+        // Horizontal rule terminates milestone collection.
+        if (inMilestones && /^---+\s*$/.test(line.trim())) {
+            if (current) {
+                milestones.push(current);
+                current = null;
+            }
+            appendixStart = i + 1;
+            break;
+        }
+        if (current) {
+            current.body += line + '\n';
+        } else if (!inMilestones) {
+            preamble.push(line);
+        }
+    }
+    if (current) milestones.push(current);
+
+    const appendix = appendixStart >= 0 ? lines.slice(appendixStart).join('\n').trim() : '';
+    return {
+        preamble: preamble.join('\n').trim(),
+        milestones,
+        appendix,
+    };
+}
+
+function extractTimeframe(title: string): string | undefined {
+    const m = title.match(/\(([^)]*)\)\s*$/);
+    return m?.[1];
+}
+
+type ParsedSection = {
+    label: string;
+    body: string;
+};
+
+function parseMilestoneBody(body: string): {
+    sections: ParsedSection[];
+    deliverables: { text: string; checked: boolean }[];
+} {
+    const lines = body.split('\n');
+    const sections: ParsedSection[] = [];
+    const deliverables: { text: string; checked: boolean }[] = [];
+    let currentLabel: string | null = null;
+    let currentLines: string[] = [];
+
+    const flushSection = () => {
+        if (currentLabel) {
+            sections.push({ label: currentLabel, body: currentLines.join('\n').trim() });
+        }
+        currentLabel = null;
+        currentLines = [];
+    };
+
+    for (const raw of lines) {
+        const line = raw;
+        const labelMatch = line.match(/^\*\*([^*]+):\*\*\s*(.*)$/);
+        if (labelMatch) {
+            flushSection();
+            currentLabel = labelMatch[1].trim();
+            currentLines = labelMatch[2] ? [labelMatch[2]] : [];
+            continue;
+        }
+        const checklistMatch = line.match(/^\s*-\s*\[\s*([ xX])\s*\]\s*(.+)$/);
+        if (checklistMatch) {
+            deliverables.push({
+                text: checklistMatch[2].trim(),
+                checked: checklistMatch[1].toLowerCase() === 'x',
+            });
+            continue;
+        }
+        if (currentLabel) {
+            currentLines.push(line);
+        }
+    }
+    flushSection();
+    return { sections, deliverables };
+}
+
+function inlineMd(text: string) {
+    return (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ p: ({ children }) => <>{children}</> }}>
+            {text}
+        </ReactMarkdown>
+    );
+}
+
+function blockMd(text: string) {
+    return (
+        <div className="prose prose-sm prose-neutral max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+        </div>
+    );
+}
+
+const SECTION_ICON: Record<string, typeof Target> = {
+    goal: Target,
+    'key deliverables': Layers,
+    'technical approach': Layers,
+    dependencies: ChevronRight,
+    risks: Flag,
+    'definition of done': Target,
+};
+
+function MilestoneCard({ milestone }: { milestone: Milestone }) {
+    const { sections, deliverables } = useMemo(() => parseMilestoneBody(milestone.body), [milestone.body]);
+    return (
+        <article
+            id={`milestone-${milestone.id}`}
+            className="bg-white rounded-xl border border-neutral-200 p-5 scroll-mt-24"
+        >
+            <header className="flex items-start gap-3 mb-3 pb-3 border-b border-neutral-100">
+                <div className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-lg bg-indigo-600 text-white text-sm font-bold">
+                    M{milestone.id}
+                </div>
+                <div className="min-w-0">
+                    <h3 className="text-base font-bold text-neutral-900 leading-snug">{milestone.title}</h3>
+                    {milestone.timeframe && (
+                        <p className="flex items-center gap-1 text-[11px] text-neutral-500 mt-0.5">
+                            <Calendar size={11} />
+                            {milestone.timeframe}
+                        </p>
+                    )}
+                </div>
+            </header>
+
+            {deliverables.length > 0 && (
+                <div className="mb-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
+                        Key Deliverables
+                    </p>
+                    <ul className="space-y-1">
+                        {deliverables.map((d, i) => (
+                            <li key={i} className="flex items-start gap-2 text-sm text-neutral-800">
+                                <input
+                                    type="checkbox"
+                                    checked={d.checked}
+                                    readOnly
+                                    aria-label={d.text}
+                                    className="mt-1 rounded border-neutral-300 cursor-default"
+                                />
+                                <span>{inlineMd(d.text)}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            {sections.length > 0 && (
+                <div className="space-y-3">
+                    {sections.map((section, i) => {
+                        const key = section.label.toLowerCase();
+                        const Icon = SECTION_ICON[key] ?? ChevronRight;
+                        return (
+                            <div key={i}>
+                                <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">
+                                    <Icon size={11} />
+                                    {section.label}
+                                </p>
+                                <div className="text-sm text-neutral-800">
+                                    {blockMd(section.body)}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </article>
+    );
+}
+
+function AppendixSection({ markdown }: { markdown: string }) {
+    if (!markdown.trim()) return null;
+    return (
+        <div className="bg-neutral-50 rounded-xl border border-neutral-200 p-5">
+            <header className="flex items-center gap-2 mb-2">
+                <Users size={14} className="text-neutral-500" />
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                    Notes &amp; Traceability
+                </p>
+            </header>
+            {blockMd(markdown)}
+        </div>
+    );
+}
+
+export function ImplementationPlanRenderer({ content }: Props) {
+    const plan = useMemo(() => parsePlan(content), [content]);
+    if (plan.milestones.length === 0) {
+        return (
+            <div className="prose prose-sm prose-neutral max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+        );
+    }
+    const tabs: SectionTabItem[] = plan.milestones.map(m => ({
+        id: `milestone-${m.id}`,
+        label: `M${m.id}`,
+    }));
+    return (
+        <div className="space-y-5">
+            <SectionTabs items={tabs} />
+            {plan.preamble && blockMd(plan.preamble)}
+            {plan.milestones.map(m => (
+                <MilestoneCard key={m.id} milestone={m} />
+            ))}
+            <AppendixSection markdown={plan.appendix} />
+        </div>
+    );
+}

--- a/src/components/renderers/PromptPackRenderer.tsx
+++ b/src/components/renderers/PromptPackRenderer.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Check, Copy, Sparkles } from 'lucide-react';
+import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+
+// Render a `prompt_pack` artifact as one card per `### N. Title` heading,
+// extracting `**Target Tool:**` / `**Category:**` chips and the fenced
+// code block that holds the actual prompt body. Each card has a
+// "Copy prompt" button that copies the prompt text to the clipboard.
+
+interface Props {
+    content: string;
+}
+
+type PromptCard = {
+    index: number;
+    title: string;
+    targetTool?: string;
+    category?: string;
+    promptBody: string;
+    expected?: string;
+};
+
+const PROMPT_HEADING = /^###\s+(\d+)\.?\s+(.+?)\s*$/;
+
+function parsePromptPack(markdown: string): { preamble: string; cards: PromptCard[] } {
+    const lines = markdown.split('\n');
+    const preambleLines: string[] = [];
+    const cards: PromptCard[] = [];
+    let active: { rawLines: string[]; index: number; title: string } | null = null;
+    let inMilestones = false;
+
+    for (const line of lines) {
+        const heading = line.match(PROMPT_HEADING);
+        if (heading) {
+            if (active) cards.push(buildCard(active));
+            active = { rawLines: [], index: Number(heading[1]), title: heading[2] };
+            inMilestones = true;
+            continue;
+        }
+        if (active) {
+            active.rawLines.push(line);
+        } else if (!inMilestones) {
+            preambleLines.push(line);
+        }
+    }
+    if (active) cards.push(buildCard(active));
+    return { preamble: preambleLines.join('\n').trim(), cards };
+}
+
+function buildCard(active: { rawLines: string[]; index: number; title: string }): PromptCard {
+    const card: PromptCard = {
+        index: active.index,
+        title: active.title,
+        promptBody: '',
+    };
+    let inFence = false;
+    const promptLines: string[] = [];
+    let collectExpected = false;
+    const expectedLines: string[] = [];
+
+    for (const line of active.rawLines) {
+        if (/^```/.test(line.trim())) {
+            inFence = !inFence;
+            continue;
+        }
+        if (inFence) {
+            promptLines.push(line);
+            continue;
+        }
+        const tool = line.match(/^\*\*Target Tool:\*\*\s*(.+)$/i);
+        if (tool) {
+            card.targetTool = tool[1].trim();
+            continue;
+        }
+        const cat = line.match(/^\*\*Category:\*\*\s*(.+)$/i);
+        if (cat) {
+            card.category = cat[1].trim();
+            continue;
+        }
+        const exp = line.match(/^\*\*Expected Output:\*\*\s*(.*)$/i);
+        if (exp) {
+            collectExpected = true;
+            if (exp[1].trim()) expectedLines.push(exp[1].trim());
+            continue;
+        }
+        if (collectExpected) {
+            expectedLines.push(line);
+        }
+    }
+    card.promptBody = promptLines.join('\n').trim();
+    if (expectedLines.length > 0) {
+        card.expected = expectedLines.join('\n').trim();
+    }
+    return card;
+}
+
+function CopyButton({ text }: { text: string }) {
+    const [copied, setCopied] = useState(false);
+    return (
+        <button
+            type="button"
+            onClick={async () => {
+                try {
+                    await navigator.clipboard.writeText(text);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1500);
+                } catch {
+                    // Clipboard API not available — silently no-op.
+                }
+            }}
+            className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700 transition"
+        >
+            {copied ? (
+                <>
+                    <Check size={12} /> Copied
+                </>
+            ) : (
+                <>
+                    <Copy size={12} /> Copy prompt
+                </>
+            )}
+        </button>
+    );
+}
+
+function PromptCardView({ card }: { card: PromptCard }) {
+    return (
+        <article
+            id={`prompt-${card.index}`}
+            className="bg-white rounded-xl border border-neutral-200 overflow-hidden scroll-mt-24"
+        >
+            <header className="px-4 py-3 border-b border-neutral-100 flex flex-wrap items-start gap-3 justify-between">
+                <div className="min-w-0">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-600">
+                        Prompt {card.index}
+                    </p>
+                    <h3 className="text-sm font-bold text-neutral-900 leading-snug mt-0.5">
+                        {card.title}
+                    </h3>
+                    {(card.targetTool || card.category) && (
+                        <div className="flex flex-wrap gap-1.5 mt-2">
+                            {card.targetTool && (
+                                <span className="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-700 border border-indigo-100">
+                                    <Sparkles size={10} />
+                                    {card.targetTool}
+                                </span>
+                            )}
+                            {card.category && (
+                                <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-700">
+                                    {card.category}
+                                </span>
+                            )}
+                        </div>
+                    )}
+                </div>
+                {card.promptBody && <CopyButton text={card.promptBody} />}
+            </header>
+            {card.promptBody && (
+                <div className="bg-neutral-900 text-neutral-100 px-4 py-3 text-xs font-mono whitespace-pre-wrap leading-relaxed max-h-72 overflow-y-auto">
+                    {card.promptBody}
+                </div>
+            )}
+            {card.expected && (
+                <div className="px-4 py-3 border-t border-neutral-100 bg-emerald-50/40">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-emerald-700 mb-1">
+                        Expected output
+                    </p>
+                    <div className="prose prose-sm prose-neutral max-w-none">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{card.expected}</ReactMarkdown>
+                    </div>
+                </div>
+            )}
+        </article>
+    );
+}
+
+export function PromptPackRenderer({ content }: Props) {
+    const { preamble, cards } = useMemo(() => parsePromptPack(content), [content]);
+    if (cards.length === 0) {
+        return (
+            <div className="prose prose-sm prose-neutral max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+        );
+    }
+    const tabs: SectionTabItem[] = cards.map(card => ({
+        id: `prompt-${card.index}`,
+        label: `${card.index}. ${card.title.length > 24 ? card.title.slice(0, 22) + '…' : card.title}`,
+    }));
+    return (
+        <div className="space-y-4">
+            <SectionTabs items={tabs} />
+            {preamble && (
+                <div className="prose prose-sm prose-neutral max-w-none">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{preamble}</ReactMarkdown>
+                </div>
+            )}
+            {cards.map(card => (
+                <PromptCardView key={card.index} card={card} />
+            ))}
+        </div>
+    );
+}

--- a/src/components/renderers/UserFlowsRenderer.tsx
+++ b/src/components/renderers/UserFlowsRenderer.tsx
@@ -1,0 +1,251 @@
+import { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { AlertCircle, GitBranch, Sparkles, Target } from 'lucide-react';
+import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+
+// Render a `user_flows` artifact as one card per `### Flow: …` heading,
+// extracting the conventional `**Goal:**`, `**Preconditions:**`, `**Steps:**`,
+// `**Success Outcome:**`, `**Error Paths:**`, `**Edge Cases:**` sub-sections.
+//
+// We keep ReactMarkdown for the actual prose so backticks, links, and
+// emphasis still work — the renderer only restructures the layout.
+
+interface Props {
+    content: string;
+}
+
+type FlowSection = {
+    title: string;
+    goal?: string;
+    preconditions?: string;
+    stepsBlock?: string;
+    successOutcome?: string;
+    errorPaths?: string;
+    edgeCases?: string;
+    rest?: string;
+};
+
+const SECTION_LABELS: Array<[keyof FlowSection, RegExp]> = [
+    ['goal', /^\*\*Goal:\*\*\s*/i],
+    ['preconditions', /^\*\*Preconditions:\*\*\s*/i],
+    ['stepsBlock', /^\*\*Steps:\*\*\s*/i],
+    ['successOutcome', /^\*\*Success Outcome:\*\*\s*/i],
+    ['errorPaths', /^\*\*Error Paths:\*\*\s*/i],
+    ['edgeCases', /^\*\*Edge Cases:\*\*\s*/i],
+];
+
+function splitFlows(markdown: string): FlowSection[] {
+    const flows: FlowSection[] = [];
+    let current: FlowSection | null = null;
+    let buffer: { key: keyof FlowSection | null; lines: string[] } = { key: null, lines: [] };
+    const flush = () => {
+        if (!current || buffer.key === null) {
+            buffer = { key: null, lines: [] };
+            return;
+        }
+        const text = buffer.lines.join('\n').trim();
+        // We only set string keys here — TS narrows correctly via the closure.
+        (current as Record<string, string>)[buffer.key as string] = text;
+        buffer = { key: null, lines: [] };
+    };
+
+    const lines = markdown.split('\n');
+    for (const rawLine of lines) {
+        const line = rawLine;
+        const headingMatch = line.match(/^#{1,4}\s+Flow:\s*(.+?)\s*$/i);
+        if (headingMatch) {
+            if (current) {
+                flush();
+                flows.push(current);
+            }
+            current = { title: headingMatch[1] };
+            buffer = { key: null, lines: [] };
+            continue;
+        }
+        if (!current) continue;
+        let matchedKey: keyof FlowSection | null = null;
+        for (const [key, re] of SECTION_LABELS) {
+            if (re.test(line)) {
+                matchedKey = key;
+                flush();
+                buffer = { key, lines: [line.replace(re, '')] };
+                break;
+            }
+        }
+        if (matchedKey) continue;
+        buffer.lines.push(line);
+    }
+    if (current) {
+        flush();
+        flows.push(current);
+    }
+    return flows;
+}
+
+function inlineMd(text: string) {
+    return (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ p: ({ children }) => <>{children}</> }}>
+            {text}
+        </ReactMarkdown>
+    );
+}
+
+function blockMd(text: string) {
+    return (
+        <div className="prose prose-sm prose-neutral max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+        </div>
+    );
+}
+
+function StepsList({ block }: { block: string }) {
+    // Parse numbered items at column 0 (`1.`, `2.`) and any indented bullets.
+    const stepGroups: Array<{ text: string; subs: string[] }> = [];
+    let active: { text: string; subs: string[] } | null = null;
+    for (const line of block.split('\n')) {
+        const top = line.match(/^\s*(\d+)\.\s+(.*)$/);
+        if (top) {
+            if (active) stepGroups.push(active);
+            active = { text: top[2], subs: [] };
+            continue;
+        }
+        const sub = line.match(/^\s+[-*]\s+(.*)$/);
+        if (sub && active) {
+            active.subs.push(sub[1]);
+            continue;
+        }
+        if (active && line.trim().length > 0) {
+            // Continuation of the previous step — append onto the current step's main text.
+            active.text += ' ' + line.trim();
+        }
+    }
+    if (active) stepGroups.push(active);
+    if (stepGroups.length === 0) return blockMd(block);
+
+    return (
+        <ol className="space-y-2">
+            {stepGroups.map((step, i) => (
+                <li key={i} className="flex gap-3">
+                    <span className="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold">
+                        {i + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                        <div className="text-sm text-neutral-800 leading-snug">
+                            {inlineMd(step.text)}
+                        </div>
+                        {step.subs.length > 0 && (
+                            <ul className="mt-1 space-y-1 pl-2 border-l-2 border-amber-200">
+                                {step.subs.map((sub, k) => (
+                                    <li
+                                        key={k}
+                                        className="text-xs text-amber-900 bg-amber-50/50 px-2 py-1 rounded"
+                                    >
+                                        {inlineMd(sub)}
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </div>
+                </li>
+            ))}
+        </ol>
+    );
+}
+
+function FlowCard({ flow, index }: { flow: FlowSection; index: number }) {
+    return (
+        <article
+            id={`flow-${index}`}
+            className="bg-white rounded-xl border border-neutral-200 p-5 scroll-mt-24"
+        >
+            <div className="flex items-start gap-3 mb-3 pb-3 border-b border-neutral-100">
+                <div className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-md bg-indigo-50 text-indigo-600">
+                    <GitBranch size={16} />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-600">
+                        Flow {index + 1}
+                    </p>
+                    <h3 className="text-base font-bold text-neutral-900 leading-snug">
+                        {flow.title}
+                    </h3>
+                </div>
+            </div>
+
+            {flow.goal && (
+                <div className="flex items-start gap-2 mb-3">
+                    <Target size={14} className="shrink-0 mt-0.5 text-emerald-600" />
+                    <div className="text-sm text-neutral-800">
+                        <span className="font-semibold text-emerald-700">Goal:</span>{' '}
+                        {inlineMd(flow.goal)}
+                    </div>
+                </div>
+            )}
+            {flow.preconditions && (
+                <div className="text-sm text-neutral-700 mb-3">
+                    <span className="font-semibold text-neutral-600">Preconditions:</span>{' '}
+                    {inlineMd(flow.preconditions)}
+                </div>
+            )}
+            {flow.stepsBlock && (
+                <div className="mb-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-2">
+                        Steps
+                    </p>
+                    <StepsList block={flow.stepsBlock} />
+                </div>
+            )}
+            {flow.successOutcome && (
+                <div className="flex items-start gap-2 mb-3 px-3 py-2 bg-emerald-50/60 border border-emerald-100 rounded-md">
+                    <Sparkles size={14} className="shrink-0 mt-0.5 text-emerald-600" />
+                    <div className="text-sm text-neutral-800">
+                        <span className="font-semibold text-emerald-700">Success outcome:</span>{' '}
+                        {inlineMd(flow.successOutcome)}
+                    </div>
+                </div>
+            )}
+            {flow.errorPaths && (
+                <div className="flex items-start gap-2 mb-3 px-3 py-2 bg-red-50/60 border border-red-100 rounded-md">
+                    <AlertCircle size={14} className="shrink-0 mt-0.5 text-red-600" />
+                    <div className="text-sm text-neutral-800 min-w-0">
+                        <span className="font-semibold text-red-700">Error paths:</span>
+                        <div className="mt-1">{blockMd(flow.errorPaths)}</div>
+                    </div>
+                </div>
+            )}
+            {flow.edgeCases && (
+                <div className="text-sm text-neutral-600 italic">
+                    <span className="font-semibold not-italic">Edge cases:</span>{' '}
+                    {inlineMd(flow.edgeCases)}
+                </div>
+            )}
+            {flow.rest && <div className="mt-3">{blockMd(flow.rest)}</div>}
+        </article>
+    );
+}
+
+export function UserFlowsRenderer({ content }: Props) {
+    const flows = useMemo(() => splitFlows(content), [content]);
+    if (flows.length === 0) {
+        // Fall back to plain markdown if we couldn't detect any Flow:
+        // headings — preserves backwards-compat with very legacy content.
+        return (
+            <div className="prose prose-sm prose-neutral max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+        );
+    }
+    const tabs: SectionTabItem[] = flows.map((flow, i) => ({
+        id: `flow-${i}`,
+        label: flow.title.length > 32 ? `${flow.title.slice(0, 30)}…` : flow.title,
+    }));
+    return (
+        <div className="space-y-4">
+            <SectionTabs items={tabs} />
+            {flows.map((flow, i) => (
+                <FlowCard key={i} flow={flow} index={i} />
+            ))}
+        </div>
+    );
+}

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -3,6 +3,10 @@ import { ScreenInventoryRenderer } from './ScreenInventoryRenderer';
 import type { ScreenImageGalleryContext } from './ScreenImageGallery';
 import { DataModelRenderer } from './DataModelRenderer';
 import { ComponentInventoryRenderer } from './ComponentInventoryRenderer';
+import { DesignSystemRenderer } from './DesignSystemRenderer';
+import { UserFlowsRenderer } from './UserFlowsRenderer';
+import { ImplementationPlanRenderer } from './ImplementationPlanRenderer';
+import { PromptPackRenderer } from './PromptPackRenderer';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -17,10 +21,17 @@ interface DispatchProps {
  * Render artifact content using a type-specific renderer if available,
  * falling back to ReactMarkdown for markdown content.
  *
- * Structured renderers expect JSON content. Since generateCoreArtifact()
- * converts JSON responses to markdown via structuredArtifactToMarkdown()
- * before storage, content is typically markdown. We check if the content
- * is valid JSON before attempting the structured renderer path.
+ * Three subtypes (`screen_inventory`, `data_model`, `component_inventory`)
+ * are stored as JSON when generation succeeds and rendered through
+ * structured renderers; the structured renderers return `null` if the
+ * content turns out not to be JSON, and we fall through.
+ *
+ * The four markdown-only subtypes (`design_system`, `user_flows`,
+ * `implementation_plan`, `prompt_pack`) get bespoke layouts that parse
+ * the conventional markdown shapes into rich visual presentations
+ * (color swatches, milestone timeline, prompt cards, etc.). Each
+ * gracefully falls back to ReactMarkdown if the conventions don't
+ * match — older artifacts always remain readable.
  */
 function isJsonString(str: string): boolean {
     try {
@@ -40,6 +51,18 @@ export function ArtifactContentRenderer({ subtype, content, screenImageContext }
     }
     if (subtype === 'component_inventory' && isJsonString(content)) {
         return <ComponentInventoryRenderer content={content} />;
+    }
+    if (subtype === 'design_system') {
+        return <DesignSystemRenderer content={content} />;
+    }
+    if (subtype === 'user_flows') {
+        return <UserFlowsRenderer content={content} />;
+    }
+    if (subtype === 'implementation_plan') {
+        return <ImplementationPlanRenderer content={content} />;
+    }
+    if (subtype === 'prompt_pack') {
+        return <PromptPackRenderer content={content} />;
     }
     return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;
 }

--- a/src/lib/__tests__/artifactValidation.test.ts
+++ b/src/lib/__tests__/artifactValidation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { detectDegenerateContent, validateArtifactContent } from '../artifactValidation';
+
+describe('detectDegenerateContent', () => {
+    it('returns null for clean content', () => {
+        const clean = `### Login Screen
+| State | Trigger | Behavior |
+|---|---|---|
+| Idle | App start | Show login form. |
+| Submitting | Submit click | Show spinner. Disable inputs. |
+| Error | Bad creds | Show error toast. Re-enable inputs. |
+`;
+        expect(detectDegenerateContent(clean)).toBeNull();
+    });
+
+    it('flags a single mega-cell over the threshold', () => {
+        const phrase = "Shows Connect Spotify button. Disables Save to Library. ";
+        const cell = phrase.repeat(30); // ~1700 chars in one cell
+        const md = `| State | User-visible |
+|---|---|
+| Idle | ${cell} |
+`;
+        expect(detectDegenerateContent(md)).toMatch(/unusually long/);
+    });
+
+    it('flags a cell whose sentences dedupe to ≤ half their original count', () => {
+        const repeated = Array.from({ length: 6 }, () => 'Shows the connect button.').join(' ');
+        const md = `| State | User-visible |
+|---|---|
+| Idle | ${repeated} Shows another sentence. Yet another. Shows the connect button. |
+`;
+        expect(detectDegenerateContent(md)).toMatch(/degenerate|repeating|repeats/i);
+    });
+});
+
+describe('validateArtifactContent', () => {
+    it('penalizes degenerate content via the new heuristic', () => {
+        const phrase = 'Shows Connect Spotify. Disables Save to Library. ';
+        const cell = phrase.repeat(30);
+        const md = `# Doc
+
+### Section
+**Goal:** something
+
+| Flow | Steps | Success | Error |
+|---|---|---|---|
+| A | ${cell} | done | none |
+`;
+        const result = validateArtifactContent('user_flows', md);
+        expect(result.warnings.some(w => /repeating|degenerate|unusually long/.test(w))).toBe(true);
+        expect(result.qualityScore).toBeLessThan(100);
+    });
+});

--- a/src/lib/__tests__/implementationSummary.test.ts
+++ b/src/lib/__tests__/implementationSummary.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+    deriveImplementationSummary,
+    isImplementationSummaryEmpty,
+} from '../derive/implementationSummary';
+import type { StructuredPRD, Feature } from '../../types';
+
+const baseFeature = (overrides: Partial<Feature>): Feature => ({
+    id: 'f',
+    name: 'Feature',
+    description: 'd',
+    userValue: 'value',
+    complexity: 'medium',
+    ...overrides,
+});
+
+const basePRD = (overrides: Partial<StructuredPRD>): StructuredPRD => ({
+    vision: 'v',
+    targetUsers: [],
+    coreProblem: 'p',
+    features: [],
+    architecture: 'a',
+    risks: [],
+    ...overrides,
+});
+
+describe('deriveImplementationSummary — feature bucketing', () => {
+    it('uses tier when present', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'f1', name: 'F1', tier: 'mvp' }),
+                baseFeature({ id: 'f2', name: 'F2', tier: 'v1' }),
+                baseFeature({ id: 'f3', name: 'F3', tier: 'later' }),
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst.map(f => f.id)).toEqual(['f1']);
+        expect(s.buildNext.map(f => f.id)).toEqual(['f2']);
+        expect(s.defer.map(f => f.id)).toEqual(['f3']);
+    });
+
+    it('falls back to priority when tier is missing', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'f1', name: 'F1', priority: 'must' }),
+                baseFeature({ id: 'f2', name: 'F2', priority: 'should' }),
+                baseFeature({ id: 'f3', name: 'F3', priority: 'could' }),
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst.map(f => f.id)).toEqual(['f1']);
+        expect(s.buildNext.map(f => f.id)).toEqual(['f2']);
+        expect(s.defer.map(f => f.id)).toEqual(['f3']);
+    });
+
+    it('legacy untagged PRDs split features by declaration order', () => {
+        const prd = basePRD({
+            features: Array.from({ length: 10 }, (_, i) =>
+                baseFeature({ id: `f${i}`, name: `F${i}` }),
+            ),
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst).toHaveLength(4);
+        expect(s.buildNext).toHaveLength(4);
+        expect(s.defer).toHaveLength(2);
+    });
+
+    it('orders buckets by ascending complexity', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'h', name: 'H', tier: 'mvp', complexity: 'high' }),
+                baseFeature({ id: 'l', name: 'L', tier: 'mvp', complexity: 'low' }),
+                baseFeature({ id: 'm', name: 'M', tier: 'mvp', complexity: 'medium' }),
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst.map(f => f.id)).toEqual(['l', 'm', 'h']);
+    });
+
+    it('caps each bucket at 5', () => {
+        const prd = basePRD({
+            features: Array.from({ length: 10 }, (_, i) =>
+                baseFeature({ id: `f${i}`, name: `F${i}`, tier: 'mvp' }),
+            ),
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst).toHaveLength(5);
+    });
+});
+
+describe('deriveImplementationSummary — risks', () => {
+    it('prefers high-likelihood detailed risks', () => {
+        const prd = basePRD({
+            risksDetailed: [
+                { risk: 'medium', likelihood: 'med', impact: 'i', mitigation: 'm' },
+                { risk: 'high', likelihood: 'high', impact: 'i', mitigation: 'm' },
+                { risk: 'low', likelihood: 'low', impact: 'i', mitigation: 'm' },
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.highestRisks[0].risk).toBe('high');
+    });
+
+    it('flags impact keywords as high', () => {
+        const prd = basePRD({
+            risksDetailed: [
+                { risk: 'data leak', likelihood: 'low', impact: 'critical breach', mitigation: 'm' },
+                { risk: 'minor', likelihood: 'low', impact: 'small', mitigation: 'm' },
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.highestRisks[0].risk).toBe('data leak');
+    });
+
+    it('falls back to legacy plain string risks', () => {
+        const prd = basePRD({ risks: ['Timezone bugs', 'Latency spikes'] });
+        const s = deriveImplementationSummary(prd);
+        expect(s.highestRisks.map(r => r.risk)).toEqual(['Timezone bugs', 'Latency spikes']);
+    });
+});
+
+describe('deriveImplementationSummary — open decisions', () => {
+    it('prefers low-confidence assumptions', () => {
+        const prd = basePRD({
+            assumptions: [
+                { id: 'a1', statement: 'high', confidence: 'high' },
+                { id: 'a2', statement: 'low', confidence: 'low' },
+                { id: 'a3', statement: 'med', confidence: 'med' },
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.openDecisions.map(d => d.id)).toEqual(['a2']);
+    });
+});
+
+describe('isImplementationSummaryEmpty', () => {
+    it('detects an empty summary', () => {
+        const prd = basePRD({});
+        const s = deriveImplementationSummary(prd);
+        expect(isImplementationSummaryEmpty(s)).toBe(true);
+    });
+
+    it('returns false when any bucket is populated', () => {
+        const prd = basePRD({
+            features: [baseFeature({ id: 'f1', name: 'F1', tier: 'mvp' })],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(isImplementationSummaryEmpty(s)).toBe(false);
+    });
+});

--- a/src/lib/__tests__/textCleanup.test.ts
+++ b/src/lib/__tests__/textCleanup.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+    coerceToBulletList,
+    collapseRepeats,
+    dedupeSentences,
+    looksDegenerate,
+} from '../textCleanup';
+
+describe('dedupeSentences', () => {
+    it('returns empty for empty input', () => {
+        expect(dedupeSentences('')).toEqual([]);
+        expect(dedupeSentences('   ')).toEqual([]);
+    });
+
+    it('splits on period+space and dedupes case-insensitively', () => {
+        expect(dedupeSentences('Shows A. shows a. Shows B.')).toEqual(['Shows A', 'Shows B']);
+    });
+
+    it('respects max', () => {
+        expect(dedupeSentences('A. B. C. D.', { max: 2 })).toEqual(['A', 'B']);
+    });
+
+    it('splits on newlines and bullet glyphs', () => {
+        const out = dedupeSentences('• Save\n• Skip\n- Share');
+        expect(out).toContain('Save');
+        expect(out).toContain('Skip');
+        expect(out).toContain('Share');
+    });
+});
+
+describe('collapseRepeats', () => {
+    it('passes short strings through', () => {
+        expect(collapseRepeats('hello')).toBe('hello');
+    });
+
+    it('collapses runs of repeated substrings without sentence boundaries', () => {
+        const chunk = 'XYZABCDEF12345QRSTUVWXYZ_ABCDEFG_XYZ_ABCD'; // > 30 chars
+        const repeated = chunk.repeat(5);
+        const out = collapseRepeats(repeated);
+        expect(out.length).toBeLessThan(repeated.length);
+        // After collapse, the chunk should still appear at least once.
+        expect(out.includes(chunk)).toBe(true);
+    });
+});
+
+describe('coerceToBulletList', () => {
+    it('returns empty for null/undefined', () => {
+        expect(coerceToBulletList(undefined)).toEqual([]);
+        expect(coerceToBulletList(null)).toEqual([]);
+    });
+
+    it('passes a clean array through with case-insensitive dedupe', () => {
+        expect(coerceToBulletList(['Save track', 'Skip track', 'save track'])).toEqual([
+            'Save track',
+            'Skip track',
+        ]);
+    });
+
+    it('splits a paragraph into bullets', () => {
+        const out = coerceToBulletList(
+            'Shows Connect Spotify button. Defaults to Preview Mode. Hides collaborative features.',
+        );
+        expect(out).toEqual([
+            'Shows Connect Spotify button',
+            'Defaults to Preview Mode',
+            'Hides collaborative features',
+        ]);
+    });
+
+    it('handles the legacy degenerate state-machine sample without exploding', () => {
+        // Drawn directly from the QA screenshot — same handful of phrases
+        // repeated dozens of times.
+        const phrases = [
+            "Shows 'Connect to collaborate' CTA on share sheet.",
+            "Disables 'Save to Library' swipe right feature.",
+            "Shows 'Preview' badge on album art.",
+            'Disables WebGL audio frequency reactivity if CORS blocks HTML5 audio analysis.',
+            'Shows clear value prop modal explaining why auth is needed (full tracks, saving, better recommendations).',
+            'Allows user to dismiss modal and continue in Preview Mode.',
+            'Hides collaborative features.',
+        ];
+        const degenerate = Array.from({ length: 30 }, () => phrases.join(' ')).join(' ');
+        expect(degenerate.length).toBeGreaterThan(5000);
+        const out = coerceToBulletList(degenerate, { max: 8 });
+        expect(out.length).toBeLessThanOrEqual(8);
+        // Every distinct phrase should be represented exactly once.
+        for (const phrase of phrases) {
+            const stripped = phrase.replace(/\.$/, '');
+            expect(out).toContain(stripped);
+        }
+    });
+
+    it('caps the output at max', () => {
+        expect(coerceToBulletList('A. B. C. D. E.', { max: 3 })).toEqual(['A', 'B', 'C']);
+    });
+
+    it('flattens an array of paragraphs into a single bullet list', () => {
+        const out = coerceToBulletList([
+            'Save track. Skip track.',
+            'Skip track. Share vibe.',
+        ]);
+        expect(out).toEqual(['Save track', 'Skip track', 'Share vibe']);
+    });
+});
+
+describe('looksDegenerate', () => {
+    it('returns false for short input', () => {
+        expect(looksDegenerate('Save the track to library.')).toBe(false);
+    });
+
+    it('returns true for the QA-screenshot-style input', () => {
+        const phrases = [
+            "Shows 'Connect to collaborate' CTA on share sheet.",
+            "Disables 'Save to Library' swipe right feature.",
+        ];
+        const degenerate = Array.from({ length: 30 }, () => phrases.join(' ')).join(' ');
+        expect(looksDegenerate(degenerate)).toBe(true);
+    });
+
+    it('returns false for a clean array of distinct sentences', () => {
+        expect(
+            looksDegenerate([
+                'Shows Connect Spotify button.',
+                'Defaults to Preview Mode.',
+                'Hides collaborative features.',
+            ]),
+        ).toBe(false);
+    });
+});

--- a/src/lib/artifactValidation.ts
+++ b/src/lib/artifactValidation.ts
@@ -1,10 +1,16 @@
 import type { CoreArtifactSubtype } from '../types';
+import { dedupeSentences } from './textCleanup';
 
 export interface ValidationResult {
     isValid: boolean;
     qualityScore: number; // 0-100
     warnings: string[];
 }
+
+// Cell-level threshold beyond which a single | … | … | markdown table cell
+// is almost certainly carrying degenerate LLM output. Cells > 800 chars
+// are visually unscannable in a 5-column table.
+const MAX_TABLE_CELL_CHARS = 800;
 
 const MIN_CONTENT_LENGTH: Record<CoreArtifactSubtype, number> = {
     screen_inventory: 200,
@@ -72,9 +78,49 @@ export function validateArtifactContent(
         score -= 10;
     }
 
+    // Quality gate: detect degenerate output patterns. The classic failure
+    // mode is a single markdown table cell holding a phrase repeated 30+
+    // times — cleanup utilities now defend against it at render time, but
+    // we surface a warning so users can choose to regenerate.
+    const degenerate = detectDegenerateContent(content);
+    if (degenerate) {
+        warnings.push(degenerate);
+        score -= 15;
+    }
+
     return {
         isValid: score >= 40,
         qualityScore: Math.max(0, Math.min(100, score)),
         warnings,
     };
+}
+
+/**
+ * Scan markdown for two degenerate patterns we want to flag:
+ *   1. A table row with any single cell over MAX_TABLE_CELL_CHARS.
+ *   2. A list bullet whose dedupe-pass collapses ≥ 50% of the original
+ *      sentence count (clear sign of a repetition loop).
+ *
+ * Returns a human-readable warning string or null when content is clean.
+ */
+export function detectDegenerateContent(content: string): string | null {
+    const lines = content.split('\n');
+    for (const line of lines) {
+        // Markdown table row: starts and ends with `|`.
+        if (!line.trim().startsWith('|') || !line.trim().endsWith('|')) continue;
+        const cells = line.split('|').slice(1, -1).map(c => c.trim());
+        for (const cell of cells) {
+            if (cell.length > MAX_TABLE_CELL_CHARS) {
+                return `A table cell is unusually long (${cell.length} chars) — output may be repeating itself. Consider regenerating.`;
+            }
+            if (cell.length > 200) {
+                const dedup = dedupeSentences(cell);
+                const rough = cell.split(/(?<=[.!?])\s+/).filter(Boolean).length;
+                if (rough >= 4 && dedup.length <= rough / 2) {
+                    return `A table cell repeats the same sentence multiple times — output may be degenerate. Consider regenerating.`;
+                }
+            }
+        }
+    }
+    return null;
 }

--- a/src/lib/derive/implementationSummary.ts
+++ b/src/lib/derive/implementationSummary.ts
@@ -1,0 +1,169 @@
+// Pure derivation from a StructuredPRD that produces the
+// "Implementation Summary" view rendered at the top of the PRD.
+// No LLM call — we already have all the data, the user just shouldn't
+// have to read 30 KB of prose to learn what to build first.
+
+import type { Feature, RiskDetailed, StructuredPRD } from '../../types';
+
+export type SummaryFeature = {
+    id: string;
+    name: string;
+    reason?: string;
+};
+
+export type SummaryRisk = {
+    risk: string;
+    likelihood: string;
+    impact: string;
+};
+
+export type SummaryDecision = {
+    id: string;
+    statement: string;
+};
+
+export type ImplementationSummary = {
+    buildFirst: SummaryFeature[];
+    buildNext: SummaryFeature[];
+    defer: SummaryFeature[];
+    highestRisks: SummaryRisk[];
+    openDecisions: SummaryDecision[];
+};
+
+const HIGH_IMPACT_KEYWORDS = /(outage|loss|critical|blocker|catastroph|exposed|leak|breach)/i;
+const MAX_FEATURES_PER_BUCKET = 5;
+const MAX_RISKS = 4;
+const MAX_DECISIONS = 4;
+
+function isMvp(feature: Feature): boolean {
+    if (feature.tier === 'mvp') return true;
+    if (!feature.tier && feature.priority === 'must') return true;
+    return false;
+}
+
+function isV1(feature: Feature): boolean {
+    if (feature.tier === 'v1') return true;
+    if (!feature.tier && feature.priority === 'should') return true;
+    return false;
+}
+
+function isLater(feature: Feature): boolean {
+    if (feature.tier === 'later') return true;
+    if (!feature.tier && feature.priority === 'could') return true;
+    return false;
+}
+
+function complexitySortKey(complexity?: 'low' | 'medium' | 'high'): number {
+    if (complexity === 'low') return 0;
+    if (complexity === 'medium') return 1;
+    if (complexity === 'high') return 2;
+    return 1;
+}
+
+function summaryFeatureFor(f: Feature, withReason: boolean): SummaryFeature {
+    const reason = withReason
+        ? buildReason(f)
+        : undefined;
+    return { id: f.id, name: f.name, reason };
+}
+
+function buildReason(f: Feature): string {
+    const parts: string[] = [];
+    if (f.complexity) parts.push(f.complexity);
+    if (f.userValue) {
+        const trimmed = f.userValue.length > 80
+            ? `${f.userValue.slice(0, 78).trim()}…`
+            : f.userValue;
+        parts.push(trimmed);
+    }
+    return parts.join(' · ');
+}
+
+function pickFeatures(features: Feature[]): {
+    buildFirst: Feature[];
+    buildNext: Feature[];
+    defer: Feature[];
+} {
+    const tagged = features.some(f => f.tier || f.priority);
+    if (!tagged) {
+        // Legacy PRDs without any prioritization. Use declaration order
+        // as a rough proxy: first 4 → first, next 4 → next, rest → defer.
+        return {
+            buildFirst: features.slice(0, 4),
+            buildNext: features.slice(4, 8),
+            defer: features.slice(8),
+        };
+    }
+    const buildFirst = features.filter(isMvp);
+    const buildNext = features.filter(f => !isMvp(f) && isV1(f));
+    const defer = features.filter(f => !isMvp(f) && !isV1(f) && isLater(f));
+
+    // Within each bucket prefer lower complexity first, then declaration order.
+    const sortByComplexity = (arr: Feature[]) =>
+        [...arr].sort((a, b) => complexitySortKey(a.complexity) - complexitySortKey(b.complexity));
+
+    return {
+        buildFirst: sortByComplexity(buildFirst),
+        buildNext: sortByComplexity(buildNext),
+        defer: sortByComplexity(defer),
+    };
+}
+
+function pickHighestRisks(prd: StructuredPRD): SummaryRisk[] {
+    const detailed = prd.risksDetailed;
+    if (detailed && detailed.length > 0) {
+        const ranked = [...detailed].sort((a, b) => {
+            const aHigh = a.likelihood === 'high' ? 0 : a.likelihood === 'med' ? 1 : 2;
+            const bHigh = b.likelihood === 'high' ? 0 : b.likelihood === 'med' ? 1 : 2;
+            if (aHigh !== bHigh) return aHigh - bHigh;
+            // Tie-break on impact keywords.
+            const aSev = HIGH_IMPACT_KEYWORDS.test(a.impact) ? 0 : 1;
+            const bSev = HIGH_IMPACT_KEYWORDS.test(b.impact) ? 0 : 1;
+            return aSev - bSev;
+        });
+        const flagged: RiskDetailed[] = ranked.filter(
+            r => r.likelihood === 'high' || HIGH_IMPACT_KEYWORDS.test(r.impact),
+        );
+        const source = flagged.length > 0 ? flagged : ranked;
+        return source.slice(0, MAX_RISKS).map(r => ({
+            risk: r.risk,
+            likelihood: r.likelihood,
+            impact: r.impact,
+        }));
+    }
+    // Legacy plain string list.
+    const fallback = (prd.risks || []).slice(0, 3);
+    return fallback.map(r => ({ risk: r, likelihood: 'unknown', impact: '' }));
+}
+
+function pickOpenDecisions(prd: StructuredPRD): SummaryDecision[] {
+    const assumptions = prd.assumptions || [];
+    const lowConfidence = assumptions.filter(a => a.confidence === 'low');
+    const source = lowConfidence.length > 0 ? lowConfidence : assumptions.slice(0, MAX_DECISIONS);
+    return source.slice(0, MAX_DECISIONS).map(a => ({
+        id: a.id,
+        statement: a.statement,
+    }));
+}
+
+export function deriveImplementationSummary(prd: StructuredPRD): ImplementationSummary {
+    const features = prd.features || [];
+    const { buildFirst, buildNext, defer } = pickFeatures(features);
+    return {
+        buildFirst: buildFirst.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, true)),
+        buildNext: buildNext.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, false)),
+        defer: defer.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, false)),
+        highestRisks: pickHighestRisks(prd),
+        openDecisions: pickOpenDecisions(prd),
+    };
+}
+
+export function isImplementationSummaryEmpty(s: ImplementationSummary): boolean {
+    return (
+        s.buildFirst.length === 0 &&
+        s.buildNext.length === 0 &&
+        s.defer.length === 0 &&
+        s.highestRisks.length === 0 &&
+        s.openDecisions.length === 0
+    );
+}

--- a/src/lib/prompts/prdPrompts.ts
+++ b/src/lib/prompts/prdPrompts.ts
@@ -34,7 +34,7 @@ Hard rules:
 - Every claim must be concrete. Prefer enumeration over prose. Prefer named entities over abstractions.
 - When you must infer a fact the user did not state, capture it as an Assumption with a confidence level — never present it as fact.
 - Every major feature must have success, edge, failure, and UI acceptance criteria.
-- State machines must list states with triggers, allowed next states, user-visible behavior, and system behavior.
+- State machines must list states with triggers, allowed next states, user-visible behavior, and system behavior. \`userVisible\` and \`systemBehavior\` are arrays of 1–5 short distinct sentences each (≤ 140 chars per item) — never one giant paragraph, never the same sentence twice, never "Disables… Shows… Hides…" mashed into one item.
 - Architecture must include at least one example data flow with numbered steps, not just a tech stack.
 - MVP scope must be opinionated: not every feature belongs in MVP. Defer aggressively.
 - Use realistic example records and example values. No "Lorem ipsum", no "Foo / Bar".
@@ -53,7 +53,7 @@ Required structure (output as a single JSON object matching the provided schema)
 - featureSystems: 3–7 systems grouping related features — { id, name, purpose, featureIds, endToEndBehavior?, dependencies?, edgeCases?, mvpVsLater? }.
 - features: 6–14 detailed feature specs — { id (f1, f2…), name, description, userValue, complexity (low/medium/high), priority (must/should/could), acceptanceCriteria (>=2, success-path), system?, successCriteria?, edgeCases?, failureModes?, uiAcceptanceCriteria?, analyticsEvents?, tier? (mvp/v1/later), dependencies? }. Cross-reference featureSystems via the system field.
 - richDataModel: { entities: [{ name, description, fields: [{name, type, required?, notes?}], relationships?, constraints?, examples? }] }. 4–10 entities. Examples are realistic records (real names, real statuses, realistic IDs).
-- stateMachines: 1–3 state machines for the most important entities — { entity, states: [{ name, trigger?, nextStates?, userVisible?, systemBehavior? }] }.
+- stateMachines: 1–3 state machines for the most important entities — { entity, states: [{ name, trigger?, nextStates?, userVisible?: string[], systemBehavior?: string[] }] }. userVisible and systemBehavior are arrays of 1–5 crisp distinct sentences each. Each sentence describes one observable behavior, ≤ 140 chars, no repetition.
 - roles: 3–6 roles — { role, allowed, restricted?, dataVisibility?, notes? }.
 - architecture: prose architecture overview that explains WHY each major choice fits the product (not just a tech stack).
 - architectureFlows: 1–3 example data/request flows — { name, steps (numbered plain strings) }.

--- a/src/lib/prompts/prdSectionPrompts.ts
+++ b/src/lib/prompts/prdSectionPrompts.ts
@@ -122,7 +122,7 @@ Grounding entities: ${grounding}
 
 Return JSON with:
 - richDataModel: { entities: array of { name, description, fields (array of { name, type, required, notes? }), relationships?, constraints?, examples? } } — 4–8 entities
-- stateMachines: array of { entity, states: array of { name, trigger?, nextStates?, userVisible?, systemBehavior? } } — for 2–3 stateful entities`,
+- stateMachines: array of { entity, states: array of { name, trigger?, nextStates?, userVisible?: string[], systemBehavior?: string[] } } — for 2–3 stateful entities. userVisible and systemBehavior are arrays of 1–5 distinct short sentences (≤ 140 chars each); never one paragraph, never repeat the same sentence.`,
         };
     },
 

--- a/src/lib/schemas/prdSchemas.ts
+++ b/src/lib/schemas/prdSchemas.ts
@@ -145,8 +145,12 @@ const machineStateSchema = {
         name: { type: "STRING" },
         trigger: { type: "STRING" },
         nextStates: { type: "ARRAY", items: { type: "STRING" } },
-        userVisible: { type: "STRING" },
-        systemBehavior: { type: "STRING" },
+        // Arrays of short distinct sentences. Older PRDs emitted a single
+        // STRING here and the model would sometimes repeat the same phrase
+        // dozens of times in one cell; the array shape plus prompt guidance
+        // and textCleanup defenses prevent that degenerate output.
+        userVisible: { type: "ARRAY", items: { type: "STRING" } },
+        systemBehavior: { type: "ARRAY", items: { type: "STRING" } },
     },
     required: ["name"],
 };

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -24,6 +24,11 @@ import type {
     ArchFlow,
     PrdEntity,
 } from '../../types';
+import { coerceToBulletList } from '../textCleanup';
+import {
+    deriveImplementationSummary,
+    isImplementationSummaryEmpty,
+} from '../derive/implementationSummary';
 
 const tierTag = (tier?: string): string => {
     if (!tier) return '';
@@ -160,15 +165,31 @@ const renderEntity = (e: PrdEntity): string[] => {
 };
 
 const renderStateMachine = (m: StateMachine): string[] => {
+    // Per-state subsections with bullet lists. The previous wide-table
+    // layout could overflow horribly when the model emitted a degenerate
+    // mega-string into one cell; bullets render cleanly at any width and
+    // collapsing through coerceToBulletList prevents repetition leaking
+    // through from legacy projects.
     const lines: string[] = [];
     lines.push(`### ${m.entity}`);
-    lines.push('| State | Trigger | Next States | User-visible | System behavior |');
-    lines.push('|---|---|---|---|---|');
-    m.states.forEach(s => {
-        const next = (s.nextStates || []).join(', ') || '—';
-        lines.push(`| ${escapeCell(s.name)} | ${escapeCell(s.trigger || '—')} | ${escapeCell(next)} | ${escapeCell(s.userVisible || '—')} | ${escapeCell(s.systemBehavior || '—')} |`);
-    });
     lines.push('');
+    m.states.forEach(s => {
+        lines.push(`#### ${s.name}`);
+        if (s.trigger) lines.push(`**Trigger:** ${s.trigger}`);
+        const next = s.nextStates && s.nextStates.length ? s.nextStates.join(' → ') : '';
+        if (next) lines.push(`**Next states:** ${next}`);
+        const userVisible = coerceToBulletList(s.userVisible, { max: 6 });
+        if (userVisible.length) {
+            lines.push('**User-visible:**');
+            userVisible.forEach(b => lines.push(`- ${b}`));
+        }
+        const systemBehavior = coerceToBulletList(s.systemBehavior, { max: 6 });
+        if (systemBehavior.length) {
+            lines.push('**System behavior:**');
+            systemBehavior.forEach(b => lines.push(`- ${b}`));
+        }
+        lines.push('');
+    });
     return lines;
 };
 
@@ -240,6 +261,47 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('## Executive Summary');
         lines.push(prd.executiveSummary);
         lines.push('');
+    }
+
+    // Implementation Summary — synthesized from features/risks/assumptions so
+    // exports (PDF, markdown download) carry the same "what to build first"
+    // entry point the in-app PRD now shows.
+    const summary = deriveImplementationSummary(prd);
+    if (!isImplementationSummaryEmpty(summary)) {
+        lines.push('## Implementation Summary');
+        lines.push('');
+        if (summary.buildFirst.length > 0) {
+            lines.push('### Build First');
+            summary.buildFirst.forEach((f, i) => {
+                const reason = f.reason ? ` — ${f.reason}` : '';
+                lines.push(`${i + 1}. **${f.id}** ${f.name}${reason}`);
+            });
+            lines.push('');
+        }
+        if (summary.buildNext.length > 0) {
+            lines.push('### Build Next');
+            summary.buildNext.forEach(f => lines.push(`- **${f.id}** ${f.name}`));
+            lines.push('');
+        }
+        if (summary.defer.length > 0) {
+            lines.push('### Defer');
+            summary.defer.forEach(f => lines.push(`- **${f.id}** ${f.name}`));
+            lines.push('');
+        }
+        if (summary.highestRisks.length > 0) {
+            lines.push('### Highest Risks');
+            summary.highestRisks.forEach(r => {
+                const tag = r.likelihood !== 'unknown' ? ` (${r.likelihood})` : '';
+                const impact = r.impact ? ` — ${r.impact}` : '';
+                lines.push(`- ${r.risk}${tag}${impact}`);
+            });
+            lines.push('');
+        }
+        if (summary.openDecisions.length > 0) {
+            lines.push('### Open Decisions');
+            summary.openDecisions.forEach(d => lines.push(`- **${d.id}** ${d.statement}`));
+            lines.push('');
+        }
     }
 
     // Vision (always present in legacy spec)

--- a/src/lib/textCleanup.ts
+++ b/src/lib/textCleanup.ts
@@ -1,0 +1,119 @@
+// Defensive text cleanup for LLM-supplied content. Two failure modes we
+// guard against:
+//
+// 1. Degenerate loops: the model emits the same sentence dozens of times
+//    in a row inside a single STRING field. We split, dedupe (case-
+//    insensitive), and cap.
+// 2. Paragraph crammed into a list slot: the model joins many distinct
+//    behaviors with periods or "Disables… Shows… Hides…" instead of
+//    using the array shape. We split on sentence boundaries so the
+//    renderer can present one bullet per behavior.
+//
+// Used on both the read path (legacy localStorage data with the bad
+// single-string shape) and the write path (defense in depth after a
+// fresh generation). The implementation is intentionally pure and
+// dependency-free.
+
+export type CoerceOptions = {
+    /** Cap the resulting list at this many sentences. */
+    max?: number;
+};
+
+const SENTENCE_SPLIT = /(?<=[.!?])\s+|\s*\n+\s*|\s*•\s*|\s*•\s*|\s+[-–]\s+/;
+
+/**
+ * Split the input on sentence-like boundaries, trim, drop empties, and
+ * deduplicate case-insensitively while preserving original casing of
+ * the first occurrence.
+ */
+export function dedupeSentences(text: string, opts: CoerceOptions = {}): string[] {
+    if (!text) return [];
+    const cleaned = String(text).replace(/\s+/g, ' ').trim();
+    if (!cleaned) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const raw of cleaned.split(SENTENCE_SPLIT)) {
+        // Strip leading "Label:" prefixes that would otherwise dedupe-conflict.
+        const trimmed = raw.trim().replace(/\.+$/, '').trim();
+        if (!trimmed) continue;
+        const key = trimmed.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(trimmed);
+        if (opts.max != null && out.length >= opts.max) break;
+    }
+    return out;
+}
+
+/**
+ * Collapse runs where a fixed-length substring repeats three or more
+ * times back-to-back. Targets the "no-period" version of the degenerate
+ * loop where dedupeSentences alone wouldn't help. Safe against
+ * catastrophic backtracking because each backreference is fixed-length.
+ */
+export function collapseRepeats(text: string): string {
+    if (!text || text.length < 90) return text;
+    // Try fixed-length backreferences (no catastrophic backtracking) of every
+    // length from 30 up to a third of the string. Step by 1 so we catch
+    // arbitrary period lengths; the regex engine is fast on fixed-length
+    // backrefs.
+    const maxLen = Math.min(300, Math.floor(text.length / 3));
+    for (let len = 30; len <= maxLen; len += 1) {
+        const re = new RegExp(`(.{${len}})\\1{2,}`, 's');
+        if (re.test(text)) {
+            const replaceRe = new RegExp(`(.{${len}})\\1{2,}`, 'gs');
+            return text.replace(replaceRe, '$1');
+        }
+    }
+    return text;
+}
+
+/**
+ * Normalize anything that should logically be a list of short distinct
+ * sentences into exactly that shape. Accepts a single string, an array
+ * of strings, or undefined/null. Strings are first run through
+ * `collapseRepeats` then `dedupeSentences`. Arrays are flattened with
+ * the same per-item processing then deduped across items.
+ */
+export function coerceToBulletList(
+    value: string | string[] | null | undefined,
+    opts: CoerceOptions = {},
+): string[] {
+    if (value == null) return [];
+    const items: string[] = Array.isArray(value) ? value : [value];
+    const flat: string[] = [];
+    for (const item of items) {
+        if (typeof item !== 'string') continue;
+        const collapsed = collapseRepeats(item);
+        flat.push(...dedupeSentences(collapsed));
+    }
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const sentence of flat) {
+        const key = sentence.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(sentence);
+        if (opts.max != null && out.length >= opts.max) break;
+    }
+    return out;
+}
+
+/**
+ * Heuristic to detect that an input string was originally a degenerate
+ * loop. Useful for surfacing a non-blocking quality warning on a
+ * section even after we've cleaned it up at render time.
+ */
+export function looksDegenerate(value: string | string[] | null | undefined): boolean {
+    if (value == null) return false;
+    const original = Array.isArray(value) ? value.join(' ') : value;
+    if (typeof original !== 'string' || original.length < 200) return false;
+    const cleaned = coerceToBulletList(value);
+    if (cleaned.length === 0) return false;
+    const cleanedJoined = cleaned.join(' ');
+    // Degenerate if the cleanup reduced character count by more than 50%
+    // OR if the original was very long but condensed to one sentence.
+    if (cleanedJoined.length < original.length * 0.5) return true;
+    if (cleaned.length === 1 && original.length > 400) return true;
+    return false;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,8 +182,12 @@ export type MachineState = {
     name: string;
     trigger?: string;                      // what causes entry
     nextStates?: string[];
-    userVisible?: string;
-    systemBehavior?: string;
+    // Arrays of short distinct sentences. Legacy projects in localStorage
+    // may have stored a single concatenated string here; the textCleanup
+    // utility (`coerceToBulletList`) accepts both shapes so the renderer
+    // never has to think about the difference.
+    userVisible?: string[] | string;
+    systemBehavior?: string[] | string;
 };
 
 export type StateMachine = {


### PR DESCRIPTION
- State machines: schema/type now use string[] for userVisible/systemBehavior; new textCleanup utilities (dedupeSentences, coerceToBulletList, collapseRepeats, looksDegenerate) defend both write and read paths so legacy localStorage data renders cleanly without forced regeneration; renderer switches from a wide table to per-state cards with bullet lists; quality warning surfaces when a degenerate cell was auto-cleaned.
- Implementation Summary: deterministic derivation from existing PRD fields (features tier/priority, risksDetailed, assumption confidence) renders Build First / Build Next / Defer / Highest Risks / Open Decisions at the top of the PRD and in markdown exports.
- New artifact-specific renderers: DesignSystemRenderer (color swatches, typography preview rows, spacing bars), UserFlowsRenderer (flow cards with numbered steps, decision/error callouts), ImplementationPlanRenderer (milestone timeline, real checkboxes), PromptPackRenderer (prompt cards with copy-prompt buttons and tool/category chips). All four fall back to plain markdown when their conventions don't match.
- Viewer polish: Generation Status right rail collapses to a slim "All ready" strip when every slot is done; sticky in-page section nav (SectionTabs) tracks the visible section in long artifacts.
- Quality gates: detectDegenerateContent flags table cells > 800 chars or those whose dedupe collapses ≥ 50 % of sentences.
- Tests: 30 new tests across textCleanup, implementationSummary, artifactValidation. Full suite stays green at 154/154.

https://claude.ai/code/session_016PqBJApkeAL9dAyuiNjhQx