### PR TITLE
fix(mockup): unblock Tailwind in iframe, auto-generate low-quality image, preserve quality variants

### DIFF
--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -1,19 +1,22 @@
 /**
  * AI Image preview panel for a single MockupScreen, powered by OpenAI
- * gpt-image-2. Three render states:
+ * gpt-image-2. Render states:
  *   - empty:    no image yet → CTA "Generate AI image" (low quality)
  *   - loading:  in-flight → spinner + cancel button
- *   - ready:    image rendered + "Regenerate as high quality" if low/medium
+ *   - ready:    image rendered + quality switcher (when multiple variants
+ *               exist) + "Regenerate as high quality" if no high yet
  *
  * Persistence and orchestration live in src/store/mockupImageStore.ts; this
- * component only reads the cache and dispatches actions.
+ * component only reads the cache and dispatches actions. Each quality is
+ * stored under its own IDB key so generating a high-quality render does not
+ * discard the low-quality original — the user can flip back to compare.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Sparkles, Loader2, Image as ImageIcon, AlertTriangle, RefreshCw, X, Settings as SettingsIcon } from 'lucide-react';
-import type { MockupPayload, MockupScreen, MockupSettings } from '../../types';
+import type { MockupImageQuality, MockupImageRecord, MockupPayload, MockupScreen, MockupSettings } from '../../types';
 import { useMockupImageStore } from '../../store/mockupImageStore';
-import { buildImageKey } from '../../lib/mockupImageStore';
+import { buildScreenScopeKey } from '../../lib/mockupImageStore';
 import { hasOpenAIKey } from '../../lib/openaiClient';
 
 interface Props {
@@ -25,27 +28,69 @@ interface Props {
     settings: MockupSettings;
 }
 
+const QUALITY_RANK: Record<MockupImageQuality, number> = { low: 0, medium: 1, high: 2 };
+
+const QUALITY_LABEL: Record<MockupImageQuality, string> = {
+    low: 'Low quality',
+    medium: 'Medium quality',
+    high: 'High quality',
+};
+
+const pickInitialQuality = (records: MockupImageRecord[]): MockupImageQuality | null => {
+    if (records.length === 0) return null;
+    return records.reduce<MockupImageRecord>((best, r) =>
+        QUALITY_RANK[r.quality] > QUALITY_RANK[best.quality] ? r : best,
+        records[0],
+    ).quality;
+};
+
 export function MockupScreenImage({ projectId, artifactId, versionId, screen, payload, settings }: Props) {
-    const key = buildImageKey(versionId, screen.id);
-    const record = useMockupImageStore((s) => s.images[key]);
-    const inFlight = useMockupImageStore((s) => s.inFlight[key]);
-    const error = useMockupImageStore((s) => s.errors[key]);
+    const scope = buildScreenScopeKey(versionId, screen.id);
+    // Subscribe to the whole image map; filtered records are derived below.
+    // The previous implementation subscribed only to a single keyed entry,
+    // which broke once we started storing per-quality variants.
+    const allImages = useMockupImageStore((s) => s.images);
+    const inFlight = useMockupImageStore((s) => s.inFlight[scope]);
+    const error = useMockupImageStore((s) => s.errors[scope]);
     const generate = useMockupImageStore((s) => s.generate);
     const cancel = useMockupImageStore((s) => s.cancel);
     const clearError = useMockupImageStore((s) => s.clearError);
-    const getRecord = useMockupImageStore((s) => s.getRecord);
+    const loadForVersion = useMockupImageStore((s) => s.loadForVersion);
 
-    // Hydrate from IndexedDB on mount (and when the screen changes) so reload
-    // / tab switches don't lose the cached image.
-    useEffect(() => {
-        if (!record) {
-            void getRecord(versionId, screen.id);
+    const records = useMemo(() => {
+        const out: MockupImageRecord[] = [];
+        for (const k of Object.keys(allImages)) {
+            if (k.startsWith(scope)) out.push(allImages[k]);
         }
-    }, [versionId, screen.id, record, getRecord]);
+        out.sort((a, b) => QUALITY_RANK[a.quality] - QUALITY_RANK[b.quality]);
+        return out;
+    }, [allImages, scope]);
+
+    // Active quality: defaults to the highest available; user can flip back
+    // to lower qualities via the quality switcher.
+    const [activeQuality, setActiveQuality] = useState<MockupImageQuality | null>(null);
+
+    const fallbackQuality = useMemo(() => pickInitialQuality(records), [records]);
+    const effectiveQuality: MockupImageQuality | null =
+        activeQuality && records.some((r) => r.quality === activeQuality)
+            ? activeQuality
+            : fallbackQuality;
+    const activeRecord = effectiveQuality
+        ? records.find((r) => r.quality === effectiveQuality)
+        : undefined;
+
+    // Hydrate this version's records from IDB on mount so reload / tab
+    // switches surface every cached quality variant. We seed once per
+    // versionId; loadForVersion is itself idempotent.
+    useEffect(() => {
+        void loadForVersion(versionId);
+    }, [versionId, loadForVersion]);
 
     const keyPresent = hasOpenAIKey();
 
-    const handleGenerate = (quality: 'low' | 'high') => {
+    const hasHighQuality = records.some((r) => r.quality === 'high');
+
+    const handleGenerate = (quality: MockupImageQuality) => {
         clearError(versionId, screen.id);
         void generate({ projectId, artifactId, versionId, screen, payload, settings, quality });
     };
@@ -71,46 +116,68 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
         );
     }
 
-    if (record) {
+    if (activeRecord) {
         return (
             <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
                 <div className="relative bg-neutral-50 flex items-center justify-center">
                     <img
-                        src={record.dataUrl}
-                        alt={`AI image preview of ${screen.name}`}
+                        src={activeRecord.dataUrl}
+                        alt={`AI image preview of ${screen.name} (${activeRecord.quality} quality)`}
                         className="max-w-full max-h-[680px] object-contain"
                     />
                 </div>
                 <div className="px-4 py-3 border-t border-neutral-100 flex items-center gap-2 flex-wrap">
                     <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 font-medium inline-flex items-center gap-1">
                         <Sparkles size={10} />
-                        gpt-image-2 · {record.quality}
+                        gpt-image-2 · {activeRecord.quality}
                     </span>
                     <span className="text-[11px] text-neutral-400">
-                        {new Date(record.generatedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                        {new Date(activeRecord.generatedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                     </span>
+                    {records.length > 1 && (
+                        <div className="inline-flex items-center bg-neutral-100 rounded-md p-0.5 text-[11px] font-medium" role="group" aria-label="Switch quality">
+                            {records.map((r) => {
+                                const selected = r.quality === effectiveQuality;
+                                return (
+                                    <button
+                                        key={r.quality}
+                                        type="button"
+                                        onClick={() => setActiveQuality(r.quality)}
+                                        className={`px-2 py-0.5 rounded transition ${
+                                            selected
+                                                ? 'bg-white text-neutral-900 shadow-sm'
+                                                : 'text-neutral-500 hover:text-neutral-800'
+                                        }`}
+                                        title={QUALITY_LABEL[r.quality]}
+                                    >
+                                        {QUALITY_LABEL[r.quality]}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    )}
                     <div className="ml-auto flex items-center gap-1.5">
-                        {record.quality !== 'high' && (
+                        {!hasHighQuality && (
                             <button
                                 type="button"
                                 disabled={!keyPresent}
                                 onClick={() => handleGenerate('high')}
                                 className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
-                                title={keyPresent ? 'Regenerate at high quality (slower, ~30-60s)' : 'Add an OpenAI API key in Settings to enable'}
+                                title={keyPresent ? 'Generate at high quality (slower, ~30-60s) — your low-quality render is preserved' : 'Add an OpenAI API key in Settings to enable'}
                             >
-                                <RefreshCw size={12} />
-                                Regenerate as high quality
+                                <Sparkles size={12} />
+                                Generate high quality
                             </button>
                         )}
                         <button
                             type="button"
                             disabled={!keyPresent}
-                            onClick={() => handleGenerate('low')}
+                            onClick={() => handleGenerate(activeRecord.quality)}
                             className="inline-flex items-center gap-1.5 text-xs px-2 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 disabled:cursor-not-allowed transition"
-                            title="Discard and re-generate at low quality"
+                            title={`Re-run gpt-image-2 at ${activeRecord.quality} quality (replaces this render)`}
                         >
                             <RefreshCw size={12} />
-                            Redo
+                            Redo {activeRecord.quality}
                         </button>
                     </div>
                 </div>
@@ -129,8 +196,8 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
             </div>
             <div className="text-xs text-neutral-500 mt-1 max-w-sm">
                 {error
-                    ? 'The mockup rendered above — this is the optional AI screenshot. Tap retry below to try again.'
-                    : 'Generate a quick draft image of this screen via OpenAI gpt-image-2. Use it as a sanity check when the HTML mockup feels off — you can regenerate at high quality once you like the draft.'}
+                    ? 'Tap retry below to try again. The HTML mockup is still available under the Preview tab.'
+                    : 'Generate a quick draft image of this screen via OpenAI gpt-image-2. You can regenerate at high quality once you like the draft — both renders stay accessible.'}
             </div>
             {error && (
                 <div className="mt-3 inline-flex items-start gap-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2 py-1.5 max-w-md">

--- a/src/components/mockups/__tests__/buildMockupSrcDoc.test.ts
+++ b/src/components/mockups/__tests__/buildMockupSrcDoc.test.ts
@@ -25,6 +25,12 @@ describe('buildMockupSrcDoc (back-compat shim)', () => {
         expect(srcDoc).toContain('horizontalOverflow');
         expect(srcDoc).toContain('bodyHeight');
         expect(srcDoc).toContain('visibleElements');
+        // Styled detection uses a `.hidden` sentinel: Tailwind resolves the
+        // class to `display: none`; an unstyled fallback leaves it `block`.
+        // This is the only reliable way to distinguish a CSP-blocked CDN
+        // from a happy-path render.
+        expect(srcDoc).toContain('mockup-probe-sentinel');
+        expect(srcDoc).toContain("className = 'hidden'");
     });
 
     it('keeps the Tailwind CDN script and defensive overflow overrides', () => {

--- a/src/components/mockups/buildMockupSrcDoc.ts
+++ b/src/components/mockups/buildMockupSrcDoc.ts
@@ -73,18 +73,27 @@ const buildProbeScript = (probeId: string): string => {
     // Pure-browser IIFE: waits for load, inspects computed styles + layout,
     // posts one MockupProbeReport. Kept inline (no external file) so the
     // iframe works even when bundled into a downloaded artifact.
+    //
+    // The styled check uses a sentinel element with the `.hidden` Tailwind
+    // utility (which resolves to `display: none`). If Tailwind loaded, the
+    // sentinel's computed display is `none`; if Tailwind failed (CSP block,
+    // network failure, sandbox restriction), the sentinel falls back to the
+    // user-agent default `display: block` and `styled` flips false. We avoid
+    // checking the root's `min-height` or `display` because every <div>
+    // defaults to `display: block` regardless of Tailwind, which let the
+    // previous probe falsely report "styled" on completely unstyled output.
     const script = `(() => {
         const report = () => {
             try {
+                const sentinel = document.createElement('div');
+                sentinel.className = 'hidden';
+                sentinel.setAttribute('data-mockup-probe-sentinel', '');
+                sentinel.setAttribute('aria-hidden', 'true');
+                document.body.appendChild(sentinel);
+                const sentinelDisplay = window.getComputedStyle(sentinel).display;
+                sentinel.remove();
+                const styled = sentinelDisplay === 'none';
                 const root = document.querySelector('.min-h-screen') || document.body;
-                // Styled check: the vetted templates always ship the root
-                // with 'min-h-screen'. If Tailwind CDN applied its styles,
-                // the computed min-height resolves to at least 100vh; if
-                // the CDN failed (CSP, network), min-height stays 0.
-                const cs = window.getComputedStyle(root);
-                const styled = parseFloat(cs.minHeight || '0') >= 1
-                    || cs.display !== 'inline'
-                    || parseFloat(cs.padding || '0') > 0;
                 const body = document.body;
                 const horizontalOverflow = (body.scrollWidth - body.clientWidth) > 1;
                 const bodyHeight = body.scrollHeight;
@@ -109,9 +118,9 @@ const buildProbeScript = (probeId: string): string => {
             }
         };
         if (document.readyState === 'complete') {
-            setTimeout(report, 50);
+            setTimeout(report, 250);
         } else {
-            window.addEventListener('load', () => setTimeout(report, 50), { once: true });
+            window.addEventListener('load', () => setTimeout(report, 250), { once: true });
         }
     })();`;
     return `<script>${script}</script>`;

--- a/src/lib/mockupImageStore.ts
+++ b/src/lib/mockupImageStore.ts
@@ -1,13 +1,17 @@
 // IndexedDB wrapper for mockup AI images. Lives outside Zustand/localStorage
 // because gpt-image-2 returns 1–3 MB base64 PNGs which would blow past the
 // ~5 MB origin quota for localStorage. Records are looked up by the composite
-// key `${versionId}:${screenId}`.
+// key `${versionId}:${screenId}:${quality}` so each quality (low / medium /
+// high) is stored as a distinct record — regenerating at a higher quality
+// preserves earlier renders so the user can still compare the original draft.
+// `buildScreenScopeKey()` returns the version-screen prefix used by callers
+// that need to enumerate every quality variant for one screen.
 //
 // Falls back to an in-memory Map if IndexedDB is unavailable (e.g. private
 // browsing in some browsers). The session keeps working; images are lost on
 // reload. We log a single warning so the regression is visible in DevTools.
 
-import type { MockupImageRecord } from '../types';
+import type { MockupImageQuality, MockupImageRecord } from '../types';
 
 const DB_NAME = 'synapse-mockup-images';
 const DB_VERSION = 1;
@@ -53,8 +57,15 @@ const openDb = (): Promise<IDBDatabase> => {
     return dbPromise;
 };
 
-export const buildImageKey = (versionId: string, screenId: string): string =>
-    `${versionId}:${screenId}`;
+export const buildImageKey = (
+    versionId: string,
+    screenId: string,
+    quality: MockupImageQuality,
+): string => `${versionId}:${screenId}:${quality}`;
+
+/** Prefix matching every quality variant for one (version, screen) pair. */
+export const buildScreenScopeKey = (versionId: string, screenId: string): string =>
+    `${versionId}:${screenId}:`;
 
 export const putImage = async (record: MockupImageRecord): Promise<void> => {
     try {

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -19,6 +19,8 @@ import {
 import { isAbortError } from '../concurrency';
 import { buildAutoMockupSettings } from '../mockupDefaults';
 import { normalizeError } from '../errors';
+import { useMockupImageStore } from '../../store/mockupImageStore';
+import { hasOpenAIKey } from '../openaiClient';
 
 export interface StartArgs {
     projectId: string;
@@ -227,7 +229,7 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
     const versions = writeStore.getArtifactVersions(projectId, artifactId);
     const parentVersionId = versions.length > 0 ? versions[versions.length - 1].id : null;
 
-    writeStore.createArtifactVersion(
+    const newVersion = writeStore.createArtifactVersion(
         projectId,
         artifactId,
         JSON.stringify(payload),
@@ -249,6 +251,31 @@ async function runMockupSlot(args: StartArgs, signal: AbortSignal): Promise<void
     );
 
     writeStore.setSlotStatus(projectId, 'mockup', { status: 'done', finishedAt: Date.now() });
+
+    // Fire-and-forget: kick off low-quality AI image generation for each
+    // screen. The user landed on the AI Image tab by default in MockupViewer
+    // — having the image start populating immediately matches the expectation
+    // that the AI image is the primary mockup output. Skipped when no OpenAI
+    // key is configured (the empty-state CTA is shown instead). High-quality
+    // can be promoted later via the regenerate button without losing the
+    // low-quality render — both qualities coexist in IndexedDB.
+    const versionId = newVersion?.versionId;
+    if (versionId && hasOpenAIKey() && !signal.aborted) {
+        const imageStore = useMockupImageStore.getState();
+        for (const screen of payload.screens) {
+            void imageStore.generate({
+                projectId,
+                artifactId,
+                versionId,
+                screen,
+                payload,
+                settings,
+                quality: 'low',
+            }).catch((err) => {
+                console.warn('[artifactJobController] auto image generation failed', err);
+            });
+        }
+    }
 }
 
 async function executeJob(args: StartArgs, controller: AbortController, slotKeys: ArtifactSlotKey[]): Promise<void> {

--- a/src/store/mockupImageStore.ts
+++ b/src/store/mockupImageStore.ts
@@ -6,6 +6,11 @@
  *
  * Persistence (the source of truth) lives in src/lib/mockupImageStore.ts
  * (IndexedDB). This store is purely a reactive cache and orchestrator.
+ *
+ * Records are keyed by `${versionId}:${screenId}:${quality}` so each quality
+ * level coexists rather than overwriting earlier renders. `getAllForScreen`
+ * returns every variant for one (version, screen) pair so the UI can show a
+ * quality switcher when both low- and high-quality images exist.
  */
 
 import { create } from 'zustand';
@@ -14,6 +19,7 @@ import { callOpenAIImage } from '../lib/openaiClient';
 import { buildScreenImagePrompt, pickImageSize } from '../lib/services/mockupImageService';
 import {
     buildImageKey,
+    buildScreenScopeKey,
     getImage as idbGetImage,
     listImagesForVersion as idbListImages,
     putImage as idbPutImage,
@@ -25,19 +31,29 @@ interface InFlight {
     abort: AbortController;
 }
 
+const screenScope = (versionId: string, screenId: string): string =>
+    buildScreenScopeKey(versionId, screenId);
+
 interface ImageStoreState {
+    /** Map of `${versionId}:${screenId}:${quality}` -> record. */
     images: Record<string, MockupImageRecord>;
+    /** Map of `${versionId}:${screenId}` -> in-flight info (one per screen). */
     inFlight: Record<string, InFlight>;
+    /** Map of `${versionId}:${screenId}` -> error message. */
     errors: Record<string, string>;
 
     /** Hydrate this version's images from IndexedDB into the reactive cache. */
     loadForVersion: (versionId: string) => Promise<void>;
 
-    /** Look up a single record (cache first, then IDB). */
-    getRecord: (versionId: string, screenId: string) => Promise<MockupImageRecord | undefined>;
+    /** Look up a single record at a specific quality (cache first, then IDB). */
+    getRecord: (
+        versionId: string,
+        screenId: string,
+        quality: MockupImageQuality,
+    ) => Promise<MockupImageRecord | undefined>;
 
-    /** Synchronous cache lookup for render-path use. */
-    peek: (versionId: string, screenId: string) => MockupImageRecord | undefined;
+    /** Synchronous lookup — returns every cached quality variant for one screen. */
+    listForScreen: (versionId: string, screenId: string) => MockupImageRecord[];
 
     /** Generate (or regenerate at higher quality) an image for one screen. */
     generate: (args: {
@@ -53,7 +69,7 @@ interface ImageStoreState {
     /** Cancel an in-flight generation. */
     cancel: (versionId: string, screenId: string) => void;
 
-    /** Clear the error state for one key (e.g. on retry click). */
+    /** Clear the error state for one screen (e.g. on retry click). */
     clearError: (versionId: string, screenId: string) => void;
 }
 
@@ -72,8 +88,8 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
         });
     },
 
-    getRecord: async (versionId, screenId) => {
-        const key = buildImageKey(versionId, screenId);
+    getRecord: async (versionId, screenId, quality) => {
+        const key = buildImageKey(versionId, screenId, quality);
         const cached = get().images[key];
         if (cached) return cached;
         const fromIdb = await idbGetImage(key);
@@ -83,18 +99,24 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
         return fromIdb;
     },
 
-    peek: (versionId, screenId) => {
-        return get().images[buildImageKey(versionId, screenId)];
+    listForScreen: (versionId, screenId) => {
+        const prefix = screenScope(versionId, screenId);
+        const out: MockupImageRecord[] = [];
+        const images = get().images;
+        for (const k of Object.keys(images)) {
+            if (k.startsWith(prefix)) out.push(images[k]);
+        }
+        return out;
     },
 
     generate: async ({ projectId, artifactId, versionId, screen, payload, settings, quality }) => {
-        const key = buildImageKey(versionId, screen.id);
-        if (get().inFlight[key]) return; // already generating this exact key
+        const scope = screenScope(versionId, screen.id);
+        if (get().inFlight[scope]) return; // already generating something for this screen
 
         const abort = new AbortController();
         set((state) => ({
-            inFlight: { ...state.inFlight, [key]: { quality, startedAt: Date.now(), abort } },
-            errors: { ...state.errors, [key]: '' },
+            inFlight: { ...state.inFlight, [scope]: { quality, startedAt: Date.now(), abort } },
+            errors: { ...state.errors, [scope]: '' },
         }));
 
         const prompt = buildScreenImagePrompt(payload, screen, settings);
@@ -102,6 +124,7 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
 
         try {
             const b64 = await callOpenAIImage(prompt, { quality, size, signal: abort.signal });
+            const key = buildImageKey(versionId, screen.id, quality);
             const record: MockupImageRecord = {
                 key,
                 projectId,
@@ -116,7 +139,7 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
             await idbPutImage(record);
             set((state) => {
                 const nextInFlight = { ...state.inFlight };
-                delete nextInFlight[key];
+                delete nextInFlight[scope];
                 return {
                     images: { ...state.images, [key]: record },
                     inFlight: nextInFlight,
@@ -129,27 +152,27 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
                 : err instanceof Error ? err.message : 'OpenAI image generation failed.';
             set((state) => {
                 const nextInFlight = { ...state.inFlight };
-                delete nextInFlight[key];
+                delete nextInFlight[scope];
                 const nextErrors = { ...state.errors };
-                if (message) nextErrors[key] = message; else delete nextErrors[key];
+                if (message) nextErrors[scope] = message; else delete nextErrors[scope];
                 return { inFlight: nextInFlight, errors: nextErrors };
             });
         }
     },
 
     cancel: (versionId, screenId) => {
-        const key = buildImageKey(versionId, screenId);
-        const inFlight = get().inFlight[key];
+        const scope = screenScope(versionId, screenId);
+        const inFlight = get().inFlight[scope];
         if (!inFlight) return;
         inFlight.abort.abort();
     },
 
     clearError: (versionId, screenId) => {
-        const key = buildImageKey(versionId, screenId);
+        const scope = screenScope(versionId, screenId);
         set((state) => {
-            if (!state.errors[key]) return state;
+            if (!state.errors[scope]) return state;
             const next = { ...state.errors };
-            delete next[key];
+            delete next[scope];
             return { errors: next };
         });
     },

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://vitals.vercel-insights.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://vitals.vercel-insights.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
         }
       ]
     },


### PR DESCRIPTION
- vercel.json CSP: whitelist cdn.tailwindcss.com for script-src so the
  iframe shell can load Tailwind. Without this, production renders fell
  back to unstyled markup (sidebar links rendering as bullet points)
  while the probe falsely reported "Render OK" because every <div>
  trivially passed its `display !== 'inline'` heuristic.
- buildMockupSrcDoc probe: replace the broken styled check with a
  `.hidden` sentinel — Tailwind resolves it to display:none, an
  unstyled fallback leaves it block. CDN failures now surface as
  "Render degraded" instead of silently lying.
- artifactJobController: after the mockup HTML artifact saves, fire-
  and-forget a low-quality gpt-image-2 render per screen so the AI
  Image tab (already the default landing tab) populates without
  requiring an explicit user click. Skipped when no OpenAI key is
  configured.
- Image store: include quality in the IDB key (was overwriting low-
  quality renders when the user promoted to high). MockupScreenImage
  gains a quality switcher when multiple variants exist so the user
  can flip back to compare; "Generate high quality" preserves the
  earlier low-quality render.

https://claude.ai/code/session_01SZwHeH1ei3SzGC4KvJkGe5