### PR TITLE
feat(data_model): replace raw schema dump with narrative product/eng explanation

### DIFF
--- a/src/components/renderers/DataModelRenderer.tsx
+++ b/src/components/renderers/DataModelRenderer.tsx
@@ -1,103 +1,394 @@
+import { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Sparkles, Database, Workflow, Layers } from 'lucide-react';
 import type { DataModelContent } from '../../types';
+import {
+    parseDataModelMarkdown,
+    dataModelToMarkdown,
+    type ParsedCallout,
+    type ParsedCalloutKind,
+    type ParsedDataModel,
+    type ParsedEntity,
+} from '../../lib/services/dataModelMarkdown';
+import { SectionTabs, type SectionTabItem } from '../SectionTabs';
 
 interface Props {
     content: string;
 }
 
-function tryParseDataModel(content: string): DataModelContent | null {
+const CALLOUT_STYLES: Record<ParsedCalloutKind, { container: string; label: string; labelText: string }> = {
+    CONSTRAINT: {
+        container: 'border-purple-200 bg-purple-50 text-purple-900',
+        label: 'bg-purple-200 text-purple-900',
+        labelText: 'Constraint',
+    },
+    PRIVACY: {
+        container: 'border-rose-200 bg-rose-50 text-rose-900',
+        label: 'bg-rose-200 text-rose-900',
+        labelText: 'Privacy',
+    },
+    INDEX: {
+        container: 'border-slate-200 bg-slate-50 text-slate-900',
+        label: 'bg-slate-200 text-slate-900',
+        labelText: 'Index',
+    },
+    RELATIONSHIP: {
+        container: 'border-indigo-200 bg-indigo-50 text-indigo-900',
+        label: 'bg-indigo-200 text-indigo-900',
+        labelText: 'Relationship',
+    },
+};
+
+const CALLOUT_ORDER: ParsedCalloutKind[] = ['RELATIONSHIP', 'CONSTRAINT', 'PRIVACY', 'INDEX'];
+
+function DataModelCallout({ kind, text }: { kind: ParsedCalloutKind; text: string }) {
+    const styles = CALLOUT_STYLES[kind];
+    return (
+        <div className={`rounded-lg border ${styles.container} px-3 py-2`}>
+            <div className="flex items-start gap-2">
+                <span
+                    className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0 ${styles.label}`}
+                >
+                    {styles.labelText}
+                </span>
+                <p className="text-sm leading-relaxed">{text}</p>
+            </div>
+        </div>
+    );
+}
+
+function VisibilityBadge({ userFacing }: { userFacing: boolean }) {
+    return userFacing ? (
+        <span className="text-[10px] px-1.5 py-0.5 rounded border font-medium bg-emerald-50 text-emerald-700 border-emerald-200">
+            User-facing
+        </span>
+    ) : (
+        <span className="text-[10px] px-1.5 py-0.5 rounded border font-medium bg-neutral-100 text-neutral-600 border-neutral-200">
+            Internal
+        </span>
+    );
+}
+
+function MutabilityBadge({ mutability }: { mutability: string }) {
+    const m = mutability.toLowerCase();
+    const cls =
+        m.includes('immutable') && !m.includes('mostly')
+            ? 'bg-slate-50 text-slate-700 border-slate-200'
+            : m.includes('mostly')
+              ? 'bg-blue-50 text-blue-700 border-blue-200'
+              : 'bg-amber-50 text-amber-700 border-amber-200';
+    return (
+        <span className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${cls}`}>
+            {mutability.replace(/_/g, ' ')}
+        </span>
+    );
+}
+
+function MethodPill({ method }: { method: string }) {
+    const m = method.toUpperCase();
+    const color =
+        m === 'GET'
+            ? 'text-green-700 bg-green-50 border-green-200'
+            : m === 'POST'
+              ? 'text-blue-700 bg-blue-50 border-blue-200'
+              : m === 'PUT' || m === 'PATCH'
+                ? 'text-amber-700 bg-amber-50 border-amber-200'
+                : m === 'DELETE'
+                  ? 'text-red-700 bg-red-50 border-red-200'
+                  : 'text-neutral-700 bg-neutral-50 border-neutral-200';
+    return (
+        <span className={`font-mono text-[11px] font-bold px-1.5 py-0.5 rounded border ${color}`}>
+            {m}
+        </span>
+    );
+}
+
+function entityAnchorId(name: string): string {
+    return `data-model-entity-${name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')}`;
+}
+
+function EntityCard({ entity }: { entity: ParsedEntity }) {
+    const groupedCallouts: Partial<Record<ParsedCalloutKind, ParsedCallout[]>> = {};
+    for (const c of entity.callouts) {
+        const list = groupedCallouts[c.kind] ?? [];
+        list.push(c);
+        groupedCallouts[c.kind] = list;
+    }
+
+    return (
+        <section
+            id={entityAnchorId(entity.name)}
+            className="bg-white rounded-lg border border-neutral-200 overflow-hidden scroll-mt-24"
+        >
+            <header className="bg-neutral-50 border-b border-neutral-200 px-4 py-3">
+                <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <h4 className="font-semibold text-neutral-900 text-base">{entity.name}</h4>
+                    {entity.userFacing !== undefined && <VisibilityBadge userFacing={entity.userFacing} />}
+                    {entity.mutability && <MutabilityBadge mutability={entity.mutability} />}
+                </div>
+                {entity.description && (
+                    <p className="text-sm text-neutral-600">{entity.description}</p>
+                )}
+                {entity.purpose && (
+                    <p className="text-sm text-neutral-700 mt-1">
+                        <span className="font-medium text-neutral-900">Purpose: </span>
+                        {entity.purpose}
+                    </p>
+                )}
+            </header>
+
+            <div className="px-4 py-3 space-y-4">
+                {entity.groupsAutoDetected && (
+                    <p className="text-[11px] text-neutral-400 italic">
+                        Grouped automatically — refine the artifact for explicit grouping.
+                    </p>
+                )}
+                {entity.fieldGroups.map((group, gi) => (
+                    <div key={gi} className="space-y-1.5">
+                        <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                            {group.name}
+                        </h5>
+                        <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+                            <table className="w-full text-xs">
+                                <thead>
+                                    <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider text-[10px]">
+                                        <th className="text-left px-3 py-2 font-medium">Field</th>
+                                        <th className="text-left px-3 py-2 font-medium">Type</th>
+                                        <th className="text-center px-3 py-2 font-medium">Required</th>
+                                        <th className="text-left px-3 py-2 font-medium">Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {group.fields.map((f, fi) => (
+                                        <tr key={fi} className="border-t border-neutral-100 align-top">
+                                            <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">
+                                                {f.name}
+                                            </td>
+                                            <td className="px-3 py-1.5 font-mono text-indigo-600 whitespace-nowrap">
+                                                {f.type}
+                                            </td>
+                                            <td className="px-3 py-1.5 text-center text-neutral-600">
+                                                {f.required ? '✓' : ''}
+                                            </td>
+                                            <td className="px-3 py-1.5 text-neutral-600">{f.description}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                ))}
+
+                {CALLOUT_ORDER.some(k => (groupedCallouts[k]?.length ?? 0) > 0) && (
+                    <div className="space-y-2">
+                        {CALLOUT_ORDER.flatMap(kind =>
+                            (groupedCallouts[kind] ?? []).map((c, idx) => (
+                                <DataModelCallout key={`${kind}-${idx}`} kind={kind} text={c.text} />
+                            )),
+                        )}
+                    </div>
+                )}
+
+                {entity.exampleRecord && (
+                    <div className="space-y-1">
+                        <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                            Example record
+                        </h5>
+                        <p className="text-[11px] text-neutral-400 italic">Illustrative — not real data.</p>
+                        <pre className="font-mono text-xs bg-neutral-900 text-neutral-100 rounded-lg p-3 overflow-x-auto whitespace-pre">
+                            {entity.exampleRecord}
+                        </pre>
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+}
+
+function tryParseAsJson(content: string): DataModelContent | null {
     try {
         const parsed = JSON.parse(content);
-        if (parsed.entities && Array.isArray(parsed.entities)) return parsed;
+        if (parsed && typeof parsed === 'object' && Array.isArray(parsed.entities)) {
+            return parsed as DataModelContent;
+        }
     } catch {
-        // Not JSON
+        // not JSON
     }
     return null;
 }
 
+function markEntityGroupsAuto(parsed: ParsedDataModel, sourceMarkdown: string): void {
+    // If the markdown didn't include any explicit `**<GroupName>**` group headers,
+    // mark the entity as auto-grouped so the renderer surfaces the hint.
+    const explicitGroupRe = /^\*\*(Key Product Fields|Relationships|System Metadata|API \/ Integration|Privacy \/ Safety)\*\*\s*$/m;
+    const hasExplicitGroups = explicitGroupRe.test(sourceMarkdown);
+    if (!hasExplicitGroups) {
+        for (const e of parsed.entities) {
+            if (e.fieldGroups.length === 1 && e.fieldGroups[0].name === 'Key Product Fields') {
+                e.groupsAutoDetected = true;
+            }
+        }
+    }
+}
+
 export function DataModelRenderer({ content }: Props) {
-    const structured = tryParseDataModel(content);
-    if (!structured) return null;
+    const { parsed, sourceMarkdown } = useMemo(() => {
+        const json = tryParseAsJson(content);
+        if (json) {
+            const md = dataModelToMarkdown(json);
+            const result = parseDataModelMarkdown(md);
+            return { parsed: result, sourceMarkdown: md };
+        }
+        const result = parseDataModelMarkdown(content);
+        return { parsed: result, sourceMarkdown: content };
+    }, [content]);
+
+    if (!parsed) {
+        return (
+            <div className="prose prose-sm prose-neutral max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+        );
+    }
+
+    markEntityGroupsAuto(parsed, sourceMarkdown);
+
+    const tabItems: SectionTabItem[] = parsed.entities.map(e => ({
+        id: entityAnchorId(e.name),
+        label: e.name,
+    }));
 
     return (
         <div className="space-y-6">
-            {structured.entities.map((entity, ei) => (
-                <div key={ei} className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
-                    <div className="bg-indigo-50 border-b border-indigo-100 px-4 py-2.5">
-                        <h4 className="font-semibold text-indigo-800 text-sm">{entity.name}</h4>
-                        <p className="text-xs text-indigo-600 mt-0.5">{entity.description}</p>
+            {parsed.entities.length > 3 && <SectionTabs items={tabItems} />}
+
+            {parsed.overview && (
+                <section className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-5">
+                    <div className="flex items-center gap-2 mb-3">
+                        <Sparkles className="w-4 h-4 text-indigo-600" />
+                        <h3 className="font-semibold text-indigo-900 text-sm uppercase tracking-wider">
+                            How This Data Model Works
+                        </h3>
                     </div>
-                    <div className="overflow-auto">
+                    {parsed.overview.summary && (
+                        <p className="text-sm text-neutral-800 leading-relaxed mb-3">
+                            {parsed.overview.summary}
+                        </p>
+                    )}
+                    <div className="space-y-2">
+                        {parsed.overview.dataFlow && (
+                            <div className="text-sm text-neutral-700">
+                                <span className="font-semibold text-indigo-900">Data flow: </span>
+                                {parsed.overview.dataFlow}
+                            </div>
+                        )}
+                        {parsed.overview.productOutcome && (
+                            <div className="text-sm text-neutral-700">
+                                <span className="font-semibold text-indigo-900">Product outcome: </span>
+                                {parsed.overview.productOutcome}
+                            </div>
+                        )}
+                    </div>
+                </section>
+            )}
+
+            {parsed.relationshipFlow && (
+                <section className="space-y-2">
+                    <div className="flex items-center gap-2">
+                        <Workflow className="w-4 h-4 text-neutral-500" />
+                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                            Relationship Flow
+                        </h3>
+                    </div>
+                    <pre className="font-mono text-xs bg-neutral-50 border border-neutral-200 rounded-lg p-4 overflow-x-auto whitespace-pre text-neutral-800">
+                        {parsed.relationshipFlow}
+                    </pre>
+                </section>
+            )}
+
+            {parsed.entities.length > 0 && (
+                <section className="space-y-4">
+                    <div className="flex items-center gap-2">
+                        <Database className="w-4 h-4 text-neutral-500" />
+                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                            Entities
+                        </h3>
+                    </div>
+                    {parsed.entities.map((entity, ei) => (
+                        <EntityCard key={ei} entity={entity} />
+                    ))}
+                </section>
+            )}
+
+            {parsed.productMapping.length > 0 && (
+                <section className="space-y-2">
+                    <div className="flex items-center gap-2">
+                        <Layers className="w-4 h-4 text-neutral-500" />
+                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                            How This Appears in the Product
+                        </h3>
+                    </div>
+                    <div className="bg-white rounded-lg border border-neutral-200 overflow-x-auto">
                         <table className="w-full text-xs">
                             <thead>
-                                <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider">
+                                <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider text-[10px]">
                                     <th className="text-left px-3 py-2 font-medium">Field</th>
-                                    <th className="text-left px-3 py-2 font-medium">Type</th>
-                                    <th className="text-center px-3 py-2 font-medium">Req</th>
-                                    <th className="text-left px-3 py-2 font-medium">Description</th>
+                                    <th className="text-left px-3 py-2 font-medium">UI behavior</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {entity.fields.map((field, fi) => (
-                                    <tr key={fi} className="border-t border-neutral-100">
-                                        <td className="px-3 py-1.5 font-mono text-neutral-800">{field.name}</td>
-                                        <td className="px-3 py-1.5 font-mono text-indigo-600">{field.type}</td>
-                                        <td className="px-3 py-1.5 text-center">{field.required ? '✓' : ''}</td>
-                                        <td className="px-3 py-1.5 text-neutral-600">{field.description}</td>
+                                {parsed.productMapping.map((m, mi) => (
+                                    <tr key={mi} className="border-t border-neutral-100 align-top">
+                                        <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">
+                                            {m.field}
+                                        </td>
+                                        <td className="px-3 py-1.5 text-neutral-600">{m.uiBehavior}</td>
                                     </tr>
                                 ))}
                             </tbody>
                         </table>
                     </div>
-                    {entity.relationships && entity.relationships.length > 0 && (
-                        <div className="border-t border-neutral-100 px-4 py-2">
-                            <span className="text-xs font-medium text-neutral-500">Relationships: </span>
-                            {entity.relationships.map((r, ri) => (
-                                <span key={ri} className="text-xs text-neutral-600">
-                                    {ri > 0 ? ' · ' : ''}
-                                    {r.type.replace(/_/g, ' ')} → {r.target}
-                                </span>
-                            ))}
-                        </div>
-                    )}
-                </div>
-            ))}
+                </section>
+            )}
 
-            {structured.apiEndpoints && structured.apiEndpoints.length > 0 && (
-                <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
-                    <div className="bg-neutral-50 border-b border-neutral-100 px-4 py-2.5">
-                        <h4 className="font-semibold text-neutral-700 text-sm">API Endpoints</h4>
-                    </div>
-                    <div className="overflow-auto">
+            {parsed.apiEndpoints.length > 0 && (
+                <section className="space-y-2">
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                        API Endpoints
+                    </h3>
+                    <div className="bg-white rounded-lg border border-neutral-200 overflow-x-auto">
                         <table className="w-full text-xs">
                             <thead>
-                                <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider">
+                                <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider text-[10px]">
                                     <th className="text-left px-3 py-2 font-medium">Method</th>
                                     <th className="text-left px-3 py-2 font-medium">Path</th>
                                     <th className="text-left px-3 py-2 font-medium">Description</th>
+                                    <th className="text-left px-3 py-2 font-medium">Entity</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {structured.apiEndpoints.map((ep, ei) => (
-                                    <tr key={ei} className="border-t border-neutral-100">
-                                        <td className="px-3 py-1.5">
-                                            <span className={`font-mono font-bold ${
-                                                ep.method === 'GET' ? 'text-green-600'
-                                                : ep.method === 'POST' ? 'text-blue-600'
-                                                : ep.method === 'PUT' || ep.method === 'PATCH' ? 'text-amber-600'
-                                                : ep.method === 'DELETE' ? 'text-red-600'
-                                                : 'text-neutral-600'
-                                            }`}>
-                                                {ep.method}
-                                            </span>
+                                {parsed.apiEndpoints.map((ep, ei) => (
+                                    <tr key={ei} className="border-t border-neutral-100 align-top">
+                                        <td className="px-3 py-1.5 whitespace-nowrap">
+                                            <MethodPill method={ep.method} />
                                         </td>
-                                        <td className="px-3 py-1.5 font-mono text-neutral-800">{ep.path}</td>
+                                        <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">
+                                            {ep.path}
+                                        </td>
                                         <td className="px-3 py-1.5 text-neutral-600">{ep.description}</td>
+                                        <td className="px-3 py-1.5 text-neutral-700 whitespace-nowrap">
+                                            {ep.entity ?? ''}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>
                         </table>
                     </div>
-                </div>
+                </section>
             )}
         </div>
     );

--- a/src/components/renderers/__tests__/index.test.tsx
+++ b/src/components/renderers/__tests__/index.test.tsx
@@ -41,13 +41,13 @@ describe('ArtifactContentRenderer', () => {
         expect(container.querySelector('ol')).toBeTruthy();
     });
 
-    it('falls back to markdown when JSON is malformed for structured type', () => {
-        const badJson = '{ this is not valid json }';
+    it('falls back to markdown when content is unparseable for data_model', () => {
+        const garbage = 'this is not a data model artifact at all';
         const { container } = render(
-            <ArtifactContentRenderer subtype="data_model" content={badJson} />
+            <ArtifactContentRenderer subtype="data_model" content={garbage} />
         );
-        // Should not crash — renders as text via ReactMarkdown
-        expect(container).toHaveTextContent('this is not valid json');
+        // Should not crash — renders as text via ReactMarkdown fallback
+        expect(container).toHaveTextContent('this is not a data model artifact at all');
     });
 
     it('renders structured data_model content when valid JSON is provided', () => {
@@ -59,13 +59,93 @@ describe('ArtifactContentRenderer', () => {
                     { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
                     { name: 'email', type: 'string', required: true, description: 'Email address' },
                 ],
+                relationships: [],
             }],
-            relationships: [],
+            apiEndpoints: [],
         });
         const { container } = render(
             <ArtifactContentRenderer subtype="data_model" content={jsonContent} />
         );
         expect(container).toHaveTextContent('User');
         expect(container).toHaveTextContent('email');
+    });
+
+    it('renders rich data_model content when full markdown shape is provided', () => {
+        const richMarkdown = `# Data Model
+
+## How This Data Model Works
+
+User input creates a Snapshot which seeds a Playlist.
+
+**Data flow:** User → Snapshot → Playlist.
+
+**Product outcome:** Adaptive playlists.
+
+## Snapshot
+
+Captures emotional state.
+
+**Purpose:** Acts as the seed.
+**Visibility:** User-facing
+**Mutability:** mostly_immutable
+
+**Key Product Fields**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| joy_score | Float | Yes | Joy intensity |
+
+> [!CONSTRAINT] joy_score must be between 0 and 1
+> [!PRIVACY] raw_input must be null when source is FACE_SCAN
+
+## How This Appears in the Product
+
+| Field | UI behavior |
+|-------|-------------|
+| \`joy_score\` | Drives playlist energy |
+
+## API Endpoints
+
+| Method | Path | Description | Entity |
+|--------|------|-------------|--------|
+| GET | /api/snapshots | List snapshots | Snapshot |
+`;
+        const { container } = render(
+            <ArtifactContentRenderer subtype="data_model" content={richMarkdown} />
+        );
+        expect(container).toHaveTextContent('How This Data Model Works');
+        expect(container).toHaveTextContent('Snapshot');
+        expect(container).toHaveTextContent('joy_score');
+        expect(container).toHaveTextContent('Constraint');
+        expect(container).toHaveTextContent('Privacy');
+        expect(container).toHaveTextContent('How This Appears in the Product');
+    });
+
+    it('renders legacy data_model markdown without crashing', () => {
+        const legacy = `# Data Model
+
+## Patient
+A patient record.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| id | UUID | Yes | Primary key |
+| name | String | Yes | Full name |
+
+**Relationships:**
+- has many Visit (via foreign key \`patient_id\`)
+
+## API Endpoints
+
+| Method | Path | Description | Entity |
+|--------|------|-------------|--------|
+| GET | /api/patients | List patients | Patient |
+`;
+        const { container } = render(
+            <ArtifactContentRenderer subtype="data_model" content={legacy} />
+        );
+        expect(container).toHaveTextContent('Patient');
+        expect(container).toHaveTextContent('id');
+        expect(container).toHaveTextContent('name');
     });
 });

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -46,7 +46,7 @@ export function ArtifactContentRenderer({ subtype, content, screenImageContext }
     if (subtype === 'screen_inventory' && isJsonString(content)) {
         return <ScreenInventoryRenderer content={content} imageContext={screenImageContext} />;
     }
-    if (subtype === 'data_model' && isJsonString(content)) {
+    if (subtype === 'data_model') {
         return <DataModelRenderer content={content} />;
     }
     if (subtype === 'component_inventory' && isJsonString(content)) {

--- a/src/lib/__tests__/dataModelMarkdown.test.ts
+++ b/src/lib/__tests__/dataModelMarkdown.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest';
+import {
+    dataModelToMarkdown,
+    parseDataModelMarkdown,
+    applyFieldGroupHeuristic,
+    buildRelationshipTree,
+} from '../services/dataModelMarkdown';
+import type { DataModelContent, DataEntity } from '../../types';
+
+const fullModel: DataModelContent = {
+    overview: {
+        summary: 'User input creates a MoodSnapshot which seeds a ResonancePlaylist.',
+        dataFlow: 'User input → MoodSnapshot → ResonancePlaylist → Swipe feedback updates targets.',
+        productOutcome: 'Users see a personalized playlist that adapts to their feedback over time.',
+    },
+    entities: [
+        {
+            name: 'MoodSnapshot',
+            description: 'Captures a single emotional state.',
+            purpose: 'Acts as the seed for playlist generation.',
+            userFacing: true,
+            mutability: 'mostly_immutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'joy_score', type: 'Float', required: true, description: 'Joy intensity 0-1' },
+                { name: 'energy_level', type: 'Float', required: true, description: 'Energy intensity 0-1' },
+                { name: 'user_id', type: 'UUID', required: true, description: 'Owning user' },
+                { name: 'created_at', type: 'Timestamp', required: true, description: 'Creation time' },
+                { name: 'raw_input', type: 'String', required: false, description: 'Sensitive PII free-text' },
+            ],
+            fieldGroups: [
+                { name: 'Key Product Fields', fieldNames: ['joy_score', 'energy_level'] },
+                { name: 'Relationships', fieldNames: ['user_id'] },
+                { name: 'System Metadata', fieldNames: ['id', 'created_at'] },
+                { name: 'Privacy / Safety', fieldNames: ['raw_input'] },
+            ],
+            relationships: [
+                { type: 'belongs_to', target: 'User' },
+                { type: 'has_many', target: 'ResonancePlaylist', description: 'Playlists derived from this snapshot' },
+            ],
+            indexes: ['idx_user_id_created_at on (user_id, created_at)'],
+            constraints: ['joy_score + sadness_score must approximate 1.0'],
+            privacyRules: ['raw_input must be null when source = FACE_SCAN'],
+            exampleRecord:
+                '{"joy_score": 0.7, "energy_level": 0.6, "vibe_title": "Warm Sunset Drift"}',
+        },
+        {
+            name: 'ResonancePlaylist',
+            description: 'Adaptive playlist of recommended tracks.',
+            purpose: 'Holds dynamic playlist state that evolves with user feedback.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'mood_snapshot_id', type: 'UUID', required: true, description: 'Source snapshot' },
+                { name: 'target_valence', type: 'Float', required: true, description: 'Target valence' },
+            ],
+            relationships: [{ type: 'belongs_to', target: 'MoodSnapshot' }],
+        },
+        {
+            name: 'User',
+            description: 'Account holder.',
+            purpose: 'Owns snapshots and playlists.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'email', type: 'String', required: true, description: 'Login email' },
+            ],
+            relationships: [{ type: 'has_many', target: 'MoodSnapshot' }],
+        },
+    ],
+    apiEndpoints: [
+        { method: 'POST', path: '/api/snapshots', description: 'Create a snapshot', entity: 'MoodSnapshot' },
+        { method: 'GET', path: '/api/playlists/:id', description: 'Fetch a playlist', entity: 'ResonancePlaylist' },
+    ],
+    productMapping: [
+        { field: 'vibe_title', uiBehavior: 'Appears as the generated playlist name' },
+        { field: 'energy_level', uiBehavior: 'Affects track intensity' },
+    ],
+};
+
+describe('dataModelToMarkdown', () => {
+    it('emits all required sections for a fully populated model', () => {
+        const md = dataModelToMarkdown(fullModel);
+
+        expect(md).toContain('# Data Model');
+        expect(md).toContain('## How This Data Model Works');
+        expect(md).toContain('## Relationship Flow');
+        expect(md).toContain('## MoodSnapshot');
+        expect(md).toContain('## ResonancePlaylist');
+        expect(md).toContain('## User');
+        expect(md).toContain('## API Endpoints');
+        expect(md).toContain('## How This Appears in the Product');
+    });
+
+    it('emits all four callout marker kinds when source data is present', () => {
+        const md = dataModelToMarkdown(fullModel);
+        expect(md).toContain('[!CONSTRAINT]');
+        expect(md).toContain('[!PRIVACY]');
+        expect(md).toContain('[!INDEX]');
+        expect(md).toContain('[!RELATIONSHIP]');
+    });
+
+    it('preserves the validation-required substrings', () => {
+        const md = dataModelToMarkdown(fullModel);
+        // artifactValidation.ts EXPECTED_HEADERS.data_model
+        expect(md).toContain('Field');
+        expect(md).toContain('Type');
+        expect(md).toContain('Required');
+        expect(md).toContain('Relationships');
+        // artifactOrchestration.ts cross-artifact check (lowercased)
+        expect(md.toLowerCase()).toContain('api endpoints');
+    });
+
+    it('emits a fenced JSON example record when present', () => {
+        const md = dataModelToMarkdown(fullModel);
+        expect(md).toContain('```json');
+        expect(md).toContain('"vibe_title"');
+    });
+
+    it('handles a minimal model (no overview, no fieldGroups, no privacy) and still passes validation strings', () => {
+        const minimal: DataModelContent = {
+            entities: [
+                {
+                    name: 'Foo',
+                    description: 'A thing.',
+                    fields: [
+                        { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                        { name: 'name', type: 'String', required: true, description: 'Name' },
+                    ],
+                    relationships: [],
+                },
+            ],
+            apiEndpoints: [
+                { method: 'GET', path: '/api/foo', description: 'List foos', entity: 'Foo' },
+            ],
+        };
+        const md = dataModelToMarkdown(minimal);
+        expect(md).toContain('## Foo');
+        expect(md).toContain('Field');
+        expect(md).toContain('Type');
+        expect(md).toContain('Required');
+        // Relationships substring still appears via the column header check
+        expect(md.toLowerCase()).toContain('api endpoints');
+        expect(md.length).toBeGreaterThan(200);
+    });
+
+    it('skips empty optional sections', () => {
+        const minimal: DataModelContent = {
+            entities: [
+                { name: 'Foo', description: 'A.', fields: [{ name: 'id', type: 'UUID', required: true, description: 'pk' }], relationships: [] },
+            ],
+            apiEndpoints: [],
+        };
+        const md = dataModelToMarkdown(minimal);
+        expect(md).not.toContain('## How This Data Model Works');
+        expect(md).not.toContain('## How This Appears in the Product');
+        expect(md).not.toContain('## API Endpoints');
+    });
+});
+
+describe('parseDataModelMarkdown', () => {
+    it('round-trips a fully populated model', () => {
+        const md = dataModelToMarkdown(fullModel);
+        const parsed = parseDataModelMarkdown(md);
+
+        expect(parsed).not.toBeNull();
+        expect(parsed!.overview?.summary).toContain('MoodSnapshot');
+        expect(parsed!.overview?.dataFlow).toContain('ResonancePlaylist');
+        expect(parsed!.overview?.productOutcome).toContain('personalized');
+        expect(parsed!.relationshipFlow).toBeTruthy();
+        expect(parsed!.relationshipFlow).toContain('User');
+        expect(parsed!.relationshipFlow).toContain('MoodSnapshot');
+
+        const names = parsed!.entities.map(e => e.name);
+        expect(names).toEqual(['MoodSnapshot', 'ResonancePlaylist', 'User']);
+
+        const moodSnapshot = parsed!.entities[0];
+        expect(moodSnapshot.userFacing).toBe(true);
+        expect(moodSnapshot.mutability?.replace(/\s/g, '_')).toBe('mostly_immutable');
+        expect(moodSnapshot.purpose).toContain('seed');
+        expect(moodSnapshot.fieldGroups.length).toBeGreaterThanOrEqual(3);
+        expect(moodSnapshot.exampleRecord).toContain('vibe_title');
+
+        const calloutKinds = moodSnapshot.callouts.map(c => c.kind);
+        expect(calloutKinds).toContain('CONSTRAINT');
+        expect(calloutKinds).toContain('PRIVACY');
+        expect(calloutKinds).toContain('INDEX');
+        expect(calloutKinds).toContain('RELATIONSHIP');
+
+        expect(parsed!.apiEndpoints).toHaveLength(2);
+        expect(parsed!.apiEndpoints[0]).toMatchObject({
+            method: 'POST',
+            path: '/api/snapshots',
+            entity: 'MoodSnapshot',
+        });
+
+        expect(parsed!.productMapping).toHaveLength(2);
+        expect(parsed!.productMapping[0]).toMatchObject({
+            field: 'vibe_title',
+            uiBehavior: 'Appears as the generated playlist name',
+        });
+    });
+
+    it('parses legacy markdown shape (no groups, no callouts) into entities + endpoints', () => {
+        const legacy = `# Data Model
+
+## Patient
+A patient record.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| id | UUID | Yes | Primary key |
+| name | String | Yes | Full name |
+
+**Relationships:**
+- has many Visit (via foreign key \`patient_id\`)
+
+**Indexes:** idx_name
+**Constraints:** name must be non-empty
+
+## API Endpoints
+
+| Method | Path | Description | Entity |
+|--------|------|-------------|--------|
+| GET | /api/patients | List patients | Patient |
+`;
+        const parsed = parseDataModelMarkdown(legacy);
+        expect(parsed).not.toBeNull();
+        expect(parsed!.entities).toHaveLength(1);
+        expect(parsed!.entities[0].name).toBe('Patient');
+        expect(parsed!.entities[0].fieldGroups[0].fields.map(f => f.name)).toEqual(['id', 'name']);
+
+        const kinds = parsed!.entities[0].callouts.map(c => c.kind);
+        expect(kinds).toContain('RELATIONSHIP');
+        expect(kinds).toContain('INDEX');
+        expect(kinds).toContain('CONSTRAINT');
+
+        expect(parsed!.apiEndpoints).toHaveLength(1);
+        expect(parsed!.apiEndpoints[0].method).toBe('GET');
+    });
+
+    it('returns null on empty or non-data-model content', () => {
+        expect(parseDataModelMarkdown('')).toBeNull();
+        expect(parseDataModelMarkdown('Just some prose with no structure.')).toBeNull();
+    });
+});
+
+describe('applyFieldGroupHeuristic', () => {
+    const entity: DataEntity = {
+        name: 'Order',
+        description: '',
+        fields: [
+            { name: 'id', type: 'UUID', required: true, description: 'pk' },
+            { name: 'created_at', type: 'Timestamp', required: true, description: 'created' },
+            { name: 'user_id', type: 'UUID', required: true, description: 'owning user' },
+            { name: 'external_id', type: 'String', required: false, description: 'unrelated id' },
+            { name: 'password_hash', type: 'String', required: true, description: 'hashed password' },
+            { name: 'webhook_url', type: 'String', required: false, description: 'integration webhook' },
+            { name: 'total_cents', type: 'Integer', required: true, description: 'order total' },
+            { name: 'notes', type: 'String', required: false, description: 'PII free-form notes' },
+        ],
+        relationships: [],
+    };
+
+    it('classifies fields by name and description rules', () => {
+        const groups = applyFieldGroupHeuristic(entity, ['Order', 'User']);
+        const flat: Record<string, string> = {};
+        for (const g of groups) for (const fn of g.fieldNames) flat[fn] = g.name;
+
+        expect(flat['id']).toBe('System Metadata');
+        expect(flat['created_at']).toBe('System Metadata');
+        expect(flat['user_id']).toBe('Relationships');
+        expect(flat['external_id']).toBe('Key Product Fields'); // not demoted to Relationships
+        expect(flat['password_hash']).toBe('Privacy / Safety');
+        expect(flat['webhook_url']).toBe('API / Integration');
+        expect(flat['total_cents']).toBe('Key Product Fields');
+        expect(flat['notes']).toBe('Privacy / Safety'); // matches "PII" in description
+    });
+});
+
+describe('buildRelationshipTree', () => {
+    it('produces an indented tree from a simple parent-child graph', () => {
+        const tree = buildRelationshipTree([
+            { name: 'User', description: '', fields: [], relationships: [{ type: 'has_many', target: 'Order' }] },
+            { name: 'Order', description: '', fields: [], relationships: [{ type: 'has_many', target: 'LineItem' }] },
+            { name: 'LineItem', description: '', fields: [], relationships: [] },
+        ]);
+        const lines = tree.split('\n');
+        expect(lines[0]).toBe('User');
+        expect(lines[1].trim()).toBe('→ Order');
+        expect(lines[2].trim()).toBe('→ LineItem');
+    });
+
+    it('handles cyclic graphs without infinite recursion', () => {
+        const tree = buildRelationshipTree([
+            { name: 'A', description: '', fields: [], relationships: [{ type: 'has_many', target: 'B' }] },
+            { name: 'B', description: '', fields: [], relationships: [{ type: 'has_many', target: 'A' }] },
+        ]);
+        expect(tree).toContain('A');
+        expect(tree).toContain('B');
+        expect(tree).toContain('see above');
+    });
+
+    it('returns empty string when there are no entities', () => {
+        expect(buildRelationshipTree([])).toBe('');
+    });
+});

--- a/src/lib/schemas/artifactSchemas.ts
+++ b/src/lib/schemas/artifactSchemas.ts
@@ -33,9 +33,26 @@ export const screenInventorySchema = {
     required: ["groups"],
 };
 
+const FIELD_GROUP_NAMES = [
+    "Key Product Fields",
+    "Relationships",
+    "System Metadata",
+    "API / Integration",
+    "Privacy / Safety",
+];
+
 export const dataModelSchema = {
     type: "OBJECT",
     properties: {
+        overview: {
+            type: "OBJECT",
+            properties: {
+                summary: { type: "STRING" },
+                dataFlow: { type: "STRING" },
+                productOutcome: { type: "STRING" },
+            },
+            required: ["summary", "dataFlow", "productOutcome"],
+        },
         entities: {
             type: "ARRAY",
             items: {
@@ -43,6 +60,9 @@ export const dataModelSchema = {
                 properties: {
                     name: { type: "STRING" },
                     description: { type: "STRING" },
+                    purpose: { type: "STRING" },
+                    userFacing: { type: "BOOLEAN" },
+                    mutability: { type: "STRING", enum: ["immutable", "mostly_immutable", "mutable"] },
                     fields: {
                         type: "ARRAY",
                         items: {
@@ -54,6 +74,17 @@ export const dataModelSchema = {
                                 description: { type: "STRING" },
                             },
                             required: ["name", "type", "required", "description"],
+                        },
+                    },
+                    fieldGroups: {
+                        type: "ARRAY",
+                        items: {
+                            type: "OBJECT",
+                            properties: {
+                                name: { type: "STRING", enum: FIELD_GROUP_NAMES },
+                                fieldNames: { type: "ARRAY", items: { type: "STRING" } },
+                            },
+                            required: ["name", "fieldNames"],
                         },
                     },
                     relationships: {
@@ -70,6 +101,8 @@ export const dataModelSchema = {
                     },
                     indexes: { type: "ARRAY", items: { type: "STRING" } },
                     constraints: { type: "ARRAY", items: { type: "STRING" } },
+                    privacyRules: { type: "ARRAY", items: { type: "STRING" } },
+                    exampleRecord: { type: "STRING" },
                 },
                 required: ["name", "description", "fields", "relationships"],
             },
@@ -85,6 +118,17 @@ export const dataModelSchema = {
                     entity: { type: "STRING" },
                 },
                 required: ["method", "path", "description", "entity"],
+            },
+        },
+        productMapping: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    field: { type: "STRING" },
+                    uiBehavior: { type: "STRING" },
+                },
+                required: ["field", "uiBehavior"],
             },
         },
     },

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -3,6 +3,7 @@ import { callGemini, callGeminiStream } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
 import { screenInventorySchema, dataModelSchema, componentInventorySchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
+import { dataModelToMarkdown } from './dataModelMarkdown';
 
 const CORE_ARTIFACT_PROMPTS: Record<CoreArtifactSubtype, { system: string; userPrefix: string }> = {
     screen_inventory: {
@@ -86,31 +87,39 @@ End with:
         userPrefix: 'Create an Implementation Plan from this PRD:',
     },
     data_model: {
-        system: `You are an expert backend architect. Create a Data Model Draft — the primary entities, relationships, and data needs.
+        system: `You are an expert backend architect. Produce a Data Model that reads as a clear product/engineering explanation, not a raw schema dump. The artifact must remain structurally parseable: use the same heading and table conventions on every regeneration, and every field must appear in exactly one fieldGroup.
 
-For each entity, use this exact format:
+The JSON you return drives both downstream artifacts and the rendered UI. Populate these top-level fields:
 
-### [EntityName]
-**Description:** What this entity represents.
-**Fields:**
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| id | UUID | Yes | Primary key |
-| ... | ... | ... | ... |
+- overview.summary: 2-3 sentences in plain English describing what this data model represents and the primary entities involved.
+- overview.dataFlow: 1-2 sentences describing how user input flows through the system (e.g., "User input creates a MoodSnapshot, which seeds a ResonancePlaylist that adapts to swipe feedback over time.").
+- overview.productOutcome: 1-2 sentences describing the resulting user-visible behavior. Keep summary + dataFlow + productOutcome combined under ~600 characters total — they appear at the top of the rendered artifact and the first slice is fed to downstream generators.
 
-**Relationships:**
-- Has many [OtherEntity] (via foreign key \`entity_id\`)
-- Belongs to [OtherEntity]
-**Indexes:** List recommended indexes for query performance.
-**Constraints:** Uniqueness, check constraints, etc.
+For each entity, populate:
 
-After all entities, include:
-- An entity-relationship summary showing all connections
-- API surface implications (key endpoints each entity needs)
-- State management notes for the frontend
+- name, description: existing fields. Description is what the entity represents; keep distinct from purpose.
+- purpose: one sentence on WHY this entity exists.
+- userFacing: true if the user directly sees or manipulates this entity's data, false for purely internal/system entities.
+- mutability: "immutable" (write-once), "mostly_immutable" (rare changes), or "mutable" (regularly updated).
+- fields: each field with name, type, required (boolean), description.
+- fieldGroups: assign EVERY field to exactly one of these groups:
+  - "Key Product Fields" (the meaningful product attributes)
+  - "Relationships" (foreign keys to other entities)
+  - "System Metadata" (id, created_at, updated_at, version, audit fields)
+  - "API / Integration" (webhook URLs, external IDs, integration payloads)
+  - "Privacy / Safety" (PII, secrets, sensitive data subject to safety rules)
+- relationships: existing array of { type: has_many|belongs_to|has_one|many_to_many, target, description? }.
+- indexes: recommended database indexes for query performance.
+- constraints: business/database constraints (uniqueness, check constraints, cardinality limits) — NOT privacy concerns.
+- privacyRules: separate from constraints. Privacy/safety rules like "raw_input must be null when source = FACE_SCAN", "PII fields must be encrypted at rest", "soft-delete only — never hard delete". Use this for anything safety, privacy, or compliance related.
+- exampleRecord: optional. For the FIRST userFacing entity (and others only when illustrative), provide a compact example record as a JSON-encoded STRING (e.g., "{\\"joy_score\\": 0.7, \\"energy_level\\": 0.6, \\"vibe_title\\": \\"Warm Sunset Drift\\"}"). 4-8 fields max; keep it illustrative, not exhaustive.
 
-Use stable names for entities and fields. Do not rename PRD concepts unless you provide an alias note.`,
-        userPrefix: 'Create a Data Model Draft from this PRD:',
+Top-level apiEndpoints: existing array of { method, path, description, entity }. Required.
+
+Top-level productMapping: an array of { field, uiBehavior } mapping the most product-relevant fields to visible UI behavior (e.g., { field: "vibe_title", uiBehavior: "Appears as the generated playlist name" }, { field: "energy_level", uiBehavior: "Affects track intensity" }). Aim for 5-10 entries covering the fields that most directly shape the user experience.
+
+Use stable names for entities and fields. Do not rename PRD concepts unless you provide an alias note. Keep terminology consistent across overview, fieldGroups, productMapping, and the entities themselves.`,
+        userPrefix: 'Create a Data Model from this PRD:',
     },
     prompt_pack: {
         system: `You are an expert at writing AI prompts. Create a Prompt Pack — a bundle of ready-to-use downstream prompts.
@@ -206,39 +215,7 @@ function structuredArtifactToMarkdown(subtype: CoreArtifactSubtype, data: unknow
     }
 
     if (subtype === 'data_model') {
-        const model = data as DataModelContent;
-        const lines: string[] = ['# Data Model\n'];
-        for (const entity of model.entities) {
-            lines.push(`## ${entity.name}`);
-            lines.push(`${entity.description}\n`);
-            lines.push('| Field | Type | Required | Description |');
-            lines.push('|-------|------|----------|-------------|');
-            for (const field of entity.fields) {
-                lines.push(`| ${field.name} | ${field.type} | ${field.required ? 'Yes' : 'No'} | ${field.description} |`);
-            }
-            lines.push('');
-            if (entity.relationships?.length) {
-                lines.push('**Relationships:**');
-                entity.relationships.forEach(r => lines.push(`- ${r.type.replace(/_/g, ' ')} → ${r.target}${r.description ? ` (${r.description})` : ''}`));
-                lines.push('');
-            }
-            if (entity.indexes?.length) {
-                lines.push(`**Indexes:** ${entity.indexes.join(', ')}`);
-            }
-            if (entity.constraints?.length) {
-                lines.push(`**Constraints:** ${entity.constraints.join(', ')}`);
-            }
-            lines.push('');
-        }
-        if (model.apiEndpoints?.length) {
-            lines.push('## API Endpoints\n');
-            lines.push('| Method | Path | Description | Entity |');
-            lines.push('|--------|------|-------------|--------|');
-            for (const ep of model.apiEndpoints) {
-                lines.push(`| ${ep.method} | ${ep.path} | ${ep.description} | ${ep.entity} |`);
-            }
-        }
-        return lines.join('\n');
+        return dataModelToMarkdown(data as DataModelContent);
     }
 
     if (subtype === 'component_inventory') {

--- a/src/lib/services/dataModelMarkdown.ts
+++ b/src/lib/services/dataModelMarkdown.ts
@@ -1,0 +1,814 @@
+import type {
+    DataEntity,
+    DataField,
+    DataModelContent,
+    FieldGroup,
+    FieldGroupName,
+} from '../../types';
+
+const GROUP_ORDER: FieldGroupName[] = [
+    'Key Product Fields',
+    'Relationships',
+    'System Metadata',
+    'API / Integration',
+    'Privacy / Safety',
+];
+
+const VALID_GROUP_NAMES = new Set<string>(GROUP_ORDER);
+
+const TOP_SECTION_HEADINGS = new Set([
+    'How This Data Model Works',
+    'Relationship Flow',
+    'API Endpoints',
+    'How This Appears in the Product',
+    'Data Model',
+]);
+
+const CALLOUT_RE = /^>\s*\[!(CONSTRAINT|PRIVACY|INDEX|RELATIONSHIP)\]\s*(.*)$/i;
+
+export type ParsedCalloutKind = 'CONSTRAINT' | 'PRIVACY' | 'INDEX' | 'RELATIONSHIP';
+
+export interface ParsedCallout {
+    kind: ParsedCalloutKind;
+    text: string;
+}
+
+export interface ParsedFieldGroup {
+    name: FieldGroupName;
+    fields: DataField[];
+}
+
+export interface ParsedEntity {
+    name: string;
+    description: string;
+    purpose?: string;
+    userFacing?: boolean;
+    mutability?: string;
+    fieldGroups: ParsedFieldGroup[];
+    callouts: ParsedCallout[];
+    exampleRecord?: string;
+    /** Heuristic was used because the source data didn't supply explicit groups. */
+    groupsAutoDetected: boolean;
+}
+
+export interface ParsedApiEndpoint {
+    method: string;
+    path: string;
+    description: string;
+    entity?: string;
+}
+
+export interface ParsedProductMapping {
+    field: string;
+    uiBehavior: string;
+}
+
+export interface ParsedDataModel {
+    overview?: {
+        summary: string;
+        dataFlow: string;
+        productOutcome: string;
+    };
+    relationshipFlow?: string;
+    entities: ParsedEntity[];
+    apiEndpoints: ParsedApiEndpoint[];
+    productMapping: ParsedProductMapping[];
+}
+
+// ---------------------------------------------------------------------------
+// Field-group heuristic
+// ---------------------------------------------------------------------------
+
+const SYSTEM_NAMES = new Set(['id', 'created_by', 'updated_by', 'version', 'schema_version']);
+const PRIVACY_NAME_TOKENS = ['password', 'secret', 'token', 'ssn'];
+const PRIVACY_DESC_TOKENS = ['pii', 'personal', 'private', 'encrypted', 'gdpr', 'redact', 'sensitive'];
+const INTEGRATION_NAME_TOKENS = ['webhook', 'api_key', 'external', 'third_party'];
+const INTEGRATION_DESC_TOKENS = ['payload', 'response'];
+
+export function applyFieldGroupHeuristic(entity: DataEntity, allEntityNames: string[]): FieldGroup[] {
+    const buckets: Record<FieldGroupName, string[]> = {
+        'Key Product Fields': [],
+        'Relationships': [],
+        'System Metadata': [],
+        'API / Integration': [],
+        'Privacy / Safety': [],
+    };
+
+    const otherEntities = new Set(
+        allEntityNames.filter(n => n.toLowerCase() !== entity.name.toLowerCase()).map(n => n.toLowerCase()),
+    );
+
+    for (const f of entity.fields) {
+        const name = f.name.toLowerCase();
+        const desc = (f.description || '').toLowerCase();
+        const type = (f.type || '').toLowerCase();
+
+        if (SYSTEM_NAMES.has(name) || name.endsWith('_at')) {
+            buckets['System Metadata'].push(f.name);
+            continue;
+        }
+
+        // `*_id` is decisive: matches an entity → Relationships, otherwise stays
+        // in Key Product Fields (don't let downstream heuristics demote orphan IDs).
+        if (name.endsWith('_id')) {
+            const stem = name.slice(0, -3);
+            const stemMatchesEntity = otherEntities.has(stem) || otherEntities.has(stem.replace(/s$/, ''));
+            buckets[stemMatchesEntity ? 'Relationships' : 'Key Product Fields'].push(f.name);
+            continue;
+        }
+
+        const isPrivacy =
+            PRIVACY_NAME_TOKENS.some(t => name.includes(t)) ||
+            PRIVACY_DESC_TOKENS.some(t => desc.includes(t));
+        if (isPrivacy) {
+            buckets['Privacy / Safety'].push(f.name);
+            continue;
+        }
+
+        const isIntegration =
+            INTEGRATION_NAME_TOKENS.some(t => name.includes(t)) ||
+            ((type === 'json' || type === 'jsonb') && INTEGRATION_DESC_TOKENS.some(t => desc.includes(t)));
+        if (isIntegration) {
+            buckets['API / Integration'].push(f.name);
+            continue;
+        }
+
+        buckets['Key Product Fields'].push(f.name);
+    }
+
+    return GROUP_ORDER
+        .filter(n => buckets[n].length > 0)
+        .map(n => ({ name: n, fieldNames: buckets[n] }));
+}
+
+function expandFieldGroups(entity: DataEntity, allEntityNames: string[]): { groups: ParsedFieldGroup[]; auto: boolean } {
+    const provided = entity.fieldGroups?.filter(g => VALID_GROUP_NAMES.has(g.name) && g.fieldNames?.length > 0);
+    const fieldsByName = new Map(entity.fields.map(f => [f.name, f]));
+
+    if (provided && provided.length > 0) {
+        const seen = new Set<string>();
+        const groups: ParsedFieldGroup[] = provided.map(g => ({
+            name: g.name,
+            fields: g.fieldNames
+                .map(name => {
+                    seen.add(name);
+                    return fieldsByName.get(name);
+                })
+                .filter((f): f is DataField => Boolean(f)),
+        }));
+        // Stash any fields the LLM forgot to assign into Key Product Fields.
+        const missing = entity.fields.filter(f => !seen.has(f.name));
+        if (missing.length > 0) {
+            const existing = groups.find(g => g.name === 'Key Product Fields');
+            if (existing) existing.fields.push(...missing);
+            else groups.unshift({ name: 'Key Product Fields', fields: missing });
+        }
+        return { groups: groups.filter(g => g.fields.length > 0), auto: false };
+    }
+
+    const heuristic = applyFieldGroupHeuristic(entity, allEntityNames);
+    const groups: ParsedFieldGroup[] = heuristic.map(g => ({
+        name: g.name,
+        fields: g.fieldNames.map(name => fieldsByName.get(name)).filter((f): f is DataField => Boolean(f)),
+    }));
+    return { groups: groups.filter(g => g.fields.length > 0), auto: true };
+}
+
+// ---------------------------------------------------------------------------
+// ASCII relationship tree
+// ---------------------------------------------------------------------------
+
+export function buildRelationshipTree(entities: DataEntity[]): string {
+    if (entities.length === 0) return '';
+
+    const byName = new Map(entities.map(e => [e.name, e]));
+    const inbound = new Map<string, number>();
+    for (const e of entities) inbound.set(e.name, 0);
+    for (const e of entities) {
+        for (const r of e.relationships) {
+            if (r.type === 'has_many' || r.type === 'has_one') {
+                if (byName.has(r.target)) inbound.set(r.target, (inbound.get(r.target) ?? 0) + 1);
+            } else if (r.type === 'belongs_to') {
+                inbound.set(e.name, (inbound.get(e.name) ?? 0) + 1);
+            }
+        }
+    }
+
+    const roots = entities.filter(e => (inbound.get(e.name) ?? 0) === 0);
+    const startNodes = roots.length > 0 ? roots : [entities[0]];
+    const lines: string[] = [];
+    const visited = new Set<string>();
+
+    const walk = (name: string, depth: number) => {
+        const indent = '  '.repeat(depth);
+        const prefix = depth === 0 ? '' : '→ ';
+        if (visited.has(name)) {
+            lines.push(`${indent}${prefix}${name} (see above)`);
+            return;
+        }
+        visited.add(name);
+        lines.push(`${indent}${prefix}${name}`);
+        const entity = byName.get(name);
+        if (!entity) return;
+        const children = entity.relationships
+            .filter(r => (r.type === 'has_many' || r.type === 'has_one') && byName.has(r.target));
+        for (const c of children) {
+            walk(c.target, depth + 1);
+        }
+    };
+
+    for (const r of startNodes) walk(r.name, 0);
+
+    for (const e of entities) {
+        if (!visited.has(e.name)) walk(e.name, 0);
+    }
+
+    return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Converter: DataModelContent -> markdown
+// ---------------------------------------------------------------------------
+
+function formatBool(b: boolean | undefined): string {
+    return b ? 'User-facing' : 'Internal';
+}
+
+function formatMutability(m: string | undefined): string | undefined {
+    if (!m) return undefined;
+    return m.replace(/_/g, ' ');
+}
+
+export function dataModelToMarkdown(model: DataModelContent): string {
+    const lines: string[] = ['# Data Model', ''];
+
+    if (model.overview) {
+        lines.push('## How This Data Model Works');
+        lines.push('');
+        lines.push(model.overview.summary.trim());
+        lines.push('');
+        lines.push(`**Data flow:** ${model.overview.dataFlow.trim()}`);
+        lines.push('');
+        lines.push(`**Product outcome:** ${model.overview.productOutcome.trim()}`);
+        lines.push('');
+    }
+
+    const tree = buildRelationshipTree(model.entities);
+    if (tree) {
+        lines.push('## Relationship Flow');
+        lines.push('');
+        lines.push('```text');
+        lines.push(tree);
+        lines.push('```');
+        lines.push('');
+    }
+
+    const allEntityNames = model.entities.map(e => e.name);
+    for (const entity of model.entities) {
+        lines.push(`## ${entity.name}`);
+        lines.push('');
+        if (entity.description) {
+            lines.push(entity.description.trim());
+            lines.push('');
+        }
+        if (entity.purpose) {
+            lines.push(`**Purpose:** ${entity.purpose.trim()}`);
+        }
+        if (entity.userFacing !== undefined) {
+            lines.push(`**Visibility:** ${formatBool(entity.userFacing)}`);
+        }
+        const mut = formatMutability(entity.mutability);
+        if (mut) {
+            lines.push(`**Mutability:** ${mut}`);
+        }
+        if (entity.purpose || entity.userFacing !== undefined || mut) {
+            lines.push('');
+        }
+
+        const { groups } = expandFieldGroups(entity, allEntityNames);
+        if (groups.length > 0) {
+            for (const group of groups) {
+                lines.push(`**${group.name}**`);
+                lines.push('');
+                lines.push('| Field | Type | Required | Description |');
+                lines.push('|-------|------|----------|-------------|');
+                for (const f of group.fields) {
+                    const desc = (f.description || '').replace(/\|/g, '\\|');
+                    lines.push(`| ${f.name} | ${f.type} | ${f.required ? 'Yes' : 'No'} | ${desc} |`);
+                }
+                lines.push('');
+            }
+        } else if (entity.fields.length > 0) {
+            // Defensive: no groups assignable; still emit a flat table to satisfy
+            // the EXPECTED_HEADERS validation (Fields/Type/Required) and stay readable.
+            lines.push('**Fields**');
+            lines.push('');
+            lines.push('| Field | Type | Required | Description |');
+            lines.push('|-------|------|----------|-------------|');
+            for (const f of entity.fields) {
+                const desc = (f.description || '').replace(/\|/g, '\\|');
+                lines.push(`| ${f.name} | ${f.type} | ${f.required ? 'Yes' : 'No'} | ${desc} |`);
+            }
+            lines.push('');
+        }
+
+        if (entity.relationships?.length) {
+            for (const r of entity.relationships) {
+                const desc = r.description ? ` (${r.description.trim()})` : '';
+                lines.push(`> [!RELATIONSHIP] ${r.type.replace(/_/g, ' ')} → ${r.target}${desc}`);
+            }
+            lines.push('');
+        }
+
+        if (entity.indexes?.length) {
+            for (const idx of entity.indexes) {
+                lines.push(`> [!INDEX] ${idx.trim()}`);
+            }
+            lines.push('');
+        }
+
+        if (entity.constraints?.length) {
+            for (const c of entity.constraints) {
+                lines.push(`> [!CONSTRAINT] ${c.trim()}`);
+            }
+            lines.push('');
+        }
+
+        if (entity.privacyRules?.length) {
+            for (const p of entity.privacyRules) {
+                lines.push(`> [!PRIVACY] ${p.trim()}`);
+            }
+            lines.push('');
+        }
+
+        if (entity.exampleRecord) {
+            const pretty = prettyJson(entity.exampleRecord);
+            lines.push('**Example record**');
+            lines.push('');
+            lines.push('```json');
+            lines.push(pretty);
+            lines.push('```');
+            lines.push('');
+        }
+    }
+
+    if (model.productMapping?.length) {
+        lines.push('## How This Appears in the Product');
+        lines.push('');
+        lines.push('| Field | UI behavior |');
+        lines.push('|-------|-------------|');
+        for (const m of model.productMapping) {
+            const ui = (m.uiBehavior || '').replace(/\|/g, '\\|');
+            lines.push(`| \`${m.field}\` | ${ui} |`);
+        }
+        lines.push('');
+    }
+
+    if (model.apiEndpoints?.length) {
+        lines.push('## API Endpoints');
+        lines.push('');
+        lines.push('| Method | Path | Description | Entity |');
+        lines.push('|--------|------|-------------|--------|');
+        for (const ep of model.apiEndpoints) {
+            const desc = (ep.description || '').replace(/\|/g, '\\|');
+            lines.push(`| ${ep.method} | ${ep.path} | ${desc} | ${ep.entity} |`);
+        }
+        lines.push('');
+    }
+
+    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim() + '\n';
+}
+
+function prettyJson(raw: string): string {
+    const trimmed = raw.trim();
+    try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+    } catch {
+        return trimmed;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parser: markdown -> ParsedDataModel
+// ---------------------------------------------------------------------------
+
+interface RawSection {
+    heading: string;
+    /** Heading level: 1 for `#`, 2 for `##`, etc. */
+    level: number;
+    body: string[];
+}
+
+function splitTopSections(markdown: string): RawSection[] {
+    const lines = markdown.split('\n');
+    const sections: RawSection[] = [];
+    let current: RawSection | null = null;
+
+    for (const line of lines) {
+        const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+        if (m && m[1].length <= 2) {
+            if (current) sections.push(current);
+            current = { heading: m[2].trim(), level: m[1].length, body: [] };
+            continue;
+        }
+        if (current) current.body.push(line);
+    }
+    if (current) sections.push(current);
+    return sections;
+}
+
+function parseFieldsTable(lines: string[]): DataField[] {
+    const fields: DataField[] = [];
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        const isHeader = /^\s*\|.*Field.*\|.*Type.*\|.*Required.*\|.*Description.*\|\s*$/i.test(line);
+        if (isHeader && i + 1 < lines.length && /^\s*\|?\s*[-:|\s]+$/.test(lines[i + 1])) {
+            i += 2;
+            while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i])) {
+                const cells = lines[i]
+                    .trim()
+                    .replace(/^\|/, '')
+                    .replace(/\|$/, '')
+                    .split(/(?<!\\)\|/)
+                    .map(c => c.replace(/\\\|/g, '|').trim());
+                if (cells.length >= 4) {
+                    const required = /^(yes|true|y|✓|✔)$/i.test(cells[2]);
+                    fields.push({
+                        name: cells[0],
+                        type: cells[1],
+                        required,
+                        description: cells[3],
+                    });
+                }
+                i += 1;
+            }
+            continue;
+        }
+        i += 1;
+    }
+    return fields;
+}
+
+function parseEntitySection(name: string, body: string[]): ParsedEntity {
+    let description = '';
+    let purpose: string | undefined;
+    let userFacing: boolean | undefined;
+    let mutability: string | undefined;
+    const callouts: ParsedCallout[] = [];
+    const groups: ParsedFieldGroup[] = [];
+    let exampleRecord: string | undefined;
+
+    // First pass: collect callouts and the example record fenced block,
+    // strip them from the body so subsequent parsing is clean.
+    const cleaned: string[] = [];
+    let inExampleFence = false;
+    let exampleLines: string[] = [];
+    let inOtherFence = false;
+    let lastWasExampleHeader = false;
+
+    for (const raw of body) {
+        const line = raw;
+
+        // Track fenced blocks
+        if (/^\s*```/.test(line)) {
+            if (inExampleFence) {
+                inExampleFence = false;
+                exampleRecord = exampleLines.join('\n').trim();
+                exampleLines = [];
+                continue;
+            }
+            if (inOtherFence) {
+                inOtherFence = false;
+                cleaned.push(line);
+                continue;
+            }
+            // Fence opens. If preceded by an "example record" label, treat as example.
+            if (lastWasExampleHeader && /^\s*```(json|text|)\s*$/i.test(line)) {
+                inExampleFence = true;
+                continue;
+            }
+            inOtherFence = true;
+            cleaned.push(line);
+            continue;
+        }
+        if (inExampleFence) {
+            exampleLines.push(line);
+            continue;
+        }
+        if (inOtherFence) {
+            cleaned.push(line);
+            continue;
+        }
+
+        const calloutMatch = line.match(CALLOUT_RE);
+        if (calloutMatch) {
+            const kind = calloutMatch[1].toUpperCase() as ParsedCalloutKind;
+            callouts.push({ kind, text: calloutMatch[2].trim() });
+            continue;
+        }
+
+        // Detect "example record" header to know that the next fenced block is the example.
+        const isExampleHeader = /^\*\*Example record\*\*\s*$/i.test(line.trim());
+        if (isExampleHeader) {
+            lastWasExampleHeader = true;
+            continue;
+        }
+        if (line.trim() !== '') lastWasExampleHeader = false;
+
+        cleaned.push(line);
+    }
+
+    // Second pass: walk cleaned body to extract description, metadata lines,
+    // and field groups (each delimited by a `**GroupName**` line followed by a table).
+    let i = 0;
+    const descParts: string[] = [];
+
+    // Capture description until the first `**...:**` line, fence, group label, or table.
+    while (i < cleaned.length) {
+        const line = cleaned[i];
+        const trimmed = line.trim();
+        if (
+            /^\*\*Purpose:\*\*/i.test(trimmed) ||
+            /^\*\*Visibility:\*\*/i.test(trimmed) ||
+            /^\*\*Mutability:\*\*/i.test(trimmed) ||
+            /^\*\*[^*]+\*\*\s*$/.test(trimmed) ||
+            /^\|/.test(trimmed)
+        ) {
+            break;
+        }
+        descParts.push(line);
+        i += 1;
+    }
+    description = descParts.join('\n').trim();
+
+    // Walk remaining: pick up purpose/visibility/mutability and field groups.
+    let currentGroup: { name: FieldGroupName; lines: string[] } | null = null;
+
+    const flushGroup = () => {
+        if (currentGroup) {
+            const fields = parseFieldsTable(currentGroup.lines);
+            if (fields.length > 0) {
+                groups.push({ name: currentGroup.name, fields });
+            }
+            currentGroup = null;
+        }
+    };
+
+    while (i < cleaned.length) {
+        const line = cleaned[i];
+        const trimmed = line.trim();
+
+        const purposeM = trimmed.match(/^\*\*Purpose:\*\*\s*(.*)$/i);
+        if (purposeM) {
+            purpose = purposeM[1].trim();
+            i += 1;
+            continue;
+        }
+        const visibilityM = trimmed.match(/^\*\*Visibility:\*\*\s*(.*)$/i);
+        if (visibilityM) {
+            const v = visibilityM[1].trim().toLowerCase();
+            userFacing = v.startsWith('user');
+            i += 1;
+            continue;
+        }
+        const mutabilityM = trimmed.match(/^\*\*Mutability:\*\*\s*(.*)$/i);
+        if (mutabilityM) {
+            mutability = mutabilityM[1].trim();
+            i += 1;
+            continue;
+        }
+
+        // Legacy `**Relationships:**` block — must check before generic group
+        // header matcher because `**Relationships:**` (with trailing colon) would
+        // otherwise be captured as a group label.
+        if (/^\*\*Relationships:\*\*\s*$/i.test(trimmed)) {
+            flushGroup();
+            i += 1;
+            while (i < cleaned.length && /^\s*-\s+/.test(cleaned[i])) {
+                callouts.push({ kind: 'RELATIONSHIP', text: cleaned[i].replace(/^\s*-\s+/, '').trim() });
+                i += 1;
+            }
+            continue;
+        }
+        // Legacy: `**Indexes:** ...`
+        const indexInlineM = trimmed.match(/^\*\*Indexes:\*\*\s*(.+)$/i);
+        if (indexInlineM) {
+            flushGroup();
+            for (const idx of indexInlineM[1].split(',')) {
+                const t = idx.trim();
+                if (t) callouts.push({ kind: 'INDEX', text: t });
+            }
+            i += 1;
+            continue;
+        }
+        // Legacy: `**Constraints:** ...`
+        const constraintInlineM = trimmed.match(/^\*\*Constraints:\*\*\s*(.+)$/i);
+        if (constraintInlineM) {
+            flushGroup();
+            for (const c of constraintInlineM[1].split(',')) {
+                const t = c.trim();
+                if (t) callouts.push({ kind: 'CONSTRAINT', text: t });
+            }
+            i += 1;
+            continue;
+        }
+
+        // Group header? `**Key Product Fields**`, etc. The legacy patterns
+        // above (with trailing colons) have already been consumed.
+        const groupM = trimmed.match(/^\*\*([^*]+)\*\*\s*$/);
+        if (groupM) {
+            flushGroup();
+            const label = groupM[1].trim();
+            if (VALID_GROUP_NAMES.has(label)) {
+                currentGroup = { name: label as FieldGroupName, lines: [] };
+            } else if (label === 'Fields') {
+                // Legacy or fallback bucket — render as Key Product Fields.
+                currentGroup = { name: 'Key Product Fields', lines: [] };
+            } else {
+                currentGroup = null;
+            }
+            i += 1;
+            continue;
+        }
+
+        if (currentGroup) {
+            currentGroup.lines.push(line);
+        }
+        i += 1;
+    }
+    flushGroup();
+
+    // If no groups parsed but we still see field-row lines in the cleaned body (legacy shape),
+    // parse them into a default Key Product Fields group.
+    if (groups.length === 0) {
+        const fallbackFields = parseFieldsTable(cleaned);
+        if (fallbackFields.length > 0) {
+            groups.push({ name: 'Key Product Fields', fields: fallbackFields });
+        }
+    }
+
+    return {
+        name,
+        description,
+        purpose,
+        userFacing,
+        mutability,
+        fieldGroups: groups,
+        callouts,
+        exampleRecord,
+        groupsAutoDetected: false,
+    };
+}
+
+function parseRelationshipFlow(body: string[]): string | undefined {
+    let inFence = false;
+    const lines: string[] = [];
+    for (const line of body) {
+        if (/^\s*```/.test(line)) {
+            if (!inFence) {
+                inFence = true;
+                continue;
+            }
+            return lines.join('\n').trim() || undefined;
+        }
+        if (inFence) lines.push(line);
+    }
+    return lines.join('\n').trim() || undefined;
+}
+
+function parseOverview(body: string[]): ParsedDataModel['overview'] | undefined {
+    let summary = '';
+    let dataFlow = '';
+    let productOutcome = '';
+    const summaryLines: string[] = [];
+    let captureSummary = true;
+
+    for (const raw of body) {
+        const line = raw.trim();
+        const dfM = line.match(/^\*\*Data flow:\*\*\s*(.*)$/i);
+        if (dfM) {
+            captureSummary = false;
+            dataFlow = dfM[1].trim();
+            continue;
+        }
+        const poM = line.match(/^\*\*Product outcome:\*\*\s*(.*)$/i);
+        if (poM) {
+            captureSummary = false;
+            productOutcome = poM[1].trim();
+            continue;
+        }
+        if (captureSummary) summaryLines.push(raw);
+    }
+    summary = summaryLines.join('\n').trim();
+    if (!summary && !dataFlow && !productOutcome) return undefined;
+    return { summary, dataFlow, productOutcome };
+}
+
+function parseApiEndpointsTable(body: string[]): ParsedApiEndpoint[] {
+    const out: ParsedApiEndpoint[] = [];
+    let i = 0;
+    while (i < body.length) {
+        const line = body[i];
+        const isHeader = /^\s*\|.*Method.*\|.*Path.*\|.*Description.*\|/i.test(line);
+        if (isHeader && i + 1 < body.length && /^\s*\|?\s*[-:|\s]+$/.test(body[i + 1])) {
+            i += 2;
+            while (i < body.length && /^\s*\|.*\|\s*$/.test(body[i])) {
+                const cells = body[i]
+                    .trim()
+                    .replace(/^\|/, '')
+                    .replace(/\|$/, '')
+                    .split(/(?<!\\)\|/)
+                    .map(c => c.replace(/\\\|/g, '|').trim());
+                if (cells.length >= 3) {
+                    out.push({
+                        method: cells[0],
+                        path: cells[1],
+                        description: cells[2],
+                        entity: cells[3],
+                    });
+                }
+                i += 1;
+            }
+            continue;
+        }
+        i += 1;
+    }
+    return out;
+}
+
+function parseProductMappingTable(body: string[]): ParsedProductMapping[] {
+    const out: ParsedProductMapping[] = [];
+    let i = 0;
+    while (i < body.length) {
+        const line = body[i];
+        const isHeader = /^\s*\|.*Field.*\|.*UI behavior.*\|/i.test(line);
+        if (isHeader && i + 1 < body.length && /^\s*\|?\s*[-:|\s]+$/.test(body[i + 1])) {
+            i += 2;
+            while (i < body.length && /^\s*\|.*\|\s*$/.test(body[i])) {
+                const cells = body[i]
+                    .trim()
+                    .replace(/^\|/, '')
+                    .replace(/\|$/, '')
+                    .split(/(?<!\\)\|/)
+                    .map(c => c.replace(/\\\|/g, '|').trim());
+                if (cells.length >= 2) {
+                    out.push({
+                        field: cells[0].replace(/^`|`$/g, ''),
+                        uiBehavior: cells[1],
+                    });
+                }
+                i += 1;
+            }
+            continue;
+        }
+        i += 1;
+    }
+    return out;
+}
+
+export function parseDataModelMarkdown(markdown: string): ParsedDataModel | null {
+    if (!markdown || !markdown.trim()) return null;
+
+    const sections = splitTopSections(markdown);
+    if (sections.length === 0) return null;
+
+    const result: ParsedDataModel = {
+        entities: [],
+        apiEndpoints: [],
+        productMapping: [],
+    };
+
+    for (const section of sections) {
+        if (section.level === 1) {
+            // top heading (`# Data Model`) — skip
+            continue;
+        }
+        const heading = section.heading;
+        if (heading === 'How This Data Model Works') {
+            result.overview = parseOverview(section.body);
+            continue;
+        }
+        if (heading === 'Relationship Flow') {
+            result.relationshipFlow = parseRelationshipFlow(section.body);
+            continue;
+        }
+        if (heading === 'API Endpoints') {
+            result.apiEndpoints = parseApiEndpointsTable(section.body);
+            continue;
+        }
+        if (heading === 'How This Appears in the Product') {
+            result.productMapping = parseProductMappingTable(section.body);
+            continue;
+        }
+        if (TOP_SECTION_HEADINGS.has(heading)) {
+            continue;
+        }
+        result.entities.push(parseEntitySection(heading, section.body));
+    }
+
+    if (result.entities.length === 0 && !result.overview && result.apiEndpoints.length === 0) {
+        return null;
+    }
+    return result;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,6 +327,18 @@ export interface DataRelationship {
     description?: string;
 }
 
+export type FieldGroupName =
+    | 'Key Product Fields'
+    | 'Relationships'
+    | 'System Metadata'
+    | 'API / Integration'
+    | 'Privacy / Safety';
+
+export interface FieldGroup {
+    name: FieldGroupName;
+    fieldNames: string[];
+}
+
 export interface DataEntity {
     name: string;
     description: string;
@@ -334,11 +346,31 @@ export interface DataEntity {
     relationships: DataRelationship[];
     indexes?: string[];
     constraints?: string[];
+    userFacing?: boolean;
+    mutability?: 'immutable' | 'mostly_immutable' | 'mutable';
+    purpose?: string;
+    fieldGroups?: FieldGroup[];
+    privacyRules?: string[];
+    /** Stored as a JSON-encoded string in Gemini output; the converter parses it. */
+    exampleRecord?: string;
+}
+
+export interface DataModelOverview {
+    summary: string;
+    dataFlow: string;
+    productOutcome: string;
+}
+
+export interface ProductMappingEntry {
+    field: string;
+    uiBehavior: string;
 }
 
 export interface DataModelContent {
     entities: DataEntity[];
     apiEndpoints?: { method: string; path: string; description: string; entity: string }[];
+    overview?: DataModelOverview;
+    productMapping?: ProductMappingEntry[];
 }
 
 export interface ComponentItem {


### PR DESCRIPTION
The data_model artifact previously rendered as a flat table dump because
the structured renderer was gated on JSON content while generation stored
markdown — so users saw plain ReactMarkdown output of unannotated tables.

Generation now produces an extended structured shape (overview, per-entity
purpose/visibility/mutability, fieldGroups, privacyRules, exampleRecord,
productMapping) and the converter emits richer markdown with [!CONSTRAINT]
/ [!PRIVACY] / [!INDEX] / [!RELATIONSHIP] callout markers and an ASCII
relationship-flow block. A new heading-walking parser in
src/lib/services/dataModelMarkdown.ts feeds a card-based renderer with an
overview hero, entity tabs, grouped field tables, color-coded callouts,
fenced JSON example records, and a "How This Appears in the Product"
mapping. A render-time field-grouping heuristic preserves legacy artifacts.

All schema fields are additive/optional and the converter still emits the
substrings required by artifactValidation and the cross-artifact API
endpoints check, so downstream implementation_plan / prompt_pack
generation, staleness detection, and existing localStorage artifacts are
unaffected.