### PR TITLE
feat(implementation_plan): refactor into structured task-driven execution system

### DIFF
--- a/src/components/renderers/ImplementationPlanRenderer.BACKLOG.md
+++ b/src/components/renderers/ImplementationPlanRenderer.BACKLOG.md
@@ -1,0 +1,40 @@
+# Implementation Plan — Backlog
+
+Deferred features for the structured Implementation Plan artifact. Documented
+here per the refactor brief; **not implemented** in the current pass.
+
+## UX
+
+- **Task detail side panel** — click a task row to open a panel with full
+  description, status history, and inline editing.
+- **Editable task state** — status updates (`todo` → `in_progress` → `done` /
+  `blocked`), assignee/ownership, and persistence back to the artifact
+  version. Likely needs a non-LLM mutation path on `ArtifactVersion`.
+- **Timeline / Gantt view** — render milestones along a horizontal time axis
+  derived from `timeframe` strings, with task bars stacked per milestone.
+- **Dependency graph visualization** — render task dependencies as a DAG
+  (e.g. via `react-flow` or a hand-rolled SVG) instead of inline
+  "Depends on:" text.
+- **Filter / sort tasks** — by status, milestone, or linked artifact.
+
+## Integration
+
+- **Artifact navigation** — clicking a `Linked: PRD · Mood Input Flow`
+  segment should jump to that section in the PRD artifact. Needs a
+  cross-artifact anchor scheme.
+- **AI task expansion** — "expand this task" action that asks the model to
+  break a single task into 3–5 subtasks (returns the same task schema
+  shape, merged into the parent milestone).
+- **Plan regeneration with diffing** — after a PRD edit, regenerate the
+  plan and surface a per-task diff (added / removed / changed status).
+
+## Data model
+
+- **First-class task primitive** — promote `ImplementationPlanTask` to a
+  Synapse-wide primitive that other artifacts can reference (e.g. a
+  data_model entity referenced by multiple tasks).
+- **Stable task IDs across regenerations** — currently the model picks IDs;
+  a regeneration may rename them. Could anchor to titles via fuzzy match
+  to preserve user state across regenerations.
+- **External tracker sync** — export tasks to GitHub Issues / Linear /
+  Jira, with bidirectional status sync.

--- a/src/components/renderers/ImplementationPlanRenderer.tsx
+++ b/src/components/renderers/ImplementationPlanRenderer.tsx
@@ -1,19 +1,43 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Calendar, ChevronRight, Flag, Layers, Target, Users } from 'lucide-react';
 import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+import type {
+    StructuredImplementationPlan,
+    ImplementationPlanMilestone,
+    ImplementationPlanTask,
+    TaskStatus,
+} from '../../types';
 
-// Render an `implementation_plan` artifact as a vertical timeline of
-// `### Milestone N: …` cards with each milestone's checklist surfaced
-// as actual checkboxes (read-only). Anything after the milestones (the
-// horizontal rule + "Critical Path Summary" / "Team Size Recommendation"
-// / "Traceability Map" sections) is rendered as plain markdown so we
-// don't lose any content.
+// Render an `implementation_plan` artifact.
+//
+// New artifacts include a trailing ```json synapse-plan fence — when present,
+// we render the structured tabbed UI (Tasks / Architecture / Risks / DoD).
+// Legacy artifacts (no fence) fall through to the original milestone-regex
+// timeline so older projects in localStorage keep rendering unchanged.
+//
+// See ImplementationPlanRenderer.BACKLOG.md for deferred features.
 
 interface Props {
     content: string;
 }
+
+const STRUCTURED_FENCE = /```json\s+synapse-plan\s*\n([\s\S]*?)\n```/;
+
+function extractStructuredPlan(markdown: string): StructuredImplementationPlan | null {
+    const match = markdown.match(STRUCTURED_FENCE);
+    if (!match) return null;
+    try {
+        const parsed = JSON.parse(match[1]) as StructuredImplementationPlan;
+        if (!Array.isArray(parsed?.milestones)) return null;
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+// --- Legacy markdown parsing (kept verbatim for backward compat) ---
 
 type Milestone = {
     id: number;
@@ -55,7 +79,6 @@ function parsePlan(markdown: string): ParsedPlan {
             };
             continue;
         }
-        // Horizontal rule terminates milestone collection.
         if (inMilestones && /^---+\s*$/.test(line.trim())) {
             if (current) {
                 milestones.push(current);
@@ -158,7 +181,7 @@ const SECTION_ICON: Record<string, typeof Target> = {
     'definition of done': Target,
 };
 
-function MilestoneCard({ milestone }: { milestone: Milestone }) {
+function LegacyMilestoneCard({ milestone }: { milestone: Milestone }) {
     const { sections, deliverables } = useMemo(() => parseMilestoneBody(milestone.body), [milestone.body]);
     return (
         <article
@@ -240,7 +263,7 @@ function AppendixSection({ markdown }: { markdown: string }) {
     );
 }
 
-export function ImplementationPlanRenderer({ content }: Props) {
+function LegacyTimeline({ content }: { content: string }) {
     const plan = useMemo(() => parsePlan(content), [content]);
     if (plan.milestones.length === 0) {
         return (
@@ -258,9 +281,289 @@ export function ImplementationPlanRenderer({ content }: Props) {
             <SectionTabs items={tabs} />
             {plan.preamble && blockMd(plan.preamble)}
             {plan.milestones.map(m => (
-                <MilestoneCard key={m.id} milestone={m} />
+                <LegacyMilestoneCard key={m.id} milestone={m} />
             ))}
             <AppendixSection markdown={plan.appendix} />
         </div>
     );
+}
+
+// --- Structured (new) rendering ---
+
+type TopTabId = 'tasks' | 'architecture' | 'risks' | 'definition_of_done';
+
+const TASK_STATUS_STYLE: Record<TaskStatus, { label: string; cls: string }> = {
+    todo: { label: 'Todo', cls: 'bg-neutral-100 text-neutral-700 border-neutral-200' },
+    in_progress: { label: 'In Progress', cls: 'bg-amber-50 text-amber-700 border-amber-200' },
+    done: { label: 'Done', cls: 'bg-green-50 text-green-700 border-green-200' },
+    blocked: { label: 'Blocked', cls: 'bg-red-50 text-red-700 border-red-200' },
+};
+
+type MilestoneStatus = 'not_started' | 'in_progress' | 'complete';
+
+const MILESTONE_STATUS_STYLE: Record<MilestoneStatus, { label: string; cls: string }> = {
+    not_started: { label: 'Not Started', cls: 'bg-neutral-100 text-neutral-700 border-neutral-200' },
+    in_progress: { label: 'In Progress', cls: 'bg-amber-50 text-amber-700 border-amber-200' },
+    complete: { label: 'Complete', cls: 'bg-green-50 text-green-700 border-green-200' },
+};
+
+function deriveMilestoneStatus(tasks: ImplementationPlanTask[]): MilestoneStatus {
+    if (tasks.length === 0) return 'not_started';
+    if (tasks.every(t => t.status === 'todo')) return 'not_started';
+    if (tasks.every(t => t.status === 'done')) return 'complete';
+    return 'in_progress';
+}
+
+function TaskRow({
+    task,
+    titleById,
+}: {
+    task: ImplementationPlanTask;
+    titleById: Map<string, string>;
+}) {
+    const style = TASK_STATUS_STYLE[task.status] ?? TASK_STATUS_STYLE.todo;
+    const deps = task.dependencies?.filter(Boolean) ?? [];
+    const links = task.linkedArtifacts;
+    const linkSegments: string[] = [];
+    if (links?.prd?.length) linkSegments.push(`PRD: ${links.prd.join(', ')}`);
+    if (links?.dataModel?.length) linkSegments.push(`Data: ${links.dataModel.join(', ')}`);
+    if (links?.mockups?.length) linkSegments.push(`Mockups: ${links.mockups.join(', ')}`);
+
+    return (
+        <li className="py-2 first:pt-0 last:pb-0 border-b border-neutral-100 last:border-b-0">
+            <div className="flex items-start gap-2">
+                <span
+                    className={`shrink-0 mt-0.5 text-[10px] px-1.5 py-0.5 rounded border font-medium ${style.cls}`}
+                >
+                    {style.label}
+                </span>
+                <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-neutral-900 leading-snug">{task.title}</p>
+                    {task.description && (
+                        <p className="text-xs text-neutral-600 mt-0.5">{task.description}</p>
+                    )}
+                    {deps.length > 0 && (
+                        <p className="text-[11px] text-neutral-500 mt-1">
+                            <span className="font-semibold">Depends on:</span>{' '}
+                            {deps.map(id => titleById.get(id) ?? id).join(', ')}
+                        </p>
+                    )}
+                    {linkSegments.length > 0 && (
+                        <p className="text-[11px] text-neutral-500 mt-0.5">
+                            <span className="font-semibold">Linked:</span> {linkSegments.join(' · ')}
+                        </p>
+                    )}
+                </div>
+            </div>
+        </li>
+    );
+}
+
+function MilestoneTaskGroup({
+    milestone,
+    index,
+    titleById,
+}: {
+    milestone: ImplementationPlanMilestone;
+    index: number;
+    titleById: Map<string, string>;
+}) {
+    const completed = milestone.tasks.filter(t => t.status === 'done').length;
+    const total = milestone.tasks.length;
+    const status = deriveMilestoneStatus(milestone.tasks);
+    const statusStyle = MILESTONE_STATUS_STYLE[status];
+
+    return (
+        <article className="bg-white rounded-xl border border-neutral-200 p-5">
+            <header className="flex items-start gap-3 mb-3 pb-3 border-b border-neutral-100">
+                <div className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-lg bg-indigo-600 text-white text-sm font-bold">
+                    M{index + 1}
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="text-base font-bold text-neutral-900 leading-snug">{milestone.name}</h3>
+                        <span
+                            className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${statusStyle.cls}`}
+                        >
+                            {statusStyle.label}
+                        </span>
+                    </div>
+                    <div className="flex items-center gap-3 text-[11px] text-neutral-500 mt-0.5">
+                        {milestone.timeframe && (
+                            <span className="flex items-center gap-1">
+                                <Calendar size={11} />
+                                {milestone.timeframe}
+                            </span>
+                        )}
+                        <span>
+                            {completed}/{total} tasks
+                        </span>
+                    </div>
+                    {milestone.goal && (
+                        <p className="flex items-start gap-1.5 text-sm text-neutral-700 mt-2">
+                            <Target size={12} className="mt-1 shrink-0 text-neutral-500" />
+                            <span>{milestone.goal}</span>
+                        </p>
+                    )}
+                </div>
+            </header>
+            {milestone.tasks.length > 0 ? (
+                <ul>
+                    {milestone.tasks.map(t => (
+                        <TaskRow key={t.id} task={t} titleById={titleById} />
+                    ))}
+                </ul>
+            ) : (
+                <p className="text-xs text-neutral-500 italic">No tasks defined.</p>
+            )}
+        </article>
+    );
+}
+
+function StructuredPlanView({ plan }: { plan: StructuredImplementationPlan }) {
+    const [tab, setTab] = useState<TopTabId>('tasks');
+
+    const titleById = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const m of plan.milestones) {
+            for (const t of m.tasks) map.set(t.id, t.title);
+        }
+        return map;
+    }, [plan]);
+
+    const tabs: { id: TopTabId; label: string; count?: number }[] = [
+        { id: 'tasks', label: 'Tasks', count: plan.milestones.reduce((n, m) => n + m.tasks.length, 0) },
+        { id: 'architecture', label: 'Architecture', count: plan.architecture?.length },
+        { id: 'risks', label: 'Risks', count: plan.risks?.length },
+        { id: 'definition_of_done', label: 'Definition of Done', count: plan.definitionOfDone?.length },
+    ];
+
+    return (
+        <div className="space-y-5">
+            {plan.overview?.summary && (
+                <div className="bg-neutral-50 rounded-xl border border-neutral-200 p-4">
+                    <p className="text-sm text-neutral-800">{plan.overview.summary}</p>
+                    {(plan.overview.criticalPath || plan.overview.teamSize) && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3 text-xs text-neutral-700">
+                            {plan.overview.criticalPath && (
+                                <div>
+                                    <span className="font-semibold text-neutral-600">Critical Path: </span>
+                                    {plan.overview.criticalPath}
+                                </div>
+                            )}
+                            {plan.overview.teamSize && (
+                                <div>
+                                    <span className="font-semibold text-neutral-600">Team: </span>
+                                    {plan.overview.teamSize}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            <nav className="flex flex-wrap gap-1 border-b border-neutral-200">
+                {tabs.map(t => {
+                    const active = tab === t.id;
+                    return (
+                        <button
+                            key={t.id}
+                            type="button"
+                            onClick={() => setTab(t.id)}
+                            className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                                active
+                                    ? 'border-indigo-600 text-indigo-700'
+                                    : 'border-transparent text-neutral-600 hover:text-neutral-900'
+                            }`}
+                        >
+                            {t.label}
+                            {typeof t.count === 'number' && t.count > 0 && (
+                                <span className="ml-1.5 text-[10px] text-neutral-500">({t.count})</span>
+                            )}
+                        </button>
+                    );
+                })}
+            </nav>
+
+            {tab === 'tasks' && (
+                <div className="space-y-4">
+                    {plan.milestones.map((m, i) => (
+                        <MilestoneTaskGroup key={m.id} milestone={m} index={i} titleById={titleById} />
+                    ))}
+                </div>
+            )}
+
+            {tab === 'architecture' && (
+                <div className="bg-white rounded-xl border border-neutral-200 p-5">
+                    {plan.architecture?.length ? (
+                        <ul className="space-y-2 text-sm text-neutral-800">
+                            {plan.architecture.map((a, i) => (
+                                <li key={i} className="flex items-start gap-2">
+                                    <Layers size={14} className="mt-0.5 shrink-0 text-neutral-500" />
+                                    <span>{inlineMd(a)}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-sm text-neutral-500 italic">No architecture decisions captured.</p>
+                    )}
+                </div>
+            )}
+
+            {tab === 'risks' && (
+                <div className="space-y-3">
+                    {plan.risks?.length ? (
+                        plan.risks.map((r, i) => (
+                            <article key={i} className="bg-white rounded-xl border border-neutral-200 p-4">
+                                <p className="flex items-start gap-2 text-sm font-semibold text-neutral-900">
+                                    <Flag size={14} className="mt-0.5 shrink-0 text-red-500" />
+                                    <span>{r.description}</span>
+                                </p>
+                                {r.mitigation && (
+                                    <p className="text-sm text-neutral-700 mt-2 ml-6">
+                                        <span className="font-semibold text-neutral-600">Mitigation: </span>
+                                        {r.mitigation}
+                                    </p>
+                                )}
+                            </article>
+                        ))
+                    ) : (
+                        <div className="bg-white rounded-xl border border-neutral-200 p-5">
+                            <p className="text-sm text-neutral-500 italic">No risks captured.</p>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {tab === 'definition_of_done' && (
+                <div className="bg-white rounded-xl border border-neutral-200 p-5">
+                    {plan.definitionOfDone?.length ? (
+                        <ul className="space-y-2">
+                            {plan.definitionOfDone.map((d, i) => (
+                                <li key={i} className="flex items-start gap-2 text-sm text-neutral-800">
+                                    <input
+                                        type="checkbox"
+                                        readOnly
+                                        aria-label={d}
+                                        className="mt-1 rounded border-neutral-300 cursor-default"
+                                    />
+                                    <span>{inlineMd(d)}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-sm text-neutral-500 italic">No definition of done captured.</p>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function ImplementationPlanRenderer({ content }: Props) {
+    const structured = useMemo(() => extractStructuredPlan(content), [content]);
+    if (structured) {
+        return <StructuredPlanView plan={structured} />;
+    }
+    return <LegacyTimeline content={content} />;
 }

--- a/src/lib/artifactValidation.ts
+++ b/src/lib/artifactValidation.ts
@@ -88,6 +88,21 @@ export function validateArtifactContent(
         score -= 15;
     }
 
+    // Soft check for the implementation_plan structured payload. The renderer
+    // falls back to legacy markdown parsing when the fence is missing or
+    // malformed, so this is a warning, not a hard fail.
+    if (subtype === 'implementation_plan') {
+        const fence = content.match(/```json\s+synapse-plan\s*\n([\s\S]*?)\n```/);
+        if (fence) {
+            try {
+                JSON.parse(fence[1]);
+            } catch {
+                warnings.push('Implementation plan structured JSON fence is malformed — UI will fall back to legacy timeline.');
+                score -= 5;
+            }
+        }
+    }
+
     return {
         isValid: score >= 40,
         qualityScore: Math.max(0, Math.min(100, score)),

--- a/src/lib/schemas/artifactSchemas.ts
+++ b/src/lib/schemas/artifactSchemas.ts
@@ -135,6 +135,72 @@ export const dataModelSchema = {
     required: ["entities", "apiEndpoints"],
 };
 
+export const implementationPlanSchema = {
+    type: "OBJECT",
+    properties: {
+        overview: {
+            type: "OBJECT",
+            properties: {
+                summary: { type: "STRING" },
+                criticalPath: { type: "STRING" },
+                teamSize: { type: "STRING" },
+            },
+        },
+        milestones: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    id: { type: "STRING" },
+                    name: { type: "STRING" },
+                    timeframe: { type: "STRING" },
+                    goal: { type: "STRING" },
+                    tasks: {
+                        type: "ARRAY",
+                        items: {
+                            type: "OBJECT",
+                            properties: {
+                                id: { type: "STRING" },
+                                title: { type: "STRING" },
+                                description: { type: "STRING" },
+                                status: {
+                                    type: "STRING",
+                                    enum: ["todo", "in_progress", "done", "blocked"],
+                                },
+                                dependencies: { type: "ARRAY", items: { type: "STRING" } },
+                                linkedArtifacts: {
+                                    type: "OBJECT",
+                                    properties: {
+                                        prd: { type: "ARRAY", items: { type: "STRING" } },
+                                        dataModel: { type: "ARRAY", items: { type: "STRING" } },
+                                        mockups: { type: "ARRAY", items: { type: "STRING" } },
+                                    },
+                                },
+                            },
+                            required: ["id", "title", "status"],
+                        },
+                    },
+                },
+                required: ["id", "name", "tasks"],
+            },
+        },
+        architecture: { type: "ARRAY", items: { type: "STRING" } },
+        risks: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    description: { type: "STRING" },
+                    mitigation: { type: "STRING" },
+                },
+                required: ["description"],
+            },
+        },
+        definitionOfDone: { type: "ARRAY", items: { type: "STRING" } },
+    },
+    required: ["milestones"],
+};
+
 export const componentInventorySchema = {
     type: "OBJECT",
     properties: {

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -1,7 +1,7 @@
-import type { StructuredPRD, CoreArtifactSubtype, ScreenInventoryContent, DataModelContent, ComponentInventoryContent } from '../../types';
+import type { StructuredPRD, CoreArtifactSubtype, ScreenInventoryContent, DataModelContent, ComponentInventoryContent, StructuredImplementationPlan } from '../../types';
 import { callGemini, callGeminiStream } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
-import { screenInventorySchema, dataModelSchema, componentInventorySchema } from '../schemas/artifactSchemas';
+import { screenInventorySchema, dataModelSchema, componentInventorySchema, implementationPlanSchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
 import { dataModelToMarkdown } from './dataModelMarkdown';
 
@@ -65,25 +65,42 @@ End with a dependency summary showing which components compose other components.
         userPrefix: 'Create a Component Inventory from this PRD:',
     },
     implementation_plan: {
-        system: `You are an expert software architect. Create a high-level Implementation Plan — a milestone-oriented development roadmap grounded in the other generated artifacts.
+        system: `You are an expert software architect. Produce a structured Implementation Plan as a task-driven execution system, not a narrative document. The JSON you return drives the rendered UI directly.
 
-Use this exact format for each milestone:
+Top-level shape:
+- overview: { summary, criticalPath, teamSize }
+  - summary: 2-3 sentences describing the build approach.
+  - criticalPath: one sentence naming the milestones on the critical path.
+  - teamSize: short recommendation (e.g. "1 frontend + 1 backend" or "Solo dev, ~6 weeks").
+- milestones: 4-6 entries. First is infrastructure/setup. Last covers testing and launch prep.
+- architecture: top-level array of cross-cutting technical decisions (tech stack picks, key architectural calls). Hoisted out of per-milestone bodies.
+- risks: top-level array of { description, mitigation } items spanning the project.
+- definitionOfDone: top-level array of project-wide acceptance criteria.
 
-### Milestone [N]: [Name] (Week [X]-[Y])
-**Goal:** One-sentence objective.
-**Key Deliverables:**
-- [ ] Deliverable 1
-- [ ] Deliverable 2
-**Technical Approach:** Specific technology choices and architectural decisions.
-**Dependencies:** Which milestones must be completed first.
-**Risks:** What could go wrong and how to mitigate it.
-**Definition of Done:** How to verify this milestone is complete.
+Per milestone:
+- id: stable lower-snake-case identifier (e.g. "m_setup", "m_emotion_extraction").
+- name: human-readable milestone name.
+- timeframe: "Week 1-2" style range.
+- goal: one-sentence objective.
+- tasks: 3-8 atomic, executable tasks.
 
-Include 4-6 milestones. First milestone should be infrastructure/setup. Last milestone should include testing and launch prep.
-End with:
-- A critical path summary
-- Team size recommendation
-- Traceability map (milestone → PRD feature IDs)`,
+Per task:
+- id: stable lower-snake-case identifier (e.g. "task_initialize_nextjs"). Unique across the whole plan.
+- title: short imperative (e.g. "Initialize Next.js SPA").
+- description: optional extra context, ONE sentence max.
+- status: ALWAYS "todo". You are generating a plan, not tracking execution.
+- dependencies: array of OTHER task ids (from this same plan) that must be done first. Empty array if none.
+- linkedArtifacts: { prd, dataModel, mockups }
+  - prd: PRD feature names this task implements, drawn from the Canonical Feature Glossary in the user prompt.
+  - dataModel: entity names from the data_model dependency context that this task touches.
+  - mockups: screen names from the screen_inventory dependency context that this task implements.
+  - Omit (or use empty arrays) if there is no genuine reference. Don't invent artifact references.
+
+Rules:
+- Task ids must be unique across the entire plan.
+- All ids in dependencies must reference other task ids in the same plan.
+- Hoist cross-cutting architecture, risks, and definition-of-done into the top-level arrays — do NOT duplicate them per milestone.
+- Tasks should read as atomic engineering work, not as themes.`,
         userPrefix: 'Create an Implementation Plan from this PRD:',
     },
     data_model: {
@@ -243,7 +260,66 @@ function structuredArtifactToMarkdown(subtype: CoreArtifactSubtype, data: unknow
         return lines.join('\n');
     }
 
+    if (subtype === 'implementation_plan') {
+        return implementationPlanToMarkdown(data as StructuredImplementationPlan);
+    }
+
     return JSON.stringify(data, null, 2);
+}
+
+// Converts the structured plan to a markdown body that the new tabbed
+// renderer can re-parse via the trailing `synapse-plan` JSON fence, while
+// the legacy milestone-regex parser still produces a usable timeline view
+// for older builds. Headers ('Milestone', 'Goal', 'Deliverables',
+// 'Dependencies') match what artifactValidation expects.
+function implementationPlanToMarkdown(plan: StructuredImplementationPlan): string {
+    const lines: string[] = ['# Implementation Plan\n'];
+    if (plan.overview?.summary) lines.push(plan.overview.summary, '');
+
+    plan.milestones.forEach((m, i) => {
+        const heading = `### Milestone ${i + 1}: ${m.name}${m.timeframe ? ` (${m.timeframe})` : ''}`;
+        lines.push(heading);
+        if (m.goal) lines.push(`**Goal:** ${m.goal}`);
+        if (m.tasks.length) {
+            lines.push('**Key Deliverables:**');
+            for (const t of m.tasks) {
+                lines.push(`- [${t.status === 'done' ? 'x' : ' '}] **${t.title}** — _${t.status}_`);
+            }
+        }
+        const deps = Array.from(new Set(m.tasks.flatMap(t => t.dependencies ?? []))).filter(Boolean);
+        if (deps.length) lines.push(`**Dependencies:** ${deps.join(', ')}`);
+        lines.push('');
+    });
+
+    if (plan.architecture?.length) {
+        lines.push('---', '', '## Architecture');
+        plan.architecture.forEach(a => lines.push(`- ${a}`));
+        lines.push('');
+    }
+    if (plan.risks?.length) {
+        lines.push('## Risks');
+        plan.risks.forEach(r => {
+            lines.push(`- **${r.description}**${r.mitigation ? ` — Mitigation: ${r.mitigation}` : ''}`);
+        });
+        lines.push('');
+    }
+    if (plan.definitionOfDone?.length) {
+        lines.push('## Definition of Done');
+        plan.definitionOfDone.forEach(d => lines.push(`- [ ] ${d}`));
+        lines.push('');
+    }
+    if (plan.overview?.criticalPath || plan.overview?.teamSize) {
+        if (!plan.architecture?.length) lines.push('---', '');
+        if (plan.overview.criticalPath) lines.push(`**Critical Path:** ${plan.overview.criticalPath}`);
+        if (plan.overview.teamSize) lines.push(`**Team Size:** ${plan.overview.teamSize}`);
+        lines.push('');
+    }
+
+    lines.push('```json synapse-plan');
+    lines.push(JSON.stringify(plan, null, 2));
+    lines.push('```');
+
+    return lines.join('\n');
 }
 
 export const generateCoreArtifact = async (
@@ -300,6 +376,7 @@ Architecture: ${structuredPRD.architecture}${
         screen_inventory: screenInventorySchema,
         data_model: dataModelSchema,
         component_inventory: componentInventorySchema,
+        implementation_plan: implementationPlanSchema,
     };
 
     const userPrompt = `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -386,6 +386,48 @@ export interface ComponentInventoryContent {
     categories: { name: string; components: ComponentItem[] }[];
 }
 
+export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'blocked';
+
+export interface LinkedArtifacts {
+    prd?: string[];
+    dataModel?: string[];
+    mockups?: string[];
+}
+
+export interface ImplementationPlanTask {
+    id: string;
+    title: string;
+    description?: string;
+    status: TaskStatus;
+    dependencies?: string[];
+    linkedArtifacts?: LinkedArtifacts;
+}
+
+export interface ImplementationPlanMilestone {
+    id: string;
+    name: string;
+    timeframe?: string;
+    goal?: string;
+    tasks: ImplementationPlanTask[];
+}
+
+export interface RiskItem {
+    description: string;
+    mitigation?: string;
+}
+
+export interface StructuredImplementationPlan {
+    overview?: {
+        summary?: string;
+        criticalPath?: string;
+        teamSize?: string;
+    };
+    milestones: ImplementationPlanMilestone[];
+    architecture?: string[];
+    risks?: RiskItem[];
+    definitionOfDone?: string[];
+}
+
 // --- Artifact System ---
 
 export type ArtifactType = 'prd' | 'mockup' | 'prompt' | 'core_artifact';


### PR DESCRIPTION
Generates the artifact via Gemini JSON mode + implementationPlanSchema, mirroring the pattern already used by screen_inventory / data_model / component_inventory. Each milestone now contains atomic tasks with stable ids, status, dependencies, and linkedArtifacts (PRD / data model / mockups). Cross-cutting architecture, risks, and definition-of-done are hoisted into top-level arrays.

Storage shape is unchanged: structuredArtifactToMarkdown emits a readable markdown body and appends a trailing ```json synapse-plan fence carrying the canonical payload. The renderer reads that fence first to drive the new tabbed UI (Tasks / Architecture / Risks / Definition of Done) with computed milestone progress and inline dependency / link references; legacy artifacts without the fence fall through to the original milestone-timeline view, so projects already in localStorage keep rendering unchanged.

Adds a soft validation check for malformed fence JSON (warning, not a hard fail) and documents deferred features (editing, graph viz, AI subtask expansion, etc.) in ImplementationPlanRenderer.BACKLOG.md.