### PR TITLE
feat(prompt-pack): make prompts editable, self-contained, and explainable

### DIFF
--- a/docs/backlog/prompt-pack-backlog.md
+++ b/docs/backlog/prompt-pack-backlog.md
@@ -1,0 +1,91 @@
+# Prompt Pack — Backlog
+
+Deferred ideas for the Prompt Pack artifact. None of these are implemented
+today; the current focus (see commit history of `PromptPackRenderer.tsx` and
+`coreArtifactService.ts`) is on making prompts trustworthy, editable, and
+self-contained. Everything below is intentionally NOT in scope until the
+core Prompt Pack experience has been validated in real usage.
+
+## 1. Full prompt orchestration graph
+
+Treat the Prompt Pack as a DAG instead of a flat list. Each prompt would
+declare its inputs (other prompts' outputs, named artifacts, source files)
+and outputs. The UI would visualize the graph and let the user run a
+sub-graph end-to-end. Depends on stable prompt IDs and on a result-storage
+model that today does not exist.
+
+## 2. Dependency-aware execution
+
+Once #1 exists, run prompts in topological order, blocking dependents until
+prerequisites complete. Surface partial-failure recovery: if Prompt 3 fails,
+allow re-running just 3 + downstream without re-running 1 and 2. Requires a
+job runner that calls external coding agents (Cursor / Claude Code) which
+Synapse doesn't currently invoke from the browser.
+
+## 3. Automatic model routing
+
+Replace the user-facing "Recommended target" reason with an automatic
+routing decision. Rough sketch: a small classifier (keyword/heuristic, then
+later an LLM) maps `(category, complexity, output_type)` to a target tool
+and model. Should remain overridable. Depends on capturing better signal at
+generation time (we currently emit one free-text Reason line).
+
+## 4. Evaluation / retry loop
+
+After a prompt is executed, capture the output and run an automated
+evaluator (rubric-based LLM critique) to score success. On low score,
+auto-revise the prompt and retry. Requires #1 (orchestration), an output
+capture mechanism, and a defined rubric per prompt category.
+
+## 5. Prompt quality scoring
+
+Score each prompt at generation time on dimensions like specificity,
+self-containedness, presence of test cases, and feature coverage. Display
+the score as a chip and gate "Copy" on a minimum threshold. Lightweight
+version: keyword heuristics. Heavy version: LLM judge call. Should reuse
+the deferred PRD quality rubric infrastructure rather than inventing a new
+one.
+
+## 6. Multi-agent workflows
+
+Bundle multiple prompts into a planner → coder → reviewer pipeline that the
+user runs as one "workflow." Each stage has its own model/tool target.
+Requires #1 + #2 + an external agent transport. Probably the right home
+for advanced features like self-critique loops.
+
+## 7. Prompt version history
+
+Per-prompt revision history with diffs, author timestamps, and "restore to
+this version" actions. Today edits are a single overlay on top of the
+generated body — there is no history beyond the original. Storing a list
+would balloon `ArtifactVersion.metadata`; this likely wants a dedicated
+`promptEditHistory` slice.
+
+## 8. Compiled prompt preview vs. source prompt diff
+
+When the prompt body contains template tokens (e.g. `{{feature.name}}`),
+show the compiled output beside the source template with a syntax-aware
+diff. Requires a templating layer the Prompt Pack does not have.
+
+## 9. Batch execution support
+
+Run all prompts (or a selected subset) in one click against a chosen
+target. Requires the same external-agent transport as #2 and #6.
+
+## 10. Cross-prompt context sharing
+
+Let prompts opt into a shared "system context" block (e.g. coding
+standards, repo layout, available scripts) that prepends each prompt body
+on copy. Today every prompt restates context inline, which is intentional
+for self-containedness — this would be a power-user shortcut to reduce
+duplication. Needs careful UX so users don't accidentally copy a prompt
+without the shared context.
+
+---
+
+## Out of scope (explicitly)
+
+- Replacing the whole artifact system or generation pipeline.
+- A separate prompt-orchestration product surface.
+- Anything that changes how `screen_inventory`, `data_model`,
+  `component_inventory`, etc. are generated, stored, or rendered.

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -75,6 +75,7 @@ export function ArtifactWorkspace({
 }: ArtifactWorkspaceProps) {
     const {
         getArtifacts, getPreferredVersion, getArtifactStaleness, getJob, getProject,
+        updateArtifactVersionMetadata,
     } = useProjectStore();
 
     const slotMetas = useMemo(() => buildSlotMetas(), []);
@@ -264,12 +265,23 @@ export function ArtifactWorkspace({
                 productSummary: structuredPRD.executiveSummary ?? structuredPRD.vision,
             }
             : undefined;
+        const promptEdits = subtype === 'prompt_pack'
+            ? ((preferred.metadata?.promptEdits as Record<number, string> | undefined) ?? {})
+            : undefined;
+        const handleUpdatePromptEdits = subtype === 'prompt_pack'
+            ? (next: Record<number, string>) => {
+                updateArtifactVersionMetadata(projectId, artifact.id, preferred.id, { promptEdits: next });
+            }
+            : undefined;
         return (
             <div className="max-w-3xl mx-auto bg-white rounded-xl border border-neutral-200 shadow-sm p-6 prose prose-sm prose-neutral max-w-none overflow-auto">
                 <ArtifactContentRenderer
                     subtype={subtype}
                     content={preferred.content}
                     screenImageContext={screenImageContext}
+                    features={subtype === 'prompt_pack' ? structuredPRD.features : undefined}
+                    promptEdits={promptEdits}
+                    onUpdatePromptEdits={handleUpdatePromptEdits}
                 />
             </div>
         );

--- a/src/components/renderers/PromptPackRenderer.tsx
+++ b/src/components/renderers/PromptPackRenderer.tsx
@@ -1,22 +1,31 @@
 import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Check, Copy, Sparkles } from 'lucide-react';
+import { AlertTriangle, Check, Copy, Pencil, RotateCcw, Sparkles } from 'lucide-react';
 import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+import type { Feature } from '../../types';
 
 // Render a `prompt_pack` artifact as one card per `### N. Title` heading,
-// extracting `**Target Tool:**` / `**Category:**` chips and the fenced
-// code block that holds the actual prompt body. Each card has a
-// "Copy prompt" button that copies the prompt text to the clipboard.
+// extracting `**Target Tool:**` / `**Reason:**` / `**Category:**` chips and
+// the fenced code block that holds the actual prompt body. Each card has a
+// "Copy prompt" button and an editable mode. User edits are stored as a
+// per-prompt overlay on the version's metadata; copy uses the edited body.
 
 interface Props {
     content: string;
+    /** Feature definitions from the current spine PRD; used to flag dangling feature IDs. */
+    features?: Feature[];
+    /** User edits keyed by prompt index; falls back to the generated body when absent. */
+    edits?: Record<number, string>;
+    /** Persist new edit overlay. Pass-through omitted = read-only render. */
+    onUpdateEdits?: (next: Record<number, string>) => void;
 }
 
 type PromptCard = {
     index: number;
     title: string;
     targetTool?: string;
+    targetReason?: string;
     category?: string;
     promptBody: string;
     expected?: string;
@@ -74,6 +83,11 @@ function buildCard(active: { rawLines: string[]; index: number; title: string })
             card.targetTool = tool[1].trim();
             continue;
         }
+        const reason = line.match(/^\*\*Reason:\*\*\s*(.+)$/i);
+        if (reason) {
+            card.targetReason = reason[1].trim();
+            continue;
+        }
         const cat = line.match(/^\*\*Category:\*\*\s*(.+)$/i);
         if (cat) {
             card.category = cat[1].trim();
@@ -96,12 +110,64 @@ function buildCard(active: { rawLines: string[]; index: number; title: string })
     return card;
 }
 
-function CopyButton({ text }: { text: string }) {
+// Find feature IDs (e.g. f1, F-014) that appear OUTSIDE a "## Features In
+// Scope" section. Dangling IDs aren't usable when the prompt is copied
+// standalone — they confuse the recipient agent.
+function findUnresolvedFeatureIds(body: string, features: Feature[]): string[] {
+    if (!body) return [];
+    const lines = body.split('\n');
+    let inScope = false;
+    let inOtherSection = false;
+    const danglingLines: string[] = [];
+    for (const line of lines) {
+        const heading = line.match(/^##\s+(.+?)\s*$/);
+        if (heading) {
+            const name = heading[1].toLowerCase();
+            inScope = name.includes('features in scope') || name.includes('feature in scope');
+            inOtherSection = !inScope;
+            continue;
+        }
+        if (!inScope) {
+            danglingLines.push(line);
+        }
+        // suppress unused-var lint for tracking variable
+        void inOtherSection;
+    }
+    const outside = danglingLines.join('\n');
+    // Match either `f<digits>` (canonical) or `F-<digits>` (legacy) tokens.
+    const tokenRegex = /\b[fF]-?\d+\b/g;
+    const found = outside.match(tokenRegex) ?? [];
+    if (found.length === 0) return [];
+    const knownIds = new Set(features.map(f => f.id.toLowerCase()));
+    const unique = Array.from(new Set(found));
+    // A token is "unresolved" if it doesn't appear in the known feature list
+    // either way; alternatively, every appearance of a known ID outside the
+    // scope section is also unresolved (bare ref). We treat both as
+    // unresolved so the warning catches the user pasting a stale ID.
+    return unique.filter(token => {
+        // Always flag tokens that aren't known features at all.
+        if (!knownIds.has(token.toLowerCase())) return true;
+        // Known IDs leaking outside Features In Scope are also unresolved
+        // (the ID is bare without its definition).
+        return true;
+    });
+}
+
+interface CopyButtonProps {
+    text: string;
+    disabled?: boolean;
+    disabledReason?: string;
+}
+
+function CopyButton({ text, disabled, disabledReason }: CopyButtonProps) {
     const [copied, setCopied] = useState(false);
     return (
         <button
             type="button"
+            disabled={disabled}
+            title={disabled ? disabledReason : 'Copy this prompt to the clipboard'}
             onClick={async () => {
+                if (disabled) return;
                 try {
                     await navigator.clipboard.writeText(text);
                     setCopied(true);
@@ -110,7 +176,11 @@ function CopyButton({ text }: { text: string }) {
                     // Clipboard API not available — silently no-op.
                 }
             }}
-            className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700 transition"
+            className={`inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md transition ${
+                disabled
+                    ? 'bg-neutral-200 text-neutral-400 cursor-not-allowed'
+                    : 'bg-indigo-600 text-white hover:bg-indigo-700'
+            }`}
         >
             {copied ? (
                 <>
@@ -125,21 +195,42 @@ function CopyButton({ text }: { text: string }) {
     );
 }
 
-function PromptCardView({ card }: { card: PromptCard }) {
+interface PromptCardViewProps {
+    card: PromptCard;
+    effectiveBody: string;
+    modified: boolean;
+    unresolvedIds: string[];
+    canEdit: boolean;
+    onEdit: (next: string) => void;
+    onReset: () => void;
+}
+
+function PromptCardView({
+    card,
+    effectiveBody,
+    modified,
+    unresolvedIds,
+    canEdit,
+    onEdit,
+    onReset,
+}: PromptCardViewProps) {
+    const [editing, setEditing] = useState(false);
+    const hasWarning = unresolvedIds.length > 0;
+    const copyDisabled = hasWarning;
     return (
         <article
             id={`prompt-${card.index}`}
             className="bg-white rounded-xl border border-neutral-200 overflow-hidden scroll-mt-24"
         >
             <header className="px-4 py-3 border-b border-neutral-100 flex flex-wrap items-start gap-3 justify-between">
-                <div className="min-w-0">
+                <div className="min-w-0 flex-1">
                     <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-600">
                         Prompt {card.index}
                     </p>
                     <h3 className="text-sm font-bold text-neutral-900 leading-snug mt-0.5">
                         {card.title}
                     </h3>
-                    {(card.targetTool || card.category) && (
+                    {(card.targetTool || card.category || modified) && (
                         <div className="flex flex-wrap gap-1.5 mt-2">
                             {card.targetTool && (
                                 <span className="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-700 border border-indigo-100">
@@ -152,15 +243,80 @@ function PromptCardView({ card }: { card: PromptCard }) {
                                     {card.category}
                                 </span>
                             )}
+                            {modified && (
+                                <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200">
+                                    Modified
+                                </span>
+                            )}
                         </div>
                     )}
+                    {card.targetReason && (
+                        <p className="text-[11px] text-neutral-500 leading-snug mt-1.5">
+                            <span className="font-medium text-neutral-600">Why this target:</span>{' '}
+                            {card.targetReason}
+                        </p>
+                    )}
                 </div>
-                {card.promptBody && <CopyButton text={card.promptBody} />}
+                <div className="flex flex-wrap items-center gap-1.5">
+                    {canEdit && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={() => setEditing(prev => !prev)}
+                                className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-neutral-200 text-neutral-700 hover:bg-neutral-50 transition"
+                            >
+                                {editing ? <Check size={12} /> : <Pencil size={12} />}
+                                {editing ? 'Done' : 'Edit'}
+                            </button>
+                            {modified && (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        onReset();
+                                        setEditing(false);
+                                    }}
+                                    title="Restore the originally generated prompt"
+                                    className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-neutral-200 text-neutral-700 hover:bg-neutral-50 transition"
+                                >
+                                    <RotateCcw size={12} />
+                                    Reset
+                                </button>
+                            )}
+                        </>
+                    )}
+                    {effectiveBody && (
+                        <CopyButton
+                            text={effectiveBody}
+                            disabled={copyDisabled}
+                            disabledReason="Resolve dangling feature references before copying."
+                        />
+                    )}
+                </div>
             </header>
-            {card.promptBody && (
-                <div className="bg-neutral-900 text-neutral-100 px-4 py-3 text-xs font-mono whitespace-pre-wrap leading-relaxed max-h-72 overflow-y-auto">
-                    {card.promptBody}
+            {hasWarning && (
+                <div className="px-4 py-2 bg-rose-50 border-b border-rose-100 flex items-start gap-2">
+                    <AlertTriangle size={14} className="text-rose-600 flex-shrink-0 mt-0.5" />
+                    <p className="text-[11px] text-rose-800 leading-snug">
+                        <span className="font-semibold">Unresolved feature references:</span>{' '}
+                        {unresolvedIds.join(', ')}. Copy is disabled — these IDs aren't expanded
+                        inside &quot;Features In Scope,&quot; so the recipient agent won't know
+                        what they mean. Edit the prompt or regenerate the artifact.
+                    </p>
                 </div>
+            )}
+            {editing && canEdit ? (
+                <textarea
+                    value={effectiveBody}
+                    onChange={e => onEdit(e.target.value)}
+                    className="w-full bg-neutral-900 text-neutral-100 px-4 py-3 text-xs font-mono leading-relaxed min-h-[18rem] focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    spellCheck={false}
+                />
+            ) : (
+                effectiveBody && (
+                    <div className="bg-neutral-900 text-neutral-100 px-4 py-3 text-xs font-mono whitespace-pre-wrap leading-relaxed max-h-72 overflow-y-auto">
+                        {effectiveBody}
+                    </div>
+                )
             )}
             {card.expected && (
                 <div className="px-4 py-3 border-t border-neutral-100 bg-emerald-50/40">
@@ -176,8 +332,11 @@ function PromptCardView({ card }: { card: PromptCard }) {
     );
 }
 
-export function PromptPackRenderer({ content }: Props) {
+export function PromptPackRenderer({ content, features, edits, onUpdateEdits }: Props) {
     const { preamble, cards } = useMemo(() => parsePromptPack(content), [content]);
+    const editsMap = edits ?? {};
+    const canEdit = typeof onUpdateEdits === 'function';
+
     if (cards.length === 0) {
         return (
             <div className="prose prose-sm prose-neutral max-w-none">
@@ -197,9 +356,32 @@ export function PromptPackRenderer({ content }: Props) {
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>{preamble}</ReactMarkdown>
                 </div>
             )}
-            {cards.map(card => (
-                <PromptCardView key={card.index} card={card} />
-            ))}
+            {cards.map(card => {
+                const overlay = editsMap[card.index];
+                const effectiveBody = overlay !== undefined ? overlay : card.promptBody;
+                const modified = overlay !== undefined && overlay !== card.promptBody;
+                const unresolvedIds = findUnresolvedFeatureIds(effectiveBody, features ?? []);
+                return (
+                    <PromptCardView
+                        key={card.index}
+                        card={card}
+                        effectiveBody={effectiveBody}
+                        modified={modified}
+                        unresolvedIds={unresolvedIds}
+                        canEdit={canEdit}
+                        onEdit={next => {
+                            if (!canEdit) return;
+                            onUpdateEdits!({ ...editsMap, [card.index]: next });
+                        }}
+                        onReset={() => {
+                            if (!canEdit) return;
+                            const { [card.index]: _omit, ...rest } = editsMap;
+                            void _omit;
+                            onUpdateEdits!(rest);
+                        }}
+                    />
+                );
+            })}
         </div>
     );
 }

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -1,4 +1,4 @@
-import type { CoreArtifactSubtype } from '../../types';
+import type { CoreArtifactSubtype, Feature } from '../../types';
 import { ScreenInventoryRenderer } from './ScreenInventoryRenderer';
 import type { ScreenImageGalleryContext } from './ScreenImageGallery';
 import { DataModelRenderer } from './DataModelRenderer';
@@ -15,6 +15,12 @@ interface DispatchProps {
     content: string;
     /** Only consumed by `screen_inventory` today. Other subtypes ignore it. */
     screenImageContext?: ScreenImageGalleryContext;
+    /** Only consumed by `prompt_pack`; supplies the canonical feature list for ID resolution. */
+    features?: Feature[];
+    /** Only consumed by `prompt_pack`; per-prompt user edit overlay keyed by index. */
+    promptEdits?: Record<number, string>;
+    /** Only consumed by `prompt_pack`; persists the new edit overlay. */
+    onUpdatePromptEdits?: (next: Record<number, string>) => void;
 }
 
 /**
@@ -42,7 +48,14 @@ function isJsonString(str: string): boolean {
     }
 }
 
-export function ArtifactContentRenderer({ subtype, content, screenImageContext }: DispatchProps) {
+export function ArtifactContentRenderer({
+    subtype,
+    content,
+    screenImageContext,
+    features,
+    promptEdits,
+    onUpdatePromptEdits,
+}: DispatchProps) {
     if (subtype === 'screen_inventory' && isJsonString(content)) {
         return <ScreenInventoryRenderer content={content} imageContext={screenImageContext} />;
     }
@@ -62,7 +75,14 @@ export function ArtifactContentRenderer({ subtype, content, screenImageContext }
         return <ImplementationPlanRenderer content={content} />;
     }
     if (subtype === 'prompt_pack') {
-        return <PromptPackRenderer content={content} />;
+        return (
+            <PromptPackRenderer
+                content={content}
+                features={features}
+                edits={promptEdits}
+                onUpdateEdits={onUpdatePromptEdits}
+            />
+        );
     }
     return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;
 }

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -130,22 +130,56 @@ Use stable names for entities and fields. Do not rename PRD concepts unless you 
         userPrefix: 'Create a Data Model from this PRD:',
     },
     prompt_pack: {
-        system: `You are an expert at writing AI prompts. Create a Prompt Pack — a bundle of ready-to-use downstream prompts.
+        system: `You are an expert at writing AI prompts. Create a Prompt Pack — a bundle of ready-to-use downstream prompts that a developer can copy directly into Cursor, Claude Code, ChatGPT, or Copilot WITHOUT also pasting the PRD.
 
 For each prompt, use this exact format:
 
 ### [N]. [Prompt Title]
 **Target Tool:** Cursor | Claude Code | ChatGPT | Copilot | Generic
+**Reason:** One short user-facing sentence (≤25 words) explaining why this target tool fits THIS prompt — e.g. "Cursor — best fit for applying multi-file code changes directly in the repo with diff preview." Keep it concrete; do not say "best AI tool".
 **Category:** UI Implementation | UX Critique | Testing | API Design | Content | Accessibility
 **Prompt:**
 \`\`\`
-[The full, copy-pasteable prompt text here. Include all necessary context from the PRD. Make it self-contained — the recipient should not need to read the PRD separately.]
+# Task
+<one-line objective in plain English>
+
+## Context
+<2–4 sentences of product/user context drawn from the PRD vision and target users>
+
+## Features In Scope
+- <id> — <Feature Name>
+  - Purpose: <one sentence>
+  - Inputs / behavior: <one sentence>
+  - Constraints: <one sentence, or 2–3 bullets if needed>
+- <id> — <Feature Name>
+  - Purpose: ...
+  - Inputs / behavior: ...
+  - Constraints: ...
+
+## Requirements
+- <bulleted, specific, testable>
+- ...
+
+## Constraints
+- <bulleted; e.g. tech stack limits, performance budgets, accessibility minimums>
+- ...
+
+## Expected Output
+- <bulleted; what artifacts/files/behaviors the recipient should produce>
+- ...
 \`\`\`
 **Expected Output:** What this prompt should produce.
 
-Include at minimum 6 prompts covering: UI implementation, UX critique, testing strategy, API design, copy/content writing, and accessibility audit.
+Hard rules — these are non-negotiable:
 
-Every prompt must explicitly reference at least two canonical feature IDs and one named screen/entity.
+1. Every prompt MUST be self-contained. The recipient receives ONLY this fenced block — no PRD, no glossary, no other artifact.
+2. Feature IDs (e.g. \`f1\`, \`f2\`) MUST appear ONLY inside the "## Features In Scope" section, where they are defined inline with name, purpose, inputs/behavior, and constraints from the canonical feature glossary above.
+3. In every other section ("# Task", "## Context", "## Requirements", "## Constraints", "## Expected Output"), refer to features by their human name only — never by bare ID. Example: write "the WebRTC emotion extractor" in Requirements, not "[f1]" or "f1".
+4. Each prompt MUST cover 2–4 features under "Features In Scope" and reference at least one named screen or entity from the dependency artifacts.
+5. Do not invent feature IDs. Only use IDs that appear in the canonical feature glossary supplied below.
+6. Keep the structure exactly as shown — same headings, same order. The renderer parses it.
+
+Include at minimum 6 prompts covering: UI implementation, UX critique, testing strategy, API design, copy/content writing, and accessibility audit.
 
 Begin your response directly with the first section heading. Do NOT include any preamble, introduction, or conversational text (e.g. "Of course", "Here are", "As a UX expert").`,
         userPrefix: 'Create a Prompt Pack from this PRD:',

--- a/src/store/slices/artifactSlice.ts
+++ b/src/store/slices/artifactSlice.ts
@@ -17,6 +17,7 @@ export type ArtifactSlice = {
     getArtifactVersions: ProjectState['getArtifactVersions'];
     getPreferredVersion: ProjectState['getPreferredVersion'];
     getLatestArtifactVersion: ProjectState['getLatestArtifactVersion'];
+    updateArtifactVersionMetadata: ProjectState['updateArtifactVersionMetadata'];
 };
 
 export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSlice> = (set, get) => ({
@@ -199,5 +200,30 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
             .filter(v => v.artifactId === artifactId);
         if (versions.length === 0) return undefined;
         return versions.reduce((latest, v) => v.versionNumber > latest.versionNumber ? v : latest);
+    },
+
+    updateArtifactVersionMetadata: (
+        projectId: string,
+        artifactId: string,
+        versionId: string,
+        patch: Record<string, unknown>,
+    ) => {
+        set((state) => {
+            const allVersions = state.artifactVersions[projectId] || [];
+            const updatedVersions = allVersions.map(v =>
+                v.id === versionId && v.artifactId === artifactId
+                    ? { ...v, metadata: { ...v.metadata, ...patch } }
+                    : v
+            );
+            const projectArtifacts = state.artifacts[projectId] || [];
+            const now = Date.now();
+            const updatedArtifacts = projectArtifacts.map(a =>
+                a.id === artifactId ? { ...a, updatedAt: now } : a
+            );
+            return {
+                artifactVersions: { ...state.artifactVersions, [projectId]: updatedVersions },
+                artifacts: { ...state.artifacts, [projectId]: updatedArtifacts },
+            };
+        });
     },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -93,6 +93,12 @@ export interface ProjectState {
     getArtifactVersions: (projectId: string, artifactId: string) => ArtifactVersion[];
     getPreferredVersion: (projectId: string, artifactId: string) => ArtifactVersion | undefined;
     getLatestArtifactVersion: (projectId: string, artifactId: string) => ArtifactVersion | undefined;
+    updateArtifactVersionMetadata: (
+        projectId: string,
+        artifactId: string,
+        versionId: string,
+        patch: Record<string, unknown>,
+    ) => void;
 
     // Feedback actions
     createFeedbackItem: (


### PR DESCRIPTION
Rewrite the Prompt Pack system instruction so each generated prompt is a
fully self-contained Task / Context / Features In Scope / Requirements /
Constraints / Expected Output block — feature IDs may appear only inside
"Features In Scope" with their full definition inlined, never bare.

Add a per-card edit/reset flow in PromptPackRenderer with a "Modified"
pill; edits are stored as an overlay on ArtifactVersion.metadata via a
new updateArtifactVersionMetadata store action so the generated content
is preserved untouched. Copy now uses the edited body.

Add a Reason line on each prompt explaining why the recommended target
tool fits, and a client-side guard that disables Copy and surfaces a
warning when a prompt body still contains dangling feature IDs.

Defer larger orchestration ideas (DAG execution, automatic routing, eval
loops, version history) to docs/backlog/prompt-pack-backlog.md.