### PR TITLE
feat(prd): widen workspace and surface per-section time estimates

### DIFF
--- a/src/components/GenerationProgress.tsx
+++ b/src/components/GenerationProgress.tsx
@@ -8,6 +8,10 @@ export interface SectionStatusInfo {
     model?: string;
     ms?: number;
     error?: string;
+    /** Rough wall-clock estimate (seconds). */
+    estimatedSeconds?: number;
+    /** Wall-clock start timestamp (ms). Set when status === 'generating'. */
+    startedAt?: number;
 }
 
 interface GenerationProgressProps {
@@ -114,11 +118,23 @@ export function GenerationProgress({
 }: GenerationProgressProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isFading, setIsFading] = useState(false);
+    const [now, setNow] = useState(() => Date.now());
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const style = VARIANT_STYLES[variant];
     const isStateDriven = typeof progress === 'number';
     const hasHistory = !!history && history.length > 0;
     const hasSectionStatus = !!sectionStatus && Object.keys(sectionStatus).length > 0;
+
+    // Tick once per second while any section is mid-generation so the
+    // "elapsed/estimate" counter on each active pip stays current.
+    const hasActiveSection = hasSectionStatus && Object.values(sectionStatus!).some(
+        info => info.status === 'generating' || info.status === 'refining',
+    );
+    useEffect(() => {
+        if (!hasActiveSection) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [hasActiveSection]);
 
     useEffect(() => {
         // Skip the rotation timer entirely when the parent supplies real
@@ -326,6 +342,35 @@ export function GenerationProgress({
                                 const isComplete = info.status === 'complete';
                                 const isError = info.status === 'error';
 
+                                // Time annotation for the pip subtitle:
+                                //   - active   → "5s / ~25s" (live elapsed vs. estimate)
+                                //   - complete → "9.7s"     (actual duration)
+                                //   - queued / pending → "~25s" (estimate only)
+                                let timeLabel = '';
+                                if (isComplete && typeof info.ms === 'number') {
+                                    timeLabel = `${(info.ms / 1000).toFixed(1)}s`;
+                                } else if (isActive) {
+                                    const elapsedS = info.startedAt
+                                        ? Math.max(0, Math.floor((now - info.startedAt) / 1000))
+                                        : null;
+                                    if (elapsedS !== null && info.estimatedSeconds) {
+                                        timeLabel = `${elapsedS}s / ~${info.estimatedSeconds}s`;
+                                    } else if (elapsedS !== null) {
+                                        timeLabel = `${elapsedS}s`;
+                                    } else if (info.estimatedSeconds) {
+                                        timeLabel = `~${info.estimatedSeconds}s`;
+                                    }
+                                } else if (info.estimatedSeconds) {
+                                    timeLabel = `~${info.estimatedSeconds}s`;
+                                }
+
+                                // Highlight the elapsed counter when it overshoots the estimate
+                                // so users can tell that a section is running long.
+                                const overEstimate = isActive
+                                    && info.startedAt
+                                    && info.estimatedSeconds
+                                    && (now - info.startedAt) / 1000 > info.estimatedSeconds;
+
                                 const pipRing = isError
                                     ? 'border-red-400 bg-red-400'
                                     : isComplete
@@ -342,6 +387,12 @@ export function GenerationProgress({
                                         ? (isFast ? 'text-teal-700' : 'text-indigo-700')
                                         : 'text-neutral-400';
 
+                                const timeColor = overEstimate
+                                    ? 'text-amber-600'
+                                    : isComplete
+                                        ? (isFast ? 'text-teal-600' : 'text-indigo-600')
+                                        : 'text-neutral-400';
+
                                 return (
                                     <div key={sectionId} className="flex flex-col items-center gap-0.5">
                                         <div className={`relative flex h-7 w-7 items-center justify-center rounded-full border-2 transition-all duration-300 ${pipRing} ${isActive ? 'animate-pulse' : ''}`}>
@@ -356,6 +407,9 @@ export function GenerationProgress({
                                         <div className="text-center min-w-0 w-full">
                                             <div className={`text-[9px] font-medium leading-tight truncate ${textColor}`}>{label}</div>
                                             <div className="text-[8px] text-neutral-400 leading-tight">{modelLabel}</div>
+                                            {timeLabel && (
+                                                <div className={`text-[8px] leading-tight tabular-nums ${timeColor}`}>{timeLabel}</div>
+                                            )}
                                         </div>
                                     </div>
                                 );

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -419,7 +419,7 @@ export function ProjectWorkspace() {
                         </div>
                     )}
 
-                    <div className="max-w-2xl mx-auto mt-4">
+                    <div className="max-w-4xl mx-auto mt-4">
                         {/* PRD Stage */}
                         {pipelineStage === 'prd' && (
                             <>

--- a/src/lib/services/progressivePrdGeneration.ts
+++ b/src/lib/services/progressivePrdGeneration.ts
@@ -42,6 +42,8 @@ export type PrdSectionTemplate = {
     order: number;
     risk: GenerationTaskRisk;
     dependencies?: SectionId[];
+    /** Rough wall-clock estimate (seconds) used by the progress UI. */
+    estimatedSeconds: number;
 };
 
 export type SectionGenerationResult = {
@@ -79,17 +81,22 @@ export type ProgressiveEvent =
 // independently; strong (Pro) sections depend on earlier results.
 
 export const DEFAULT_PRD_SECTIONS: PrdSectionTemplate[] = [
-    { id: 'product_basics',       title: SECTION_TITLES.product_basics,       order: 1,  risk: 'low' },
-    { id: 'product_thesis',       title: SECTION_TITLES.product_thesis,       order: 2,  risk: 'high', dependencies: ['product_basics'] },
-    { id: 'grounding',            title: SECTION_TITLES.grounding,            order: 3,  risk: 'low',  dependencies: ['product_basics'] },
-    { id: 'features',             title: SECTION_TITLES.features,             order: 4,  risk: 'high', dependencies: ['product_basics', 'product_thesis'] },
-    { id: 'data_model',           title: SECTION_TITLES.data_model,           order: 5,  risk: 'high', dependencies: ['features', 'grounding'] },
-    { id: 'ux_loops',             title: SECTION_TITLES.ux_loops,             order: 6,  risk: 'high', dependencies: ['features', 'product_thesis'] },
-    { id: 'architecture',         title: SECTION_TITLES.architecture,         order: 7,  risk: 'high', dependencies: ['features', 'data_model'] },
-    { id: 'quality_risks',        title: SECTION_TITLES.quality_risks,        order: 8,  risk: 'low',  dependencies: ['features', 'architecture'] },
-    { id: 'metrics_scope',        title: SECTION_TITLES.metrics_scope,        order: 9,  risk: 'low',  dependencies: ['features'] },
-    { id: 'implementation_plan',  title: SECTION_TITLES.implementation_plan,  order: 10, risk: 'high', dependencies: ['features', 'data_model', 'architecture'] },
+    { id: 'product_basics',       title: SECTION_TITLES.product_basics,       order: 1,  risk: 'low',  estimatedSeconds: 8 },
+    { id: 'product_thesis',       title: SECTION_TITLES.product_thesis,       order: 2,  risk: 'high', estimatedSeconds: 25, dependencies: ['product_basics'] },
+    { id: 'grounding',            title: SECTION_TITLES.grounding,            order: 3,  risk: 'low',  estimatedSeconds: 10, dependencies: ['product_basics'] },
+    { id: 'features',             title: SECTION_TITLES.features,             order: 4,  risk: 'high', estimatedSeconds: 35, dependencies: ['product_basics', 'product_thesis'] },
+    { id: 'data_model',           title: SECTION_TITLES.data_model,           order: 5,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'grounding'] },
+    { id: 'ux_loops',             title: SECTION_TITLES.ux_loops,             order: 6,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'product_thesis'] },
+    { id: 'architecture',         title: SECTION_TITLES.architecture,         order: 7,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'data_model'] },
+    { id: 'quality_risks',        title: SECTION_TITLES.quality_risks,        order: 8,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features', 'architecture'] },
+    { id: 'metrics_scope',        title: SECTION_TITLES.metrics_scope,        order: 9,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features'] },
+    { id: 'implementation_plan',  title: SECTION_TITLES.implementation_plan,  order: 10, risk: 'high', estimatedSeconds: 30, dependencies: ['features', 'data_model', 'architecture'] },
 ];
+
+/** Lookup of estimated wall-clock seconds per section, derived from DEFAULT_PRD_SECTIONS. */
+export const SECTION_ESTIMATES_S: Record<string, number> = Object.fromEntries(
+    DEFAULT_PRD_SECTIONS.map(s => [s.id, s.estimatedSeconds]),
+);
 
 const nowIso = () => new Date().toISOString();
 

--- a/src/lib/services/progressivePrdPipeline.ts
+++ b/src/lib/services/progressivePrdPipeline.ts
@@ -20,6 +20,8 @@ export type SectionStatusUpdate = {
     model?: string;
     ms?: number;
     error?: string;
+    /** Rough wall-clock estimate (seconds) shown in the progress UI. */
+    estimatedSeconds?: number;
 };
 
 export interface ProgressivePrdPipelineOptions extends PrdPipelineOptions {
@@ -79,13 +81,16 @@ export const runProgressivePrdPipeline = async (
         onEvent: (event) => {
             if (event.type === 'section_started') {
                 sectionStarts[event.sectionId] = performance.now();
-                onProgress?.(`Generating ${
-                    DEFAULT_PRD_SECTIONS.find(s => s.id === event.sectionId)?.title ?? event.sectionId
-                } (${event.modelTier === 'fast' ? 'Flash' : 'Pro'})…`);
+                const startedSection = DEFAULT_PRD_SECTIONS.find(s => s.id === event.sectionId);
+                const tierLabel = event.modelTier === 'fast' ? 'Flash' : 'Pro';
+                const estimate = startedSection?.estimatedSeconds;
+                const estimateSuffix = estimate ? ` · ~${estimate}s` : '';
+                onProgress?.(`Generating ${startedSection?.title ?? event.sectionId} (${tierLabel}${estimateSuffix})…`);
                 onSectionStatus?.(event.sectionId as SectionId, {
                     tier: event.modelTier === 'fast' ? 'fast' : 'strong',
                     status: 'generating',
                     model: event.model,
+                    estimatedSeconds: estimate,
                 });
             } else if (event.type === 'section_completed') {
                 const ms = performance.now() - (sectionStarts[event.sectionId] ?? overallStart);

--- a/src/store/slices/prdProgressSlice.ts
+++ b/src/store/slices/prdProgressSlice.ts
@@ -13,6 +13,10 @@ export interface PrdSectionStatusEntry {
     model?: string;
     ms?: number;
     error?: string;
+    /** Rough wall-clock estimate (seconds) for this section. */
+    estimatedSeconds?: number;
+    /** Wall-clock start timestamp (ms) — set when status flips to 'generating'. */
+    startedAt?: number;
 }
 
 export type PrdProgressSlice = {
@@ -73,12 +77,18 @@ export const createPrdProgressSlice: StateCreator<
         set((state) => {
             const current = state.prdSectionStatus[projectId] ?? {} as Record<SectionId, PrdSectionStatusEntry>;
             const existing = current[sectionId] ?? { tier: update.tier ?? 'strong', status: 'pending' };
+            const merged: PrdSectionStatusEntry = { ...existing, ...update };
+            // Stamp wall-clock start the first time a section flips to 'generating'
+            // so the live elapsed counter has a stable origin across re-renders.
+            if (update.status === 'generating' && !merged.startedAt) {
+                merged.startedAt = Date.now();
+            }
             return {
                 prdSectionStatus: {
                     ...state.prdSectionStatus,
                     [projectId]: {
                         ...current,
-                        [sectionId]: { ...existing, ...update },
+                        [sectionId]: merged,
                     },
                 },
             };


### PR DESCRIPTION
The PRD page now uses max-w-4xl (was max-w-2xl) so the structured/markdown
view fills the workspace instead of leaving large empty margins on either
side. Each PRD section template gains an estimatedSeconds field that flows
through the progress pipeline into the GenerationProgress section grid:
queued sections show "~Ns", active sections show a live elapsed counter
("5s / ~25s") that turns amber when the run overshoots, and completed
sections still show their actual duration. The live header line also
includes the estimate, e.g. "Generating Features (Pro · ~35s)…".