### PR TITLE
fix(artifacts): flatten dep graph so generation runs in parallel

### DIFF
--- a/src/lib/__tests__/coreArtifactPipeline.test.ts
+++ b/src/lib/__tests__/coreArtifactPipeline.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+    CORE_ARTIFACT_PIPELINE,
+    buildDependencyLayers,
+    getArtifactMeta,
+} from '../coreArtifactPipeline';
+
+describe('coreArtifactPipeline', () => {
+    it('every dependency references a real subtype', () => {
+        const subtypes = new Set(CORE_ARTIFACT_PIPELINE.map(m => m.subtype));
+        for (const meta of CORE_ARTIFACT_PIPELINE) {
+            for (const dep of meta.dependsOn) {
+                expect(subtypes.has(dep)).toBe(true);
+            }
+        }
+    });
+
+    it('layers are topologically valid — every dep is in an earlier layer', () => {
+        const layers = buildDependencyLayers();
+        const placed = new Map<string, number>();
+        layers.forEach((layer, i) => layer.forEach(meta => placed.set(meta.subtype, i)));
+        for (const [subtype, layerIdx] of placed) {
+            const meta = getArtifactMeta(subtype as never);
+            for (const dep of meta.dependsOn) {
+                const depLayer = placed.get(dep)!;
+                expect(depLayer).toBeLessThan(layerIdx);
+            }
+        }
+    });
+
+    it('parallelism: layer 1 fans out to >= 4 artifacts so generation feels parallel', () => {
+        const layers = buildDependencyLayers();
+        // The first layer dictates the initial concurrency the user sees in
+        // the right rail. Anything less than 4 means the UI shows a single
+        // spinner at start, which feels sequential. This is intentionally a
+        // stronger floor than the topological-validity check.
+        expect(layers[0].length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('depth: <= 2 sequential layers so the worst-case waiter is one hop deep', () => {
+        const layers = buildDependencyLayers();
+        expect(layers.length).toBeLessThanOrEqual(2);
+    });
+
+    it('buildDependencyLayers throws on an unsatisfiable graph', () => {
+        expect(() =>
+            buildDependencyLayers([
+                {
+                    subtype: 'screen_inventory',
+                    title: 'A',
+                    description: '',
+                    dependsOn: ['user_flows'],
+                    displayOrder: 1,
+                },
+                {
+                    subtype: 'user_flows',
+                    title: 'B',
+                    description: '',
+                    dependsOn: ['screen_inventory'],
+                    displayOrder: 2,
+                },
+            ]),
+        ).toThrow();
+    });
+});

--- a/src/lib/coreArtifactPipeline.ts
+++ b/src/lib/coreArtifactPipeline.ts
@@ -11,6 +11,13 @@ export interface CoreArtifactMeta {
 
 // Pipeline is ordered so dependencies appear before dependents (topologically valid).
 // Use CORE_ARTIFACT_DISPLAY_ORDER for UI rendering instead of this array.
+//
+// Dependency rule of thumb: only declare a dep when the dependent artifact
+// genuinely needs the dep's *output* to be high quality (e.g. user_flows
+// referencing screen names from screen_inventory). The PRD itself is in every
+// prompt, so most artifacts can be generated independently from it. Spurious
+// deps serialize the pipeline — buildDependencyLayers turns them into wait
+// gates — which kneecaps parallelism with little quality benefit.
 export const CORE_ARTIFACT_PIPELINE: CoreArtifactMeta[] = [
     {
         subtype: 'screen_inventory',
@@ -30,28 +37,28 @@ export const CORE_ARTIFACT_PIPELINE: CoreArtifactMeta[] = [
         subtype: 'component_inventory',
         title: 'Component Inventory',
         description: 'Reusable components implied by the product design',
-        dependsOn: ['screen_inventory', 'user_flows'],
+        dependsOn: ['screen_inventory'],
         displayOrder: 4,
     },
     {
         subtype: 'data_model',
         title: 'Data Model Draft',
         description: 'Primary entities, relationships, and data needs',
-        dependsOn: ['user_flows'],
+        dependsOn: [],
         displayOrder: 1,
     },
     {
         subtype: 'implementation_plan',
         title: 'Implementation Plan',
         description: 'High-level build sequence and milestone-oriented dev plan',
-        dependsOn: ['component_inventory', 'data_model'],
+        dependsOn: [],
         displayOrder: 6,
     },
     {
         subtype: 'design_system',
         title: 'Design System Starter',
         description: 'Foundational UI system draft with patterns and components',
-        dependsOn: ['component_inventory'],
+        dependsOn: [],
         displayOrder: 5,
     },
     {


### PR DESCRIPTION
The right-rail "Generation Status" was showing one core artifact running
with six queued because the dependency chain serialized the pipeline into
five layers of one or two items each. The PRD itself is in every prompt,
so most cross-artifact deps were informational, not load-bearing.

Drop spurious deps:
- component_inventory no longer waits on user_flows
- data_model no longer waits on user_flows
- design_system no longer waits on component_inventory
- implementation_plan no longer waits on component_inventory + data_model

Kept the genuinely load-bearing deps:
- user_flows still consumes screen_inventory (for screen names)
- component_inventory still consumes screen_inventory (for screen names)
- prompt_pack still consumes implementation_plan, design_system, and
  data_model (its job is to summarize them)

Result: layer 1 now fans out to 4 parallel core artifacts plus the
mockup bucket, so the user sees ~5 generating + 3 queued at start
instead of 1 + 6.

Add coreArtifactPipeline.test.ts to lock in the parallelism floor and
catch regressions in dep validity / topology depth.

https://claude.ai/code/session_01UnTcyXV7ttYZdHDoxSkQ1t