### PR TITLE
Fix infinite render loops and improve mockup error recovery

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -232,7 +232,7 @@ export function ArtifactWorkspace({
                             <RefreshCcw size={12} /> Regenerate Mockup
                         </button>
                     </div>
-                    <MockupErrorBoundary>
+                    <MockupErrorBoundary resetKey={preferred.id}>
                         <MockupViewer
                             payload={payload}
                             settings={settings}

--- a/src/components/mockups/MockupErrorBoundary.tsx
+++ b/src/components/mockups/MockupErrorBoundary.tsx
@@ -1,42 +1,80 @@
 import { Component } from 'react';
 import type { ReactNode, ErrorInfo } from 'react';
+import { RefreshCcw } from 'lucide-react';
 
 interface Props {
     children: ReactNode;
     /** Rendered when the child tree throws during render. */
     fallback?: ReactNode;
+    /**
+     * When this value changes between renders, the boundary clears its
+     * error state and re-attempts rendering its children. Pass something
+     * that uniquely identifies the rendered content (e.g. the mockup
+     * version id) so navigating to a different version automatically
+     * recovers without a manual click.
+     */
+    resetKey?: string | number;
 }
 
 interface State {
     hasError: boolean;
+    /** Snapshot of resetKey at the time the error was captured. */
+    capturedResetKey?: string | number;
 }
 
 /**
  * Lightweight error boundary scoped to mockup rendering. If the MockupViewer
- * or MockupHtmlPreview tree throws (e.g. due to corrupted payload data), this
- * catches it and shows a clean placeholder instead of crashing the entire
- * MockupsView panel.
+ * or MockupHtmlPreview tree throws (e.g. due to corrupted payload data or an
+ * infinite render loop), this catches it and shows a clean placeholder
+ * instead of crashing the entire MockupsView panel. The fallback exposes a
+ * "Try again" button so users aren't trapped on the error UI when the
+ * surrounding app state has moved on.
  */
 export class MockupErrorBoundary extends Component<Props, State> {
     state: State = { hasError: false };
 
-    static getDerivedStateFromError(): State {
+    static getDerivedStateFromError(): Partial<State> {
         return { hasError: true };
+    }
+
+    static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
+        // Auto-reset when the caller swaps to a different rendered subject
+        // (e.g. switching mockup version). Without this, hasError stays true
+        // forever once a render has thrown — even after the user navigates
+        // away — and they get stuck on the fallback indefinitely.
+        if (state.hasError && state.capturedResetKey !== props.resetKey) {
+            return { hasError: false, capturedResetKey: undefined };
+        }
+        return null;
     }
 
     componentDidCatch(error: Error, info: ErrorInfo) {
         console.error('[MockupErrorBoundary] Render crash caught:', error, info.componentStack);
+        this.setState({ capturedResetKey: this.props.resetKey });
     }
+
+    private handleReset = () => {
+        this.setState({ hasError: false, capturedResetKey: undefined });
+    };
 
     render() {
         if (this.state.hasError) {
-            return this.props.fallback ?? (
+            if (this.props.fallback !== undefined) return this.props.fallback;
+            return (
                 <div className="bg-white rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500">
                     <p className="font-medium text-neutral-700 mb-1">Unable to render this mockup</p>
                     <p>
                         Something went wrong while displaying this version. Try regenerating the mockup
                         or selecting a different version.
                     </p>
+                    <button
+                        type="button"
+                        onClick={this.handleReset}
+                        className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-xs text-neutral-700 hover:bg-neutral-50 transition"
+                    >
+                        <RefreshCcw size={12} />
+                        Try again
+                    </button>
                 </div>
             );
         }

--- a/src/lib/designTokens/storeSelectors.ts
+++ b/src/lib/designTokens/storeSelectors.ts
@@ -13,6 +13,28 @@ interface MinimalArtifactState {
     artifactVersions: Record<string, ArtifactVersion[]>;
 }
 
+// Reference-stable normalization cache. `normalizeDesignTokens` allocates
+// fresh nested objects on every call, so calling it inside a Zustand
+// selector (`useProjectStore(state => selectPreferredDesignTokens(...))`)
+// produced a brand-new tokens reference on every store update — Zustand's
+// default `Object.is` equality then schedules a re-render, which re-runs
+// the selector, which produces yet another reference. The result is
+// React error #185 ("Maximum update depth exceeded"). Caching keyed on the
+// ArtifactVersion identity guarantees the same version always yields the
+// same DesignTokens reference. WeakMap means the cache cleans itself when
+// the version is evicted from the store.
+const TOKENS_CACHE = new WeakMap<ArtifactVersion, DesignTokens>();
+
+function memoizedNormalize(version: ArtifactVersion, raw: unknown): DesignTokens | null {
+    if (!raw || typeof raw !== 'object') return null;
+    let cached = TOKENS_CACHE.get(version);
+    if (!cached) {
+        cached = normalizeDesignTokens(raw);
+        TOKENS_CACHE.set(version, cached);
+    }
+    return cached;
+}
+
 /**
  * Resolve the preferred Design System artifact + its tokens for a given
  * project. Returns `null` when there is no design_system artifact, no
@@ -37,10 +59,9 @@ export function selectPreferredDesignSystem(
     const preferred = versions.find(v => v.id === designSystem.currentVersionId);
     if (!preferred) return null;
 
-    const rawTokens = preferred.metadata?.tokens;
+    const tokens = memoizedNormalize(preferred, preferred.metadata?.tokens);
+    if (!tokens) return null;
     const rawHash = preferred.metadata?.tokensHash;
-    if (!rawTokens || typeof rawTokens !== 'object') return null;
-    const tokens = normalizeDesignTokens(rawTokens);
     const tokensHash = typeof rawHash === 'string' ? rawHash : '';
     return {
         artifactId: designSystem.id,
@@ -53,7 +74,9 @@ export function selectPreferredDesignSystem(
 /**
  * Convenience: returns just the DesignTokens for a project (or undefined
  * if no tokens are available). Suitable for cheap consumer code that
- * doesn't need the artifact id / hash.
+ * doesn't need the artifact id / hash. Reference-stable across calls for
+ * the same underlying ArtifactVersion — safe to use directly inside a
+ * Zustand selector.
  */
 export function selectPreferredDesignTokens(
     state: MinimalArtifactState,


### PR DESCRIPTION
## Summary
This PR addresses two critical issues: infinite render loops caused by unstable object references in design token selectors, and poor error recovery UX in the mockup error boundary.

## Key Changes

- **MockupErrorBoundary improvements**
  - Added `resetKey` prop to automatically clear error state when the rendered subject changes (e.g., switching mockup versions)
  - Implemented `getDerivedStateFromProps` to detect when `resetKey` changes and auto-recover from errors
  - Added "Try again" button to the default fallback UI so users can manually retry rendering
  - Improved JSDoc to clarify the auto-recovery behavior and use cases

- **Design token selector memoization**
  - Introduced `TOKENS_CACHE` WeakMap to cache normalized design tokens by ArtifactVersion identity
  - Created `memoizedNormalize` function to ensure the same ArtifactVersion always returns the same DesignTokens reference
  - This prevents React error #185 ("Maximum update depth exceeded") caused by fresh object allocations on every selector call
  - WeakMap automatically cleans up cached entries when versions are evicted from the store

- **ArtifactWorkspace integration**
  - Connected MockupErrorBoundary's `resetKey` to the preferred artifact version ID so errors auto-clear on version changes

## Notable Implementation Details

The design token caching uses a WeakMap keyed on ArtifactVersion objects rather than string IDs. This ensures:
1. Reference stability across Zustand selector calls (preventing unnecessary re-renders)
2. Automatic garbage collection when versions are removed from the store
3. No manual cache invalidation logic needed

The error boundary's auto-recovery via `getDerivedStateFromProps` ensures users aren't trapped on the error UI when the surrounding app state has moved on (e.g., after navigating to a different mockup version).

https://claude.ai/code/session_01Y9qER92E7zvVTfUjHSUUW4