### PR TITLE
Refactor ScreenInventoryRenderer: extract components & enhance UX

### DIFF
--- a/src/components/renderers/ScreenInventoryRenderer.BACKLOG.md
+++ b/src/components/renderers/ScreenInventoryRenderer.BACKLOG.md
@@ -1,0 +1,37 @@
+# Screen Inventory — Backlog
+
+Deferred features for the structured Screen Inventory artifact. Documented
+here per the formatting refactor brief; **not implemented** in the current
+pass.
+
+## UX
+
+- **Clickable Linked-Feature pills** — tapping a feature pill (e.g. `f8
+  Ingredient Aggregation`) opens a side panel with the full feature
+  description, originating PRD section, and the other screens that
+  reference it. Requires an artifact-wide feature lookup and a generic
+  side-panel primitive that doesn't yet exist; see also the
+  Implementation-Plan backlog item for a similar cross-artifact anchor
+  scheme.
+- **Filter / sort screens** — by priority (P0 → P3), linked feature, or
+  flow membership, scoped to a section or to the whole artifact.
+- **Mini-map / overview visualization** — a top-of-artifact diagram of
+  all screens and the journeys between them, using `flowSummary` per
+  section plus `entryPoints` / `exitPaths` per screen. Likely a hand-
+  rolled SVG or `react-flow` graph.
+- **Audience modes** — PM / Design / Engineering toggles that re-rank or
+  hide subsections per audience (e.g. Engineering hides Intent and
+  Outputs but emphasizes States and Risks).
+
+## Data quality
+
+- **Validation overlays** — surface orphan screens (no entry points),
+  dead-end exits (target not present in inventory), missing required
+  states (e.g. an "input" screen with no error state). Render as a
+  per-card warning chip plus a section-header summary count.
+
+## Integration
+
+- **Artifact navigation** — clicking a Linked-Feature pill could jump to
+  the feature's anchor inside the PRD artifact once a cross-artifact
+  anchor scheme exists.

--- a/src/components/renderers/ScreenInventoryRenderer.tsx
+++ b/src/components/renderers/ScreenInventoryRenderer.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { AlertTriangle, ArrowRight } from 'lucide-react';
+import { useEffect, type ReactNode } from 'react';
+import { AlertTriangle, ChevronRight, ArrowRight } from 'lucide-react';
 import type { ExitPath, ScreenItem, ScreenPriority, ScreenState } from '../../types';
 import { ScreenImageGallery, type ScreenImageGalleryContext } from './ScreenImageGallery';
 import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
@@ -30,26 +30,16 @@ export function ScreenInventoryRenderer({ content, imageContext }: Props) {
     if (!inventory) return null;
 
     return (
-        <div className="space-y-8">
+        <div className="space-y-10">
             {inventory.sections.map((section, sectionIndex) => (
                 <section key={sectionIndex}>
-                    <header className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
-                        <div>
-                            <h3 className="text-base font-semibold text-neutral-800">
-                                <span className="text-neutral-400 font-normal mr-2">{sectionIndex + 1}.</span>
-                                {section.title}
-                            </h3>
-                            {section.description && (
-                                <p className="text-xs text-neutral-500 mt-0.5">{section.description}</p>
-                            )}
-                        </div>
-                        {section.flowSummary && (
-                            <p className="text-[11px] font-mono text-neutral-500 bg-neutral-50 rounded px-2 py-1">
-                                <span className="text-neutral-400 mr-1">flow:</span>
-                                {section.flowSummary}
-                            </p>
-                        )}
-                    </header>
+                    <SectionHeader
+                        index={sectionIndex}
+                        title={section.title}
+                        description={section.description}
+                        screenCount={section.screens.length}
+                        flowSummary={section.flowSummary}
+                    />
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
                         {section.screens.map((screen, screenIndex) => (
                             <ScreenCard
@@ -61,6 +51,69 @@ export function ScreenInventoryRenderer({ content, imageContext }: Props) {
                     </div>
                 </section>
             ))}
+        </div>
+    );
+}
+
+function SectionHeader({
+    index,
+    title,
+    description,
+    screenCount,
+    flowSummary,
+}: {
+    index: number;
+    title: string;
+    description?: string;
+    screenCount: number;
+    flowSummary?: string;
+}) {
+    const journeySteps = parseJourney(flowSummary);
+    return (
+        <header className="mb-4 space-y-3">
+            <div>
+                <h3 className="text-base font-semibold text-neutral-800">
+                    <span className="text-neutral-400 font-normal mr-2">{index + 1}.</span>
+                    {title}
+                </h3>
+                {description && (
+                    <p className="text-xs text-neutral-500 mt-1">{description}</p>
+                )}
+                <div className="mt-1.5 text-[11px] uppercase tracking-wide text-neutral-400">
+                    {screenCount} {screenCount === 1 ? 'screen' : 'screens'}
+                </div>
+            </div>
+            {journeySteps.length > 0 && <JourneyRow steps={journeySteps} />}
+        </header>
+    );
+}
+
+function parseJourney(flowSummary?: string): string[] {
+    if (!flowSummary) return [];
+    return flowSummary
+        .split(/\s*(?:→|->|»|>)\s*/)
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+}
+
+function JourneyRow({ steps }: { steps: string[] }) {
+    return (
+        <div className="rounded-md border border-neutral-200 bg-neutral-50/60 px-3 py-2">
+            <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1.5">
+                Journey
+            </div>
+            <div className="flex items-center gap-1.5 overflow-x-auto flex-nowrap sm:flex-wrap pb-0.5">
+                {steps.map((step, i) => (
+                    <div key={i} className="flex items-center gap-1.5 shrink-0">
+                        <span className="text-xs bg-white text-neutral-700 px-2 py-1 rounded-md border border-neutral-200 shadow-sm whitespace-nowrap">
+                            {step}
+                        </span>
+                        {i < steps.length - 1 && (
+                            <ChevronRight size={14} className="text-neutral-400 shrink-0" aria-hidden />
+                        )}
+                    </div>
+                ))}
+            </div>
         </div>
     );
 }
@@ -79,9 +132,12 @@ function ScreenCard({
         ? screen.priority
         : 'P1') as ScreenPriority;
 
+    const hasNavigation = (screen.entryPoints?.length ?? 0) > 0
+        || (screen.exitPaths?.length ?? 0) > 0;
+
     return (
-        <article className="bg-white rounded-lg border border-neutral-200 p-4 space-y-3">
-            <header className="flex items-center justify-between gap-2">
+        <article className="bg-white rounded-lg border border-neutral-200 p-4 space-y-3.5">
+            <header className="flex items-start justify-between gap-2">
                 <h4 className="font-semibold text-neutral-800 text-sm leading-tight">
                     {screen.name}
                 </h4>
@@ -97,56 +153,62 @@ function ScreenCard({
                 </div>
             </header>
 
-            <p className="text-xs text-neutral-700">{screen.purpose}</p>
+            {screen.purpose && (
+                <p className="text-xs leading-relaxed text-neutral-700">{screen.purpose}</p>
+            )}
 
             {screen.userIntent && (
-                <p className="text-xs italic text-neutral-500">
-                    <span className="not-italic font-medium text-neutral-600 mr-1">Intent:</span>
-                    {screen.userIntent}
-                </p>
+                <CardField label="Intent">
+                    <p className="text-xs italic text-neutral-600">{screen.userIntent}</p>
+                </CardField>
             )}
 
             {screen.states && screen.states.length > 0 && (
-                <StatesRow states={screen.states} />
+                <CardField label="States">
+                    <div className="flex flex-wrap gap-1">
+                        {screen.states.map((s, i) => (
+                            <StateChip key={i} state={s} />
+                        ))}
+                    </div>
+                </CardField>
             )}
 
-            {(screen.entryPoints?.length || screen.exitPaths?.length) ? (
-                <FlowBlock screen={screen} />
-            ) : null}
+            {hasNavigation && <NavigationBlock screen={screen} />}
 
             {ui.length > 0 && (
-                <div>
-                    <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">Core UI</div>
+                <CardField label="Core UI">
                     <div className="flex flex-wrap gap-1">
                         {ui.map((c, ci) => (
-                            <span key={ci} className="text-xs bg-neutral-100 text-neutral-600 px-1.5 py-0.5 rounded">
+                            <span
+                                key={ci}
+                                className="text-xs bg-neutral-100 text-neutral-700 px-1.5 py-0.5 rounded"
+                            >
                                 {c}
                             </span>
                         ))}
                     </div>
-                </div>
+                </CardField>
             )}
 
             {screen.outputData && screen.outputData.length > 0 && (
-                <div className="text-xs">
-                    <span className="text-[10px] uppercase tracking-wide text-neutral-400 mr-1">Outputs:</span>
-                    <span className="text-neutral-600">{screen.outputData.join(' · ')}</span>
-                </div>
+                <CardField label="Outputs">
+                    <ul className="text-xs text-neutral-700 space-y-0.5">
+                        {screen.outputData.map((o, i) => (
+                            <li key={i} className="flex gap-1.5">
+                                <span className="text-neutral-300 select-none">·</span>
+                                <span>{o}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </CardField>
             )}
 
             {screen.risks && screen.risks.length > 0 && (
-                <div className="rounded bg-amber-50 border border-amber-200 px-2 py-1.5 flex gap-1.5 items-start">
-                    <AlertTriangle size={12} className="text-amber-600 mt-0.5 shrink-0" />
-                    <ul className="text-xs text-amber-800 space-y-0.5">
-                        {screen.risks.map((r, ri) => <li key={ri}>{r}</li>)}
-                    </ul>
-                </div>
+                <RisksBlock risks={screen.risks} />
             )}
 
             {screen.featureRefs && screen.featureRefs.length > 0 && (
-                <div className="text-[10px] font-mono text-neutral-400">
-                    {screen.featureRefs.join(' · ')}
-                </div>
+                <LinkedFeatures refs={screen.featureRefs} />
             )}
 
             {imageContext && <ScreenImageGallery screen={screen} context={imageContext} />}
@@ -154,58 +216,131 @@ function ScreenCard({
     );
 }
 
-function StatesRow({ states }: { states: ScreenState[] }) {
+function CardField({ label, children }: { label: string; children: ReactNode }) {
     return (
         <div>
-            <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">States</div>
-            <div className="flex flex-wrap gap-1">
-                {states.map((s, i) => (
-                    <span
-                        key={i}
-                        title={[s.description, s.trigger ? `Trigger: ${s.trigger}` : null, s.recoveryPath ? `Recovery: ${s.recoveryPath}` : null]
-                            .filter(Boolean).join('\n')}
-                        className="text-xs bg-neutral-100 text-neutral-700 px-1.5 py-0.5 rounded border border-neutral-200"
-                    >
-                        {s.name}
-                    </span>
-                ))}
+            <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">
+                {label}
+            </div>
+            {children}
+        </div>
+    );
+}
+
+function StateChip({ state }: { state: ScreenState }) {
+    const tooltip = [
+        state.description,
+        state.trigger ? `Trigger: ${state.trigger}` : null,
+        state.recoveryPath ? `Recovery: ${state.recoveryPath}` : null,
+    ].filter(Boolean).join('\n');
+    return (
+        <span
+            title={tooltip}
+            className="text-xs bg-neutral-100 text-neutral-700 px-1.5 py-0.5 rounded border border-neutral-200"
+        >
+            {state.name}
+        </span>
+    );
+}
+
+function NavigationBlock({ screen }: { screen: ScreenItem }) {
+    const entry = screen.entryPoints ?? [];
+    const exits: ExitPath[] = screen.exitPaths ?? [];
+    return (
+        <div>
+            <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1.5">
+                Navigation
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                {entry.length > 0 && (
+                    <div>
+                        <div className="text-[10px] font-medium text-neutral-500 mb-1">Entry</div>
+                        <ul className="text-neutral-700 space-y-0.5">
+                            {entry.map((e, i) => (
+                                <li key={i} className="flex gap-1.5">
+                                    <span className="text-neutral-300 select-none">·</span>
+                                    <span>{e}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+                {exits.length > 0 && (
+                    <div>
+                        <div className="text-[10px] font-medium text-neutral-500 mb-1">Exit</div>
+                        <ul className="text-neutral-700 space-y-1">
+                            {exits.map((p, i) => (
+                                <li key={i}>
+                                    <div className="flex items-center gap-1 flex-wrap">
+                                        <span>{p.label}</span>
+                                        <ArrowRight size={10} className="text-neutral-400 shrink-0" aria-hidden />
+                                        <span className="text-neutral-700">{p.target}</span>
+                                    </div>
+                                    {p.condition && (
+                                        <div className="text-[11px] text-neutral-400 italic mt-0.5">
+                                            when {p.condition}
+                                        </div>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
             </div>
         </div>
     );
 }
 
-function FlowBlock({ screen }: { screen: ScreenItem }) {
-    const entry = screen.entryPoints ?? [];
-    const exits: ExitPath[] = screen.exitPaths ?? [];
+function RisksBlock({ risks }: { risks: string[] }) {
     return (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
-            {entry.length > 0 && (
-                <div>
-                    <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">Entry</div>
-                    <ul className="text-neutral-600 space-y-0.5">
-                        {entry.map((e, i) => (
-                            <li key={i}>· {e}</li>
-                        ))}
-                    </ul>
-                </div>
-            )}
-            {exits.length > 0 && (
-                <div>
-                    <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">Exits</div>
-                    <ul className="text-neutral-600 space-y-0.5">
-                        {exits.map((p, i) => (
-                            <li key={i} className="flex items-center gap-1 flex-wrap">
-                                <span>{p.label}</span>
-                                <ArrowRight size={10} className="text-neutral-400 shrink-0" />
-                                <span className="text-neutral-700">{p.target}</span>
-                                {p.condition && (
-                                    <span className="text-neutral-400 italic">— {p.condition}</span>
-                                )}
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            )}
+        <div>
+            <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">
+                Risks / Edge Cases
+            </div>
+            <ul className="text-xs text-amber-800 space-y-1">
+                {risks.map((r, i) => (
+                    <li key={i} className="flex gap-1.5 items-start">
+                        <AlertTriangle size={12} className="text-amber-600 mt-0.5 shrink-0" aria-hidden />
+                        <span>{r}</span>
+                    </li>
+                ))}
+            </ul>
         </div>
+    );
+}
+
+const FEATURE_REF_PATTERN = /^(f-?\d+|feat-?\d+)\b\s*[:\-—]?\s*(.*)$/i;
+
+function parseFeatureRef(ref: string): { id: string; label?: string } {
+    const trimmed = ref.trim();
+    const match = trimmed.match(FEATURE_REF_PATTERN);
+    if (match) {
+        const id = match[1];
+        const label = match[2]?.trim();
+        return { id, label: label && label.length > 0 ? label : undefined };
+    }
+    return { id: trimmed };
+}
+
+function LinkedFeatures({ refs }: { refs: string[] }) {
+    return (
+        <CardField label="Linked Features">
+            <div className="flex flex-wrap gap-1">
+                {refs.map((ref, i) => {
+                    const { id, label } = parseFeatureRef(ref);
+                    return (
+                        <span
+                            key={i}
+                            className="inline-flex items-center gap-1 text-[11px] bg-violet-50 text-violet-700 ring-1 ring-violet-200 rounded-md px-1.5 py-0.5"
+                        >
+                            <span className="font-mono font-medium">{id}</span>
+                            {label && (
+                                <span className="text-violet-600/90">{label}</span>
+                            )}
+                        </span>
+                    );
+                })}
+            </div>
+        </CardField>
     );
 }

--- a/src/components/renderers/__tests__/index.test.tsx
+++ b/src/components/renderers/__tests__/index.test.tsx
@@ -57,6 +57,46 @@ describe('ArtifactContentRenderer', () => {
         expect(container).toHaveTextContent('Text Fallback');
         // Risk callout copy.
         expect(container).toHaveTextContent('Camera permission denied');
+        // Section-level Journey row (replaces the old `flow:` text).
+        expect(container).toHaveTextContent('Journey');
+        expect(container).not.toHaveTextContent(/^\s*flow:/);
+        expect(container).toHaveTextContent('Landing');
+        expect(container).toHaveTextContent('Capture');
+        expect(container).toHaveTextContent('Player');
+        // Card-level Navigation subsection groups Entry + Exit.
+        expect(container).toHaveTextContent('Navigation');
+        expect(container).toHaveTextContent('Entry');
+        expect(container).toHaveTextContent('Exit');
+        // Linked Features label + the feature ref still surfaces.
+        expect(container).toHaveTextContent('Linked Features');
+        expect(container).toHaveTextContent('F-014');
+        // Screen count metadata.
+        expect(container).toHaveTextContent('1 screen');
+    });
+
+    it('renders feature ref pills with id + label when refs include names', () => {
+        const jsonContent = JSON.stringify({
+            sections: [{
+                title: 'Household Meal Logistics',
+                screens: [{
+                    name: 'Smart Grocery List',
+                    priority: 'P0',
+                    purpose: 'Aggregate ingredients into a shopping list',
+                    featureRefs: ['f8 Ingredient Aggregation', 'f10 Grocery Export', 'f12'],
+                }],
+            }],
+        });
+        const { container } = render(
+            <ArtifactContentRenderer subtype="screen_inventory" content={jsonContent} />
+        );
+        expect(container).toHaveTextContent('Linked Features');
+        // Ids and human-readable labels both render.
+        expect(container).toHaveTextContent('f8');
+        expect(container).toHaveTextContent('Ingredient Aggregation');
+        expect(container).toHaveTextContent('f10');
+        expect(container).toHaveTextContent('Grocery Export');
+        // Bare ids without a label still render.
+        expect(container).toHaveTextContent('f12');
     });
 
     it('renders legacy groups + core/secondary priorities by normalizing on read', () => {


### PR DESCRIPTION
## Summary

Refactored the `ScreenInventoryRenderer` component to improve code organization, maintainability, and user experience. Extracted inline markup into reusable sub-components and enhanced the visual presentation of screen metadata, navigation flows, and feature references.

## Key Changes

- **Extracted `SectionHeader` component** — moved section-level header logic out of the main render loop; now displays section title, description, screen count, and a new journey visualization
- **Added `JourneyRow` component** — parses and visualizes `flowSummary` as a step-by-step journey with chevron separators; replaces the inline `flow:` text label with a more prominent, structured layout
- **Extracted `CardField` component** — reusable wrapper for screen card subsections (Intent, States, Core UI, Outputs, etc.) with consistent label styling
- **Extracted `StateChip` component** — isolated state badge rendering with tooltip support
- **Renamed & refactored `FlowBlock` → `NavigationBlock`** — consolidated entry points and exit paths under a single "Navigation" section; improved layout and condition display
- **Extracted `RisksBlock` component** — separated risk/edge-case rendering with improved list styling and icon alignment
- **Extracted `LinkedFeatures` component** — new feature reference display with `parseFeatureRef()` utility to parse and render feature IDs and optional labels (e.g., `f8 Ingredient Aggregation`)
- **Updated imports** — added `ReactNode` type and `ChevronRight` icon for journey visualization
- **Enhanced spacing & typography** — adjusted margins, padding, and text sizes throughout for better visual hierarchy and readability
- **Improved accessibility** — added `aria-hidden` attributes to decorative icons

## Notable Implementation Details

- `parseJourney()` utility splits `flowSummary` on arrow delimiters (`→`, `->`, `»`, `>`) to extract individual journey steps
- `parseFeatureRef()` utility uses regex pattern matching to extract feature ID and optional label from refs like `"f8 Ingredient Aggregation"`
- Screen count metadata now displays at the section level (e.g., "3 screens")
- Navigation block now groups entry and exit paths under a single "Navigation" label with improved visual separation
- Added `ScreenInventoryRenderer.BACKLOG.md` documenting deferred features (clickable feature pills, filtering, mini-map visualization, audience modes, validation overlays, cross-artifact navigation)
- Test coverage updated to verify journey rendering, navigation grouping, linked features display, and feature ref parsing with labels

https://claude.ai/code/session_019VdDTSqZUd2qc1GDCC11hq