### PR TITLE
Fix infinite update loop in useDownstreamSummary with Zustand v5

### DIFF
--- a/src/components/renderers/DesignSystemRenderer.tsx
+++ b/src/components/renderers/DesignSystemRenderer.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -350,7 +351,11 @@ interface DownstreamSummary {
 }
 
 function useDownstreamSummary(projectId: string | undefined): DownstreamSummary | null {
-    return useProjectStore(state => {
+    // useShallow is required: Zustand v5's useSyncExternalStore-based subscription
+    // calls getSnapshot multiple times per render and compares with Object.is —
+    // returning a fresh `{ mockupCount, componentInventoryExists }` object on each
+    // call triggers React error #185 ("Maximum update depth exceeded").
+    return useProjectStore(useShallow(state => {
         if (!projectId) return null;
         const artifacts = state.artifacts[projectId] ?? [];
         const mockupCount = artifacts.filter(a => a.type === 'mockup' && a.status !== 'archived').length;
@@ -358,7 +363,7 @@ function useDownstreamSummary(projectId: string | undefined): DownstreamSummary 
             a => a.type === 'core_artifact' && a.subtype === 'component_inventory' && a.status !== 'archived',
         );
         return { mockupCount, componentInventoryExists };
-    });
+    }));
 }
 
 function DownstreamUsage({ projectId }: { projectId?: string }) {


### PR DESCRIPTION
## Summary
Fixed a React error ("Maximum update depth exceeded") in the `useDownstreamSummary` hook caused by incompatibility with Zustand v5's new subscription mechanism.

## Key Changes
- Added `useShallow` import from `zustand/react/shallow`
- Wrapped the selector function in `useDownstreamSummary` with `useShallow()` to ensure stable object identity across multiple `getSnapshot` calls

## Implementation Details
Zustand v5 changed its internal subscription mechanism to use `useSyncExternalStore`, which calls `getSnapshot` multiple times per render and compares results using `Object.is`. The previous implementation returned a fresh object literal `{ mockupCount, componentInventoryExists }` on each call, causing `Object.is` comparisons to fail and triggering infinite re-renders.

The `useShallow` utility from Zustand performs shallow equality comparison instead of reference equality, preventing the infinite update loop while maintaining the correct behavior when the actual data changes.

https://claude.ai/code/session_01YLh6UEbAcLcdPmisQ5SBV4