### PR TITLE
Remove risks section and reorder features by ID instead of complexity

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -150,7 +150,7 @@ export function ArtifactWorkspace({
     const renderMain = () => {
         if (selected === 'prd') {
             return (
-                <div className="max-w-3xl mx-auto">
+                <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto">
                     <StructuredPRDView
                         projectId={projectId}
                         spineId={spineVersionId}
@@ -282,7 +282,7 @@ export function ArtifactWorkspace({
             }
             : undefined;
         return (
-            <div className="max-w-3xl mx-auto space-y-4">
+            <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto space-y-4">
                 {subtype === 'implementation_plan' && (
                     <div className="flex items-center justify-end">
                         <button

--- a/src/components/prd/ImplementationSummarySection.tsx
+++ b/src/components/prd/ImplementationSummarySection.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ArrowRight, ListChecks, Pause, ShieldQuestion } from 'lucide-react';
+import { ArrowRight, ListChecks, Pause, ShieldQuestion } from 'lucide-react';
 import type { StructuredPRD } from '../../types';
 import {
     deriveImplementationSummary,
@@ -88,7 +88,7 @@ export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
                     Implementation Summary
                 </h3>
                 <span className="text-[11px] text-neutral-400">
-                    Derived from features, risks, assumptions
+                    Derived from features and assumptions
                 </span>
             </div>
 
@@ -117,76 +117,30 @@ export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
                     />
                 </div>
 
-                {(summary.highestRisks.length > 0 || summary.openDecisions.length > 0) && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t border-indigo-100">
-                        {summary.highestRisks.length > 0 && (
-                            <div>
-                                <div className="flex items-center gap-2 mb-2">
-                                    <AlertTriangle size={14} className="text-red-600" />
-                                    <h4 className="text-[11px] font-bold uppercase tracking-wider text-red-700">
-                                        Highest Risks
-                                    </h4>
-                                    <span className="text-[11px] text-neutral-400">{summary.highestRisks.length}</span>
-                                </div>
-                                <ul className="space-y-1.5">
-                                    {summary.highestRisks.map((r, i) => (
-                                        <li
-                                            key={i}
-                                            className="rounded-md border border-red-100 bg-red-50/40 px-3 py-2"
-                                        >
-                                            <div className="flex items-start gap-2">
-                                                <span
-                                                    className={`shrink-0 mt-0.5 inline-block text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${
-                                                        r.likelihood === 'high'
-                                                            ? 'bg-red-200 text-red-900'
-                                                            : r.likelihood === 'med'
-                                                                ? 'bg-amber-200 text-amber-900'
-                                                                : 'bg-neutral-200 text-neutral-700'
-                                                    }`}
-                                                >
-                                                    {r.likelihood}
-                                                </span>
-                                                <div className="min-w-0">
-                                                    <p className="text-sm text-neutral-900">{r.risk}</p>
-                                                    {r.impact && (
-                                                        <p className="text-[11px] text-neutral-600 mt-0.5">
-                                                            {r.impact}
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            </div>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-
-                        {summary.openDecisions.length > 0 && (
-                            <div>
-                                <div className="flex items-center gap-2 mb-2">
-                                    <ShieldQuestion size={14} className="text-amber-700" />
-                                    <h4 className="text-[11px] font-bold uppercase tracking-wider text-amber-700">
-                                        Open Decisions
-                                    </h4>
-                                    <span className="text-[11px] text-neutral-400">{summary.openDecisions.length}</span>
-                                </div>
-                                <ul className="space-y-1.5">
-                                    {summary.openDecisions.map(d => (
-                                        <li
-                                            key={d.id}
-                                            className="rounded-md border border-amber-100 bg-amber-50/40 px-3 py-2"
-                                        >
-                                            <div className="flex items-start gap-2">
-                                                <span className="shrink-0 mt-0.5 text-[10px] font-mono font-bold text-amber-700">
-                                                    {d.id}
-                                                </span>
-                                                <p className="text-sm text-neutral-900">{d.statement}</p>
-                                            </div>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
+                {summary.openDecisions.length > 0 && (
+                    <div className="pt-4 border-t border-indigo-100">
+                        <div className="flex items-center gap-2 mb-2">
+                            <ShieldQuestion size={14} className="text-amber-700" />
+                            <h4 className="text-[11px] font-bold uppercase tracking-wider text-amber-700">
+                                Open Decisions
+                            </h4>
+                            <span className="text-[11px] text-neutral-400">{summary.openDecisions.length}</span>
+                        </div>
+                        <ul className="space-y-1.5">
+                            {summary.openDecisions.map(d => (
+                                <li
+                                    key={d.id}
+                                    className="rounded-md border border-amber-100 bg-amber-50/40 px-3 py-2"
+                                >
+                                    <div className="flex items-start gap-2">
+                                        <span className="shrink-0 mt-0.5 text-[10px] font-mono font-bold text-amber-700">
+                                            {d.id}
+                                        </span>
+                                        <p className="text-sm text-neutral-900">{d.statement}</p>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
                     </div>
                 )}
             </div>

--- a/src/lib/__tests__/implementationSummary.test.ts
+++ b/src/lib/__tests__/implementationSummary.test.ts
@@ -65,16 +65,16 @@ describe('deriveImplementationSummary — feature bucketing', () => {
         expect(s.defer).toHaveLength(2);
     });
 
-    it('orders buckets by ascending complexity', () => {
+    it('orders buckets by feature id so f1, f2, f3… stay in natural order', () => {
         const prd = basePRD({
             features: [
-                baseFeature({ id: 'h', name: 'H', tier: 'mvp', complexity: 'high' }),
-                baseFeature({ id: 'l', name: 'L', tier: 'mvp', complexity: 'low' }),
-                baseFeature({ id: 'm', name: 'M', tier: 'mvp', complexity: 'medium' }),
+                baseFeature({ id: 'f3', name: 'F3', tier: 'mvp', complexity: 'low' }),
+                baseFeature({ id: 'f1', name: 'F1', tier: 'mvp', complexity: 'high' }),
+                baseFeature({ id: 'f2', name: 'F2', tier: 'mvp', complexity: 'medium' }),
             ],
         });
         const s = deriveImplementationSummary(prd);
-        expect(s.buildFirst.map(f => f.id)).toEqual(['l', 'm', 'h']);
+        expect(s.buildFirst.map(f => f.id)).toEqual(['f1', 'f2', 'f3']);
     });
 
     it('caps each bucket at 5', () => {

--- a/src/lib/derive/implementationSummary.ts
+++ b/src/lib/derive/implementationSummary.ts
@@ -53,11 +53,9 @@ function isLater(feature: Feature): boolean {
     return false;
 }
 
-function complexitySortKey(complexity?: 'low' | 'medium' | 'high'): number {
-    if (complexity === 'low') return 0;
-    if (complexity === 'medium') return 1;
-    if (complexity === 'high') return 2;
-    return 1;
+function featureIdSortKey(id: string): number {
+    const match = id.match(/\d+/);
+    return match ? parseInt(match[0], 10) : Number.MAX_SAFE_INTEGER;
 }
 
 function summaryFeatureFor(f: Feature, withReason: boolean): SummaryFeature {
@@ -98,14 +96,16 @@ function pickFeatures(features: Feature[]): {
     const buildNext = features.filter(f => !isMvp(f) && isV1(f));
     const defer = features.filter(f => !isMvp(f) && !isV1(f) && isLater(f));
 
-    // Within each bucket prefer lower complexity first, then declaration order.
-    const sortByComplexity = (arr: Feature[]) =>
-        [...arr].sort((a, b) => complexitySortKey(a.complexity) - complexitySortKey(b.complexity));
+    // Within each bucket sort by the numeric portion of the feature id so the
+    // user sees f1, f2, f3… in their natural order rather than a complexity
+    // re-ranking that scrambles the numbers visible in the cards.
+    const sortById = (arr: Feature[]) =>
+        [...arr].sort((a, b) => featureIdSortKey(a.id) - featureIdSortKey(b.id));
 
     return {
-        buildFirst: sortByComplexity(buildFirst),
-        buildNext: sortByComplexity(buildNext),
-        defer: sortByComplexity(defer),
+        buildFirst: sortById(buildFirst),
+        buildNext: sortById(buildNext),
+        defer: sortById(defer),
     };
 }
 


### PR DESCRIPTION
## Summary
Simplifies the implementation summary UI by removing the "Highest Risks" display and changes feature ordering from complexity-based to ID-based sorting to preserve the user's intended feature sequence.

## Changes

- **Removed risks display**: Deleted the entire "Highest Risks" section from `ImplementationSummarySection`, including the `AlertTriangle` icon import. Updated the subtitle from "Derived from features, risks, assumptions" to "Derived from features and assumptions".

- **Changed feature sorting strategy**: Replaced `complexitySortKey()` with `featureIdSortKey()` in `implementationSummary.ts`. Features are now sorted by the numeric portion of their ID (e.g., f1, f2, f3) rather than by complexity level. This preserves the natural order users see in the feature cards instead of scrambling them via complexity re-ranking.

- **Updated test expectations**: Modified the test case in `implementationSummary.test.ts` to verify features are ordered by ID (f1, f2, f3) rather than by complexity.

- **Improved layout responsiveness**: Extended the max-width breakpoints in `ArtifactWorkspace.tsx` to use `xl:max-w-5xl 2xl:max-w-6xl` alongside the base `max-w-3xl`, allowing the PRD and implementation plan views to expand on larger screens.

## Implementation Details

The feature ID sorting extracts the numeric portion from IDs like "f1", "f2", etc., using a regex match and falls back to `Number.MAX_SAFE_INTEGER` for IDs without numbers. This maintains a stable, predictable order that aligns with how features are presented elsewhere in the UI.

https://claude.ai/code/session_01UyiqmKv1NYFwoC4HepwGXi