### PR TITLE
Split snapshot images into separate blobs to avoid serverless body cap

### DIFF
--- a/api/snapshots.js
+++ b/api/snapshots.js
@@ -5,26 +5,37 @@ import { enforceRateLimit } from './_lib/rateLimit.js';
 import { requireOwner } from './_lib/ownerAuth.js';
 
 // Single endpoint for the whole snapshot lifecycle. Vercel Hobby caps a
-// deployment at 12 serverless functions, so we dispatch by method + the
-// optional `?id=<uuid>` query param instead of splitting into per-id and
-// collection files.
+// deployment at 12 serverless functions, so we dispatch by method + query
+// params instead of splitting into per-id and collection files.
 //
-//   POST   /api/snapshots             -> save (body: { title, project, images })
-//   GET    /api/snapshots             -> list summaries (owner)
-//   GET    /api/snapshots?id=...      -> load one (owner)
-//   DELETE /api/snapshots?id=...      -> remove one (owner)
-//   GET    /api/snapshots?demo=1      -> load the demo snapshot (PUBLIC)
-//   PUT    /api/snapshots?demo=1&id=  -> mark a snapshot as the demo (owner)
-//   PUT    /api/snapshots?demo=1      -> clear the demo pointer (owner)
+//   POST   /api/snapshots                     -> save bundle (no image bodies)
+//   POST   /api/snapshots?id=...&image=1      -> upload one image blob (owner)
+//   GET    /api/snapshots                     -> list summaries (owner)
+//   GET    /api/snapshots?id=...              -> load bundle + image refs (owner)
+//   GET    /api/snapshots?id=...&image=<key>  -> load one image (owner)
+//   DELETE /api/snapshots?id=...              -> remove one snapshot (owner)
+//   GET    /api/snapshots?demo=1              -> load the demo snapshot (PUBLIC)
+//   GET    /api/snapshots?demo=1&image=<key>  -> load one demo image (PUBLIC)
+//   PUT    /api/snapshots?demo=1&id=          -> mark a snapshot as the demo (owner)
+//   PUT    /api/snapshots?demo=1              -> clear the demo pointer (owner)
+//
+// Schema v2 stores mockup images as separate per-image blobs under
+// `snapshots/<id>/images/<hash>.json` so a single project with N large
+// images doesn't blow past Vercel's ~4.5 MB serverless body cap on either
+// the upload or the download side. v1 snapshots (inline images) are still
+// readable on GET — the response just preserves the legacy shape.
 
-// Hard cap on a single snapshot payload — guards against runaway uploads
-// (e.g. accidentally bundling a giant project). Vercel's Hobby request
-// body cap is ~4.5 MB; this matches.
+// Per-request body cap. Vercel's serverless platform enforces its own
+// ~4.5 MB limit upstream, so this is a defense-in-depth check and keeps
+// `req.on('data')` from buffering an unbounded payload if Vercel ever
+// changes that limit.
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
 
 const SNAPSHOT_PREFIX = 'snapshots/';
 const DEMO_POINTER_PATH = 'snapshots/_demo.json';
 const ID_RE = /^[0-9a-f-]{8,64}$/i;
+const IMAGE_KEY_MAX = 512;
+const CURRENT_SCHEMA_VERSION = 2;
 
 async function readJsonBody(req) {
   if (req.body && typeof req.body === 'object') return req.body;
@@ -61,6 +72,27 @@ function sanitizeTitle(title) {
   if (typeof title !== 'string') return 'Untitled';
   const trimmed = title.trim().slice(0, 200);
   return trimmed.length > 0 ? trimmed : 'Untitled';
+}
+
+// Image keys look like `${versionId}:${screenId}:${quality}`. Hashing to a
+// fixed hex digest gives us a URL- and storage-safe filename regardless of
+// how the caller composed the key, and avoids any path-traversal foot-guns
+// from raw client input.
+function hashImageKey(key) {
+  return crypto.createHash('sha256').update(String(key)).digest('hex');
+}
+
+function imageBlobPath(snapshotId, key) {
+  return `${SNAPSHOT_PREFIX}${snapshotId}/images/${hashImageKey(key)}.json`;
+}
+
+// Strip dataUrl off an image record so we can store the metadata next to
+// the project bundle without inlining the (large) base64 payload.
+function imageMetadata(record) {
+  if (!record || typeof record !== 'object') return null;
+  const meta = { ...record };
+  delete meta.dataUrl;
+  return meta;
 }
 
 async function findBlobsForId(id) {
@@ -122,10 +154,17 @@ async function handlePost(req, res) {
   }
 
   const project = body?.project;
-  const images = Array.isArray(body?.images) ? body.images : [];
+  const rawImages = Array.isArray(body?.images) ? body.images : [];
   if (!project || typeof project !== 'object') {
     return json(res, 400, { error: 'missing_project' });
   }
+
+  // Drop any dataUrl that snuck through — image blobs are uploaded
+  // individually via `?id=...&image=1`. Storing dataUrl inline would just
+  // bring back the size problem this split was meant to solve.
+  const imageRefs = rawImages
+    .map(imageMetadata)
+    .filter((m) => m && typeof m.key === 'string' && m.key.length > 0 && m.key.length <= IMAGE_KEY_MAX);
 
   const id = crypto.randomUUID();
   const manifest = {
@@ -133,11 +172,19 @@ async function handlePost(req, res) {
     title: sanitizeTitle(body.title),
     projectName: typeof project?.project?.name === 'string' ? project.project.name : 'Untitled',
     createdAt: nowIso(),
-    schemaVersion: 1,
-    imageCount: images.length,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    imageCount: imageRefs.length,
   };
 
-  const data = { schemaVersion: 1, manifest, project, images };
+  const data = {
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    manifest,
+    project,
+    // v2: images carry metadata only; the dataUrl for each lives in a
+    // separate blob under snapshots/<id>/images/<hash>.json so that no
+    // single request crosses the 4.5 MB serverless body cap.
+    images: imageRefs,
+  };
   const dataJson = JSON.stringify(data);
   const manifestJson = JSON.stringify({ ...manifest, sizeBytes: dataJson.length });
 
@@ -155,6 +202,52 @@ async function handlePost(req, res) {
   });
 
   return json(res, 201, { id, manifest: JSON.parse(manifestJson) });
+}
+
+// POST /api/snapshots?id=<id>&image=1
+// Body: { image: MockupImageRecord }
+// Writes one image to snapshots/<id>/images/<hash>.json. The data.json
+// already records the metadata (key, screenId, etc.) — the per-image blob
+// just carries the dataUrl so it can be fetched on demand at load time.
+async function handleImagePost(id, req, res) {
+  // Make sure the snapshot exists before writing under it, so a stray
+  // image POST doesn't leave orphaned blobs behind.
+  const blobs = await findBlobsForId(id);
+  const dataBlob = blobs.find((b) => b.pathname.endsWith('/data.json'));
+  if (!dataBlob) return json(res, 404, { error: 'not_found' });
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (err) {
+    if (err?.message === 'payload_too_large') {
+      return json(res, 413, { error: 'payload_too_large', limitBytes: MAX_BODY_BYTES });
+    }
+    return json(res, 400, { error: 'invalid_json' });
+  }
+
+  const image = body?.image;
+  if (!image || typeof image !== 'object') {
+    return json(res, 400, { error: 'missing_image' });
+  }
+  if (typeof image.key !== 'string' || image.key.length === 0 || image.key.length > IMAGE_KEY_MAX) {
+    return json(res, 400, { error: 'invalid_image_key' });
+  }
+  if (typeof image.dataUrl !== 'string' || !image.dataUrl.startsWith('data:')) {
+    return json(res, 400, { error: 'invalid_image_dataurl' });
+  }
+
+  const payload = JSON.stringify({ key: image.key, image });
+  await put(imageBlobPath(id, image.key), payload, {
+    contentType: 'application/json',
+    access: 'private',
+    addRandomSuffix: false,
+    // Allow overwrite so a partial save can be retried by re-running the
+    // whole upload loop without first deleting any half-written images.
+    allowOverwrite: true,
+  });
+
+  return json(res, 201, { id, key: image.key });
 }
 
 // Private blob URLs require the read/write token in the Authorization header
@@ -226,6 +319,15 @@ async function handleGetDemo(res) {
   }
 }
 
+// Public counterpart to `handleGetImage` — looks up the image via the
+// current demo pointer so anonymous viewers can hydrate the demo project's
+// mockup images without an owner token.
+async function handleGetDemoImage(key, res) {
+  const pointer = await readDemoPointer();
+  if (!pointer) return json(res, 404, { error: 'no_demo_set' });
+  return await handleGetImage(pointer.snapshotId, key, res);
+}
+
 async function handlePutDemo(id, res) {
   // PUT /api/snapshots?demo=1&id=<id>  -> set pointer
   // PUT /api/snapshots?demo=1          -> clear pointer
@@ -249,6 +351,25 @@ async function handleGetOne(id, res) {
 
   try {
     const data = await fetchBlobJson(dataBlob.url);
+    return json(res, 200, data);
+  } catch (err) {
+    return json(res, 502, { error: 'blob_fetch_failed', message: err?.message ?? 'unknown' });
+  }
+}
+
+// GET one per-image blob written by `handleImagePost`. The key is the
+// caller-supplied image key (`${versionId}:${screenId}:${quality}`); we
+// hash it to find the blob path.
+async function handleGetImage(id, key, res) {
+  if (typeof key !== 'string' || key.length === 0 || key.length > IMAGE_KEY_MAX) {
+    return json(res, 400, { error: 'invalid_image_key' });
+  }
+  const path = imageBlobPath(id, key);
+  const page = await list({ prefix: path });
+  const blob = page.blobs.find((b) => b.pathname === path);
+  if (!blob) return json(res, 404, { error: 'image_not_found' });
+  try {
+    const data = await fetchBlobJson(blob.url);
     return json(res, 200, data);
   } catch (err) {
     return json(res, 502, { error: 'blob_fetch_failed', message: err?.message ?? 'unknown' });
@@ -302,13 +423,28 @@ export default async function handler(req, res) {
     return json(res, 400, { error: 'invalid_id' });
   }
 
+  // `image=1` (POST) flags a per-image upload; any other string value of
+  // `image` is treated as the image key to fetch on GET.
+  const imageQuery = typeof req.query?.image === 'string' ? req.query.image : null;
+  const isImageUpload = req.method === 'POST' && imageQuery === '1';
+  const imageReadKey = req.method === 'GET' && imageQuery !== null && imageQuery !== '1'
+    ? imageQuery
+    : null;
+
   try {
     if (isDemoChannel) {
-      if (req.method === 'GET') return await handleGetDemo(res);
+      if (req.method === 'GET') {
+        if (imageReadKey !== null) return await handleGetDemoImage(imageReadKey, res);
+        return await handleGetDemo(res);
+      }
       if (req.method === 'PUT') return await handlePutDemo(id, res);
       return methodNotAllowed(res, ['GET', 'PUT']);
     }
     if (req.method === 'POST') {
+      if (isImageUpload) {
+        if (id === null) return json(res, 400, { error: 'missing_id' });
+        return await handleImagePost(id, req, res);
+      }
       if (id !== null) return json(res, 400, { error: 'unexpected_id' });
       return await handlePost(req, res);
     }
@@ -322,6 +458,7 @@ export default async function handler(req, res) {
     }
     // GET
     if (id === null) return await handleList(req, res);
+    if (imageReadKey !== null) return await handleGetImage(id, imageReadKey, res);
     return await handleGetOne(id, res);
   } catch (err) {
     console.error('[snapshots]', err);

--- a/src/components/SnapshotsPanel.tsx
+++ b/src/components/SnapshotsPanel.tsx
@@ -5,6 +5,7 @@ import {
     saveSnapshot, listSnapshots, loadSnapshot, restoreSnapshot, deleteSnapshot,
     setDemoSnapshot,
     type SnapshotListItem,
+    type SnapshotProgress,
 } from '../lib/snapshotClient';
 import { useProjectStore } from '../store/projectStore';
 
@@ -35,6 +36,7 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
     const [snapshots, setSnapshots] = useState<SnapshotListItem[] | null>(null);
     const [demoSnapshotId, setDemoSnapshotIdState] = useState<string | null>(null);
     const [busy, setBusy] = useState<string | null>(null);
+    const [saveProgress, setSaveProgress] = useState<SnapshotProgress | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [title, setTitle] = useState<string>(project?.name ?? 'Untitled');
 
@@ -72,16 +74,26 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
 
     const handleSave = async () => {
         setBusy('saving');
+        setSaveProgress(null);
         setError(null);
         try {
-            await saveSnapshot(projectId, title.trim() || 'Untitled');
+            await saveSnapshot(projectId, title.trim() || 'Untitled', (p) => setSaveProgress(p));
             await refresh();
         } catch (err) {
             setError(err instanceof Error ? err.message : String(err));
         } finally {
             setBusy(null);
+            setSaveProgress(null);
         }
     };
+
+    const saveButtonLabel = (() => {
+        if (busy !== 'saving') return 'Save';
+        if (!saveProgress) return 'Saving…';
+        if (saveProgress.phase === 'bundle') return 'Saving…';
+        if (saveProgress.total === 0) return 'Saving…';
+        return `Image ${saveProgress.completed}/${saveProgress.total}…`;
+    })();
 
     const handleLoad = async (id: string) => {
         if (!confirm('Loading will replace the current copy of this project in the workspace. Continue?')) return;
@@ -214,7 +226,7 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
                                         className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 text-white rounded transition"
                                     >
                                         <Save size={14} />
-                                        {busy === 'saving' ? 'Saving…' : 'Save'}
+                                        {saveButtonLabel}
                                     </button>
                                 </div>
                             </div>

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -10,6 +10,14 @@
 // One snapshot can also be designated "the demo project": the server keeps a
 // pointer blob (_demo.json) and exposes a public `?demo=1` read so anonymous
 // visitors can load it from the home page without an owner token.
+//
+// Save/load splits images out of the JSON envelope. Each mockup image (base64
+// PNG, 1–3 MB) is shipped as its own request so neither the upload body nor
+// the download response crosses Vercel's ~4.5 MB serverless cap. The initial
+// POST/GET carries the project bundle plus a list of image *metadata*
+// records (no `dataUrl`); the per-image dataUrls are uploaded/fetched one at
+// a time. Legacy v1 snapshots that still embed dataUrls inline are detected
+// on load and returned as-is.
 
 import type {
     Project, SpineVersion, HistoryEvent, Branch,
@@ -53,6 +61,16 @@ export type SnapshotListResult = {
     snapshots: SnapshotListItem[];
     demoSnapshotId: string | null;
 };
+
+// Progress callback shape. `phase` lets the UI render different messages
+// for "uploading the bundle" vs "uploading image N of M". `total` is 0 for
+// the bundle phase.
+export type SnapshotProgress = {
+    phase: 'bundle' | 'images';
+    completed: number;
+    total: number;
+};
+export type SnapshotProgressCallback = (p: SnapshotProgress) => void;
 
 const API_BASE = '/api/snapshots';
 
@@ -124,21 +142,58 @@ const collectProjectImages = async (bundle: SnapshotProjectBundle): Promise<Mock
     return out;
 };
 
+// Strip the (large) base64 payload off an image record so the bundle POST
+// only carries the routing metadata. The dataUrl is uploaded in its own
+// request immediately after.
+const imageMetadata = (img: MockupImageRecord): Omit<MockupImageRecord, 'dataUrl'> => {
+    // We intentionally destructure-then-discard so a future field added to
+    // MockupImageRecord automatically makes it into the metadata blob.
+    const { dataUrl: _dataUrl, ...meta } = img;
+    void _dataUrl;
+    return meta;
+};
+
 export const saveSnapshot = async (
     projectId: string,
     title: string,
+    onProgress?: SnapshotProgressCallback,
 ): Promise<SnapshotManifest> => {
     const bundle = collectProjectBundle(projectId);
     const images = await collectProjectImages(bundle);
 
-    const resp = await fetch(API_BASE, {
+    onProgress?.({ phase: 'bundle', completed: 0, total: 0 });
+
+    // Step 1 — POST the project bundle plus image metadata only. This is
+    // bounded (typically a few hundred KB) regardless of how many or how
+    // large the mockup images are.
+    const bundleResp = await fetch(API_BASE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
-        body: JSON.stringify({ title, project: bundle, images }),
+        body: JSON.stringify({
+            title,
+            project: bundle,
+            images: images.map(imageMetadata),
+        }),
     });
-    if (!resp.ok) throw await errorFromResponse(resp, 'save_failed');
-    const result = await resp.json();
-    return result.manifest as SnapshotManifest;
+    if (!bundleResp.ok) throw await errorFromResponse(bundleResp, 'save_failed');
+    const { id, manifest } = await bundleResp.json() as { id: string; manifest: SnapshotManifest };
+
+    // Step 2 — upload each image as a separate request. We go sequentially
+    // so a slow/flaky uplink doesn't try to push all images at once and so
+    // browsers don't hold every base64 payload in flight concurrently.
+    onProgress?.({ phase: 'images', completed: 0, total: images.length });
+    for (let i = 0; i < images.length; i++) {
+        const img = images[i];
+        const resp = await fetch(`${API_BASE}?id=${encodeURIComponent(id)}&image=1`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeaders() },
+            body: JSON.stringify({ image: img }),
+        });
+        if (!resp.ok) throw await errorFromResponse(resp, 'save_image_failed');
+        onProgress?.({ phase: 'images', completed: i + 1, total: images.length });
+    }
+
+    return manifest;
 };
 
 export const listSnapshots = async (): Promise<SnapshotListResult> => {
@@ -162,19 +217,75 @@ export const setDemoSnapshot = async (snapshotId: string | null): Promise<string
     return typeof body?.demoSnapshotId === 'string' ? body.demoSnapshotId : null;
 };
 
+// True if the bundle still has every image dataUrl inline — i.e. a legacy
+// v1 snapshot. v2 bundles return image metadata only and need a follow-up
+// fetch per image to hydrate the dataUrls.
+const isFullyInlined = (images: unknown[]): images is MockupImageRecord[] => {
+    if (!Array.isArray(images)) return false;
+    if (images.length === 0) return true;
+    return images.every((img) =>
+        img != null
+        && typeof img === 'object'
+        && typeof (img as { dataUrl?: unknown }).dataUrl === 'string',
+    );
+};
+
+// Pull each image blob into a full MockupImageRecord. Runs the fetches
+// with a small concurrency limit so a project with dozens of screens
+// doesn't try to open a fetch for every one simultaneously.
+const hydrateImages = async (
+    fetchOne: (key: string) => Promise<Response>,
+    refs: Array<Omit<MockupImageRecord, 'dataUrl'>>,
+): Promise<MockupImageRecord[]> => {
+    const CONCURRENCY = 4;
+    const out: MockupImageRecord[] = new Array(refs.length);
+    let cursor = 0;
+    const workers = Array.from({ length: Math.min(CONCURRENCY, refs.length) }, async () => {
+        while (true) {
+            const idx = cursor++;
+            if (idx >= refs.length) return;
+            const ref = refs[idx];
+            const resp = await fetchOne(ref.key);
+            if (!resp.ok) throw await errorFromResponse(resp, 'load_image_failed');
+            const body = await resp.json() as { image?: MockupImageRecord };
+            if (!body?.image || typeof body.image.dataUrl !== 'string') {
+                throw new Error(`load_image_failed: malformed image record for ${ref.key}`);
+            }
+            out[idx] = body.image;
+        }
+    });
+    await Promise.all(workers);
+    return out;
+};
+
 // Public: fetch the snapshot the owner has marked as the demo. No auth.
 // Returns null when no demo has been set (server returns 404 in that case).
 export const loadDemoSnapshotPublic = async (): Promise<SnapshotPayload | null> => {
     const resp = await fetch(`${API_BASE}?demo=1`);
     if (resp.status === 404) return null;
     if (!resp.ok) throw await errorFromResponse(resp, 'load_demo_failed');
-    return await resp.json();
+    const payload = await resp.json() as SnapshotPayload;
+    if (isFullyInlined(payload.images)) return payload;
+    const hydrated = await hydrateImages(
+        (key) => fetch(`${API_BASE}?demo=1&image=${encodeURIComponent(key)}`),
+        payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
+    );
+    return { ...payload, images: hydrated };
 };
 
 export const loadSnapshot = async (id: string): Promise<SnapshotPayload> => {
     const resp = await fetch(`${API_BASE}?id=${encodeURIComponent(id)}`, { headers: authHeaders() });
     if (!resp.ok) throw await errorFromResponse(resp, 'load_failed');
-    return await resp.json();
+    const payload = await resp.json() as SnapshotPayload;
+    if (isFullyInlined(payload.images)) return payload;
+    const hydrated = await hydrateImages(
+        (key) => fetch(
+            `${API_BASE}?id=${encodeURIComponent(id)}&image=${encodeURIComponent(key)}`,
+            { headers: authHeaders() },
+        ),
+        payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
+    );
+    return { ...payload, images: hydrated };
 };
 
 export const deleteSnapshot = async (id: string): Promise<void> => {


### PR DESCRIPTION
## Summary

Refactor snapshot storage to split mockup images out of the main JSON envelope into separate per-image blobs. This allows projects with multiple large mockup images (1–3 MB each) to be saved and loaded without exceeding Vercel's ~4.5 MB serverless request/response body limit.

## Key Changes

**Backend (`api/snapshots.js`)**
- Updated endpoint documentation to reflect new schema v2 structure with separate image upload/download routes
- Added `handleImagePost()` to accept per-image blob uploads via `POST /api/snapshots?id=<id>&image=1`
- Added `handleGetImage()` to fetch individual image blobs via `GET /api/snapshots?id=<id>&image=<key>`
- Added `handleGetDemoImage()` for public demo image fetches
- Introduced `hashImageKey()` to safely hash caller-supplied image keys to storage-safe filenames
- Introduced `imageMetadata()` to strip `dataUrl` from image records before storage
- Updated `handlePost()` to store only image metadata (no `dataUrl`) in the main bundle
- Added schema version constant (`CURRENT_SCHEMA_VERSION = 2`) and image key validation
- Improved comments explaining the size-splitting rationale and v1 backward compatibility

**Client (`src/lib/snapshotClient.ts`)**
- Added `SnapshotProgress` type to track upload phases (bundle vs. images)
- Updated `saveSnapshot()` to split into two steps: (1) POST bundle with image metadata only, (2) sequentially upload each image blob
- Added `imageMetadata()` helper to strip `dataUrl` before bundle POST
- Added `isFullyInlined()` to detect legacy v1 snapshots (images with inline `dataUrl`)
- Added `hydrateImages()` to fetch per-image blobs with concurrency control (4 concurrent fetches)
- Updated `loadSnapshot()` and `loadDemoSnapshotPublic()` to hydrate image metadata into full records on load
- Added detailed comments explaining the v1/v2 compatibility strategy

**UI (`src/components/SnapshotsPanel.tsx`)**
- Updated `saveSnapshot()` call to accept progress callback
- Added `saveProgress` state to track upload phases
- Updated save button label to show image upload progress ("Image N/M…")
- Reset progress state on save completion

## Implementation Details

- **Backward compatibility**: v1 snapshots with inline `dataUrl` are detected on load and returned as-is; v2 snapshots are hydrated on demand
- **Sequential image uploads**: Images are uploaded one at a time to avoid overwhelming slow/flaky uplinks and to prevent browsers from holding all base64 payloads in flight concurrently
- **Concurrent image downloads**: Image fetches use a concurrency limit of 4 to balance parallelism with resource constraints
- **Safe key hashing**: Image keys are SHA256-hashed to filenames, preventing path-traversal attacks and ensuring URL-safe storage paths
- **Validation**: Image keys are validated for length (0 < length ≤ 512) and `dataUrl` format on both upload and download

https://claude.ai/code/session_012b7hWB5M6M2NBRbwtruGtw