### PR TITLE
Add related artifacts panel and risk inference to user flows

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -311,6 +311,10 @@ export function ArtifactWorkspace({
                                 ? structuredPRD.features
                                 : undefined
                         }
+                        uxPages={subtype === 'user_flows' ? structuredPRD.uxPages : undefined}
+                        domainEntities={subtype === 'user_flows' ? structuredPRD.domainEntities : undefined}
+                        featureSystems={subtype === 'user_flows' ? structuredPRD.featureSystems : undefined}
+                        implementationPlan={subtype === 'user_flows' ? structuredPRD.implementationPlan : undefined}
                         promptEdits={promptEdits}
                         onUpdatePromptEdits={handleUpdatePromptEdits}
                     />

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -1,4 +1,6 @@
-import type { CoreArtifactSubtype, Feature } from '../../types';
+import type {
+    CoreArtifactSubtype, DomainEntity, Feature, FeatureSystem, ImplementationPlan, UXPage,
+} from '../../types';
 import { ScreenInventoryRenderer } from './ScreenInventoryRenderer';
 import type { ScreenImageGalleryContext } from './ScreenImageGallery';
 import { DataModelRenderer } from './DataModelRenderer';
@@ -29,6 +31,11 @@ interface DispatchProps {
     projectId?: string;
     /** Consumed by `prompt_pack` and `user_flows` for canonical feature ID resolution. */
     features?: Feature[];
+    /** Consumed only by `user_flows` to surface heuristic related-artifact links. */
+    uxPages?: UXPage[];
+    domainEntities?: DomainEntity[];
+    featureSystems?: FeatureSystem[];
+    implementationPlan?: ImplementationPlan;
     /** Only consumed by `prompt_pack`; per-prompt user edit overlay keyed by index. */
     promptEdits?: Record<number, string>;
     /** Only consumed by `prompt_pack`; persists the new edit overlay. */
@@ -67,6 +74,10 @@ export function ArtifactContentRenderer({
     metadata,
     projectId,
     features,
+    uxPages,
+    domainEntities,
+    featureSystems,
+    implementationPlan,
     promptEdits,
     onUpdatePromptEdits,
 }: DispatchProps) {
@@ -83,7 +94,16 @@ export function ArtifactContentRenderer({
         return <DesignSystemRenderer content={content} metadata={metadata} projectId={projectId} />;
     }
     if (subtype === 'user_flows') {
-        return <UserFlowsRenderer content={content} features={features} />;
+        return (
+            <UserFlowsRenderer
+                content={content}
+                features={features}
+                uxPages={uxPages}
+                domainEntities={domainEntities}
+                featureSystems={featureSystems}
+                implementationPlan={implementationPlan}
+            />
+        );
     }
     if (subtype === 'implementation_plan') {
         return <ImplementationPlanRenderer content={content} />;

--- a/src/components/renderers/userFlows/AssumptionsPanel.tsx
+++ b/src/components/renderers/userFlows/AssumptionsPanel.tsx
@@ -1,0 +1,84 @@
+import { HelpCircle, Lightbulb } from 'lucide-react';
+import type { Feature } from '../../../types';
+import type { FeatureRef, ParsedFlow } from './types';
+import { inlineWithFeatures } from './inlineWithFeatures';
+
+interface Props {
+    flow: ParsedFlow;
+    featuresById?: Map<string, Feature>;
+    onSelectFeature: (refToken: FeatureRef) => void;
+}
+
+function splitBullets(block: string): string[] {
+    const lines = block.split('\n').map(l => l.trim()).filter(Boolean);
+    const items: string[] = [];
+    let buffer = '';
+    for (const line of lines) {
+        if (/^[-*]\s+/.test(line)) {
+            if (buffer) items.push(buffer);
+            buffer = line.replace(/^[-*]\s+/, '');
+        } else if (buffer) {
+            buffer += ' ' + line;
+        } else {
+            items.push(line);
+        }
+    }
+    if (buffer) items.push(buffer);
+    return items;
+}
+
+/**
+ * Surfaces explicit `**Assumptions:**` and `**Open Questions:**`
+ * sections from the generated artifact. Hidden entirely when neither
+ * section exists so we don't introduce empty cards on legacy data.
+ */
+export function AssumptionsPanel({ flow, featuresById, onSelectFeature }: Props) {
+    const assumptions = flow.assumptions ? splitBullets(flow.assumptions) : [];
+    const openQuestions = flow.openQuestions ? splitBullets(flow.openQuestions) : [];
+    if (assumptions.length === 0 && openQuestions.length === 0) return null;
+
+    const renderText = (text: string) =>
+        inlineWithFeatures(text, { featuresById, onSelectFeature });
+
+    return (
+        <section className="mb-4">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2 inline-flex items-center gap-1">
+                <Lightbulb size={11} /> Assumptions & open questions
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {assumptions.length > 0 && (
+                    <section className="rounded-xl border border-neutral-200 bg-white p-3.5">
+                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-600 mb-2 inline-flex items-center gap-1">
+                            <Lightbulb size={11} className="text-amber-600" /> Assumptions
+                            <span className="ml-1 font-normal text-neutral-400">· {assumptions.length}</span>
+                        </p>
+                        <ul className="space-y-1.5 text-sm text-neutral-800">
+                            {assumptions.map((a, i) => (
+                                <li key={i} className="flex gap-2">
+                                    <span className="shrink-0 mt-1.5 inline-block w-1.5 h-1.5 rounded-full bg-amber-400" />
+                                    <span className="min-w-0 flex-1">{renderText(a)}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                )}
+                {openQuestions.length > 0 && (
+                    <section className="rounded-xl border border-neutral-200 bg-white p-3.5">
+                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-600 mb-2 inline-flex items-center gap-1">
+                            <HelpCircle size={11} className="text-sky-600" /> Open questions
+                            <span className="ml-1 font-normal text-neutral-400">· {openQuestions.length}</span>
+                        </p>
+                        <ul className="space-y-1.5 text-sm text-neutral-800">
+                            {openQuestions.map((q, i) => (
+                                <li key={i} className="flex gap-2">
+                                    <span className="shrink-0 mt-1.5 inline-block w-1.5 h-1.5 rounded-full bg-sky-400" />
+                                    <span className="min-w-0 flex-1">{renderText(q)}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/renderers/userFlows/FlowSidebar.tsx
+++ b/src/components/renderers/userFlows/FlowSidebar.tsx
@@ -1,7 +1,13 @@
 import { useEffect } from 'react';
-import { Clock, GitBranch, Menu, X } from 'lucide-react';
-import type { FlowCategory, FlowIssueKind, ParsedFlow } from './types';
+import { Clock, GitBranch, Menu, Sparkles, X } from 'lucide-react';
+import type { FlowCategory, FlowIssueKind, FlowRiskLevel, ParsedFlow } from './types';
 import { CATEGORY_ORDER } from './categorize';
+
+const RISK_DOT: Record<FlowRiskLevel, { color: string; label: string }> = {
+    low: { color: 'bg-emerald-400', label: 'Low risk' },
+    medium: { color: 'bg-amber-400', label: 'Medium risk' },
+    high: { color: 'bg-red-500', label: 'High risk' },
+};
 
 interface Props {
     flows: ParsedFlow[];
@@ -73,7 +79,13 @@ export function FlowSidebar({
                             const active = originalIndex === selectedIndex;
                             const stepCount = flow.steps.length;
                             const { altPaths, edgeCases, unresolved } = summarizeIssues(flow);
+                            const featureCount = flow.featureRefs.length;
                             const ttv = ttvByFlow?.[originalIndex] ?? null;
+                            const risk = RISK_DOT[flow.risk];
+                            // Only surface the risk dot when there's something to
+                            // warn about — a green "low risk" dot on every flow
+                            // teaches the eye to ignore the indicator.
+                            const showRisk = flow.risk !== 'low' || flow.issues.length > 0;
                             return (
                                 <li key={originalIndex}>
                                     <button
@@ -97,20 +109,35 @@ export function FlowSidebar({
                                                 {originalIndex + 1}
                                             </span>
                                             <div className="min-w-0 flex-1">
-                                                <p
-                                                    className="text-sm font-medium leading-snug break-words"
-                                                    title={flow.title}
-                                                >
-                                                    {flow.title}
-                                                </p>
+                                                <div className="flex items-start gap-1.5">
+                                                    <p
+                                                        className="text-sm font-medium leading-snug break-words min-w-0 flex-1"
+                                                        title={flow.title}
+                                                    >
+                                                        {flow.title}
+                                                    </p>
+                                                    {showRisk && (
+                                                        <span
+                                                            className={`mt-1.5 shrink-0 inline-block w-2 h-2 rounded-full ${risk.color}`}
+                                                            title={risk.label}
+                                                            aria-label={risk.label}
+                                                        />
+                                                    )}
+                                                </div>
                                                 <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-neutral-500">
                                                     <span className="inline-flex items-center gap-0.5">
                                                         <GitBranch size={10} />
                                                         {stepCount} {stepCount === 1 ? 'step' : 'steps'}
                                                     </span>
+                                                    {featureCount > 0 && (
+                                                        <span className="inline-flex items-center gap-0.5">
+                                                            <Sparkles size={10} className="text-fuchsia-500" />
+                                                            {featureCount} {featureCount === 1 ? 'feature' : 'features'}
+                                                        </span>
+                                                    )}
                                                     {altPaths > 0 && (
                                                         <span>
-                                                            {altPaths} alternate {altPaths === 1 ? 'path' : 'paths'}
+                                                            {altPaths} alt {altPaths === 1 ? 'path' : 'paths'}
                                                         </span>
                                                     )}
                                                     {edgeCases > 0 && (

--- a/src/components/renderers/userFlows/FlowSummaryCard.tsx
+++ b/src/components/renderers/userFlows/FlowSummaryCard.tsx
@@ -1,12 +1,13 @@
 import { type ReactNode } from 'react';
 import {
-    Bookmark, Clock, DoorOpen, GitBranch, ListChecks, MoreHorizontal, Server,
-    Share2, ShieldCheck, Sparkles, Target,
+    AlertTriangle, Bookmark, Clock, DoorOpen, GitBranch, ListChecks,
+    MoreHorizontal, Server, Share2, ShieldCheck, Sparkles, Target,
 } from 'lucide-react';
 import type { Feature } from '../../../types';
-import type { FeatureRef, ParsedFlow } from './types';
+import type { FeatureRef, FlowRiskLevel, ParsedFlow } from './types';
 import { inlineMd } from './markdown';
 import { inlineWithFeatures } from './inlineWithFeatures';
+import { FeatureReferenceChip } from './FeatureReferenceChip';
 
 interface Props {
     flow: ParsedFlow;
@@ -15,6 +16,12 @@ interface Props {
     featuresById?: Map<string, Feature>;
     onSelectFeature: (refToken: FeatureRef) => void;
 }
+
+const RISK_META: Record<FlowRiskLevel, { label: string; classes: string }> = {
+    low: { label: 'Low risk', classes: 'bg-emerald-50 border-emerald-200 text-emerald-800' },
+    medium: { label: 'Medium risk', classes: 'bg-amber-50 border-amber-200 text-amber-800' },
+    high: { label: 'High risk', classes: 'bg-red-50 border-red-200 text-red-800' },
+};
 
 function MetadataChip({
     icon, label, tone,
@@ -75,8 +82,18 @@ export function FlowSummaryCard({
 }: Props) {
     const stepCount = flow.steps.length;
     const altPaths = flow.issues.filter(i => i.kind === 'alternate_path' || i.kind === 'failure_mode').length;
+    const edgeCount = flow.issues.filter(i => i.kind === 'edge_case').length;
     const renderText = (text: string) =>
         inlineWithFeatures(text, { featuresById, onSelectFeature });
+
+    const risk = RISK_META[flow.risk];
+    const showRisk = flow.risk !== 'low' || flow.issues.length > 0;
+
+    // Drop preconditions block entirely when there's nothing useful to add —
+    // older artifacts sometimes emit a precondition identical to the entry
+    // point sentence, which we want to avoid double-rendering.
+    const hasPreconditions = Boolean(flow.preconditions && flow.preconditions.trim().length > 0);
+    const hasEntryPoints = flow.entryPoints.length > 0;
 
     return (
         <section className="bg-white rounded-xl border border-neutral-200 p-5 mb-4">
@@ -108,6 +125,15 @@ export function FlowSummaryCard({
                                 tone="amber"
                             />
                         )}
+                        {edgeCount > 0 && (
+                            <span
+                                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[11px] bg-sky-50 border-sky-200 text-sky-800"
+                                title={`${edgeCount} edge case${edgeCount === 1 ? '' : 's'}`}
+                            >
+                                <AlertTriangle size={11} />
+                                <span>{edgeCount} edge {edgeCount === 1 ? 'case' : 'cases'}</span>
+                            </span>
+                        )}
                         {timeToValue && (
                             <MetadataChip
                                 icon={<Clock size={11} />}
@@ -115,7 +141,28 @@ export function FlowSummaryCard({
                                 tone="emerald"
                             />
                         )}
+                        {showRisk && (
+                            <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[11px] ${risk.classes}`}>
+                                <span className="inline-block w-1.5 h-1.5 rounded-full bg-current" />
+                                <span>{risk.label}</span>
+                            </span>
+                        )}
                     </div>
+                    {flow.featureRefs.length > 0 && (
+                        <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+                            <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mr-0.5">
+                                Related features
+                            </span>
+                            {flow.featureRefs.map(ref => (
+                                <FeatureReferenceChip
+                                    key={ref.id}
+                                    refToken={ref}
+                                    feature={featuresById?.get(ref.id)}
+                                    onSelect={onSelectFeature}
+                                />
+                            ))}
+                        </div>
+                    )}
                 </div>
                 <div className="hidden sm:flex items-center gap-1 shrink-0">
                     <button
@@ -152,17 +199,17 @@ export function FlowSummaryCard({
                     </FullWidthSection>
                 )}
 
-                {(flow.preconditions || flow.inferredEntryPoints.length > 0) && (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        {flow.preconditions && (
+                {(hasPreconditions || hasEntryPoints) && (
+                    <div className={`grid grid-cols-1 ${hasPreconditions && hasEntryPoints ? 'sm:grid-cols-2' : ''} gap-3`}>
+                        {hasPreconditions && (
                             <HalfSection title="Preconditions" icon={<ShieldCheck size={11} />}>
-                                {renderText(flow.preconditions)}
+                                {renderText(flow.preconditions!)}
                             </HalfSection>
                         )}
-                        {flow.inferredEntryPoints.length > 0 && (
+                        {hasEntryPoints && (
                             <HalfSection title="Entry points" icon={<DoorOpen size={11} />}>
                                 <ul className="space-y-1">
-                                    {flow.inferredEntryPoints.slice(0, 5).map((ep, i) => (
+                                    {flow.entryPoints.slice(0, 5).map((ep, i) => (
                                         <li key={i} className="flex gap-2">
                                             <span className="text-neutral-400">•</span>
                                             <span className="min-w-0 flex-1">{renderText(ep)}</span>
@@ -194,37 +241,6 @@ export function FlowSummaryCard({
                                     {s}
                                 </code>
                             ))}
-                        </div>
-                    </section>
-                )}
-
-                {/* Aggregate feature refs (if any) appear as quick-access chips */}
-                {flow.featureRefs.length > 0 && (
-                    <section className="rounded-lg border border-neutral-200 bg-white p-3.5">
-                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
-                            Referenced features
-                        </p>
-                        <div className="flex flex-wrap gap-1.5">
-                            {flow.featureRefs.map(ref => {
-                                const feature = featuresById?.get(ref.id);
-                                const id = feature?.id ?? ref.id.toUpperCase();
-                                const name = feature?.name;
-                                return (
-                                    <button
-                                        key={ref.id}
-                                        type="button"
-                                        onClick={() => onSelectFeature(ref)}
-                                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-fuchsia-50 hover:bg-fuchsia-100 border border-fuchsia-200 text-fuchsia-700 text-[11px] font-semibold transition-colors"
-                                    >
-                                        <span className="font-mono uppercase">{id}</span>
-                                        {name && (
-                                            <span className="font-medium normal-case text-fuchsia-800">
-                                                {name}
-                                            </span>
-                                        )}
-                                    </button>
-                                );
-                            })}
                         </div>
                     </section>
                 )}

--- a/src/components/renderers/userFlows/RelatedArtifactsPanel.tsx
+++ b/src/components/renderers/userFlows/RelatedArtifactsPanel.tsx
@@ -1,0 +1,283 @@
+import { useMemo } from 'react';
+import { AppWindow, Database, ListChecks, Network, Sparkles } from 'lucide-react';
+import type {
+    DomainEntity, Feature, FeatureSystem, ImplementationPlan, UXPage,
+} from '../../../types';
+import type { FeatureRef, ParsedFlow } from './types';
+import { FeatureReferenceChip } from './FeatureReferenceChip';
+
+interface Props {
+    flow: ParsedFlow;
+    featuresById?: Map<string, Feature>;
+    onSelectFeature: (refToken: FeatureRef) => void;
+    /** PRD-derived screen / page catalog. Heuristic matching only. */
+    uxPages?: UXPage[];
+    /** PRD-derived domain entities. Heuristic matching only. */
+    domainEntities?: DomainEntity[];
+    /** PRD-derived implementation plan; we surface phases whose
+     *  feature ids overlap with this flow's referenced features. */
+    implementationPlan?: ImplementationPlan;
+    /** PRD-derived feature systems; we surface ones whose feature ids
+     *  overlap with this flow's referenced features. */
+    featureSystems?: FeatureSystem[];
+}
+
+/**
+ * Normalize a string for fuzzy contains-matching. Lowercase + strip
+ * non-alphanumerics so "Active Workout" matches "active-workout" and
+ * "ActiveWorkout".
+ */
+function fold(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function flowTextCorpus(flow: ParsedFlow): string {
+    const parts: string[] = [
+        flow.title,
+        flow.goal ?? '',
+        flow.preconditions ?? '',
+        flow.successOutcome ?? '',
+        flow.edgeCases ?? '',
+        flow.assumptions ?? '',
+        flow.openQuestions ?? '',
+        ...flow.entryPoints,
+        ...flow.inferredSystems,
+    ];
+    for (const step of flow.steps) {
+        parts.push(
+            step.title ?? '',
+            step.userAction ?? '',
+            step.systemBehavior ?? '',
+            step.uiFeedback ?? '',
+            step.rawText,
+            ...step.decisions,
+            ...step.errorRefs,
+            ...step.apiRefs,
+        );
+    }
+    return parts.join(' ');
+}
+
+/**
+ * Heuristic membership test: does `needle` appear in the flow text?
+ * Uses folded substring matching plus a quick word-boundary check so
+ * short tokens like "DB" don't match "feedback".
+ */
+function flowMentions(corpus: string, needle: string): boolean {
+    const trimmed = needle.trim();
+    if (trimmed.length < 3) return false;
+    return fold(corpus).includes(fold(trimmed));
+}
+
+function Section({
+    title, icon, children, count,
+}: {
+    title: string;
+    icon: React.ReactNode;
+    count?: number;
+    children: React.ReactNode;
+}) {
+    return (
+        <section className="rounded-lg border border-neutral-200 bg-white p-3.5">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2 inline-flex items-center gap-1">
+                {icon}
+                <span>{title}</span>
+                {typeof count === 'number' && (
+                    <span className="ml-1 text-neutral-400 font-normal">· {count}</span>
+                )}
+            </p>
+            {children}
+        </section>
+    );
+}
+
+function EmptyChip({ label }: { label: string }) {
+    return (
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] text-neutral-400 italic">
+            {label}
+        </span>
+    );
+}
+
+export function RelatedArtifactsPanel({
+    flow,
+    featuresById,
+    onSelectFeature,
+    uxPages,
+    domainEntities,
+    implementationPlan,
+    featureSystems,
+}: Props) {
+    const corpus = useMemo(() => flowTextCorpus(flow), [flow]);
+    const featureIds = useMemo(() => new Set(flow.featureRefs.map(r => r.id)), [flow.featureRefs]);
+
+    // Heuristic matching — keep it cheap and explainable. We surface pages
+    // whose name appears in the flow text *or* whose component list shows
+    // up among the step titles.
+    const linkedScreens = useMemo(() => {
+        if (!uxPages || uxPages.length === 0) return [];
+        return uxPages.filter(p => flowMentions(corpus, p.name));
+    }, [uxPages, corpus]);
+
+    const linkedEntities = useMemo(() => {
+        if (!domainEntities || domainEntities.length === 0) return [];
+        return domainEntities.filter(e => flowMentions(corpus, e.name));
+    }, [domainEntities, corpus]);
+
+    // For implementation plan + systems we rely on feature-id overlap
+    // first (more reliable than name matching), and fall back to name
+    // matching for systems that don't list features.
+    const linkedPhases = useMemo(() => {
+        const phases = implementationPlan?.phases ?? [];
+        if (phases.length === 0 || featureIds.size === 0) return [];
+        return phases.filter(phase => {
+            const ids = phase.featureIds ?? [];
+            return ids.some(id => featureIds.has(id.toLowerCase().replace(/-/g, '')));
+        });
+    }, [implementationPlan, featureIds]);
+
+    const linkedSystems = useMemo(() => {
+        if (!featureSystems || featureSystems.length === 0) return [];
+        return featureSystems.filter(sys => {
+            const overlap = sys.featureIds.some(
+                id => featureIds.has(id.toLowerCase().replace(/-/g, '')),
+            );
+            return overlap || flowMentions(corpus, sys.name);
+        });
+    }, [featureSystems, featureIds, corpus]);
+
+    const hasFeatures = flow.featureRefs.length > 0;
+    const hasScreens = linkedScreens.length > 0;
+    const hasEntities = linkedEntities.length > 0;
+    const hasPhases = linkedPhases.length > 0;
+    const hasSystems = linkedSystems.length > 0;
+
+    // If literally nothing connects, render nothing — avoids an empty
+    // panel that adds noise without information.
+    if (!hasFeatures && !hasScreens && !hasEntities && !hasPhases && !hasSystems) {
+        return null;
+    }
+
+    return (
+        <section className="mb-4">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2 inline-flex items-center gap-1">
+                <Network size={11} /> Related artifacts
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {hasFeatures && (
+                    <Section
+                        title="Features"
+                        icon={<Sparkles size={11} className="text-fuchsia-600" />}
+                        count={flow.featureRefs.length}
+                    >
+                        <div className="flex flex-wrap gap-1.5">
+                            {flow.featureRefs.map(ref => (
+                                <FeatureReferenceChip
+                                    key={ref.id}
+                                    refToken={ref}
+                                    feature={featuresById?.get(ref.id)}
+                                    onSelect={onSelectFeature}
+                                />
+                            ))}
+                        </div>
+                    </Section>
+                )}
+
+                {(uxPages !== undefined) && (
+                    <Section
+                        title="Screens"
+                        icon={<AppWindow size={11} className="text-indigo-600" />}
+                        count={linkedScreens.length}
+                    >
+                        {hasScreens ? (
+                            <div className="flex flex-wrap gap-1.5">
+                                {linkedScreens.map(p => (
+                                    <span
+                                        key={p.id || p.name}
+                                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-indigo-50 border border-indigo-200 text-indigo-700 text-[11px] font-medium"
+                                        title={p.purpose}
+                                    >
+                                        {p.name}
+                                    </span>
+                                ))}
+                            </div>
+                        ) : (
+                            <EmptyChip label="No screens detected — verify in Screen Inventory" />
+                        )}
+                    </Section>
+                )}
+
+                {(domainEntities !== undefined) && (
+                    <Section
+                        title="Data entities"
+                        icon={<Database size={11} className="text-emerald-600" />}
+                        count={linkedEntities.length}
+                    >
+                        {hasEntities ? (
+                            <div className="flex flex-wrap gap-1.5">
+                                {linkedEntities.map(e => (
+                                    <span
+                                        key={e.name}
+                                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-emerald-50 border border-emerald-200 text-emerald-800 text-[11px] font-medium"
+                                        title={e.description ?? ''}
+                                    >
+                                        {e.name}
+                                    </span>
+                                ))}
+                            </div>
+                        ) : (
+                            <EmptyChip label="No entities detected — verify in Data Model" />
+                        )}
+                    </Section>
+                )}
+
+                {hasPhases && (
+                    <Section
+                        title="Implementation phases"
+                        icon={<ListChecks size={11} className="text-sky-600" />}
+                        count={linkedPhases.length}
+                    >
+                        <ul className="space-y-1">
+                            {linkedPhases.map((phase, i) => (
+                                <li
+                                    key={i}
+                                    className="flex items-start gap-1.5 text-[11px] text-neutral-700"
+                                >
+                                    <span className="shrink-0 mt-0.5 inline-block w-1.5 h-1.5 rounded-full bg-sky-400" />
+                                    <span className="min-w-0 flex-1">
+                                        <span className="font-medium text-neutral-800">{phase.name}</span>
+                                        {phase.estimatedWeeks && (
+                                            <span className="ml-1 text-neutral-500">
+                                                · {phase.estimatedWeeks}w
+                                            </span>
+                                        )}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </Section>
+                )}
+
+                {hasSystems && (
+                    <Section
+                        title="Feature systems"
+                        icon={<Network size={11} className="text-violet-600" />}
+                        count={linkedSystems.length}
+                    >
+                        <div className="flex flex-wrap gap-1.5">
+                            {linkedSystems.map(s => (
+                                <span
+                                    key={s.id}
+                                    className="inline-flex items-center px-2 py-0.5 rounded-md bg-violet-50 border border-violet-200 text-violet-700 text-[11px] font-medium"
+                                    title={s.purpose}
+                                >
+                                    {s.name}
+                                </span>
+                            ))}
+                        </div>
+                    </Section>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/renderers/userFlows/UserFlowsRenderer.tsx
+++ b/src/components/renderers/userFlows/UserFlowsRenderer.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { Feature } from '../../../types';
+import type {
+    DomainEntity, Feature, FeatureSystem, ImplementationPlan, UXPage,
+} from '../../../types';
 import { parseFlows } from './parseFlow';
 import type { FeatureRef, FlowIssue } from './types';
 import { FlowSidebar } from './FlowSidebar';
@@ -11,12 +13,20 @@ import { StepCard } from './StepCard';
 import { SuccessCriteriaBlock } from './SuccessCriteriaBlock';
 import { IssuesPanel } from './IssuesPanel';
 import { FeatureDetailDrawer } from './FeatureDetailDrawer';
+import { RelatedArtifactsPanel } from './RelatedArtifactsPanel';
+import { AssumptionsPanel } from './AssumptionsPanel';
 
 interface Props {
     content: string;
     /** Canonical feature catalog from the current spine PRD. Optional — drawer
      * shows a graceful fallback when missing. */
     features?: Feature[];
+    /** Optional related-artifact context from the structured PRD. Surfaced
+     * in the "Related artifacts" panel via heuristic matching. */
+    uxPages?: UXPage[];
+    domainEntities?: DomainEntity[];
+    featureSystems?: FeatureSystem[];
+    implementationPlan?: ImplementationPlan;
 }
 
 const TTV_RE = /<\s*(\d+(?:\.\d+)?)\s*(s|sec|seconds|m|min|minutes|h|hr|hours)\b|\b(\d+(?:\.\d+)?)\s*(s|sec|seconds|m|min|minutes|h|hr|hours)\s+to\s+value\b/i;
@@ -31,7 +41,9 @@ function inferTimeToValue(sources: Array<string | undefined>): string | null {
     return `<${value}${unit}`;
 }
 
-export function UserFlowsRenderer({ content, features }: Props) {
+export function UserFlowsRenderer({
+    content, features, uxPages, domainEntities, featureSystems, implementationPlan,
+}: Props) {
     const flows = useMemo(() => parseFlows(content), [content]);
     const featuresById = useMemo(() => {
         if (!features) return undefined;
@@ -125,12 +137,10 @@ export function UserFlowsRenderer({ content, features }: Props) {
                     issuesByStep={issuesByStep}
                 />
 
-                <SuccessCriteriaBlock flow={flow} />
-
                 {flow.steps.length > 0 && (
                     <section className="mb-4">
                         <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2">
-                            Steps
+                            Step-by-step flow
                         </p>
                         {flow.steps.map(step => (
                             <StepCard
@@ -151,11 +161,29 @@ export function UserFlowsRenderer({ content, features }: Props) {
                     </section>
                 )}
 
+                <SuccessCriteriaBlock flow={flow} />
+
+                <RelatedArtifactsPanel
+                    flow={flow}
+                    featuresById={featuresById}
+                    onSelectFeature={onSelectFeature}
+                    uxPages={uxPages}
+                    domainEntities={domainEntities}
+                    featureSystems={featureSystems}
+                    implementationPlan={implementationPlan}
+                />
+
                 <IssuesPanel
                     flowIndex={safeIndex}
                     issues={flow.issues.filter(i => typeof i.linkedStepIndex !== 'number')}
                     edgeCases={flow.edgeCases}
                     steps={flow.steps}
+                    featuresById={featuresById}
+                    onSelectFeature={onSelectFeature}
+                />
+
+                <AssumptionsPanel
+                    flow={flow}
                     featuresById={featuresById}
                     onSelectFeature={onSelectFeature}
                 />

--- a/src/components/renderers/userFlows/__tests__/entryPoints.test.ts
+++ b/src/components/renderers/userFlows/__tests__/entryPoints.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { parseFlows } from '../parseFlow';
+
+describe('parseFlows — entry points vs preconditions', () => {
+    it('uses an explicit `**Entry Points:**` block when present', () => {
+        const md = `### Flow: Workout
+**Preconditions:** User has an active \`WorkoutSession\`.
+**Entry Points:**
+- Tap "Resume workout" on the Today screen
+- Open notification deep-link
+**Steps:**
+1. [Today] — User taps resume → System loads cached program`;
+        const flow = parseFlows(md)[0];
+        expect(flow.entryPoints).toEqual([
+            'Tap "Resume workout" on the Today screen',
+            'Open notification deep-link',
+        ]);
+        expect(flow.preconditions).toMatch(/active `WorkoutSession`/);
+    });
+
+    it('drops entry-point lines that are byte-equal to the preconditions sentence', () => {
+        const md = `### Flow: Onboarding
+**Preconditions:** User has installed the PWA, authenticated, and has no active \`AdaptiveProgram\`.
+**Entry Points:**
+- User has installed the PWA, authenticated, and has no active \`AdaptiveProgram\`.
+**Steps:**
+1. [Home] — User taps Get Started → System launches the setup wizard`;
+        const flow = parseFlows(md)[0];
+        // The duplicated entry-point line should be removed (this is the
+        // exact pathology seen in the screenshot of the current UI).
+        expect(flow.entryPoints).toEqual([]);
+    });
+
+    it('infers entry points from preconditions only when they look like a list', () => {
+        const md = `### Flow: Mixed
+**Preconditions:**
+- User is authenticated
+- Today screen is open
+**Steps:**
+1. [Today] — User taps start → System begins workout`;
+        const flow = parseFlows(md)[0];
+        // Multi-bullet preconditions get surfaced as inferred entry points.
+        expect(flow.entryPoints.length).toBe(2);
+    });
+
+    it('does NOT infer an entry point from a single-paragraph precondition', () => {
+        const md = `### Flow: Mixed
+**Preconditions:** User is authenticated.
+**Steps:**
+1. [Home] — User taps a button → System fires`;
+        const flow = parseFlows(md)[0];
+        // Single-sentence preconditions are state-facts, not entry points.
+        // Surfacing them would just duplicate the preconditions card.
+        expect(flow.entryPoints).toEqual([]);
+    });
+});
+
+describe('parseFlows — assumptions / open questions / risk', () => {
+    it('parses `**Assumptions:**` and `**Open Questions:**` sections', () => {
+        const md = `### Flow: Recovery
+**Steps:**
+1. [Home] — User opens app → System checks state
+**Assumptions:**
+- Service Worker installs on first visit
+- Cached program is at most 7 days old
+**Open Questions:**
+- What if the user changes devices mid-flow?`;
+        const flow = parseFlows(md)[0];
+        expect(flow.assumptions).toMatch(/Service Worker/);
+        expect(flow.openQuestions).toMatch(/changes devices/);
+    });
+
+    it('assigns a high-risk label when failure modes or unresolved refs exist', () => {
+        const md = `### Flow: Dangerous
+**Steps:**
+1. [Home] — User does X → System returns 500 and cannot recover
+**Error Paths:**
+- Service returns 500 and cannot recover, hard fail
+- TBD: confirm canonical id once feature catalog ships`;
+        const flow = parseFlows(md)[0];
+        expect(flow.risk).toBe('high');
+    });
+
+    it('assigns a medium-risk label when only alternate paths or edge cases exist', () => {
+        const md = `### Flow: Reasonable
+**Steps:**
+1. [Home] — User opens app → System loads
+**Error Paths:**
+- Network timeout → retry with backoff`;
+        const flow = parseFlows(md)[0];
+        expect(flow.risk).toBe('medium');
+    });
+
+    it('assigns a low-risk label when no issues are present', () => {
+        const md = `### Flow: Safe
+**Steps:**
+1. [Home] — User opens app → System renders`;
+        const flow = parseFlows(md)[0];
+        expect(flow.risk).toBe('low');
+    });
+});

--- a/src/components/renderers/userFlows/__tests__/stripTraceMetadata.test.ts
+++ b/src/components/renderers/userFlows/__tests__/stripTraceMetadata.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { parseFlows, stripTraceMetadata } from '../parseFlow';
+
+describe('stripTraceMetadata', () => {
+    it('strips a trailing [Traces to: f1, f2, f3] block and extracts the ids', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            'Offline Core Workout Loop & Real-Time Tracking [Traces to: f1, f2, f3, f4, f5, f6]',
+        );
+        expect(cleanTitle).toBe('Offline Core Workout Loop & Real-Time Tracking');
+        expect(extracted.map(e => e.id)).toEqual(['f1', 'f2', 'f3', 'f4', 'f5', 'f6']);
+    });
+
+    it('strips a parenthesized "Traces: ..." form', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            'Workout Loop (Traces: f1, f2)',
+        );
+        expect(cleanTitle).toBe('Workout Loop');
+        expect(extracted.map(e => e.id)).toEqual(['f1', 'f2']);
+    });
+
+    it('strips a trailing dash "— Traces to: f1" form', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            'Offline Mode — Traces to: f1, F-014',
+        );
+        expect(cleanTitle).toBe('Offline Mode');
+        expect(extracted.map(e => e.id)).toContain('f1');
+        expect(extracted.map(e => e.id)).toContain('f014');
+    });
+
+    it('strips "Maps to: f1" alternative wording', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            'Coach Triage & Program Override [Maps to: f4, f5, f7]',
+        );
+        expect(cleanTitle).toBe('Coach Triage & Program Override');
+        expect(extracted.map(e => e.id)).toEqual(['f4', 'f5', 'f7']);
+    });
+
+    it('handles "[Features: f1, f2]" wording', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            'Onboarding [Features: f1, f2]',
+        );
+        expect(cleanTitle).toBe('Onboarding');
+        expect(extracted.map(e => e.id)).toEqual(['f1', 'f2']);
+    });
+
+    it('leaves a title without trace metadata unchanged', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            'AI Baseline Setup & Initial Onboarding',
+        );
+        expect(cleanTitle).toBe('AI Baseline Setup & Initial Onboarding');
+        expect(extracted).toEqual([]);
+    });
+
+    it('does NOT eat a bracketed prefix that is part of the title', () => {
+        // `[Beta]` is not a trace-metadata token — it should stay in the title.
+        const { cleanTitle, extracted } = stripTraceMetadata(
+            '[Beta] Onboarding Flow',
+        );
+        expect(cleanTitle).toBe('[Beta] Onboarding Flow');
+        expect(extracted).toEqual([]);
+    });
+
+    it('handles an empty string gracefully', () => {
+        const { cleanTitle, extracted } = stripTraceMetadata('');
+        expect(cleanTitle).toBe('');
+        expect(extracted).toEqual([]);
+    });
+});
+
+describe('parseFlows — trace metadata in headings', () => {
+    it('cleans the title in the heading and lifts the feature refs to the flow', () => {
+        const md = `### Flow: Offline Core Workout Loop & Real-Time Tracking [Traces to: f1, f2, f3]
+**Steps:**
+1. [Active Workout] — User starts a set → System records the rep`;
+        const flow = parseFlows(md)[0];
+        expect(flow.title).toBe('Offline Core Workout Loop & Real-Time Tracking');
+        expect(flow.rawTitle).toBe(
+            'Offline Core Workout Loop & Real-Time Tracking [Traces to: f1, f2, f3]',
+        );
+        const ids = flow.featureRefs.map(r => r.id);
+        expect(ids).toEqual(expect.arrayContaining(['f1', 'f2', 'f3']));
+    });
+
+    it('keeps original feature refs from steps and adds the title-extracted ones', () => {
+        const md = `### Flow: Recipe Ingestion [Traces to: f9]
+**Steps:**
+1. [Importer] — User pastes URL → System scrapes via [f1] microservice`;
+        const flow = parseFlows(md)[0];
+        const ids = flow.featureRefs.map(r => r.id);
+        // Both the title-extracted (f9) and the step-extracted (f1) appear.
+        expect(ids).toEqual(expect.arrayContaining(['f9', 'f1']));
+        expect(flow.title).toBe('Recipe Ingestion');
+    });
+});

--- a/src/components/renderers/userFlows/parseFlow.ts
+++ b/src/components/renderers/userFlows/parseFlow.ts
@@ -1,28 +1,95 @@
 import type {
-    FeatureRef, FlowIssue, FlowIssueKind, ParsedErrorPath, ParsedFlow, ParsedStep,
+    FeatureRef, FlowIssue, FlowIssueKind, FlowRiskLevel, ParsedErrorPath, ParsedFlow, ParsedStep,
 } from './types';
 import { categorize } from './categorize';
 
 type RawSection = {
     goal?: string;
     preconditions?: string;
+    entryPoints?: string;
     stepsBlock?: string;
     successOutcome?: string;
     errorPaths?: string;
     edgeCases?: string;
+    assumptions?: string;
+    openQuestions?: string;
     rest?: string;
 };
 
 const SECTION_LABELS: Array<[keyof RawSection, RegExp]> = [
     ['goal', /^\*\*Goal:\*\*\s*/i],
     ['preconditions', /^\*\*Preconditions:\*\*\s*/i],
+    ['entryPoints', /^\*\*Entry\s*Points?:\*\*\s*/i],
     ['stepsBlock', /^\*\*Steps:\*\*\s*/i],
     ['successOutcome', /^\*\*Success Outcome:\*\*\s*/i],
     ['errorPaths', /^\*\*Error Paths:\*\*\s*/i],
     ['edgeCases', /^\*\*Edge Cases:\*\*\s*/i],
+    ['assumptions', /^\*\*Assumptions?:\*\*\s*/i],
+    ['openQuestions', /^\*\*Open\s*Questions?:\*\*\s*/i],
 ];
 
-type RawFlow = RawSection & { title: string };
+type RawFlow = RawSection & { rawTitle: string };
+
+/**
+ * Strip `[Traces to: f1, f2, ...]` / `(Traces: f1, f2)` / `[Maps to: f1]`
+ * style metadata from a flow title. Returns the cleaned title plus the
+ * extracted feature reference tokens so the renderer can surface them as
+ * chips outside the heading.
+ *
+ * Real-world generated titles include shapes like:
+ *   "Onboarding [Traces to: f1, f3, f4]"
+ *   "Workout Loop (Traces: f1, f2)"
+ *   "Offline Mode — Maps to: f1, f2"
+ *
+ * We keep the matcher narrow to avoid eating bracketed text that is part
+ * of the actual title (e.g. "[Beta] Onboarding").
+ */
+const TRACE_BRACKET_RE = /\s*[[(]\s*(?:traces?(?:\s+to)?|maps?\s+to|covers|implements|features?|refs?)\s*:?\s+([^)\]]+?)\s*[\])]/gi;
+const TRACE_DASH_RE = /\s+[—–-]\s+(?:traces?(?:\s+to)?|maps?\s+to|covers|implements|features?|refs?)\s*:?\s+([\w\s,;.&/-]+?)\s*$/i;
+const FEATURE_TOKEN_RE = /\b([fF]-?\d{1,4})\b/g;
+
+export function stripTraceMetadata(title: string): {
+    cleanTitle: string;
+    extracted: FeatureRef[];
+} {
+    if (!title) return { cleanTitle: '', extracted: [] };
+    const seen = new Set<string>();
+    const extracted: FeatureRef[] = [];
+
+    const pushTokens = (chunk: string) => {
+        FEATURE_TOKEN_RE.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = FEATURE_TOKEN_RE.exec(chunk)) !== null) {
+            const id = normalizeFeatureId(m[1]);
+            if (seen.has(id)) continue;
+            seen.add(id);
+            extracted.push({ id, raw: m[1] });
+        }
+    };
+
+    let out = title;
+
+    // Bracketed / parenthesized trace metadata — may appear anywhere in the title.
+    out = out.replace(TRACE_BRACKET_RE, (_full, contents: string) => {
+        pushTokens(contents);
+        return '';
+    });
+
+    // Trailing " — Traces to: f1, f2" form (no brackets).
+    out = out.replace(TRACE_DASH_RE, (_full, contents: string) => {
+        pushTokens(contents);
+        return '';
+    });
+
+    // Collapse double-spaces / dangling separators left behind.
+    out = out
+        .replace(/\s{2,}/g, ' ')
+        .replace(/[\s—–-]+$/g, '')
+        .replace(/^[\s—–-]+/g, '')
+        .trim();
+
+    return { cleanTitle: out, extracted };
+}
 
 function splitFlows(markdown: string): RawFlow[] {
     const flows: RawFlow[] = [];
@@ -49,7 +116,7 @@ function splitFlows(markdown: string): RawFlow[] {
                 flush();
                 flows.push(current);
             }
-            current = { title: headingMatch[1] };
+            current = { rawTitle: headingMatch[1] };
             bufferKey = null;
             bufferLines = [];
             continue;
@@ -347,16 +414,63 @@ export function classifyIssue(text: string): FlowIssueKind {
     return 'edge_case';
 }
 
-function parseEntryPoints(preconditions?: string): string[] {
-    if (!preconditions) return [];
+function parseBulletLines(block?: string): string[] {
+    if (!block) return [];
     const out: string[] = [];
-    for (const line of preconditions.split('\n')) {
+    for (const line of block.split('\n')) {
         const trimmed = line.trim().replace(/^[-*]\s+/, '');
         if (trimmed.length === 0) continue;
         out.push(trimmed);
     }
     return out;
 }
+
+/**
+ * Normalize text for dedupe — strip punctuation, lowercase, collapse
+ * whitespace. We use this when comparing preconditions vs entry points so
+ * that "User has installed the PWA." matches "user has installed the
+ * PWA" regardless of trailing periods or capitalization.
+ */
+function normalizeForCompare(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[`*_]/g, '')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+}
+
+/**
+ * Pick a final list of entry points for display. Prefers an explicit
+ * `**Entry Points:**` section when present. Falls back to inferring from
+ * preconditions, but skips any line that is byte-equal (after
+ * normalization) to the preconditions text itself — otherwise the UI
+ * shows the same sentence in both cards.
+ */
+function chooseEntryPoints(opts: {
+    explicit?: string;
+    preconditions?: string;
+}): string[] {
+    if (opts.explicit && opts.explicit.trim().length > 0) {
+        const explicit = parseBulletLines(opts.explicit);
+        if (!opts.preconditions) return explicit;
+        const preNorms = new Set(
+            parseBulletLines(opts.preconditions).map(normalizeForCompare),
+        );
+        // Also compare against the precondition text as a whole, since the
+        // common shape is a single paragraph rather than a bullet list.
+        preNorms.add(normalizeForCompare(opts.preconditions));
+        return explicit.filter(line => !preNorms.has(normalizeForCompare(line)));
+    }
+
+    // No explicit section — infer from preconditions but only when the
+    // preconditions look like a list of distinct entry-style triggers.
+    // A single-paragraph precondition like "User has an account." is more
+    // of a state-fact than an entry point; surfacing it duplicates content.
+    const inferred = parseBulletLines(opts.preconditions);
+    if (inferred.length <= 1) return [];
+    return inferred;
+}
+
 
 function parseInferredSystems(steps: ParsedStep[]): string[] {
     const seen = new Set<string>();
@@ -371,9 +485,19 @@ function parseInferredSystems(steps: ParsedStep[]): string[] {
 function aggregateFeatureRefs(
     steps: ParsedStep[],
     extras: Array<string | undefined>,
+    titleExtracted: FeatureRef[] = [],
 ): FeatureRef[] {
     const seen = new Set<string>();
     const out: FeatureRef[] = [];
+
+    // Refs extracted from the title's `[Traces to: ...]` metadata go first
+    // so they always surface — even when no step or section mentions them.
+    for (const f of titleExtracted) {
+        if (seen.has(f.id)) continue;
+        seen.add(f.id);
+        out.push(f);
+    }
+
     for (const step of steps) {
         for (const f of step.featureRefs) {
             if (seen.has(f.id)) continue;
@@ -425,31 +549,72 @@ function buildIssues(
     return out;
 }
 
+/**
+ * Compute a coarse risk score for the flow from its issue mix and
+ * step density. Used to give product/eng a "where to look first"
+ * indicator in the sidebar.
+ *
+ *   - high   : any failure_mode, or >=3 alt paths/edge cases combined, or >=1 unresolved ref
+ *   - medium : any alternate_path / edge_case / validation_warning
+ *   - low    : otherwise (including a flow with no recognized issues)
+ */
+function inferRisk(issues: FlowIssue[]): FlowRiskLevel {
+    if (issues.length === 0) return 'low';
+    let alt = 0;
+    let edge = 0;
+    let failure = 0;
+    let unresolved = 0;
+    let validation = 0;
+    for (const i of issues) {
+        if (i.kind === 'failure_mode') failure++;
+        else if (i.kind === 'alternate_path') alt++;
+        else if (i.kind === 'edge_case') edge++;
+        else if (i.kind === 'unresolved_reference') unresolved++;
+        else if (i.kind === 'validation_warning') validation++;
+    }
+    if (failure > 0 || unresolved > 0) return 'high';
+    if (alt + edge >= 3) return 'high';
+    if (alt + edge + validation > 0) return 'medium';
+    return 'low';
+}
+
 export function parseFlows(markdown: string): ParsedFlow[] {
     const raw = splitFlows(markdown);
     return raw.map(r => {
+        const { cleanTitle, extracted: titleExtractedRefs } = stripTraceMetadata(r.rawTitle);
         const steps = r.stepsBlock ? parseStepsBlock(r.stepsBlock) : [];
         const errorPaths = r.errorPaths ? parseErrorPaths(r.errorPaths, steps) : [];
-        const inferredEntryPoints = parseEntryPoints(r.preconditions);
+        const entryPoints = chooseEntryPoints({
+            explicit: r.entryPoints,
+            preconditions: r.preconditions,
+        });
         const inferredSystems = parseInferredSystems(steps);
         const issues = buildIssues({ errorPaths, edgeCases: r.edgeCases, steps });
-        const featureRefs = aggregateFeatureRefs(steps, [
-            r.goal, r.preconditions, r.successOutcome, r.edgeCases,
-        ]);
+        const featureRefs = aggregateFeatureRefs(
+            steps,
+            [r.goal, r.preconditions, r.entryPoints, r.successOutcome, r.edgeCases, r.assumptions, r.openQuestions],
+            titleExtractedRefs,
+        );
+        const risk = inferRisk(issues);
         return {
-            title: r.title,
-            category: categorize(r.title, r.goal),
+            title: cleanTitle || r.rawTitle,
+            rawTitle: r.rawTitle,
+            category: categorize(cleanTitle || r.rawTitle, r.goal),
             goal: r.goal,
             preconditions: r.preconditions,
             successOutcome: r.successOutcome,
             edgeCases: r.edgeCases,
+            assumptions: r.assumptions,
+            openQuestions: r.openQuestions,
             rest: r.rest,
             steps,
             errorPaths,
             issues,
-            inferredEntryPoints,
+            entryPoints,
+            inferredEntryPoints: entryPoints,
             inferredSystems,
             featureRefs,
+            risk,
         };
     });
 }

--- a/src/components/renderers/userFlows/types.ts
+++ b/src/components/renderers/userFlows/types.ts
@@ -12,6 +12,9 @@ export type FeatureRef = {
     raw: string;
 };
 
+/** Heuristic risk level inferred from the issue mix on a flow. */
+export type FlowRiskLevel = 'low' | 'medium' | 'high';
+
 export type ParsedStep = {
     index: number;
     rawText: string;
@@ -71,20 +74,37 @@ export type FlowJourneyNode = {
 };
 
 export type ParsedFlow = {
+    /** Title with any `[Traces to: …]` / `(Traces: …)` metadata stripped. */
     title: string;
+    /** Original heading text — kept so authors editing the source can debug. */
+    rawTitle: string;
     category: FlowCategory;
     goal?: string;
     preconditions?: string;
     successOutcome?: string;
     edgeCases?: string;
+    /** Optional explicit assumptions section (`**Assumptions:**`). */
+    assumptions?: string;
+    /** Optional explicit open-questions section (`**Open Questions:**`). */
+    openQuestions?: string;
     rest?: string;
     steps: ParsedStep[];
     /** Raw error-paths block items, kept for backwards-compat consumers. */
     errorPaths: ParsedErrorPath[];
     /** Normalized issues with categorization (alternate path, edge case, etc.). */
     issues: FlowIssue[];
+    /**
+     * Entry points presented in the UI. Sourced from an explicit
+     * `**Entry Points:**` block when available, otherwise inferred from
+     * `**Preconditions:**`. May be empty when the only entry point is
+     * indistinguishable from the preconditions text.
+     */
+    entryPoints: string[];
+    /** Legacy alias for `entryPoints` — older callers may still read this. */
     inferredEntryPoints: string[];
     inferredSystems: string[];
     /** Aggregated feature references across the whole flow. */
     featureRefs: FeatureRef[];
+    /** Heuristic risk level derived from the issue mix. */
+    risk: FlowRiskLevel;
 };


### PR DESCRIPTION
## Summary

Enhances the user flows renderer with two major features: (1) a new "Related Artifacts" panel that surfaces heuristically-matched screens, data entities, implementation phases, and feature systems from the structured PRD, and (2) automatic risk-level inference based on issue mix and step density, with visual indicators in the sidebar and summary card.

## Key Changes

- **New `RelatedArtifactsPanel` component** — Displays linked screens, data entities, implementation phases, and feature systems via fuzzy text matching and feature-ID overlap detection. Renders nothing when no artifacts connect, avoiding empty cards on legacy data.

- **Risk inference system** — Added `inferRisk()` function that assigns `low` / `medium` / `high` risk levels based on failure modes, unresolved references, and edge-case density. Risk indicators appear in the sidebar (colored dot) and summary card (badge) only when meaningful.

- **Title metadata extraction** — New `stripTraceMetadata()` function parses `[Traces to: f1, f2]`, `(Traces: f1)`, and `— Traces to: f1` patterns from flow headings, extracts feature IDs, and returns a clean title. Handles multiple wording variants (`Maps to`, `Features`, `Covers`, etc.) and avoids false positives on bracketed title prefixes like `[Beta]`.

- **Entry points vs. preconditions refinement** — Added `chooseEntryPoints()` logic that prefers explicit `**Entry Points:**` sections when present, falls back to inferring from multi-bullet preconditions (skipping single-paragraph state-facts), and deduplicates lines that match the preconditions text after normalization.

- **New `AssumptionsPanel` component** — Surfaces optional `**Assumptions:**` and `**Open Questions:**` sections from the flow. Hidden entirely when neither section exists to avoid empty cards on legacy artifacts.

- **Updated `FlowSummaryCard`** — Now displays edge-case count, risk badge, and related features inline. Conditionally hides preconditions block when redundant with entry points.

- **Updated `FlowSidebar`** — Shows risk dot (colored indicator) next to flow titles when risk is medium/high or issues exist. Avoids green "low risk" dots on every flow to prevent indicator fatigue.

- **Type additions** — Added `FlowRiskLevel` type, `rawTitle` field to `ParsedFlow`, and optional `assumptions` / `openQuestions` / `entryPoints` / `inferredSystems` fields.

- **Comprehensive test coverage** — New test suites for `stripTraceMetadata()`, entry-point deduplication, assumptions/open-questions parsing, and risk classification.

## Implementation Details

- **Heuristic matching** — Text corpus built from flow title, goal, preconditions, steps, and inferred systems; matching uses case-insensitive, punctuation-stripped substring search with a 3-character minimum to avoid false positives.

- **Feature-ID normalization** — IDs are lowercased and dashes removed (`F-014` → `f014`) for consistent deduplication across title metadata, steps, and sections.

- **Risk scoring** — Prioritizes failure modes and unresolved references as high-risk signals; combines alternate paths + edge cases (≥3 total) as high-risk; any alternate path / edge case / validation warning alone is medium-risk.

- **Backward compatibility** — All new panels and fields are optional; legacy flows without trace metadata, assumptions, or entry points render gracefully without empty cards.

https://claude.ai/code/session_01E5hthGtHZxee1D7BsoockL