### PR TITLE
Fix mobile mockup AI-image preview dead-ending on stalled cellular sockets

### DIFF
--- a/src/lib/__tests__/openaiClient.test.ts
+++ b/src/lib/__tests__/openaiClient.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { callOpenAIImage } from '../openaiClient';
+
+// A fetch that never resolves on its own but rejects with AbortError the
+// moment its signal is aborted — mirrors a real socket that has silently
+// stalled (no bytes, no error) until our per-attempt timeout fires, and also
+// the behaviour when the caller cancels.
+const hangUntilAbort = (signal?: AbortSignal): Promise<Response> =>
+    new Promise((_resolve, reject) => {
+        if (signal?.aborted) return reject(new DOMException('Aborted', 'AbortError'));
+        signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+    });
+
+const okImageResponse = (b64: string): Response =>
+    ({ ok: true, json: async () => ({ data: [{ b64_json: b64 }] }) } as unknown as Response);
+
+const ATTEMPT_TIMEOUT_MS = 75_000;
+const opts = { quality: 'low' as const, size: '1024x1536' };
+
+describe('callOpenAIImage timeout + retry', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        localStorage.setItem('OPENAI_API_KEY', 'test-key');
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        localStorage.clear();
+        vi.restoreAllMocks();
+    });
+
+    it('retries a stalled attempt on a fresh connection instead of dead-ending', async () => {
+        const fetchMock = vi.fn()
+            // Attempt 1: stalls until our timeout aborts it.
+            .mockImplementationOnce((_url, init: RequestInit) => hangUntilAbort(init.signal as AbortSignal))
+            // Attempt 2 (fresh socket): succeeds.
+            .mockImplementationOnce(async () => okImageResponse('IMG_B64'));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const p = callOpenAIImage('prompt', opts);
+        await vi.advanceTimersByTimeAsync(ATTEMPT_TIMEOUT_MS); // attempt 1 times out
+        await vi.advanceTimersByTimeAsync(1000);               // backoff before retry
+
+        await expect(p).resolves.toBe('IMG_B64');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces the "try again on Wi-Fi" guidance once timeout retries are exhausted', async () => {
+        const fetchMock = vi.fn((_url, init: RequestInit) => hangUntilAbort(init.signal as AbortSignal));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const p = callOpenAIImage('prompt', opts);
+        const assertion = expect(p).rejects.toThrow(/timing out after several attempts.*Try again on Wi-Fi/s);
+        await vi.advanceTimersByTimeAsync(ATTEMPT_TIMEOUT_MS); // attempt 1 times out
+        await vi.advanceTimersByTimeAsync(1000);               // backoff
+        await vi.advanceTimersByTimeAsync(ATTEMPT_TIMEOUT_MS); // attempt 2 (last) times out
+        await assertion;
+
+        // initial attempt + MAX_TIMEOUT_RETRIES (1) = 2 attempts, no more.
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('propagates a user cancel as AbortError without retrying', async () => {
+        const fetchMock = vi.fn((_url, init: RequestInit) => hangUntilAbort(init.signal as AbortSignal));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const controller = new AbortController();
+        const p = callOpenAIImage('prompt', { ...opts, signal: controller.signal });
+        const assertion = expect(p).rejects.toMatchObject({ name: 'AbortError' });
+        controller.abort();
+        await assertion;
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/openaiClient.ts
+++ b/src/lib/openaiClient.ts
@@ -34,14 +34,31 @@ export const hasOpenAIKey = (): boolean => {
 // Mobile Safari surfaces transient connection drops as `TypeError: Load failed`
 // during a single in-flight fetch. Image generation can take 20–60s, so a
 // flaky cellular link kills the request before it ever reaches the server.
-// Retry connection-level failures with exponential backoff; HTTP errors,
-// auth failures, and AbortError bypass retry and propagate immediately.
+// Retry connection-level failures with exponential backoff; HTTP errors and
+// auth failures bypass retry and propagate immediately.
 const MAX_FETCH_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 
-// gpt-image-2 high-quality p99 sits around 60s; 75s gives headroom without
-// leaving doomed sockets open on cellular eating retry budget.
-const REQUEST_TIMEOUT_MS = 75_000;
+// gpt-image-2 high-quality p99 sits around 60s; 75s per attempt gives headroom
+// without leaving doomed sockets open on cellular. This is a PER-ATTEMPT
+// timeout, not a global budget: on mobile the common failure is a silently
+// stalled socket (connection dies without throwing), and the only thing that
+// fires is this timeout. We therefore treat a timed-out attempt as a
+// retryable stall and reconnect on a fresh socket rather than dead-ending.
+const ATTEMPT_TIMEOUT_MS = 75_000;
+
+// A stall can recur, but waiting 4×75s on an *optional* screenshot is poor UX,
+// so cap timeout-driven retries tighter than connection-error retries.
+const MAX_TIMEOUT_RETRIES = 1;
+
+// Thrown when every attempt timed out — lets callOpenAIImage surface the
+// "took too long, try Wi-Fi" guidance instead of a generic network error.
+class ImageRequestTimeoutError extends Error {
+    constructor() {
+        super('Image request timed out on every attempt.');
+        this.name = 'ImageRequestTimeoutError';
+    }
+}
 
 const sleepWithAbort = (ms: number, signal?: AbortSignal): Promise<void> =>
     new Promise((resolve, reject) => {
@@ -53,21 +70,54 @@ const sleepWithAbort = (ms: number, signal?: AbortSignal): Promise<void> =>
         }, { once: true });
     });
 
-const fetchWithRetry = async (url: string, init: RequestInit): Promise<Response> => {
-    const signal = init.signal as AbortSignal | undefined;
-    let lastError: unknown;
-    for (let attempt = 0; attempt <= MAX_FETCH_RETRIES; attempt++) {
+// Each attempt gets its own AbortController + timeout, combined with the
+// caller's cancel signal. A timed-out attempt aborts only this private
+// controller (never the caller's signal), so the UI can still distinguish a
+// timeout (banner shown) from a user cancel (silent). Timeouts and
+// connection-level network errors are both retryable, on separate budgets.
+const fetchWithRetry = async (
+    url: string,
+    init: RequestInit,
+    callerSignal?: AbortSignal,
+): Promise<Response> => {
+    let timeoutRetries = 0;
+    let networkRetries = 0;
+    for (let attempt = 0; ; attempt++) {
+        const attemptController = new AbortController();
+        let attemptTimedOut = false;
+        const timeoutHandle = setTimeout(() => {
+            attemptTimedOut = true;
+            attemptController.abort();
+        }, ATTEMPT_TIMEOUT_MS);
+        const onCallerAbort = () => attemptController.abort();
+        callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
+        if (callerSignal?.aborted) attemptController.abort();
+
         try {
-            return await fetch(url, init);
+            return await fetch(url, { ...init, signal: attemptController.signal });
         } catch (e) {
-            lastError = e;
-            if (!isRetryableNetworkError(e) || attempt === MAX_FETCH_RETRIES) throw e;
+            // Caller cancelled — propagate untouched, never retry.
+            if (callerSignal?.aborted) throw e;
+
+            const retryableNetwork = isRetryableNetworkError(e);
+            const canRetry = attemptTimedOut
+                ? timeoutRetries < MAX_TIMEOUT_RETRIES
+                : retryableNetwork && networkRetries < MAX_FETCH_RETRIES;
+            if (!canRetry) {
+                if (attemptTimedOut) throw new ImageRequestTimeoutError();
+                throw e;
+            }
+            if (attemptTimedOut) timeoutRetries++; else networkRetries++;
+
             const delay = RETRY_BASE_MS * 2 ** attempt;
-            console.warn(`[openai] fetch failed (${(e as Error).message}); retrying in ${delay}ms (attempt ${attempt + 2}/${MAX_FETCH_RETRIES + 1})`);
-            await sleepWithAbort(delay, signal);
+            const reason = attemptTimedOut ? `timed out after ${ATTEMPT_TIMEOUT_MS}ms` : (e as Error).message;
+            console.warn(`[openai] fetch failed (${reason}); retrying in ${delay}ms...`);
+            await sleepWithAbort(delay, callerSignal);
+        } finally {
+            clearTimeout(timeoutHandle);
+            callerSignal?.removeEventListener('abort', onCallerAbort);
         }
     }
-    throw lastError;
 };
 
 const formatOpenAIError = (status: number, errorData: unknown): string => {
@@ -107,19 +157,9 @@ export const callOpenAIImage = async (
         n: 1,
     };
 
-    // Combine the caller-cancel signal with a hard request timeout. We track
-    // `timedOut` separately so the error path can distinguish "we gave up"
-    // from "the user clicked Cancel" — both surface as AbortError otherwise.
-    const composite = new AbortController();
-    let timedOut = false;
-    const timeoutHandle = setTimeout(() => {
-        timedOut = true;
-        composite.abort();
-    }, REQUEST_TIMEOUT_MS);
-    const onCallerAbort = () => composite.abort();
-    opts.signal?.addEventListener('abort', onCallerAbort, { once: true });
-    if (opts.signal?.aborted) composite.abort();
-
+    // fetchWithRetry owns the per-attempt timeout and retry-on-stall logic;
+    // we just pass the caller's cancel signal through and translate the
+    // terminal failure modes into user-facing copy.
     let response: Response;
     try {
         response = await fetchWithRetry(OPENAI_IMAGE_URL, {
@@ -129,17 +169,17 @@ export const callOpenAIImage = async (
                 'Authorization': `Bearer ${apiKey}`,
             },
             body: JSON.stringify(body),
-            signal: composite.signal,
-        });
+        }, opts.signal);
     } catch (err) {
-        // Bubble user-cancellation untouched, but rewrap timeout-driven aborts
-        // so the UI can show "took too long" instead of swallowing silently.
+        // Every attempt timed out — surface "took too long" guidance rather
+        // than swallowing it as a silent cancel.
+        if (err instanceof ImageRequestTimeoutError) {
+            throw new Error(
+                `Image preview kept timing out after several attempts. The mockup itself rendered above — this is just the optional AI screenshot. Try again on Wi-Fi.`
+            );
+        }
+        // User-initiated cancellation bubbles untouched (no error banner).
         if ((err as { name?: string })?.name === 'AbortError') {
-            if (timedOut) {
-                throw new Error(
-                    `Image preview took longer than ${Math.round(REQUEST_TIMEOUT_MS / 1000)}s. The mockup itself rendered above — this is just the optional AI screenshot. Try again on Wi-Fi.`
-                );
-            }
             throw err;
         }
         // Browser-level fetch failures arrive as TypeError with messages like
@@ -154,9 +194,6 @@ export const callOpenAIImage = async (
             );
         }
         throw new Error(`OpenAI image request failed before a response was received. Raw: ${raw}`);
-    } finally {
-        clearTimeout(timeoutHandle);
-        opts.signal?.removeEventListener('abort', onCallerAbort);
     }
 
     if (!response.ok) {


### PR DESCRIPTION
The optional gpt-image-2 screenshot for a mockup screen failed after 75s on
mobile with "took longer than 75s — try again on Wi-Fi", even for low-quality
renders that only need 5-15s of real work.

Root cause: callOpenAIImage wrapped the request in a single global 75s
AbortController timeout outside the retry loop. On cellular the common failure
is a silently stalled socket (connection dies without throwing), so the only
thing that fires is that timeout — and an AbortError is not retryable, so the
timeout was treated as a fatal, non-retryable failure and dead-ended even
though a fresh attempt would likely succeed.

Make the timeout per-attempt inside fetchWithRetry and treat a timed-out
attempt as a retryable stall: each attempt gets its own AbortController +
timeout combined with the caller's cancel signal, and a stall reconnects on a
fresh socket (bounded by MAX_TIMEOUT_RETRIES) before surfacing the "try Wi-Fi"
guidance. User-initiated cancels still propagate silently as AbortError.

Adds src/lib/__tests__/openaiClient.test.ts covering retry-on-stall, bounded
give-up, and silent user-cancel.

https://claude.ai/code/session_01JAv3qojADvbtxduCnkBBfT