### PR TITLE
Make PRD highlight edit dialog work on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,17 @@ localStorage via Zustand. A separate Vercel-hosted backend (under `api/`)
 powers a recruiter-portal sub-product with OAuth, MongoDB, and snapshot
 storage; do not confuse it with the PRD workspace.
 
+## Documentation rule
+
+**Keep this file in sync with the code in the same change.** Whenever you
+add, remove, or meaningfully alter architecture, data flow, state slices,
+the LLM pipeline, domain types, or a cross-cutting pattern (e.g. the PRD
+selection pipeline), update the relevant section of CLAUDE.md as part of
+the same commit — do not leave it for a follow-up. If a change makes an
+existing description wrong, fix the description; if it introduces a
+pattern others must follow or must not break, document it here as a rule.
+Treat docs drift as a defect in the change itself.
+
 ## Commands
 
 ```bash
@@ -128,15 +139,51 @@ User prompt → HomePage.handleCreateProject() → generateStructuredPRD()
               Pass A streams structured JSON → onPartial paints draft
               ↓
               SpineVersion stored, currentStage='prd'
-  PRD stage:       SelectableSpine — text selection → branch creation →
-                   AI conversation → consolidateBranch() merges into
-                   spine (local or doc-wide scope, see ConsolidationModal)
+  PRD stage:       SelectableSpine / StructuredPRDView — text selection →
+                   branch creation → AI conversation → consolidateBranch()
+                   merges into spine (local or doc-wide scope, see
+                   ConsolidationModal). Selection → action dialog runs
+                   through the shared touch-aware pipeline (see "PRD
+                   highlight → branch selection pipeline" below).
   Workspace stage: ArtifactsView (bundle/individual gen, refine, validate)
                    + MockupsView (platform/fidelity/scope config)
                    + MarkupImageView (MarkupImageSpec → SVG via
                    MarkupImageRenderer)
   History stage:   HistoryView — chronological timeline with diffs
 ```
+
+### PRD highlight → branch selection pipeline
+
+The core PRD-refinement gesture — highlight PRD text, get a contextual
+action dialog (Clarify / Expand / Specify / Alternative / Replace), spawn
+a history-tracked branch — is detection-source-agnostic and works on
+both desktop and touch. Both PRD renderers (`SelectableSpine.tsx` for
+markdown PRDs, `StructuredPRDView.tsx` for structured PRDs) share one
+pipeline; do not reintroduce per-component `onMouseUp` selection logic.
+
+- **`src/lib/selectionPopover.ts`** — pure, framework-free helpers:
+  `isValidSelection` (rejects null / collapsed / empty / out-of-container
+  selections), `getSelectionInfo` (text + bounding rect), and
+  `computePopoverPosition` (viewport clamp + flip-above math for the
+  desktop popover). These are unit-tested in isolation.
+- **`src/lib/useSelectionPopover.ts`** — the React hook owning detection.
+  Listens on `document` for **`pointerup`** (mouse/pen/touch, short read
+  delay) *and* **`selectionchange`** (debounced — the mobile long-press +
+  drag-handle route, which never fires a matching `mouseup`). Validates
+  against a `containerRef`; a *collapsing* selection never auto-dismisses
+  an open dialog (focusing the mobile input collapses the native range) —
+  dismissal is explicit via `clear()`.
+- **`src/lib/useIsMobile.ts`** — `matchMedia` hook at the Tailwind `md`
+  breakpoint (jsdom-safe).
+- **`src/components/SelectionActionDialog.tsx`** — shared presentation:
+  desktop = floating popover anchored to the selection rect; mobile =
+  bottom sheet with `env(safe-area-inset-*)` insets and ≥44px tap
+  targets. Both call the same branch handlers — there is no parallel
+  edit path. The branch/history flow itself (`createBranch` →
+  `replyInBranch` → `addBranchMessage`) is unchanged by this layer.
+
+`index.html` carries `viewport-fit=cover` so safe-area insets resolve on
+notched devices.
 
 ### Progress UI (`src/components/GenerationProgress.tsx`)
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <link rel="apple-touch-icon" href="/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Synapse</title>
   </head>
   <body>

--- a/src/components/SelectableSpine.tsx
+++ b/src/components/SelectableSpine.tsx
@@ -4,7 +4,8 @@ import remarkGfm from 'remark-gfm';
 import Mark from 'mark.js';
 import { useProjectStore } from '../store/projectStore';
 import { replyInBranch } from '../lib/llmProvider';
-import { IntentHelperInline } from '../lib/intentHelper';
+import { useSelectionPopover } from '../lib/useSelectionPopover';
+import { SelectionActionDialog } from './SelectionActionDialog';
 import { Callout } from './prd/Callout';
 
 interface SelectableSpineProps {
@@ -15,11 +16,16 @@ interface SelectableSpineProps {
 }
 
 export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: SelectableSpineProps) {
-    const [selection, setSelection] = useState<{ text: string; top: number; left: number } | null>(null);
     const [intent, setIntent] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const spineRef = useRef<HTMLDivElement>(null);
     const { createBranch, addBranchMessage, branches } = useProjectStore();
+
+    // Shared, touch-aware selection pipeline (mouse + pointer + selectionchange).
+    const { selection, clear } = useSelectionPopover({
+        containerRef: spineRef,
+        enabled: !readOnly,
+    });
 
     // Get active branches for this spine to highlight their anchors
     const activeBranches = (branches[projectId] || []).filter(b => b.spineVersionId === spineVersionId && b.status === 'active');
@@ -27,7 +33,7 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
     useEffect(() => {
         if (!spineRef.current) return;
 
-        // Use mark.js to highlight actual rendered text, 
+        // Use mark.js to highlight actual rendered text,
         // bypassing ReactMarkdown AST and matching across HTML tags
         const instance = new Mark(spineRef.current);
         instance.unmark();
@@ -47,82 +53,49 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
         return () => instance.unmark();
     }, [text, activeBranches]);
 
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape' && selection) {
-                setSelection(null);
-                setIntent('');
-                window.getSelection()?.removeAllRanges();
-            }
-        };
-
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [selection]);
-
-
-    const handleMouseUp = () => {
-        if (readOnly) return;
-        // Small delay to allow double-click selections to resolve
-        setTimeout(() => {
-            const sel = window.getSelection();
-            if (sel && sel.toString().trim().length > 0 && sel.rangeCount > 0) {
-                const range = sel.getRangeAt(0);
-                const rect = range.getBoundingClientRect();
-
-                // Clamp popover to viewport bounds (320px = w-80 popover width)
-                const popoverWidth = 320;
-                const popoverHeight = 220;
-                const rawLeft = rect.left + (rect.width / 2);
-                const rawTop = rect.bottom + 8;
-
-                const clampedLeft = Math.max(popoverWidth / 2 + 8, Math.min(rawLeft, window.innerWidth - popoverWidth / 2 - 8));
-                const clampedTop = rawTop + popoverHeight > window.innerHeight
-                    ? rect.top - popoverHeight - 8  // Flip above if overflowing bottom
-                    : rawTop;
-
-                setSelection({
-                    text: sel.toString().trim(),
-                    top: Math.max(8, clampedTop),
-                    left: clampedLeft,
-                });
-            } else if (!isSubmitting) { // Don't hide if interacting with the form
-                setSelection(null);
-            }
-        }, 10);
+    const dismiss = () => {
+        clear();
+        setIntent('');
     };
 
-    const handleCreateBranch = async (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!selection || !intent.trim() || isSubmitting) return;
-
+    // Single branch-creation path shared by the typed-intent form (desktop) and
+    // the one-tap action chips (mobile). Keeps the existing history-tracked flow:
+    // createBranch → replyInBranch → addBranchMessage.
+    const submitBranch = async (rawIntent: string) => {
+        if (!selection || !rawIntent.trim() || isSubmitting) return;
         try {
             setIsSubmitting(true);
             const anchorText = selection.text;
-            const userIntent = intent.trim();
+            const userIntent = rawIntent.trim();
 
             const { branchId } = createBranch(projectId, spineVersionId, anchorText, userIntent);
 
             // Clear selection UI immediately
-            setSelection(null);
+            clear();
             setIntent('');
-            window.getSelection()?.removeAllRanges();
 
-            // Mock LLM Response
             const response = await replyInBranch({ anchorText, intent: userIntent, threadHistory: [] });
             addBranchMessage(projectId, branchId, 'assistant', response);
-
         } finally {
             setIsSubmitting(false);
         }
     };
 
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        submitBranch(intent);
+    };
+
+    const handleQuickAction = (tag: string) => {
+        submitBranch(tag + ': ');
+    };
+
     return (
-        <div className="relative" onMouseUp={handleMouseUp}>
+        <div className="relative">
             <div
                 ref={spineRef}
                 className="
-                    prose prose-neutral max-w-none 
+                    prose prose-neutral max-w-none
                     prose-h1:text-3xl prose-h1:font-extrabold prose-h1:text-neutral-900 prose-h1:mb-8 prose-h1:mt-2
                     prose-h2:text-2xl prose-h2:font-bold prose-h2:text-neutral-900 prose-h2:mt-10 prose-h2:mb-4
                     prose-h3:text-xl prose-h3:font-bold prose-h3:text-neutral-900 prose-h3:mt-8 prose-h3:mb-3
@@ -144,50 +117,15 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
             </div>
 
             {selection && (
-                <div
-                    onMouseDown={(e) => e.preventDefault()}
-                    onMouseUp={(e) => e.stopPropagation()}
-                    className="fixed z-50 bg-neutral-900 border border-neutral-700 shadow-2xl rounded-xl p-4 w-[340px] -translate-x-1/2 flex flex-col gap-3"
-                    style={{ top: selection.top, left: selection.left }}
-                >
-                    <div className="text-xs text-neutral-400">
-                        <span className="font-semibold text-neutral-300">Anchor:</span> "{selection.text.length > 50 ? selection.text.substring(0, 50) + '...' : selection.text}"
-                    </div>
-
-                    <div className="flex flex-wrap gap-1.5 mt-1 mb-2">
-                        {['Clarify', 'Expand', 'Specify', 'Alternative', 'Replace'].map(tag => (
-                            <button
-                                key={tag}
-                                type="button"
-                                onClick={() => setIntent(tag + ": ")}
-                                className="text-xs px-2.5 py-1.5 bg-neutral-800 hover:bg-neutral-700 text-neutral-200 rounded-full border border-neutral-700 hover:border-neutral-500 transition shadow-sm"
-                            >
-                                {tag}
-                            </button>
-                        ))}
-                    </div>
-
-                    <IntentHelperInline text={intent} />
-
-                    <form onSubmit={handleCreateBranch} className="flex gap-2">
-                        <input
-                            autoFocus
-                            type="text"
-                            value={intent}
-                            onChange={e => setIntent(e.target.value)}
-                            placeholder="How should this change?"
-                            className="flex-1 bg-neutral-800 border border-neutral-700 text-sm text-neutral-100 rounded px-2 py-1.5 outline-none focus:border-indigo-500 transition"
-                            disabled={isSubmitting}
-                        />
-                        <button
-                            type="submit"
-                            disabled={isSubmitting || !intent.trim()}
-                            className="bg-indigo-600 hover:bg-indigo-700 text-white text-sm px-3 py-1.5 rounded transition disabled:opacity-50 min-w-[60px]"
-                        >
-                            {isSubmitting ? 'Creating...' : 'Branch'}
-                        </button>
-                    </form>
-                </div>
+                <SelectionActionDialog
+                    selection={selection}
+                    intent={intent}
+                    setIntent={setIntent}
+                    isSubmitting={isSubmitting}
+                    onSubmit={handleSubmit}
+                    onQuickAction={handleQuickAction}
+                    onDismiss={dismiss}
+                />
             )}
         </div>
     );

--- a/src/components/SelectionActionDialog.tsx
+++ b/src/components/SelectionActionDialog.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useRef } from 'react';
+import { IntentHelperInline } from '../lib/intentHelper';
+import { useIsMobile } from '../lib/useIsMobile';
+import {
+    computePopoverPosition,
+    type SelectionInfo,
+} from '../lib/selectionPopover';
+
+/** Action chips shown in the dialog. Desktop prefills; mobile one-taps. */
+export const SELECTION_ACTIONS = ['Clarify', 'Expand', 'Specify', 'Alternative', 'Replace'] as const;
+
+const POPOVER_SIZE = { width: 320, height: 220 };
+
+interface SelectionActionDialogProps {
+    selection: SelectionInfo;
+    intent: string;
+    setIntent: (value: string) => void;
+    isSubmitting: boolean;
+    /** Submit the typed intent (form submit / Branch button). */
+    onSubmit: (e: React.FormEvent) => void;
+    /** One-tap action — create a branch directly with `"<tag>: "` intent. */
+    onQuickAction: (tag: string) => void;
+    /** Dismiss the dialog (Escape, backdrop tap, cancel). */
+    onDismiss: () => void;
+}
+
+/**
+ * Shared action UI for the PRD highlight feature.
+ *
+ * - Desktop / tablet: a floating popover anchored to the selection rect
+ *   (preserves the original behavior — chips prefill the intent input, the
+ *   form submits to create a branch).
+ * - Mobile (< md): a bottom sheet with safe-area insets and ≥44px tap targets.
+ *   Chips create the branch in one tap; a free-text field remains for custom
+ *   intent. Backdrop tap dismisses.
+ *
+ * Both presentations call the same branch/history handlers passed in by the
+ * parent — there is no parallel editing path.
+ */
+export function SelectionActionDialog({
+    selection,
+    intent,
+    setIntent,
+    isSubmitting,
+    onSubmit,
+    onQuickAction,
+    onDismiss,
+}: SelectionActionDialogProps) {
+    const isMobile = useIsMobile();
+    const desktopRef = useRef<HTMLDivElement>(null);
+
+    // Escape dismisses on every platform. On desktop, a pointerdown outside the
+    // popover also dismisses (mobile uses the backdrop instead).
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onDismiss();
+        };
+        window.addEventListener('keydown', onKeyDown);
+
+        let onPointerDown: ((e: PointerEvent) => void) | undefined;
+        if (!isMobile) {
+            onPointerDown = (e: PointerEvent) => {
+                if (desktopRef.current && !desktopRef.current.contains(e.target as Node)) {
+                    onDismiss();
+                }
+            };
+            document.addEventListener('pointerdown', onPointerDown);
+        }
+
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+            if (onPointerDown) document.removeEventListener('pointerdown', onPointerDown);
+        };
+    }, [onDismiss, isMobile]);
+
+    const anchorPreview =
+        selection.text.length > 50 ? `${selection.text.substring(0, 50)}...` : selection.text;
+
+    if (isMobile) {
+        return (
+            <>
+                {/* Backdrop — tap to dismiss */}
+                <div
+                    data-testid="selection-dialog-backdrop"
+                    className="fixed inset-0 z-50 bg-black/40"
+                    onPointerDown={onDismiss}
+                    aria-hidden="true"
+                />
+                {/* Bottom sheet */}
+                <div
+                    role="dialog"
+                    aria-label="PRD edit actions"
+                    className="fixed inset-x-0 bottom-0 z-50 flex max-h-[70vh] flex-col gap-3 rounded-t-2xl border-t border-neutral-700 bg-neutral-900 p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] shadow-2xl"
+                >
+                    <div className="mx-auto mb-1 h-1 w-10 rounded-full bg-neutral-700" aria-hidden="true" />
+                    <div className="text-xs text-neutral-400">
+                        <span className="font-semibold text-neutral-300">Anchor:</span> "{anchorPreview}"
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                        {SELECTION_ACTIONS.map(tag => (
+                            <button
+                                key={tag}
+                                type="button"
+                                disabled={isSubmitting}
+                                onClick={() => onQuickAction(tag)}
+                                className="min-h-[44px] flex-1 basis-[28%] rounded-lg border border-neutral-700 bg-neutral-800 px-3 text-sm font-medium text-neutral-100 transition hover:bg-neutral-700 active:bg-neutral-600 disabled:opacity-50"
+                            >
+                                {tag}
+                            </button>
+                        ))}
+                    </div>
+
+                    <IntentHelperInline text={intent} />
+
+                    <form onSubmit={onSubmit} className="flex gap-2">
+                        <input
+                            type="text"
+                            value={intent}
+                            onChange={e => setIntent(e.target.value)}
+                            placeholder="Or type a custom change…"
+                            className="min-h-[44px] flex-1 rounded-lg border border-neutral-700 bg-neutral-800 px-3 text-sm text-neutral-100 outline-none transition focus:border-indigo-500"
+                            disabled={isSubmitting}
+                        />
+                        <button
+                            type="submit"
+                            disabled={isSubmitting || !intent.trim()}
+                            className="min-h-[44px] rounded-lg bg-indigo-600 px-4 text-sm font-medium text-white transition hover:bg-indigo-700 disabled:opacity-50"
+                        >
+                            {isSubmitting ? '…' : 'Branch'}
+                        </button>
+                    </form>
+                </div>
+            </>
+        );
+    }
+
+    // Desktop / tablet floating popover.
+    const pos = computePopoverPosition(
+        selection.rect,
+        { width: window.innerWidth, height: window.innerHeight },
+        POPOVER_SIZE,
+    );
+
+    return (
+        <div
+            ref={desktopRef}
+            role="dialog"
+            aria-label="PRD edit actions"
+            onMouseDown={e => e.preventDefault()}
+            onMouseUp={e => e.stopPropagation()}
+            className="fixed z-50 flex w-[340px] -translate-x-1/2 flex-col gap-3 rounded-xl border border-neutral-700 bg-neutral-900 p-4 shadow-2xl"
+            style={{ top: pos.top, left: pos.left }}
+        >
+            <div className="text-xs text-neutral-400">
+                <span className="font-semibold text-neutral-300">Anchor:</span> "{anchorPreview}"
+            </div>
+
+            <div className="mb-2 mt-1 flex flex-wrap gap-1.5">
+                {SELECTION_ACTIONS.map(tag => (
+                    <button
+                        key={tag}
+                        type="button"
+                        onClick={() => setIntent(tag + ': ')}
+                        className="rounded-full border border-neutral-700 bg-neutral-800 px-2.5 py-1.5 text-xs text-neutral-200 shadow-sm transition hover:border-neutral-500 hover:bg-neutral-700"
+                    >
+                        {tag}
+                    </button>
+                ))}
+            </div>
+
+            <IntentHelperInline text={intent} />
+
+            <form onSubmit={onSubmit} className="flex gap-2">
+                <input
+                    autoFocus
+                    type="text"
+                    value={intent}
+                    onChange={e => setIntent(e.target.value)}
+                    placeholder="How should this change?"
+                    className="flex-1 rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-100 outline-none transition focus:border-indigo-500"
+                    disabled={isSubmitting}
+                />
+                <button
+                    type="submit"
+                    disabled={isSubmitting || !intent.trim()}
+                    className="min-w-[60px] rounded bg-indigo-600 px-3 py-1.5 text-sm text-white transition hover:bg-indigo-700 disabled:opacity-50"
+                >
+                    {isSubmitting ? 'Creating...' : 'Branch'}
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -4,6 +4,8 @@ import Mark from 'mark.js';
 import { useProjectStore } from '../store/projectStore';
 import { structuredPRDToMarkdown, replyInBranch, generateStructuredPRD } from '../lib/llmProvider';
 import { FeatureCard } from './FeatureCard';
+import { useSelectionPopover } from '../lib/useSelectionPopover';
+import { SelectionActionDialog } from './SelectionActionDialog';
 import { v4 as uuidv4 } from 'uuid';
 import type { StructuredPRD, Feature } from '../types';
 import {
@@ -52,10 +54,16 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
     const { updateSpineStructuredPRD, createBranch, addBranchMessage, branches } = useProjectStore();
     const [editingSection, setEditingSection] = useState<EditingSection>(null);
     const [editValue, setEditValue] = useState('');
-    const [selection, setSelection] = useState<{ text: string; top: number; left: number } | null>(null);
     const [intent, setIntent] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const contentRef = useRef<HTMLDivElement>(null);
+
+    // Shared, touch-aware selection pipeline. Disabled while inline-editing a
+    // section so the textarea selection doesn't open the branch dialog.
+    const { selection, clear } = useSelectionPopover({
+        containerRef: contentRef,
+        enabled: !readOnly && !editingSection,
+    });
 
     // Get active branches for this spine to highlight their anchors.
     // Memoized so the Mark.js effect below doesn't re-run on every parent
@@ -109,82 +117,36 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
         };
     }, [structuredPRD, anchorTexts]);
 
-    // Escape to dismiss popover
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape' && selection) {
-                setSelection(null);
-                setIntent('');
-                window.getSelection()?.removeAllRanges();
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [selection]);
-
-    const getIntentHelper = (intentStr: string) => {
-        if (!intentStr) return null;
-        const lower = intentStr.toLowerCase();
-        let helper = '';
-        if (lower.startsWith('clarify')) helper = 'Ask for precision, fix ambiguity, or correct a specific detail tied to this text.';
-        else if (lower.startsWith('expand')) helper = 'Add depth or options. Generate UX ideas, NB3 prompts, or elaborations.';
-        else if (lower.startsWith('specify')) helper = 'Turn this into implementable requirements: constraints, acceptance criteria, data/API details.';
-        else if (lower.startsWith('alternative')) helper = 'Propose a different approach or architecture and explain tradeoffs.';
-        else if (lower.startsWith('replace')) helper = 'Suggest a concrete change. The system will apply locally or across the document during consolidation.';
-        if (!helper) return null;
-        return (
-            <div className="text-xs text-neutral-400 italic leading-snug bg-neutral-800/50 p-2 rounded border border-neutral-700/50 mb-2">
-                {helper}
-            </div>
-        );
+    const dismiss = () => {
+        clear();
+        setIntent('');
     };
 
-    const handleMouseUp = () => {
-        if (readOnly || editingSection) return;
-        setTimeout(() => {
-            const sel = window.getSelection();
-            if (sel && sel.toString().trim().length > 0 && sel.rangeCount > 0) {
-                const range = sel.getRangeAt(0);
-                const rect = range.getBoundingClientRect();
-
-                // Clamp popover to viewport bounds (320px = w-80 popover width)
-                const popoverWidth = 320;
-                const popoverHeight = 220;
-                const rawLeft = rect.left + (rect.width / 2);
-                const rawTop = rect.bottom + 8;
-
-                const clampedLeft = Math.max(popoverWidth / 2 + 8, Math.min(rawLeft, window.innerWidth - popoverWidth / 2 - 8));
-                const clampedTop = rawTop + popoverHeight > window.innerHeight
-                    ? rect.top - popoverHeight - 8
-                    : rawTop;
-
-                setSelection({
-                    text: sel.toString().trim(),
-                    top: Math.max(8, clampedTop),
-                    left: clampedLeft,
-                });
-            } else if (!isSubmitting) {
-                setSelection(null);
-            }
-        }, 10);
-    };
-
-    const handleCreateBranch = async (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!selection || !intent.trim() || isSubmitting) return;
+    // Single branch-creation path shared by the typed-intent form (desktop) and
+    // the one-tap action chips (mobile). Same history-tracked flow as before.
+    const submitBranch = async (rawIntent: string) => {
+        if (!selection || !rawIntent.trim() || isSubmitting) return;
         try {
             setIsSubmitting(true);
             const anchorText = selection.text;
-            const userIntent = intent.trim();
+            const userIntent = rawIntent.trim();
             const { branchId } = createBranch(projectId, spineId, anchorText, userIntent);
-            setSelection(null);
+            clear();
             setIntent('');
-            window.getSelection()?.removeAllRanges();
             const response = await replyInBranch({ anchorText, intent: userIntent, threadHistory: [] });
             addBranchMessage(projectId, branchId, 'assistant', response);
         } finally {
             setIsSubmitting(false);
         }
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        submitBranch(intent);
+    };
+
+    const handleQuickAction = (tag: string) => {
+        submitBranch(tag + ': ');
     };
 
     const savePRD = (updated: StructuredPRD) => {
@@ -543,7 +505,7 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
     };
 
     return (
-        <div className="relative" onMouseUp={handleMouseUp}>
+        <div className="relative">
             <div ref={contentRef} className="space-y-2">
                 {renderGroundingBackfill()}
 
@@ -667,50 +629,15 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
             </div>
 
             {selection && (
-                <div
-                    onMouseDown={(e) => e.preventDefault()}
-                    onMouseUp={(e) => e.stopPropagation()}
-                    className="fixed z-50 bg-neutral-900 border border-neutral-700 shadow-2xl rounded-xl p-4 w-[340px] -translate-x-1/2 flex flex-col gap-3"
-                    style={{ top: selection.top, left: selection.left }}
-                >
-                    <div className="text-xs text-neutral-400">
-                        <span className="font-semibold text-neutral-300">Anchor:</span> "{selection.text.length > 50 ? selection.text.substring(0, 50) + '...' : selection.text}"
-                    </div>
-
-                    <div className="flex flex-wrap gap-1.5 mt-1 mb-2">
-                        {['Clarify', 'Expand', 'Specify', 'Alternative', 'Replace'].map(tag => (
-                            <button
-                                key={tag}
-                                type="button"
-                                onClick={() => setIntent(tag + ": ")}
-                                className="text-xs px-2.5 py-1.5 bg-neutral-800 hover:bg-neutral-700 text-neutral-200 rounded-full border border-neutral-700 hover:border-neutral-500 transition shadow-sm"
-                            >
-                                {tag}
-                            </button>
-                        ))}
-                    </div>
-
-                    {getIntentHelper(intent)}
-
-                    <form onSubmit={handleCreateBranch} className="flex gap-2">
-                        <input
-                            autoFocus
-                            type="text"
-                            value={intent}
-                            onChange={e => setIntent(e.target.value)}
-                            placeholder="How should this change?"
-                            className="flex-1 bg-neutral-800 border border-neutral-700 text-sm text-neutral-100 rounded px-2 py-1.5 outline-none focus:border-indigo-500 transition"
-                            disabled={isSubmitting}
-                        />
-                        <button
-                            type="submit"
-                            disabled={isSubmitting || !intent.trim()}
-                            className="bg-indigo-600 hover:bg-indigo-700 text-white text-sm px-3 py-1.5 rounded transition disabled:opacity-50"
-                        >
-                            {isSubmitting ? '...' : 'Branch'}
-                        </button>
-                    </form>
-                </div>
+                <SelectionActionDialog
+                    selection={selection}
+                    intent={intent}
+                    setIntent={setIntent}
+                    isSubmitting={isSubmitting}
+                    onSubmit={handleSubmit}
+                    onQuickAction={handleQuickAction}
+                    onDismiss={dismiss}
+                />
             )}
         </div>
     );

--- a/src/components/__tests__/SelectionActionDialog.test.tsx
+++ b/src/components/__tests__/SelectionActionDialog.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SelectionActionDialog } from '../SelectionActionDialog';
+import type { SelectionInfo } from '../../lib/selectionPopover';
+
+const selection: SelectionInfo = {
+    text: 'a highlighted PRD phrase',
+    rect: { top: 100, bottom: 120, left: 200, width: 120, height: 20 },
+};
+
+function mockMatchMedia(matches: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+}
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof SelectionActionDialog>> = {}) {
+    const props = {
+        selection,
+        intent: '',
+        setIntent: vi.fn(),
+        isSubmitting: false,
+        onSubmit: vi.fn((e: React.FormEvent) => e.preventDefault()),
+        onQuickAction: vi.fn(),
+        onDismiss: vi.fn(),
+        ...overrides,
+    };
+    return { props, ...render(<SelectionActionDialog {...props} />) };
+}
+
+afterEach(() => {
+    // @ts-expect-error allow removing the stub between tests
+    delete window.matchMedia;
+    vi.restoreAllMocks();
+});
+
+describe('SelectionActionDialog — desktop', () => {
+    it('renders the action chips and the anchor preview', () => {
+        mockMatchMedia(false);
+        renderDialog();
+        expect(screen.getByText(/a highlighted PRD phrase/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Clarify' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Expand' })).toBeInTheDocument();
+        // No bottom-sheet backdrop on desktop.
+        expect(screen.queryByTestId('selection-dialog-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('prefills the intent when a chip is clicked (does not create a branch)', () => {
+        mockMatchMedia(false);
+        const { props } = renderDialog();
+        fireEvent.click(screen.getByRole('button', { name: 'Clarify' }));
+        expect(props.setIntent).toHaveBeenCalledWith('Clarify: ');
+        expect(props.onQuickAction).not.toHaveBeenCalled();
+    });
+
+    it('submits the typed intent via the form', () => {
+        mockMatchMedia(false);
+        const { props } = renderDialog({ intent: 'Clarify: make it precise' });
+        fireEvent.click(screen.getByRole('button', { name: 'Branch' }));
+        expect(props.onSubmit).toHaveBeenCalled();
+    });
+});
+
+describe('SelectionActionDialog — mobile', () => {
+    it('renders a bottom sheet with a dismissable backdrop', () => {
+        mockMatchMedia(true);
+        const { props } = renderDialog();
+        const backdrop = screen.getByTestId('selection-dialog-backdrop');
+        expect(backdrop).toBeInTheDocument();
+        fireEvent.pointerDown(backdrop);
+        expect(props.onDismiss).toHaveBeenCalled();
+    });
+
+    it('creates a branch in one tap when a chip is clicked', () => {
+        mockMatchMedia(true);
+        const { props } = renderDialog();
+        fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+        expect(props.onQuickAction).toHaveBeenCalledWith('Expand');
+        // Mobile chips do not just prefill.
+        expect(props.setIntent).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/__tests__/selectionPopover.test.ts
+++ b/src/lib/__tests__/selectionPopover.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isValidSelection,
+    computePopoverPosition,
+    type SelectionRect,
+} from '../selectionPopover';
+
+/**
+ * Builds a minimal fake `Selection` for validation tests. Only the fields read
+ * by `isValidSelection` are populated.
+ */
+function fakeSelection(opts: {
+    text?: string;
+    collapsed?: boolean;
+    rangeCount?: number;
+    anchorNode?: Node | null;
+    focusNode?: Node | null;
+}): Selection {
+    return {
+        isCollapsed: opts.collapsed ?? false,
+        rangeCount: opts.rangeCount ?? 1,
+        anchorNode: opts.anchorNode ?? null,
+        focusNode: opts.focusNode ?? null,
+        toString: () => opts.text ?? '',
+    } as unknown as Selection;
+}
+
+describe('isValidSelection', () => {
+    const container = document.createElement('div');
+    container.textContent = 'Some PRD content here';
+    const inside = container.firstChild as Node;
+
+    const outside = document.createElement('p');
+    outside.textContent = 'chrome outside the PRD';
+    const outsideNode = outside.firstChild as Node;
+
+    it('rejects a null selection', () => {
+        expect(isValidSelection(null, container)).toBe(false);
+    });
+
+    it('rejects when there is no container', () => {
+        expect(isValidSelection(fakeSelection({ text: 'x', anchorNode: inside, focusNode: inside }), null)).toBe(false);
+    });
+
+    it('rejects a collapsed (caret-only) selection', () => {
+        expect(
+            isValidSelection(
+                fakeSelection({ text: 'x', collapsed: true, anchorNode: inside, focusNode: inside }),
+                container,
+            ),
+        ).toBe(false);
+    });
+
+    it('rejects when rangeCount is 0', () => {
+        expect(
+            isValidSelection(
+                fakeSelection({ text: 'x', rangeCount: 0, anchorNode: inside, focusNode: inside }),
+                container,
+            ),
+        ).toBe(false);
+    });
+
+    it('rejects whitespace-only text', () => {
+        expect(
+            isValidSelection(
+                fakeSelection({ text: '   \n ', anchorNode: inside, focusNode: inside }),
+                container,
+            ),
+        ).toBe(false);
+    });
+
+    it('rejects a selection whose endpoints are outside the container', () => {
+        expect(
+            isValidSelection(
+                fakeSelection({ text: 'outside', anchorNode: outsideNode, focusNode: outsideNode }),
+                container,
+            ),
+        ).toBe(false);
+    });
+
+    it('accepts a non-empty selection anchored inside the container', () => {
+        expect(
+            isValidSelection(
+                fakeSelection({ text: 'PRD content', anchorNode: inside, focusNode: inside }),
+                container,
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('computePopoverPosition', () => {
+    const viewport = { width: 1000, height: 800 };
+    const size = { width: 320, height: 220 };
+
+    const rect = (over: Partial<SelectionRect> = {}): SelectionRect => ({
+        top: 100,
+        bottom: 120,
+        left: 400,
+        width: 100,
+        height: 20,
+        ...over,
+    });
+
+    it('centers horizontally on the selection and sits below it', () => {
+        const pos = computePopoverPosition(rect(), viewport, size);
+        expect(pos.left).toBe(450); // 400 + 100/2
+        expect(pos.top).toBe(128); // 120 + 8
+    });
+
+    it('clamps to the left edge so the centered popover stays on screen', () => {
+        const pos = computePopoverPosition(rect({ left: 0, width: 10 }), viewport, size);
+        expect(pos.left).toBe(size.width / 2 + 8); // 168
+    });
+
+    it('clamps to the right edge', () => {
+        const pos = computePopoverPosition(rect({ left: 990, width: 10 }), viewport, size);
+        expect(pos.left).toBe(viewport.width - size.width / 2 - 8); // 832
+    });
+
+    it('flips above the selection when it would overflow the bottom', () => {
+        const pos = computePopoverPosition(
+            rect({ top: 700, bottom: 720 }),
+            viewport,
+            size,
+        );
+        // 720 + 8 + 220 > 800 -> flip above: 700 - 220 - 8 = 472
+        expect(pos.top).toBe(472);
+    });
+
+    it('enforces an 8px top floor', () => {
+        const pos = computePopoverPosition(
+            rect({ top: 5, bottom: 790 }),
+            viewport,
+            size,
+        );
+        expect(pos.top).toBe(8);
+    });
+});

--- a/src/lib/__tests__/useSelectionPopover.test.ts
+++ b/src/lib/__tests__/useSelectionPopover.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSelectionPopover } from '../useSelectionPopover';
+
+/**
+ * Exercises the shared selection pipeline that powers both the desktop popover
+ * and the mobile bottom sheet. Verifies the two detection routes:
+ *  - `pointerup` (mouse/pen/touch — the desktop regression path)
+ *  - `selectionchange` (the mobile long-press route)
+ */
+
+function makeFakeSelection(opts: {
+    text: string;
+    node: Node | null;
+    collapsed?: boolean;
+}): Selection {
+    return {
+        isCollapsed: opts.collapsed ?? false,
+        rangeCount: 1,
+        anchorNode: opts.node,
+        focusNode: opts.node,
+        toString: () => opts.text,
+        getRangeAt: () => ({
+            getBoundingClientRect: () => ({
+                top: 10,
+                bottom: 30,
+                left: 40,
+                width: 60,
+                height: 20,
+            }),
+        }),
+        removeAllRanges: () => {},
+    } as unknown as Selection;
+}
+
+describe('useSelectionPopover', () => {
+    let container: HTMLDivElement;
+    let ref: { current: HTMLElement | null };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        container = document.createElement('div');
+        container.textContent = 'Hello PRD world';
+        document.body.appendChild(container);
+        ref = { current: container };
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    it('surfaces a valid selection after pointerup (desktop path)', () => {
+        const node = container.firstChild;
+        vi.spyOn(window, 'getSelection').mockReturnValue(
+            makeFakeSelection({ text: 'PRD', node }),
+        );
+
+        const { result } = renderHook(() =>
+            useSelectionPopover({ containerRef: ref, enabled: true }),
+        );
+
+        act(() => {
+            document.dispatchEvent(new Event('pointerup'));
+            vi.advanceTimersByTime(20);
+        });
+
+        expect(result.current.selection?.text).toBe('PRD');
+        expect(result.current.selection?.rect.left).toBe(40);
+    });
+
+    it('surfaces a valid selection after a debounced selectionchange (mobile path)', () => {
+        const node = container.firstChild;
+        vi.spyOn(window, 'getSelection').mockReturnValue(
+            makeFakeSelection({ text: 'world', node }),
+        );
+
+        const { result } = renderHook(() =>
+            useSelectionPopover({ containerRef: ref, enabled: true }),
+        );
+
+        act(() => {
+            document.dispatchEvent(new Event('selectionchange'));
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(result.current.selection?.text).toBe('world');
+    });
+
+    it('ignores selections outside the container', () => {
+        const stray = document.createElement('span');
+        stray.textContent = 'elsewhere';
+        document.body.appendChild(stray);
+
+        vi.spyOn(window, 'getSelection').mockReturnValue(
+            makeFakeSelection({ text: 'elsewhere', node: stray.firstChild }),
+        );
+
+        const { result } = renderHook(() =>
+            useSelectionPopover({ containerRef: ref, enabled: true }),
+        );
+
+        act(() => {
+            document.dispatchEvent(new Event('pointerup'));
+            vi.advanceTimersByTime(20);
+        });
+
+        expect(result.current.selection).toBeNull();
+    });
+
+    it('does not dismiss an open dialog when the selection later collapses', () => {
+        const node = container.firstChild;
+        const getSel = vi.spyOn(window, 'getSelection');
+
+        const { result } = renderHook(() =>
+            useSelectionPopover({ containerRef: ref, enabled: true }),
+        );
+
+        // First: a real selection opens the dialog.
+        getSel.mockReturnValue(makeFakeSelection({ text: 'PRD', node }));
+        act(() => {
+            document.dispatchEvent(new Event('pointerup'));
+            vi.advanceTimersByTime(20);
+        });
+        expect(result.current.selection?.text).toBe('PRD');
+
+        // Then: focusing the input collapses the native selection. The dialog
+        // must stay open (this is the mobile-keyboard failure mode).
+        getSel.mockReturnValue(makeFakeSelection({ text: '', node, collapsed: true }));
+        act(() => {
+            document.dispatchEvent(new Event('selectionchange'));
+            vi.advanceTimersByTime(300);
+        });
+        expect(result.current.selection?.text).toBe('PRD');
+    });
+
+    it('clears when disabled', () => {
+        const node = container.firstChild;
+        vi.spyOn(window, 'getSelection').mockReturnValue(
+            makeFakeSelection({ text: 'PRD', node }),
+        );
+
+        const { result, rerender } = renderHook(
+            ({ enabled }) => useSelectionPopover({ containerRef: ref, enabled }),
+            { initialProps: { enabled: true } },
+        );
+
+        act(() => {
+            document.dispatchEvent(new Event('pointerup'));
+            vi.advanceTimersByTime(20);
+        });
+        expect(result.current.selection?.text).toBe('PRD');
+
+        rerender({ enabled: false });
+        expect(result.current.selection).toBeNull();
+    });
+});

--- a/src/lib/selectionPopover.ts
+++ b/src/lib/selectionPopover.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure, framework-agnostic helpers for the PRD text-selection action dialog.
+ *
+ * These were extracted from the duplicated inline logic in
+ * `SelectableSpine.tsx` and `StructuredPRDView.tsx` so the selection-validation
+ * and viewport-clamping rules can be unit tested and shared by the
+ * desktop popover and the mobile bottom sheet.
+ */
+
+export interface SelectionRect {
+    top: number;
+    bottom: number;
+    left: number;
+    width: number;
+    height: number;
+}
+
+export interface SelectionInfo {
+    text: string;
+    rect: SelectionRect;
+}
+
+export interface Viewport {
+    width: number;
+    height: number;
+}
+
+export interface PopoverSize {
+    width: number;
+    height: number;
+}
+
+export interface PopoverPosition {
+    top: number;
+    left: number;
+}
+
+/**
+ * True when `sel` is a usable text selection wholly anchored inside
+ * `container`. Rejects: null selection, collapsed (caret-only) selections,
+ * whitespace-only text, and selections whose endpoints are not contained by
+ * the PRD content element (so selecting chrome/UI outside the PRD never opens
+ * the dialog).
+ */
+export function isValidSelection(
+    sel: Selection | null,
+    container: HTMLElement | null,
+): boolean {
+    if (!sel || !container) return false;
+    if (sel.isCollapsed) return false;
+    if (sel.rangeCount === 0) return false;
+    if (sel.toString().trim().length === 0) return false;
+
+    const { anchorNode, focusNode } = sel;
+    if (!anchorNode || !focusNode) return false;
+
+    // Both endpoints must live inside the PRD container.
+    return container.contains(anchorNode) && container.contains(focusNode);
+}
+
+/**
+ * Reads the trimmed text and bounding rect from the first range of `sel`.
+ * Returns null if there is no range. Caller should validate with
+ * `isValidSelection` first.
+ */
+export function getSelectionInfo(sel: Selection | null): SelectionInfo | null {
+    if (!sel || sel.rangeCount === 0) return null;
+    const range = sel.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    return {
+        text: sel.toString().trim(),
+        rect: {
+            top: rect.top,
+            bottom: rect.bottom,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+        },
+    };
+}
+
+/**
+ * Computes a viewport-clamped position for the floating desktop popover.
+ *
+ * - Horizontally centers on the selection, then clamps so the (centered)
+ *   popover stays fully on screen with an 8px margin.
+ * - Vertically sits 8px below the selection, but flips above it when it would
+ *   overflow the bottom edge.
+ * - Enforces an 8px top floor.
+ *
+ * The returned `left` is the popover's horizontal center (the popover element
+ * uses `-translate-x-1/2`).
+ */
+export function computePopoverPosition(
+    rect: SelectionRect,
+    viewport: Viewport,
+    size: PopoverSize,
+): PopoverPosition {
+    const rawLeft = rect.left + rect.width / 2;
+    const rawTop = rect.bottom + 8;
+
+    const clampedLeft = Math.max(
+        size.width / 2 + 8,
+        Math.min(rawLeft, viewport.width - size.width / 2 - 8),
+    );
+    const clampedTop =
+        rawTop + size.height > viewport.height
+            ? rect.top - size.height - 8 // flip above if overflowing bottom
+            : rawTop;
+
+    return {
+        top: Math.max(8, clampedTop),
+        left: clampedLeft,
+    };
+}

--- a/src/lib/useIsMobile.ts
+++ b/src/lib/useIsMobile.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns true when the viewport is at or below the given max width.
+ * Defaults to 767px, matching Tailwind's `md` breakpoint (mobile = below `md`).
+ *
+ * SSR / jsdom-safe: guards `window` and `matchMedia` so it can run in tests
+ * and during server rendering without throwing. Subscribes to viewport
+ * changes so the dialog can switch between floating popover and bottom sheet
+ * if the device rotates or the window is resized.
+ */
+export function useIsMobile(maxWidth = 767): boolean {
+    const query = `(max-width: ${maxWidth}px)`;
+
+    const getInitial = () => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return false;
+        }
+        return window.matchMedia(query).matches;
+    };
+
+    const [isMobile, setIsMobile] = useState<boolean>(getInitial);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return;
+        }
+        const mql = window.matchMedia(query);
+        // The lazy initializer already read `matchMedia` at render time, so the
+        // mount value is correct; we only need to subscribe to later changes.
+        const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+
+        // addEventListener is the modern API; addListener is the Safari < 14 fallback.
+        if (typeof mql.addEventListener === 'function') {
+            mql.addEventListener('change', handler);
+            return () => mql.removeEventListener('change', handler);
+        }
+        mql.addListener(handler);
+        return () => mql.removeListener(handler);
+    }, [query]);
+
+    return isMobile;
+}

--- a/src/lib/useSelectionPopover.ts
+++ b/src/lib/useSelectionPopover.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+import {
+    getSelectionInfo,
+    isValidSelection,
+    type SelectionInfo,
+} from './selectionPopover';
+
+interface UseSelectionPopoverOptions {
+    /** Ref to the PRD content container that selections must live inside. */
+    containerRef: RefObject<HTMLElement | null>;
+    /** When false, no listeners are attached and no selection is surfaced. */
+    enabled: boolean;
+    /** Debounce (ms) for the `selectionchange` path — the mobile route. */
+    selectionChangeDelay?: number;
+    /** Delay (ms) after `pointerup` before reading the selection. */
+    pointerUpDelay?: number;
+}
+
+interface UseSelectionPopoverResult {
+    selection: SelectionInfo | null;
+    /** Imperatively dismiss the dialog and drop the native selection. */
+    clear: () => void;
+}
+
+/**
+ * Shared, touch-aware selection pipeline for the PRD action dialog.
+ *
+ * Detection sources (so mobile works, not just desktop mouse):
+ *  - `pointerup` on the document — covers mouse, pen and touch taps; read with a
+ *    tiny delay so double-click/word selections finish resolving (preserves the
+ *    snappy desktop feel of the previous `mouseup` handler).
+ *  - `selectionchange` on the document — the mobile route. Native long-press +
+ *    drag-handle selection does not emit a `mouseup`/`pointerup` matching the
+ *    final range, but it does fire `selectionchange`. Debounced so dragging a
+ *    selection handle doesn't thrash state.
+ *
+ * Behavior:
+ *  - A selection is surfaced only when `isValidSelection` passes (non-collapsed,
+ *    non-empty, both endpoints inside `containerRef`).
+ *  - A *collapsing* selection never auto-dismisses the dialog. This is what
+ *    makes mobile usable: focusing the dialog's input (soft keyboard) collapses
+ *    the native selection, which would otherwise close the dialog. Dismissal is
+ *    explicit instead — `clear()` (Escape / backdrop tap / outside click /
+ *    submit / cancel), wired up by `SelectionActionDialog`.
+ *  - When `enabled` is false (read-only / mid-edit) no listeners are attached
+ *    and nothing is surfaced.
+ */
+export function useSelectionPopover({
+    containerRef,
+    enabled,
+    selectionChangeDelay = 300,
+    pointerUpDelay = 10,
+}: UseSelectionPopoverOptions): UseSelectionPopoverResult {
+    const [selection, setSelection] = useState<SelectionInfo | null>(null);
+
+    const clear = useCallback(() => {
+        setSelection(null);
+        if (typeof window !== 'undefined') {
+            window.getSelection()?.removeAllRanges();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        let pointerTimer: ReturnType<typeof setTimeout> | undefined;
+        let changeTimer: ReturnType<typeof setTimeout> | undefined;
+
+        // setState here is event-driven (fired from a debounced listener), not
+        // synchronous within the effect body, so it doesn't cascade renders.
+        const evaluate = () => {
+            const sel = window.getSelection();
+            if (isValidSelection(sel, containerRef.current)) {
+                const info = getSelectionInfo(sel);
+                if (info) setSelection(info);
+            }
+            // Invalid/collapsed selection: keep whatever is open. Dismissal is
+            // explicit (see the dialog), which is what keeps mobile usable.
+        };
+
+        const onPointerUp = () => {
+            clearTimeout(pointerTimer);
+            pointerTimer = setTimeout(evaluate, pointerUpDelay);
+        };
+
+        const onSelectionChange = () => {
+            clearTimeout(changeTimer);
+            changeTimer = setTimeout(evaluate, selectionChangeDelay);
+        };
+
+        document.addEventListener('pointerup', onPointerUp);
+        document.addEventListener('selectionchange', onSelectionChange);
+
+        return () => {
+            clearTimeout(pointerTimer);
+            clearTimeout(changeTimer);
+            document.removeEventListener('pointerup', onPointerUp);
+            document.removeEventListener('selectionchange', onSelectionChange);
+        };
+    }, [enabled, containerRef, selectionChangeDelay, pointerUpDelay]);
+
+    // Gate the surfaced value on `enabled` so toggling read-only / entering an
+    // inline edit hides the dialog without a setState-in-effect.
+    return { selection: enabled ? selection : null, clear };
+}


### PR DESCRIPTION
Root cause: both PRD views (SelectableSpine, StructuredPRDView) detected
text selection only via onMouseUp, which mobile long-press + drag-handle
selection never fires, so the contextual action dialog never appeared on
touch devices. The popover was also positioned with desktop-only coords
(no bottom sheet, no safe-area) and its autoFocus input opened the
keyboard and collapsed the selection.

Fix: extract the duplicated selection + popover logic into a shared,
touch-aware pipeline and add a mobile bottom-sheet presentation, leaving
the branch/history-tracked edit flow unchanged.

- selectionPopover.ts: pure, tested helpers (isValidSelection,
  getSelectionInfo, computePopoverPosition)
- useSelectionPopover.ts: detection via pointerup + debounced
  selectionchange; validates the selection is inside the PRD container;
  ignores collapse while the dialog is open (fixes mobile keyboard
  dismissing it)
- useIsMobile.ts: matchMedia hook at the md breakpoint
- SelectionActionDialog.tsx: desktop floating popover (unchanged
  behavior) vs mobile bottom sheet with safe-area insets, 44px tap
  targets, backdrop dismiss, and one-tap action chips
- SelectableSpine / StructuredPRDView: use the shared hook + dialog
- index.html: viewport-fit=cover for safe-area support
- tests: validation, viewport clamp/flip, the hook (both detection
  paths, collapse-while-open, disabled), and the dialog (desktop +
  mobile)

https://claude.ai/code/session_014gBKDz53DJ8HKko6qZrvEe