### PR TITLE
Extend component inventory data model with accessibility, previewType, and required props

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,17 @@ otherwise have nothing in common — keep that distinction in mind:
     `schemas/artifactSchemas.ts`, then convert to markdown via
     `structuredArtifactToMarkdown()` for storage; renderers in
     `src/components/renderers/` parse that markdown back to card layouts.
+    The `component_inventory` renderer is a mobile-first, searchable
+    component library (sticky search + category/complexity/used-in
+    filters, expandable cards with live previews) decomposed under
+    `src/components/renderers/componentInventory/`. Its schema/types carry
+    optional `accessibility`, `previewType`, and per-prop `required`
+    fields (all backward-compatible — older saved inventories lack them);
+    when absent, `inferPreview.ts` derives a `previewType` and a
+    heuristic, review-flagged accessibility contract at render time so
+    every card still shows a preview and a dedicated a11y block.
+    `componentInventoryParse.ts` round-trips all these fields through
+    markdown.
   - `branchService.ts` — branch consolidation back into the spine.
   - `artifactJobController.ts` — concurrency control for artifact bundle
     generation.

--- a/src/components/renderers/ComponentInventoryRenderer.tsx
+++ b/src/components/renderers/ComponentInventoryRenderer.tsx
@@ -1,4 +1,11 @@
+import { useMemo, useState } from 'react';
 import type { ComponentInventoryContent } from '../../types';
+import {
+    flattenComponents, categoryOptions, usedInOptions, matchesFilters, ALL,
+    type FilterState,
+} from './componentInventory/filter';
+import { ComponentInventoryToolbar } from './componentInventory/ComponentInventoryToolbar';
+import { ComponentCard } from './componentInventory/ComponentCard';
 
 interface Props {
     content: string;
@@ -9,56 +16,71 @@ function tryParseComponentInventory(content: string): ComponentInventoryContent 
         const parsed = JSON.parse(content);
         if (parsed.categories && Array.isArray(parsed.categories)) return parsed;
     } catch {
-        // Not JSON
+        // Not JSON — dispatcher falls back to ReactMarkdown.
     }
     return null;
 }
 
+const INITIAL_FILTERS: FilterState = {
+    searchQuery: '',
+    selectedCategory: ALL,
+    selectedComplexity: ALL,
+    selectedUsedIn: ALL,
+};
+
 export function ComponentInventoryRenderer({ content }: Props) {
     const structured = tryParseComponentInventory(content);
+    const [filters, setFilters] = useState<FilterState>(INITIAL_FILTERS);
+    // Track expansion by component name; default-expand the first component.
+    const [expandedIds, setExpandedIds] = useState<Set<string> | null>(null);
+
+    const flat = useMemo(() => (structured ? flattenComponents(structured) : []), [structured]);
+    const categories = useMemo(() => (structured ? categoryOptions(structured) : []), [structured]);
+    const usedInScreens = useMemo(() => usedInOptions(flat), [flat]);
+
+    const visible = useMemo(() => flat.filter(c => matchesFilters(c, filters)), [flat, filters]);
+
     if (!structured) return null;
 
+    // First card expanded by default until the user interacts with expansion.
+    const firstId = visible[0]?.name;
+    const isExpanded = (id: string) =>
+        expandedIds === null ? id === firstId : expandedIds.has(id);
+
+    const toggle = (id: string) => {
+        setExpandedIds(prev => {
+            const next = new Set(prev ?? (firstId ? [firstId] : []));
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
     return (
-        <div className="space-y-6">
-            {structured.categories.map((cat, ci) => (
-                <div key={ci}>
-                    <h3 className="text-sm font-bold text-neutral-500 uppercase tracking-wider mb-3">{cat.name}</h3>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        {cat.components.map((comp, coi) => (
-                            <div key={coi} className="bg-white rounded-lg border border-neutral-200 p-4 space-y-2">
-                                <div className="flex items-center justify-between">
-                                    <h4 className="font-semibold text-neutral-800 text-sm font-mono">{comp.name}</h4>
-                                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                                        comp.complexity === 'simple' ? 'bg-green-100 text-green-700'
-                                        : comp.complexity === 'moderate' ? 'bg-amber-100 text-amber-700'
-                                        : 'bg-red-100 text-red-700'
-                                    }`}>
-                                        {comp.complexity}
-                                    </span>
-                                </div>
-                                <p className="text-xs text-neutral-600">{comp.purpose}</p>
-                                {comp.props && comp.props.length > 0 && (
-                                    <div>
-                                        <span className="text-xs font-medium text-neutral-500">Props:</span>
-                                        <div className="flex flex-wrap gap-1 mt-1">
-                                            {comp.props.map((p, pi) => (
-                                                <span key={pi} className="text-xs bg-neutral-100 text-neutral-600 px-1.5 py-0.5 rounded font-mono">
-                                                    {p.name}: {p.type}
-                                                </span>
-                                            ))}
-                                        </div>
-                                    </div>
-                                )}
-                                {comp.usedIn && comp.usedIn.length > 0 && (
-                                    <p className="text-xs text-neutral-400">
-                                        Used in: {comp.usedIn.join(', ')}
-                                    </p>
-                                )}
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            ))}
+        <div>
+            <ComponentInventoryToolbar
+                state={filters}
+                onChange={partial => setFilters(f => ({ ...f, ...partial }))}
+                categories={categories}
+                usedInScreens={usedInScreens}
+            />
+
+            <div className="space-y-3 pt-4">
+                {visible.length === 0 ? (
+                    <p className="text-sm text-neutral-400 text-center py-12">
+                        No components match the current filters.
+                    </p>
+                ) : (
+                    visible.map(comp => (
+                        <ComponentCard
+                            key={`${comp.category}/${comp.name}`}
+                            component={comp}
+                            expanded={isExpanded(comp.name)}
+                            onToggle={() => toggle(comp.name)}
+                        />
+                    ))
+                )}
+            </div>
         </div>
     );
 }

--- a/src/components/renderers/__tests__/index.test.tsx
+++ b/src/components/renderers/__tests__/index.test.tsx
@@ -257,4 +257,59 @@ A patient record.
         expect(container).toHaveTextContent('id');
         expect(container).toHaveTextContent('name');
     });
+
+    it('renders the component_inventory card library with badges, props table, and a11y block', () => {
+        const jsonContent = JSON.stringify({
+            categories: [{
+                name: 'Navigation',
+                components: [{
+                    name: 'SettingsAccordion',
+                    purpose: 'Collapsible container for advanced configuration options.',
+                    complexity: 'simple',
+                    usedIn: ['Endpoint Discovery', 'Device Setup', 'Settings'],
+                    props: [
+                        { name: 'title', type: 'string', required: true, description: 'Header text of the accordion.' },
+                        { name: 'isExpanded', type: 'boolean', required: true, description: 'Controls visibility of child content.' },
+                    ],
+                    accessibility: { keyboard: true, focusManagement: true, screenReader: true, aria: ['aria-expanded'] },
+                    previewType: 'accordion',
+                }],
+            }],
+        });
+        const { container } = render(
+            <ArtifactContentRenderer subtype="component_inventory" content={jsonContent} />
+        );
+        // Search toolbar present.
+        expect(container.querySelector('input[placeholder="Search components..."]')).toBeTruthy();
+        // Card content (first card is expanded by default).
+        expect(container).toHaveTextContent('SettingsAccordion');
+        expect(container).toHaveTextContent('Used in 3');
+        // Props rendered as a table, not prose.
+        const table = container.querySelector('table');
+        expect(table).toBeTruthy();
+        expect(table).toHaveTextContent('title');
+        expect(table).toHaveTextContent('Required');
+        // Dedicated accessibility block.
+        expect(container).toHaveTextContent('Accessibility');
+        expect(container).toHaveTextContent('Keyboard Navigation');
+    });
+
+    it('renders an old-shape component_inventory (no accessibility/previewType) with a review-needed a11y note', () => {
+        const jsonContent = JSON.stringify({
+            categories: [{
+                name: 'Forms',
+                components: [{
+                    name: 'AddressSearchInput',
+                    purpose: 'Geospatial search input with async autocomplete.',
+                    complexity: 'moderate',
+                    usedIn: ['Mapping'],
+                }],
+            }],
+        });
+        const { container } = render(
+            <ArtifactContentRenderer subtype="component_inventory" content={jsonContent} />
+        );
+        expect(container).toHaveTextContent('AddressSearchInput');
+        expect(container).toHaveTextContent('review needed');
+    });
 });

--- a/src/components/renderers/componentInventory/AccessibilityChecklist.tsx
+++ b/src/components/renderers/componentInventory/AccessibilityChecklist.tsx
@@ -1,0 +1,52 @@
+// Dedicated accessibility block for a component card. Accessibility is never
+// buried in notes. When the contract was inferred rather than authored we show
+// an "Accessibility review needed" caption so the heuristic data isn't mistaken
+// for a verified guarantee.
+
+import { CircleCheck, CircleDashed, AlertCircle } from 'lucide-react';
+import type { DerivedA11y } from './inferPreview';
+
+function Row({ ok, label }: { ok: boolean | undefined; label: string }) {
+    return (
+        <li className="flex items-center gap-1.5 text-xs">
+            {ok ? (
+                <CircleCheck size={14} className="text-green-600 shrink-0" />
+            ) : (
+                <CircleDashed size={14} className="text-neutral-300 shrink-0" />
+            )}
+            <span className={ok ? 'text-neutral-700' : 'text-neutral-400'}>{label}</span>
+        </li>
+    );
+}
+
+export function AccessibilityChecklist({ a11y }: { a11y: DerivedA11y }) {
+    return (
+        <div>
+            <div className="flex items-center gap-2 mb-2">
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Accessibility</span>
+                {a11y.reviewNeeded && (
+                    <span className="inline-flex items-center gap-1 text-[10px] text-amber-600">
+                        <AlertCircle size={12} />
+                        review needed
+                    </span>
+                )}
+            </div>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1">
+                <Row ok={a11y.keyboard} label="Keyboard Navigation" />
+                <Row ok={a11y.focusManagement} label="Focus Management" />
+                <Row ok={a11y.screenReader} label="Screen Reader Support" />
+                <Row ok={!!a11y.aria?.length} label="ARIA Attributes" />
+            </ul>
+            {a11y.aria && a11y.aria.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                    {a11y.aria.map((attr, i) => (
+                        <span key={i} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600">
+                            {attr}
+                        </span>
+                    ))}
+                </div>
+            )}
+            {a11y.notes && <p className="text-xs text-neutral-500 mt-2">{a11y.notes}</p>}
+        </div>
+    );
+}

--- a/src/components/renderers/componentInventory/ComponentCard.tsx
+++ b/src/components/renderers/componentInventory/ComponentCard.tsx
@@ -1,0 +1,93 @@
+// A single component card. Collapsed: live preview + name + badges + short
+// purpose + used-in line. Expanded: adds full purpose, props table, the
+// dedicated accessibility block, and notes. Progressive disclosure — the
+// heavy detail stays hidden until expanded. The preview is the primary object
+// and stays visible in both states (stacked on mobile, side-by-side at sm+).
+
+import { ChevronDown } from 'lucide-react';
+import type { FlatComponent } from './filter';
+import { inferPreviewType, deriveAccessibility } from './inferPreview';
+import { ComponentPreview } from './ComponentPreview';
+import { CategoryBadge, ComplexityBadge, UsageBadge } from './badges';
+import { PropsTable } from './PropsTable';
+import { AccessibilityChecklist } from './AccessibilityChecklist';
+import { UsedInList } from './UsedInList';
+
+interface Props {
+    component: FlatComponent;
+    expanded: boolean;
+    onToggle: () => void;
+}
+
+export function ComponentCard({ component, expanded, onToggle }: Props) {
+    const previewType = inferPreviewType(component);
+    const usedIn = component.usedIn ?? [];
+
+    return (
+        <article className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
+            <div className="flex flex-col sm:flex-row">
+                {/* Preview — primary object, top on mobile / left on wider screens */}
+                <div className="sm:w-56 sm:shrink-0 p-3 sm:border-r border-b sm:border-b-0 border-neutral-100">
+                    <ComponentPreview previewType={previewType} />
+                </div>
+
+                {/* Details */}
+                <div className="flex-1 min-w-0 p-4">
+                    <button
+                        type="button"
+                        onClick={onToggle}
+                        aria-expanded={expanded}
+                        className="w-full flex items-start justify-between gap-2 text-left"
+                    >
+                        <h4 className="font-semibold text-neutral-800 text-sm">{component.name}</h4>
+                        <ChevronDown
+                            size={18}
+                            className={`text-neutral-400 shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`}
+                        />
+                    </button>
+
+                    <div className="flex flex-wrap items-center gap-1.5 mt-2">
+                        <CategoryBadge category={component.category} />
+                        <ComplexityBadge complexity={component.complexity} />
+                        <UsageBadge count={usedIn.length} />
+                    </div>
+
+                    <p className="text-xs text-neutral-600 mt-2 leading-relaxed">{component.purpose}</p>
+
+                    {!expanded && usedIn.length > 0 && (
+                        <p className="text-[11px] text-neutral-400 mt-2">
+                            Used In: {usedIn.join(' • ')}
+                        </p>
+                    )}
+
+                    {expanded && (
+                        <div className="mt-4 space-y-4">
+                            {component.props && component.props.length > 0 && (
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1.5">Props</div>
+                                    <PropsTable props={component.props} />
+                                </div>
+                            )}
+
+                            <AccessibilityChecklist a11y={deriveAccessibility(component)} />
+
+                            {usedIn.length > 0 && (
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1.5">Used In</div>
+                                    <UsedInList screens={usedIn} />
+                                </div>
+                            )}
+
+                            {component.notes && (
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-1">Notes</div>
+                                    <p className="text-xs text-neutral-600 leading-relaxed">{component.notes}</p>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </article>
+    );
+}

--- a/src/components/renderers/componentInventory/ComponentInventoryToolbar.tsx
+++ b/src/components/renderers/componentInventory/ComponentInventoryToolbar.tsx
@@ -1,0 +1,94 @@
+// Sticky search + filter toolbar. The chip rows scroll horizontally on narrow
+// screens so the controls stay compact and component cards remain visible
+// above the fold on mobile.
+
+import { Search } from 'lucide-react';
+import { ALL, type FilterState } from './filter';
+
+interface Props {
+    state: FilterState;
+    onChange: (next: Partial<FilterState>) => void;
+    categories: string[];
+    usedInScreens: string[];
+}
+
+const COMPLEXITIES = ['simple', 'moderate', 'complex'];
+
+function ChipRow({ options, selected, onSelect }: { options: string[]; selected: string; onSelect: (v: string) => void }) {
+    return (
+        <div className="flex gap-1.5 overflow-x-auto flex-nowrap pb-0.5 -mx-1 px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            {[ALL, ...options].map(opt => {
+                const active = selected === opt;
+                return (
+                    <button
+                        key={opt}
+                        type="button"
+                        onClick={() => onSelect(opt)}
+                        className={`shrink-0 text-xs px-3 py-1 rounded-full font-medium capitalize transition-colors ${
+                            active
+                                ? 'bg-indigo-600 text-white'
+                                : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'
+                        }`}
+                    >
+                        {opt}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+function Dropdown({ label, value, options, onChange }: { label: string; value: string; options: string[]; onChange: (v: string) => void }) {
+    return (
+        <label className="inline-flex items-center gap-1.5 text-xs text-neutral-500">
+            <span className="shrink-0">{label}</span>
+            <select
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                className="text-xs text-neutral-700 bg-white border border-neutral-200 rounded-md px-2 py-1 focus:outline-none focus:border-indigo-400 max-w-[10rem]"
+            >
+                {[ALL, ...options].map(opt => (
+                    <option key={opt} value={opt} className="capitalize">{opt}</option>
+                ))}
+            </select>
+        </label>
+    );
+}
+
+export function ComponentInventoryToolbar({ state, onChange, categories, usedInScreens }: Props) {
+    return (
+        <div className="sticky top-0 z-10 -mx-4 md:-mx-8 px-4 md:px-8 py-3 bg-neutral-50/95 backdrop-blur border-b border-neutral-200 space-y-2.5">
+            <div className="flex items-center gap-2 bg-white border border-neutral-200 rounded-lg px-3 py-2">
+                <Search size={15} className="text-neutral-400 shrink-0" />
+                <input
+                    type="text"
+                    value={state.searchQuery}
+                    onChange={e => onChange({ searchQuery: e.target.value })}
+                    placeholder="Search components..."
+                    className="flex-1 min-w-0 text-sm text-neutral-700 outline-none bg-transparent placeholder:text-neutral-400"
+                />
+            </div>
+
+            <ChipRow
+                options={categories}
+                selected={state.selectedCategory}
+                onSelect={v => onChange({ selectedCategory: v })}
+            />
+
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                <Dropdown
+                    label="Complexity:"
+                    value={state.selectedComplexity}
+                    options={COMPLEXITIES}
+                    onChange={v => onChange({ selectedComplexity: v })}
+                />
+                <Dropdown
+                    label="Used In:"
+                    value={state.selectedUsedIn}
+                    options={usedInScreens}
+                    onChange={v => onChange({ selectedUsedIn: v })}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/renderers/componentInventory/ComponentPreview.tsx
+++ b/src/components/renderers/componentInventory/ComponentPreview.tsx
@@ -1,0 +1,118 @@
+// Live, interactive-but-inert previews. Each archetype demonstrates the
+// component's behavior with local state (accordion opens, toggle flips, button
+// shows a pressed state) but never triggers real app behavior. Previews are
+// the primary visual object on every card.
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, MapPin } from 'lucide-react';
+import type { ComponentPreviewType } from '../../../types';
+
+function AccordionPreview() {
+    const [open, setOpen] = useState(false);
+    return (
+        <button
+            type="button"
+            onClick={() => setOpen(o => !o)}
+            className="w-full text-left bg-white border border-neutral-200 rounded-md p-2.5 text-xs"
+        >
+            <div className="flex items-center justify-between font-medium text-neutral-700">
+                Settings
+                <ChevronDown size={14} className={`text-neutral-400 transition-transform ${open ? 'rotate-180' : ''}`} />
+            </div>
+            {open ? (
+                <div className="mt-2 pt-2 border-t border-neutral-100 space-y-1.5 text-neutral-500">
+                    <div className="flex items-center justify-between">
+                        <span>Enable Discovery</span>
+                        <span className="w-7 h-4 rounded-full bg-indigo-500 relative">
+                            <span className="absolute right-0.5 top-0.5 w-3 h-3 rounded-full bg-white" />
+                        </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                        <span>Discovery Timeout</span>
+                        <span className="text-neutral-400">30s ▾</span>
+                    </div>
+                </div>
+            ) : (
+                <div className="mt-1.5 flex items-center justify-between text-neutral-400">
+                    Advanced Settings
+                    <ChevronRight size={13} />
+                </div>
+            )}
+        </button>
+    );
+}
+
+function InputPreview() {
+    const [value, setValue] = useState('');
+    return (
+        <div className="flex items-center gap-2 bg-white border border-neutral-200 rounded-md px-2.5 py-2">
+            <input
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                placeholder="Search address..."
+                className="flex-1 min-w-0 text-xs text-neutral-700 outline-none bg-transparent placeholder:text-neutral-400"
+            />
+            <MapPin size={14} className="text-neutral-400 shrink-0" />
+        </div>
+    );
+}
+
+function TogglePreview() {
+    const [on, setOn] = useState(true);
+    return (
+        <div className="flex items-center justify-between bg-white border border-neutral-200 rounded-md px-2.5 py-2 text-xs">
+            <span className="text-neutral-600">Enable Notifications</span>
+            <button
+                type="button"
+                role="switch"
+                aria-checked={on}
+                onClick={() => setOn(o => !o)}
+                className={`w-9 h-5 rounded-full relative transition-colors ${on ? 'bg-indigo-500' : 'bg-neutral-300'}`}
+            >
+                <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all ${on ? 'left-[18px]' : 'left-0.5'}`} />
+            </button>
+        </div>
+    );
+}
+
+function ButtonPreview() {
+    const [pressed, setPressed] = useState(false);
+    return (
+        <button
+            type="button"
+            onPointerDown={() => setPressed(true)}
+            onPointerUp={() => setPressed(false)}
+            onPointerLeave={() => setPressed(false)}
+            className={`w-full rounded-md px-3 py-2 text-xs font-medium text-white transition-all ${
+                pressed ? 'bg-indigo-700 scale-[0.98]' : 'bg-indigo-600 hover:bg-indigo-700'
+            }`}
+        >
+            Save Changes
+        </button>
+    );
+}
+
+function CustomPreview() {
+    return (
+        <div className="flex items-center justify-center bg-white border border-dashed border-neutral-200 rounded-md px-2.5 py-4 text-[11px] text-neutral-400">
+            Component preview
+        </div>
+    );
+}
+
+const PREVIEWS: Record<ComponentPreviewType, () => React.ReactElement> = {
+    accordion: AccordionPreview,
+    input: InputPreview,
+    toggle: TogglePreview,
+    button: ButtonPreview,
+    custom: CustomPreview,
+};
+
+export function ComponentPreview({ previewType }: { previewType: ComponentPreviewType }) {
+    const Preview = PREVIEWS[previewType] ?? CustomPreview;
+    return (
+        <div className="bg-neutral-50 rounded-lg p-3 border border-neutral-100">
+            <Preview />
+        </div>
+    );
+}

--- a/src/components/renderers/componentInventory/PropsTable.tsx
+++ b/src/components/renderers/componentInventory/PropsTable.tsx
@@ -1,0 +1,43 @@
+// Props rendered as a real table — never as paragraph or bullet text.
+// Monospace is scoped to the prop name/type only. The wrapper scrolls
+// horizontally on narrow screens so the table stays readable on mobile.
+
+import type { ComponentItem } from '../../../types';
+
+type Prop = NonNullable<ComponentItem['props']>[number];
+
+export function PropsTable({ props }: { props: Prop[] }) {
+    if (props.length === 0) return null;
+    return (
+        <div className="overflow-x-auto -mx-1 px-1">
+            <table className="w-full text-xs border-collapse">
+                <thead>
+                    <tr className="text-left text-[10px] uppercase tracking-wide text-neutral-400 border-b border-neutral-200">
+                        <th className="font-medium py-1.5 pr-3">Prop</th>
+                        <th className="font-medium py-1.5 pr-3">Type</th>
+                        <th className="font-medium py-1.5 pr-3 whitespace-nowrap">Required</th>
+                        <th className="font-medium py-1.5">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {props.map((p, i) => (
+                        <tr key={i} className="border-b border-neutral-100 last:border-0 align-top">
+                            <td className="py-1.5 pr-3 font-mono text-neutral-800 whitespace-nowrap">{p.name}</td>
+                            <td className="py-1.5 pr-3 font-mono text-neutral-500 whitespace-nowrap">{p.type}</td>
+                            <td className="py-1.5 pr-3 whitespace-nowrap">
+                                {p.required === true ? (
+                                    <span className="text-green-600 font-medium">Yes</span>
+                                ) : p.required === false ? (
+                                    <span className="text-neutral-400">No</span>
+                                ) : (
+                                    <span className="text-neutral-300">—</span>
+                                )}
+                            </td>
+                            <td className="py-1.5 text-neutral-600">{p.description || '—'}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/components/renderers/componentInventory/UsedInList.tsx
+++ b/src/components/renderers/componentInventory/UsedInList.tsx
@@ -1,0 +1,19 @@
+// Static "used in" screen pills. No app routes exist for screens yet, so
+// these are non-interactive; the component is structured so they can become
+// links later without touching call sites.
+
+export function UsedInList({ screens }: { screens: string[] }) {
+    if (screens.length === 0) return null;
+    return (
+        <div className="flex flex-wrap gap-1.5">
+            {screens.map((screen, i) => (
+                <span
+                    key={i}
+                    className="text-[11px] px-2 py-0.5 rounded-md bg-neutral-100 text-neutral-600 border border-neutral-200"
+                >
+                    {screen}
+                </span>
+            ))}
+        </div>
+    );
+}

--- a/src/components/renderers/componentInventory/__tests__/filter.test.ts
+++ b/src/components/renderers/componentInventory/__tests__/filter.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+    flattenComponents, categoryOptions, usedInOptions, matchesFilters, ALL,
+    type FilterState, type FlatComponent,
+} from '../filter';
+import type { ComponentInventoryContent } from '../../../../types';
+
+const inventory: ComponentInventoryContent = {
+    categories: [
+        {
+            name: 'Navigation',
+            components: [
+                { name: 'SettingsAccordion', purpose: 'Collapsible container', complexity: 'simple', usedIn: ['Settings', 'Device Setup'] },
+            ],
+        },
+        {
+            name: 'Forms',
+            components: [
+                { name: 'AddressSearchInput', purpose: 'Geospatial search', complexity: 'moderate', usedIn: ['Mapping', 'Settings'] },
+                { name: 'ToggleSwitch', purpose: 'Boolean toggle', complexity: 'simple', usedIn: ['Settings'] },
+            ],
+        },
+    ],
+};
+
+const base: FilterState = { searchQuery: '', selectedCategory: ALL, selectedComplexity: ALL, selectedUsedIn: ALL };
+
+describe('flattenComponents', () => {
+    it('flattens and tags each component with its category', () => {
+        const flat = flattenComponents(inventory);
+        expect(flat).toHaveLength(3);
+        expect(flat[0]).toMatchObject({ name: 'SettingsAccordion', category: 'Navigation' });
+        expect(flat[1]).toMatchObject({ name: 'AddressSearchInput', category: 'Forms' });
+    });
+});
+
+describe('option helpers', () => {
+    it('lists distinct categories and the usedIn union in first-seen order', () => {
+        expect(categoryOptions(inventory)).toEqual(['Navigation', 'Forms']);
+        expect(usedInOptions(flattenComponents(inventory))).toEqual(['Settings', 'Device Setup', 'Mapping']);
+    });
+});
+
+describe('matchesFilters', () => {
+    const flat = flattenComponents(inventory);
+    const find = (name: string) => flat.find(c => c.name === name) as FlatComponent;
+
+    it('passes everything when no filters are set', () => {
+        expect(flat.every(c => matchesFilters(c, base))).toBe(true);
+    });
+
+    it('search matches name, purpose, category, and usedIn', () => {
+        expect(matchesFilters(find('AddressSearchInput'), { ...base, searchQuery: 'geospatial' })).toBe(true);
+        expect(matchesFilters(find('AddressSearchInput'), { ...base, searchQuery: 'forms' })).toBe(true);
+        expect(matchesFilters(find('SettingsAccordion'), { ...base, searchQuery: 'device setup' })).toBe(true);
+        expect(matchesFilters(find('SettingsAccordion'), { ...base, searchQuery: 'nonexistent' })).toBe(false);
+    });
+
+    it('ANDs the dropdown filters together', () => {
+        expect(matchesFilters(find('ToggleSwitch'), { ...base, selectedCategory: 'Forms' })).toBe(true);
+        expect(matchesFilters(find('ToggleSwitch'), { ...base, selectedCategory: 'Navigation' })).toBe(false);
+        expect(matchesFilters(find('AddressSearchInput'), { ...base, selectedComplexity: 'moderate' })).toBe(true);
+        expect(matchesFilters(find('AddressSearchInput'), { ...base, selectedComplexity: 'simple' })).toBe(false);
+        expect(matchesFilters(find('SettingsAccordion'), { ...base, selectedUsedIn: 'Mapping' })).toBe(false);
+        expect(matchesFilters(find('AddressSearchInput'), { ...base, selectedUsedIn: 'Mapping' })).toBe(true);
+    });
+});

--- a/src/components/renderers/componentInventory/__tests__/inferPreview.test.ts
+++ b/src/components/renderers/componentInventory/__tests__/inferPreview.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { inferPreviewType, deriveAccessibility } from '../inferPreview';
+import type { ComponentItem } from '../../../../types';
+
+function comp(overrides: Partial<ComponentItem>): ComponentItem {
+    return { name: 'X', purpose: '', complexity: 'simple', ...overrides };
+}
+
+describe('inferPreviewType', () => {
+    it('honors an explicit previewType', () => {
+        expect(inferPreviewType(comp({ name: 'Anything', previewType: 'toggle' }))).toBe('toggle');
+    });
+
+    it('matches archetypes from the component name', () => {
+        expect(inferPreviewType(comp({ name: 'SettingsAccordion' }))).toBe('accordion');
+        expect(inferPreviewType(comp({ name: 'AddressSearchInput' }))).toBe('input');
+        expect(inferPreviewType(comp({ name: 'ToggleSwitch' }))).toBe('toggle');
+        expect(inferPreviewType(comp({ name: 'PrimaryButton' }))).toBe('button');
+    });
+
+    it('falls back to prop hints, then custom', () => {
+        expect(inferPreviewType(comp({ name: 'Widget', props: [{ name: 'onToggle', type: 'function' }] }))).toBe('toggle');
+        expect(inferPreviewType(comp({ name: 'Widget', props: [{ name: 'placeholder', type: 'string' }] }))).toBe('input');
+        expect(inferPreviewType(comp({ name: 'Mystery' }))).toBe('custom');
+    });
+});
+
+describe('deriveAccessibility', () => {
+    it('returns authored data with reviewNeeded=false', () => {
+        const a = deriveAccessibility(comp({ accessibility: { keyboard: true, aria: ['aria-label'] } }));
+        expect(a.reviewNeeded).toBe(false);
+        expect(a.keyboard).toBe(true);
+        expect(a.aria).toEqual(['aria-label']);
+    });
+
+    it('derives a heuristic contract flagged for review when absent', () => {
+        const a = deriveAccessibility(comp({ name: 'SettingsAccordion' }));
+        expect(a.reviewNeeded).toBe(true);
+        expect(a.keyboard).toBe(true);
+        expect(a.aria).toContain('aria-expanded');
+    });
+});

--- a/src/components/renderers/componentInventory/badges.tsx
+++ b/src/components/renderers/componentInventory/badges.tsx
@@ -1,0 +1,35 @@
+// Small badge primitives for component cards. Complexity uses the app's
+// green/amber/red scale; category and usage use the indigo/neutral accents.
+
+import type { ComponentItem } from '../../../types';
+
+const COMPLEXITY_STYLES: Record<ComponentItem['complexity'], string> = {
+    simple: 'bg-green-100 text-green-700',
+    moderate: 'bg-amber-100 text-amber-700',
+    complex: 'bg-red-100 text-red-700',
+};
+
+export function ComplexityBadge({ complexity }: { complexity: ComponentItem['complexity'] }) {
+    const label = complexity.charAt(0).toUpperCase() + complexity.slice(1);
+    return (
+        <span className={`text-[11px] px-2 py-0.5 rounded-full font-medium capitalize ${COMPLEXITY_STYLES[complexity]}`}>
+            {label}
+        </span>
+    );
+}
+
+export function CategoryBadge({ category }: { category: string }) {
+    return (
+        <span className="text-[11px] px-2 py-0.5 rounded-full font-medium bg-indigo-100 text-indigo-700 ring-1 ring-indigo-200">
+            {category}
+        </span>
+    );
+}
+
+export function UsageBadge({ count }: { count: number }) {
+    return (
+        <span className="text-[11px] px-2 py-0.5 rounded-full font-medium bg-neutral-100 text-neutral-600 ring-1 ring-neutral-200">
+            Used in {count}
+        </span>
+    );
+}

--- a/src/components/renderers/componentInventory/filter.ts
+++ b/src/components/renderers/componentInventory/filter.ts
@@ -1,0 +1,66 @@
+// Pure flatten + filter helpers for the Component Inventory renderer. Kept
+// framework-free so the filtering predicate is unit-testable in isolation.
+
+import type { ComponentInventoryContent, ComponentItem } from '../../../types';
+
+/** A component flattened out of its category, carrying the category name. */
+export interface FlatComponent extends ComponentItem {
+    category: string;
+}
+
+/** The toolbar's current filter selection. 'All' means no constraint. */
+export interface FilterState {
+    searchQuery: string;
+    selectedCategory: string;
+    selectedComplexity: string;
+    selectedUsedIn: string;
+}
+
+export const ALL = 'All';
+
+/** Flatten categories into a single list, tagging each component with its category. */
+export function flattenComponents(inventory: ComponentInventoryContent): FlatComponent[] {
+    return inventory.categories.flatMap(cat =>
+        cat.components.map(comp => ({ ...comp, category: cat.name })),
+    );
+}
+
+/** The distinct category names, in first-seen order. */
+export function categoryOptions(inventory: ComponentInventoryContent): string[] {
+    return inventory.categories.map(c => c.name).filter((n, i, arr) => arr.indexOf(n) === i);
+}
+
+/** The union of every component's usedIn screens, in first-seen order. */
+export function usedInOptions(components: FlatComponent[]): string[] {
+    const seen: string[] = [];
+    for (const comp of components) {
+        for (const screen of comp.usedIn ?? []) {
+            if (!seen.includes(screen)) seen.push(screen);
+        }
+    }
+    return seen;
+}
+
+/**
+ * True when a flattened component satisfies every active filter. Search is a
+ * case-insensitive substring match across name, purpose, category, and the
+ * usedIn screens; the three dropdown filters AND together.
+ */
+export function matchesFilters(item: FlatComponent, state: FilterState): boolean {
+    const query = state.searchQuery.trim().toLowerCase();
+    if (query) {
+        const haystack = [
+            item.name,
+            item.purpose,
+            item.category,
+            ...(item.usedIn ?? []),
+        ].join(' ').toLowerCase();
+        if (!haystack.includes(query)) return false;
+    }
+
+    if (state.selectedCategory !== ALL && item.category !== state.selectedCategory) return false;
+    if (state.selectedComplexity !== ALL && item.complexity !== state.selectedComplexity) return false;
+    if (state.selectedUsedIn !== ALL && !(item.usedIn ?? []).includes(state.selectedUsedIn)) return false;
+
+    return true;
+}

--- a/src/components/renderers/componentInventory/inferPreview.ts
+++ b/src/components/renderers/componentInventory/inferPreview.ts
@@ -1,0 +1,65 @@
+// Render-side fallbacks for the two fields older Component Inventory data
+// lacks: `previewType` and `accessibility`. Newer generations supply both
+// (see componentInventorySchema); when absent we derive sensible defaults so
+// every card still shows a live preview and a non-empty accessibility block.
+
+import type { ComponentA11y, ComponentItem, ComponentPreviewType } from '../../../types';
+
+/** Accessibility data plus a flag marking it as heuristic (unverified). */
+export interface DerivedA11y extends ComponentA11y {
+    /** True when the contract was inferred rather than authored. */
+    reviewNeeded: boolean;
+}
+
+const NAME_RULES: ReadonlyArray<[RegExp, ComponentPreviewType]> = [
+    [/accordion|collapse|expand|disclosure|drawer/i, 'accordion'],
+    [/toggle|switch|checkbox/i, 'toggle'],
+    [/button|cta|fab/i, 'button'],
+    [/input|search|field|select|textarea|combobox|picker|dropdown/i, 'input'],
+];
+
+/**
+ * Best-effort preview archetype for a component. Honors an explicit
+ * `previewType` when present, otherwise matches the component name (and, as a
+ * last resort, its props) against keyword rules. Falls back to 'custom'.
+ */
+export function inferPreviewType(component: Pick<ComponentItem, 'name' | 'previewType' | 'props'>): ComponentPreviewType {
+    if (component.previewType) return component.previewType;
+
+    const name = component.name ?? '';
+    for (const [pattern, type] of NAME_RULES) {
+        if (pattern.test(name)) return type;
+    }
+
+    // Fall back to prop-name hints (e.g. an `onToggle` or `checked` prop).
+    const propBlob = (component.props ?? []).map(p => `${p.name} ${p.type}`).join(' ');
+    if (/toggle|checked|switch/i.test(propBlob)) return 'toggle';
+    if (/value|placeholder|onchange/i.test(propBlob)) return 'input';
+    if (/onclick|onpress/i.test(propBlob)) return 'button';
+
+    return 'custom';
+}
+
+// Heuristic accessibility contracts keyed by preview archetype. These are
+// deliberately conservative defaults — the UI labels them "review needed".
+const A11Y_BY_PREVIEW: Record<ComponentPreviewType, ComponentA11y> = {
+    accordion: { keyboard: true, focusManagement: true, screenReader: true, aria: ['aria-expanded', 'aria-controls'] },
+    input: { keyboard: true, focusManagement: true, screenReader: true, aria: ['aria-label'] },
+    toggle: { keyboard: true, focusManagement: true, screenReader: true, aria: ['aria-checked', 'role="switch"'] },
+    button: { keyboard: true, focusManagement: true, screenReader: true, aria: ['aria-label'] },
+    custom: { keyboard: true, focusManagement: false, screenReader: true, aria: [] },
+};
+
+/**
+ * Returns the component's authored accessibility contract when present
+ * (reviewNeeded=false), otherwise a heuristic contract derived from the
+ * inferred preview type (reviewNeeded=true). Never returns null so the card
+ * always renders a dedicated accessibility block.
+ */
+export function deriveAccessibility(component: Pick<ComponentItem, 'name' | 'previewType' | 'props' | 'accessibility'>): DerivedA11y {
+    if (component.accessibility) {
+        return { ...component.accessibility, reviewNeeded: false };
+    }
+    const preview = inferPreviewType(component);
+    return { ...A11Y_BY_PREVIEW[preview], reviewNeeded: true };
+}

--- a/src/lib/__tests__/componentInventoryRoundTrip.test.ts
+++ b/src/lib/__tests__/componentInventoryRoundTrip.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { structuredArtifactToMarkdown } from '../services/coreArtifactService';
+import { parseComponentInventoryMarkdown } from '../componentInventoryParse';
+import type { ComponentInventoryContent } from '../../types';
+
+describe('component inventory markdown round-trip', () => {
+    it('preserves accessibility, previewType, and per-prop required through markdown', () => {
+        const inventory: ComponentInventoryContent = {
+            categories: [{
+                name: 'Navigation',
+                components: [{
+                    name: 'SettingsAccordion',
+                    purpose: 'Collapsible container for advanced configuration options.',
+                    complexity: 'simple',
+                    previewType: 'accordion',
+                    props: [
+                        { name: 'title', type: 'string', required: true, description: 'Header text of the accordion.' },
+                        { name: 'onToggle', type: 'function', description: 'Callback when header is toggled.' },
+                    ],
+                    usedIn: ['Endpoint Discovery', 'Settings'],
+                    accessibility: { keyboard: true, focusManagement: true, screenReader: true, aria: ['aria-expanded', 'aria-controls'] },
+                    notes: 'Must animate height deterministically.',
+                }],
+            }],
+        };
+
+        const markdown = structuredArtifactToMarkdown('component_inventory', inventory);
+        const parsed = parseComponentInventoryMarkdown(markdown);
+
+        expect(parsed).not.toBeNull();
+        const comp = parsed!.categories[0].components[0];
+        expect(comp.name).toBe('SettingsAccordion');
+        expect(comp.complexity).toBe('simple');
+        expect(comp.previewType).toBe('accordion');
+        expect(comp.usedIn).toEqual(['Endpoint Discovery', 'Settings']);
+        expect(comp.props).toEqual([
+            { name: 'title', type: 'string', required: true, description: 'Header text of the accordion.' },
+            { name: 'onToggle', type: 'function', description: 'Callback when header is toggled.' },
+        ]);
+        expect(comp.accessibility).toMatchObject({
+            keyboard: true,
+            focusManagement: true,
+            screenReader: true,
+            aria: ['aria-expanded', 'aria-controls'],
+        });
+        expect(comp.notes).toBe('Must animate height deterministically.');
+    });
+});

--- a/src/lib/componentInventoryParse.ts
+++ b/src/lib/componentInventoryParse.ts
@@ -3,11 +3,55 @@
 // so downstream consumers like the mockup spec builder need a way to walk
 // back to component-name + usedIn pairs.
 
-import type { ComponentInventoryContent, ComponentItem } from '../types';
+import type { ComponentA11y, ComponentInventoryContent, ComponentItem, ComponentPreviewType } from '../types';
 
 const HEADING_CATEGORY = /^##\s+(.+?)\s*$/;
 const HEADING_COMPONENT = /^####?\s+(.+?)\s*$/;
 const FIELD_LINE = /^\*\*([A-Za-z][A-Za-z /]+?):\*\*\s*(.+?)\s*$/;
+// A props bullet emitted by structuredArtifactToMarkdown, e.g.
+//   - `title`: string (required) — Header text of the accordion.
+const PROP_LINE = /^-\s+`([^`]+)`:\s*(.+?)\s*$/;
+const PREVIEW_TYPES: ReadonlySet<string> = new Set(['accordion', 'input', 'toggle', 'button', 'custom']);
+
+/** Parse a single props bullet value like "string (required) — Header text". */
+function parsePropValue(name: string, value: string): NonNullable<ComponentItem['props']>[number] {
+    let rest = value;
+    let description: string | undefined;
+    const dashIdx = rest.indexOf(' — ');
+    if (dashIdx !== -1) {
+        description = rest.slice(dashIdx + 3).trim() || undefined;
+        rest = rest.slice(0, dashIdx);
+    }
+    let required = false;
+    rest = rest.replace(/\(required\)/i, () => {
+        required = true;
+        return '';
+    });
+    const type = rest.trim();
+    const prop: NonNullable<ComponentItem['props']>[number] = { name, type };
+    if (required) prop.required = true;
+    if (description) prop.description = description;
+    return prop;
+}
+
+/** Parse the inline accessibility summary line into a structured contract. */
+function parseAccessibility(value: string): ComponentA11y {
+    const a11y: ComponentA11y = {};
+    for (const rawSeg of value.split(';')) {
+        const seg = rawSeg.trim();
+        if (!seg) continue;
+        const lower = seg.toLowerCase();
+        if (lower === 'keyboard') a11y.keyboard = true;
+        else if (lower === 'focus management') a11y.focusManagement = true;
+        else if (lower === 'screen reader') a11y.screenReader = true;
+        else if (lower.startsWith('aria:')) {
+            a11y.aria = seg.slice(seg.indexOf(':') + 1).split(',').map(s => s.trim()).filter(Boolean);
+        } else {
+            a11y.notes = a11y.notes ? `${a11y.notes}; ${seg}` : seg;
+        }
+    }
+    return a11y;
+}
 
 /**
  * Parse the markdown form emitted by `structuredArtifactToMarkdown('component_inventory', ...)`.
@@ -65,6 +109,13 @@ export function parseComponentInventoryMarkdown(content: string): ComponentInven
 
         if (!currentComponent) continue;
 
+        const propMatch = line.match(PROP_LINE);
+        if (propMatch) {
+            const prop = parsePropValue(propMatch[1], propMatch[2]);
+            (currentComponent.props ??= []).push(prop);
+            continue;
+        }
+
         const fieldMatch = line.match(FIELD_LINE);
         if (!fieldMatch) continue;
         const key = fieldMatch[1].toLowerCase();
@@ -82,6 +133,13 @@ export function parseComponentInventoryMarkdown(content: string): ComponentInven
                 .split(/[,;]/)
                 .map(s => s.trim())
                 .filter(Boolean);
+        } else if (key === 'preview') {
+            const v = value.toLowerCase();
+            if (PREVIEW_TYPES.has(v)) {
+                currentComponent.previewType = v as ComponentPreviewType;
+            }
+        } else if (key === 'accessibility') {
+            currentComponent.accessibility = parseAccessibility(value);
         } else if (key === 'notes') {
             currentComponent.notes = value;
         }

--- a/src/lib/schemas/artifactSchemas.ts
+++ b/src/lib/schemas/artifactSchemas.ts
@@ -435,6 +435,7 @@ export const componentInventorySchema = {
                                         properties: {
                                             name: { type: "STRING" },
                                             type: { type: "STRING" },
+                                            required: { type: "BOOLEAN" },
                                             description: { type: "STRING" },
                                         },
                                         required: ["name", "type"],
@@ -443,6 +444,20 @@ export const componentInventorySchema = {
                                 usedIn: { type: "ARRAY", items: { type: "STRING" } },
                                 complexity: { type: "STRING", enum: ["simple", "moderate", "complex"] },
                                 notes: { type: "STRING" },
+                                previewType: {
+                                    type: "STRING",
+                                    enum: ["accordion", "input", "toggle", "button", "custom"],
+                                },
+                                accessibility: {
+                                    type: "OBJECT",
+                                    properties: {
+                                        keyboard: { type: "BOOLEAN" },
+                                        focusManagement: { type: "BOOLEAN" },
+                                        screenReader: { type: "BOOLEAN" },
+                                        aria: { type: "ARRAY", items: { type: "STRING" } },
+                                        notes: { type: "STRING" },
+                                    },
+                                },
                             },
                             required: ["name", "purpose", "complexity"],
                         },

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -91,6 +91,10 @@ Group by category. For each component, use this exact format:
 **Complexity:** Simple | Moderate | Complex
 **Notes:** Any implementation considerations.
 
+For each prop, mark whether it is required. For each component, also provide:
+- previewType: one of "accordion", "input", "toggle", "button", or "custom" — the visual archetype that best represents how the component looks/behaves.
+- accessibility: which of keyboard navigation, focus management, and screen-reader support the component must implement, plus any required ARIA attributes/states. Be honest — only mark a capability when the component genuinely requires it.
+
 Categories to cover: Navigation, Forms & Inputs, Data Display, Feedback & Status, Layout & Containers, Overlays & Modals.`,
         userPrefix: 'Create a Component Inventory from this PRD:',
     },
@@ -268,12 +272,25 @@ export function structuredArtifactToMarkdown(subtype: CoreArtifactSubtype, data:
                 lines.push(`### ${comp.name}`);
                 lines.push(`**Purpose:** ${comp.purpose}`);
                 lines.push(`**Complexity:** ${comp.complexity}`);
+                if (comp.previewType) {
+                    lines.push(`**Preview:** ${comp.previewType}`);
+                }
                 if (comp.props?.length) {
                     lines.push('**Props:**');
-                    comp.props.forEach(p => lines.push(`- \`${p.name}\`: ${p.type}${p.description ? ` — ${p.description}` : ''}`));
+                    comp.props.forEach(p => lines.push(`- \`${p.name}\`: ${p.type}${p.required ? ' (required)' : ''}${p.description ? ` — ${p.description}` : ''}`));
                 }
                 if (comp.usedIn?.length) {
                     lines.push(`**Used In:** ${comp.usedIn.join(', ')}`);
+                }
+                if (comp.accessibility) {
+                    const a = comp.accessibility;
+                    const flags: string[] = [];
+                    if (a.keyboard) flags.push('Keyboard');
+                    if (a.focusManagement) flags.push('Focus Management');
+                    if (a.screenReader) flags.push('Screen Reader');
+                    if (a.aria?.length) flags.push(`ARIA: ${a.aria.join(', ')}`);
+                    if (a.notes) flags.push(a.notes);
+                    if (flags.length) lines.push(`**Accessibility:** ${flags.join('; ')}`);
                 }
                 if (comp.notes) {
                     lines.push(`**Notes:** ${comp.notes}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -413,13 +413,32 @@ export interface DataModelContent {
     productMapping?: ProductMappingEntry[];
 }
 
+/** Visual preview archetype for a component card. Optional in stored data —
+ * inferred from the component name/props when absent. */
+export type ComponentPreviewType = 'accordion' | 'input' | 'toggle' | 'button' | 'custom';
+
+/** Accessibility contract for a component. All fields optional; older
+ * inventories have none, in which case the renderer derives a heuristic set
+ * and flags it as needing review. */
+export interface ComponentA11y {
+    keyboard?: boolean;
+    focusManagement?: boolean;
+    screenReader?: boolean;
+    aria?: string[];
+    notes?: string;
+}
+
 export interface ComponentItem {
     name: string;
     purpose: string;
-    props?: { name: string; type: string; description?: string }[];
+    props?: { name: string; type: string; required?: boolean; description?: string }[];
     usedIn?: string[];
     complexity: 'simple' | 'moderate' | 'complex';
     notes?: string;
+    /** Optional — added by newer generations; inferred at render time otherwise. */
+    accessibility?: ComponentA11y;
+    /** Optional — added by newer generations; inferred at render time otherwise. */
+    previewType?: ComponentPreviewType;
 }
 
 export interface ComponentInventoryContent {


### PR DESCRIPTION
Add optional accessibility/previewType fields to ComponentItem plus a
per-prop required flag. Thread them through the generation schema, the
markdown round-trip, the read-side parser, and the generation prompt. All
new fields are optional so older saved inventories remain valid.

https://claude.ai/code/session_01V8bcN3ahfii55h5hMTcVE9