### PR TITLE
Fix Prompt Pack mobile UI to match User Flows navigation

### DIFF
--- a/src/components/renderers/PromptPackRenderer.tsx
+++ b/src/components/renderers/PromptPackRenderer.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { AlertTriangle, Check, Copy, Pencil, RotateCcw, Sparkles } from 'lucide-react';
-import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+import { AlertTriangle, Check, Copy, Pencil, RotateCcw } from 'lucide-react';
+import { PromptPackSidebar, type PromptNavItem } from './PromptPackSidebar';
 import type { Feature } from '../../types';
 
 // Render a `prompt_pack` artifact as one card per `### N. Title` heading,
@@ -218,46 +218,30 @@ function PromptCardView({
     const hasWarning = unresolvedIds.length > 0;
     const copyDisabled = hasWarning;
     return (
-        <article
-            id={`prompt-${card.index}`}
-            className="bg-white rounded-xl border border-neutral-200 overflow-hidden scroll-mt-24"
-        >
-            <header className="px-4 py-3 border-b border-neutral-100 flex flex-wrap items-start gap-3 justify-between">
-                <div className="min-w-0 flex-1">
-                    <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-600">
-                        Prompt {card.index}
-                    </p>
-                    <h3 className="text-sm font-bold text-neutral-900 leading-snug mt-0.5">
-                        {card.title}
-                    </h3>
-                    {(card.targetTool || card.category || modified) && (
-                        <div className="flex flex-wrap gap-1.5 mt-2">
-                            {card.targetTool && (
-                                <span className="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-700 border border-indigo-100">
-                                    <Sparkles size={10} />
-                                    {card.targetTool}
-                                </span>
-                            )}
-                            {card.category && (
-                                <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-700">
-                                    {card.category}
-                                </span>
-                            )}
-                            {modified && (
-                                <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200">
-                                    Modified
-                                </span>
-                            )}
-                        </div>
-                    )}
-                    {card.targetReason && (
-                        <p className="text-[11px] text-neutral-500 leading-snug mt-1.5">
-                            <span className="font-medium text-neutral-600">Why this target:</span>{' '}
-                            {card.targetReason}
-                        </p>
-                    )}
-                </div>
-                <div className="flex flex-wrap items-center gap-1.5">
+        <article className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
+
+            <header className="px-4 py-3 border-b border-neutral-100">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-600">
+                    Prompt {card.index}
+                </p>
+                <h3 className="text-sm font-bold text-neutral-900 leading-snug mt-0.5">
+                    {card.title}
+                </h3>
+                {(card.category || modified) && (
+                    <div className="flex flex-wrap gap-1.5 mt-2">
+                        {card.category && (
+                            <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-700">
+                                {card.category}
+                            </span>
+                        )}
+                        {modified && (
+                            <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200">
+                                Modified
+                            </span>
+                        )}
+                    </div>
+                )}
+                <div className="flex flex-wrap items-center gap-1.5 mt-3">
                     {canEdit && (
                         <>
                             <button
@@ -337,6 +321,9 @@ export function PromptPackRenderer({ content, features, edits, onUpdateEdits }: 
     const editsMap = edits ?? {};
     const canEdit = typeof onUpdateEdits === 'function';
 
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
     if (cards.length === 0) {
         return (
             <div className="prose prose-sm prose-neutral max-w-none">
@@ -344,44 +331,60 @@ export function PromptPackRenderer({ content, features, edits, onUpdateEdits }: 
             </div>
         );
     }
-    const tabs: SectionTabItem[] = cards.map(card => ({
-        id: `prompt-${card.index}`,
-        label: `${card.index}. ${card.title.length > 24 ? card.title.slice(0, 22) + '…' : card.title}`,
+
+    const safeIndex = Math.min(selectedIndex, cards.length - 1);
+    const card = cards[safeIndex];
+    const overlay = editsMap[card.index];
+    const effectiveBody = overlay !== undefined ? overlay : card.promptBody;
+    const modified = overlay !== undefined && overlay !== card.promptBody;
+    const unresolvedIds = findUnresolvedFeatureIds(effectiveBody, features ?? []);
+
+    const navItems: PromptNavItem[] = cards.map(c => ({
+        index: c.index,
+        title: c.title,
+        category: c.category,
     }));
+    const modifiedIndices = new Set(
+        cards
+            .filter(c => editsMap[c.index] !== undefined && editsMap[c.index] !== c.promptBody)
+            .map(c => c.index),
+    );
+
     return (
-        <div className="space-y-4">
-            <SectionTabs items={tabs} />
-            {preamble && (
-                <div className="prose prose-sm prose-neutral max-w-none">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{preamble}</ReactMarkdown>
-                </div>
-            )}
-            {cards.map(card => {
-                const overlay = editsMap[card.index];
-                const effectiveBody = overlay !== undefined ? overlay : card.promptBody;
-                const modified = overlay !== undefined && overlay !== card.promptBody;
-                const unresolvedIds = findUnresolvedFeatureIds(effectiveBody, features ?? []);
-                return (
-                    <PromptCardView
-                        key={card.index}
-                        card={card}
-                        effectiveBody={effectiveBody}
-                        modified={modified}
-                        unresolvedIds={unresolvedIds}
-                        canEdit={canEdit}
-                        onEdit={next => {
-                            if (!canEdit) return;
-                            onUpdateEdits!({ ...editsMap, [card.index]: next });
-                        }}
-                        onReset={() => {
-                            if (!canEdit) return;
-                            const { [card.index]: _omit, ...rest } = editsMap;
-                            void _omit;
-                            onUpdateEdits!(rest);
-                        }}
-                    />
-                );
-            })}
+        <div className="md:flex md:gap-5 md:items-start">
+            <PromptPackSidebar
+                items={navItems}
+                selectedIndex={safeIndex}
+                onSelect={setSelectedIndex}
+                isMobileOpen={mobileNavOpen}
+                onToggleMobile={setMobileNavOpen}
+                modifiedIndices={modifiedIndices}
+            />
+            <div className="flex-1 min-w-0 space-y-4">
+                {preamble && (
+                    <div className="prose prose-sm prose-neutral max-w-none">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{preamble}</ReactMarkdown>
+                    </div>
+                )}
+                <PromptCardView
+                    key={card.index}
+                    card={card}
+                    effectiveBody={effectiveBody}
+                    modified={modified}
+                    unresolvedIds={unresolvedIds}
+                    canEdit={canEdit}
+                    onEdit={next => {
+                        if (!canEdit) return;
+                        onUpdateEdits!({ ...editsMap, [card.index]: next });
+                    }}
+                    onReset={() => {
+                        if (!canEdit) return;
+                        const { [card.index]: _omit, ...rest } = editsMap;
+                        void _omit;
+                        onUpdateEdits!(rest);
+                    }}
+                />
+            </div>
         </div>
     );
 }

--- a/src/components/renderers/PromptPackSidebar.tsx
+++ b/src/components/renderers/PromptPackSidebar.tsx
@@ -1,0 +1,161 @@
+import { useEffect } from 'react';
+import { Menu, X } from 'lucide-react';
+
+// In-page navigation for the Prompt Pack artifact. Mirrors the User Flows
+// FlowSidebar shell (desktop rail + mobile drawer) so artifact navigation
+// stays consistent across the workspace. Shows one prompt at a time.
+
+export type PromptNavItem = {
+    index: number;
+    title: string;
+    category?: string;
+};
+
+interface Props {
+    items: PromptNavItem[];
+    selectedIndex: number;
+    onSelect: (index: number) => void;
+    isMobileOpen: boolean;
+    onToggleMobile: (open: boolean) => void;
+    /** Prompt indices with user edits, surfaced as a "Modified" marker. */
+    modifiedIndices?: Set<number>;
+}
+
+export function PromptPackSidebar({
+    items, selectedIndex, onSelect, isMobileOpen, onToggleMobile, modifiedIndices,
+}: Props) {
+    const selected = items[selectedIndex];
+
+    useEffect(() => {
+        if (!isMobileOpen) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onToggleMobile(false);
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [isMobileOpen, onToggleMobile]);
+
+    const renderList = (onPick: (i: number) => void) => (
+        <ul className="space-y-1">
+            {items.map((item, i) => {
+                const active = i === selectedIndex;
+                const modified = modifiedIndices?.has(item.index) ?? false;
+                return (
+                    <li key={item.index}>
+                        <button
+                            type="button"
+                            onClick={() => onPick(i)}
+                            aria-current={active ? 'true' : undefined}
+                            className={`w-full text-left px-2.5 py-2.5 rounded-md transition border ${
+                                active
+                                    ? 'bg-indigo-50 border-indigo-200 ring-1 ring-indigo-200 text-indigo-900 shadow-sm'
+                                    : 'border-transparent hover:bg-neutral-50 text-neutral-700'
+                            }`}
+                        >
+                            <div className="flex items-start gap-2">
+                                <span
+                                    className={`shrink-0 inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold ${
+                                        active
+                                            ? 'bg-indigo-600 text-white'
+                                            : 'bg-neutral-200 text-neutral-700'
+                                    }`}
+                                >
+                                    {item.index}
+                                </span>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-start gap-1.5">
+                                        <p
+                                            className="text-sm font-medium leading-snug break-words min-w-0 flex-1"
+                                            title={item.title}
+                                        >
+                                            {item.title}
+                                        </p>
+                                        {modified && (
+                                            <span className="mt-0.5 shrink-0 text-[9px] font-medium px-1 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200">
+                                                Edited
+                                            </span>
+                                        )}
+                                    </div>
+                                    {item.category && (
+                                        <p className="mt-0.5 text-[10px] text-neutral-500 truncate">
+                                            {item.category}
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+
+    return (
+        <>
+            {/* Desktop rail */}
+            <aside
+                className="hidden md:block w-72 shrink-0 self-start sticky top-0 max-h-[calc(100vh-6rem)] overflow-y-auto pr-2 border-r border-neutral-200"
+                aria-label="Prompt navigation"
+            >
+                <div className="px-2 mb-3 flex items-center justify-between">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-700">
+                        Prompts
+                    </p>
+                    <span className="text-[10px] text-neutral-400 font-mono">{items.length}</span>
+                </div>
+                {renderList(onSelect)}
+            </aside>
+
+            {/* Mobile trigger */}
+            <div className="md:hidden mb-3 flex items-center justify-between gap-2">
+                <button
+                    type="button"
+                    onClick={() => onToggleMobile(true)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-white border border-neutral-300 rounded-md text-neutral-700 hover:bg-neutral-50"
+                >
+                    <Menu size={14} /> Prompts
+                    <span className="text-neutral-400">({items.length})</span>
+                </button>
+                {selected && (
+                    <span className="text-xs text-neutral-500 truncate flex-1 text-right">
+                        {selected.index}. {selected.title}
+                    </span>
+                )}
+            </div>
+
+            {/* Mobile drawer overlay + panel */}
+            {isMobileOpen && (
+                <button
+                    type="button"
+                    aria-label="Close prompt navigation"
+                    onClick={() => onToggleMobile(false)}
+                    className="md:hidden fixed inset-0 bg-black/40 z-40"
+                />
+            )}
+            <aside
+                className={`md:hidden fixed top-0 left-0 h-full w-80 max-w-[85vw] bg-white border-r border-neutral-200 z-50 transform transition-transform duration-200 ease-out ${
+                    isMobileOpen ? 'translate-x-0' : '-translate-x-full'
+                }`}
+                aria-hidden={!isMobileOpen}
+            >
+                <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-200">
+                    <span className="text-sm font-semibold text-neutral-900">Prompts</span>
+                    <button
+                        type="button"
+                        onClick={() => onToggleMobile(false)}
+                        className="p-1 rounded hover:bg-neutral-100 text-neutral-500"
+                        aria-label="Close"
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+                <div className="overflow-y-auto h-[calc(100%-2.75rem)] p-2">
+                    {renderList(i => {
+                        onSelect(i);
+                        onToggleMobile(false);
+                    })}
+                </div>
+            </aside>
+        </>
+    );
+}

--- a/src/components/renderers/__tests__/PromptPackRenderer.test.tsx
+++ b/src/components/renderers/__tests__/PromptPackRenderer.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { PromptPackRenderer } from '../PromptPackRenderer';
+
+// Two-prompt pack exercising the parser: title, target tool/reason (now
+// intentionally NOT rendered), category, and a fenced prompt body.
+const CONTENT = `Intro preamble line.
+
+### 1. Geofence Configuration View
+**Target Tool:** Cursor
+**Reason:** Cursor applies multi-file code changes directly.
+**Category:** UI Implementation
+\`\`\`
+# Task
+Implement the Geofence Configuration screen.
+\`\`\`
+
+### 2. Playback State Dashboard
+**Target Tool:** ChatGPT
+**Category:** State Management
+\`\`\`
+# Task
+Build the playback dashboard.
+\`\`\`
+`;
+
+describe('PromptPackRenderer', () => {
+    it('renders the first prompt full-width without the target-tool callout', () => {
+        render(<PromptPackRenderer content={CONTENT} />);
+
+        // Selected prompt title + body show.
+        expect(screen.getByRole('heading', { name: 'Geofence Configuration View' })).toBeInTheDocument();
+        expect(screen.getByText(/Implement the Geofence Configuration screen/)).toBeInTheDocument();
+
+        // Category chip survives.
+        const main = document.querySelector('.flex-1') as HTMLElement;
+        expect(within(main).getByText('UI Implementation')).toBeInTheDocument();
+
+        // The useless tool callout is gone.
+        expect(screen.queryByText('Cursor')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Why this target/i)).not.toBeInTheDocument();
+    });
+
+    it('lists every prompt in the sidebar and switches the visible prompt on select', () => {
+        render(<PromptPackRenderer content={CONTENT} />);
+
+        // Desktop rail header.
+        const rail = screen.getByRole('complementary', { name: 'Prompt navigation' });
+        expect(within(rail).getByText('Prompts')).toBeInTheDocument();
+
+        // Both prompts are reachable from the rail.
+        expect(within(rail).getByRole('button', { name: /Geofence Configuration View/ })).toBeInTheDocument();
+        const second = within(rail).getByRole('button', { name: /Playback State Dashboard/ });
+        fireEvent.click(second);
+
+        expect(screen.getByRole('heading', { name: 'Playback State Dashboard' })).toBeInTheDocument();
+        expect(screen.getByText(/Build the playback dashboard/)).toBeInTheDocument();
+    });
+
+    it('falls back to raw markdown when there are no prompt headings', () => {
+        const { container } = render(<PromptPackRenderer content={'# Just markdown\n\nNo prompts here.'} />);
+        expect(container.querySelector('h1')).toHaveTextContent('Just markdown');
+    });
+});


### PR DESCRIPTION
- Replace the horizontal "1-6" pill row (SectionTabs) with a sidebar that
  mirrors the User Flows FlowSidebar: a sticky rail on desktop and a drawer
  trigger on mobile, showing one prompt at a time.
- Remove the useless target-tool callout (the "Cursor"/"ChatGPT" badge and
  the "Why this target" reason) from each prompt card.
- Restructure the prompt card header to stack the title, badges, and action
  buttons into full-width rows so the title and code body span the card
  instead of being squeezed into a narrow left column.
- Add PromptPackRenderer tests covering sidebar navigation, the removed
  callout, and the markdown fallback.

https://claude.ai/code/session_01VycfqPaniFKh1XcMBuMQqv