### PR TITLE
Upgrade default Gemini Flash to GA 3.5 Flash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { RecruiterAdminPage } from './components/RecruiterAdminPage';
 import { GlobalErrorBoundary } from './components/GlobalErrorBoundary';
 import { ToastContainer } from './components/ToastContainer';
 import { useAuthStore } from './store/authStore';
+import { migrateGeminiFlashModel } from './lib/modelMigration';
 import { Analytics } from '@vercel/analytics/react';
 
 function HomeRoute() {
@@ -52,6 +53,7 @@ function App() {
 
   useEffect(() => {
     migrateGeminiModel();
+    migrateGeminiFlashModel();
     refreshSession();
   }, [refreshSession]);
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase, Sparkles, Zap, Brain, Github } from 'lucide-react';
 import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 
-const DEFAULT_FAST_MODEL = 'gemini-3-flash-preview';
+const DEFAULT_FAST_MODEL = 'gemini-3.5-flash';
 const DEFAULT_STRONG_MODEL = 'gemini-3.1-pro-preview';
 
 interface SettingsModalProps {
@@ -25,9 +25,9 @@ interface ModelOption {
 
 const MODEL_CATALOG: ModelOption[] = [
     {
-        id: 'gemini-3-flash-preview',
-        name: 'Gemini 3 Flash',
-        description: 'Recommended default. Frontier-class quality with capacity to spare.',
+        id: 'gemini-3.5-flash',
+        name: 'Gemini 3.5 Flash',
+        description: 'Recommended default. Latest GA Flash — frontier-class quality with full quotas.',
         tier: 'current',
     },
     {
@@ -43,6 +43,12 @@ const MODEL_CATALOG: ModelOption[] = [
         tier: 'current',
     },
     {
+        id: 'gemini-3-flash-preview',
+        name: 'Gemini 3 Flash',
+        description: 'Previous-generation Flash preview — prefer 3.5 Flash, which is GA.',
+        tier: 'legacy',
+    },
+    {
         id: 'gemini-2.5-pro',
         name: 'Gemini 2.5 Pro',
         description: 'Previous-generation high-reasoning model.',
@@ -51,7 +57,7 @@ const MODEL_CATALOG: ModelOption[] = [
     {
         id: 'gemini-2.5-flash',
         name: 'Gemini 2.5 Flash',
-        description: 'Previous-generation fast model. Often hits capacity limits — prefer 3 Flash.',
+        description: 'Previous-generation fast model. Often hits capacity limits — prefer 3.5 Flash.',
         tier: 'legacy',
     },
 ];

--- a/src/lib/__tests__/geminiModel.test.ts
+++ b/src/lib/__tests__/geminiModel.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DEFAULT_GEMINI_MODEL } from '../geminiClient';
+import { migrateGeminiFlashModel } from '../modelMigration';
+import { normalizeError, userMessage } from '../errors';
+
+const LATEST_FLASH = 'gemini-3.5-flash';
+const FLASH_MIGRATION_KEY = 'GEMINI_MODEL_MIGRATED_2026_05';
+
+describe('Gemini Flash model default', () => {
+    it('defaults to the latest GA Flash model', () => {
+        expect(DEFAULT_GEMINI_MODEL).toBe(LATEST_FLASH);
+    });
+
+    it('is a GA model id (no preview suffix) and not an older Flash id', () => {
+        expect(DEFAULT_GEMINI_MODEL).not.toMatch(/preview/i);
+        expect(DEFAULT_GEMINI_MODEL).not.toBe('gemini-3-flash-preview');
+        expect(DEFAULT_GEMINI_MODEL).not.toBe('gemini-2.5-flash');
+    });
+});
+
+describe('migrateGeminiFlashModel', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('moves an older preview Flash primary selection to 3.5 Flash', () => {
+        localStorage.setItem('GEMINI_MODEL', 'gemini-3-flash-preview');
+        migrateGeminiFlashModel();
+        expect(localStorage.getItem('GEMINI_MODEL')).toBe(LATEST_FLASH);
+    });
+
+    it('moves a legacy 2.5 Flash selection to 3.5 Flash', () => {
+        localStorage.setItem('GEMINI_MODEL', 'gemini-2.5-flash');
+        migrateGeminiFlashModel();
+        expect(localStorage.getItem('GEMINI_MODEL')).toBe(LATEST_FLASH);
+    });
+
+    it('migrates the fast-tier selection too', () => {
+        localStorage.setItem('GEMINI_FAST_MODEL', 'gemini-3-flash-preview');
+        migrateGeminiFlashModel();
+        expect(localStorage.getItem('GEMINI_FAST_MODEL')).toBe(LATEST_FLASH);
+    });
+
+    it('leaves Pro and Flash-Lite selections untouched', () => {
+        localStorage.setItem('GEMINI_MODEL', 'gemini-3.1-pro-preview');
+        localStorage.setItem('GEMINI_FAST_MODEL', 'gemini-3.1-flash-lite-preview');
+        migrateGeminiFlashModel();
+        expect(localStorage.getItem('GEMINI_MODEL')).toBe('gemini-3.1-pro-preview');
+        expect(localStorage.getItem('GEMINI_FAST_MODEL')).toBe('gemini-3.1-flash-lite-preview');
+    });
+
+    it('runs at most once — a later re-selection is respected', () => {
+        localStorage.setItem('GEMINI_MODEL', 'gemini-2.5-flash');
+        migrateGeminiFlashModel();
+        expect(localStorage.getItem(FLASH_MIGRATION_KEY)).toBe('1');
+
+        // User deliberately re-picks an older model afterward.
+        localStorage.setItem('GEMINI_MODEL', 'gemini-3-flash-preview');
+        migrateGeminiFlashModel();
+        expect(localStorage.getItem('GEMINI_MODEL')).toBe('gemini-3-flash-preview');
+    });
+});
+
+describe('model access guard message', () => {
+    it('surfaces a clear access-guard message for model-not-found errors', () => {
+        const err = normalizeError(new Error('Gemini API Error: 404 - Publisher model `gemini-3.5-flash` not found'));
+        expect(err.category).toBe('model_not_found');
+        const msg = userMessage(err);
+        expect(msg).toMatch(/could not access the selected model/i);
+        expect(msg).toMatch(/API key is valid/i);
+        // No silent fallback to an older model id is named in the guidance.
+        expect(msg).not.toMatch(/gemini-2\.5-flash/i);
+    });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -88,9 +88,9 @@ const USER_MESSAGES: Record<Exclude<ErrorCategory, 'unknown' | 'project_access_d
         'Billing is not enabled on the Google Cloud project tied to this API key. Enable billing on ' +
         'that project (or switch to a key from a project that has billing enabled), then try again.',
     model_not_found:
-        'The selected Gemini model is not available to your project. Open Settings and switch to a ' +
-        'stable model like Gemini 2.5 Flash — preview model IDs (e.g. Gemini 3 Flash Preview) are ' +
-        'sometimes renamed or restricted.',
+        'Gemini Flash is configured, but the current API key could not access the selected model. ' +
+        'Check that the Gemini API key is valid and that the model is available for this account. ' +
+        'You can also open Settings and pick a different model.',
     bad_request:
         'Gemini rejected the request as malformed. This usually means the selected model does not ' +
         'support structured JSON output, or the prompt is too long. Try a different model in Settings.',

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -60,12 +60,13 @@ const getApiKey = () => {
 };
 
 /**
- * Default model. Gemini 3 Flash (preview) replaced 2.5 Flash as the recommended
- * everyday model in early 2026 — it has more capacity headroom and better
- * quality at a similar price. See SettingsModal for the full catalog + legacy
- * migration flag.
+ * Default model. Gemini 3.5 Flash (GA, announced at I/O May 2026) is the
+ * recommended everyday Flash model — it replaced the earlier Gemini 3 Flash
+ * preview, shipping as GA with full (non-preview) quotas and frontier-class
+ * quality at a similar price. See SettingsModal for the full catalog and
+ * `modelMigration.ts` for the one-shot upgrade of older Flash selections.
  */
-export const DEFAULT_GEMINI_MODEL = 'gemini-3-flash-preview';
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
 
 const getModel = () => {
     return localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL;
@@ -163,8 +164,8 @@ const formatGeminiError = (status: string, errorData: unknown): string => {
             'Gemini quota error — your request hit the FREE-TIER quota even though you expect paid tier. ' +
             'Likely causes: (1) your API key is tied to a Google Cloud project without billing enabled — ' +
             'recreate the key in AI Studio on the project that has billing; (2) set your billing project ID ' +
-            'in Settings so Synapse sends x-goog-user-project; (3) preview models (e.g. Gemini 3 Flash Preview) ' +
-            'have reduced quotas even on paid tier — switch to a stable model like gemini-2.5-flash. ' +
+            'in Settings so Synapse sends x-goog-user-project; (3) preview models (e.g. Gemini 3.1 Flash-Lite Preview) ' +
+            'have reduced quotas even on paid tier — switch to a GA model like gemini-3.5-flash. ' +
             `Raw: ${message}`
         );
     }

--- a/src/lib/modelMigration.ts
+++ b/src/lib/modelMigration.ts
@@ -1,0 +1,36 @@
+/**
+ * One-shot localStorage migrations for the Gemini model selection.
+ *
+ * Each migration is gated by a sentinel key so it runs at most once — a user
+ * who deliberately re-selects an older model afterward is respected. All access
+ * is wrapped in try/catch because localStorage throws in private-browsing modes.
+ */
+
+const LATEST_FLASH_MODEL = 'gemini-3.5-flash';
+
+// Flash model IDs that predate the GA 3.5 Flash default. Users sitting on one
+// of these (whether as their primary or fast-tier selection) are moved forward;
+// Pro and Flash-Lite selections are intentionally left untouched.
+const SUPERSEDED_FLASH_MODELS = new Set(['gemini-3-flash-preview', 'gemini-2.5-flash']);
+
+const FLASH_MIGRATION_KEY = 'GEMINI_MODEL_MIGRATED_2026_05';
+
+/**
+ * Move anyone whose stored Flash selection predates 3.5 Flash up to the new
+ * GA default. Applies to both `GEMINI_MODEL` (primary) and `GEMINI_FAST_MODEL`
+ * (fast tier used for simpler PRD sections).
+ */
+export function migrateGeminiFlashModel() {
+    try {
+        if (localStorage.getItem(FLASH_MIGRATION_KEY)) return;
+        for (const key of ['GEMINI_MODEL', 'GEMINI_FAST_MODEL']) {
+            const current = localStorage.getItem(key);
+            if (current && SUPERSEDED_FLASH_MODELS.has(current)) {
+                localStorage.setItem(key, LATEST_FLASH_MODEL);
+            }
+        }
+        localStorage.setItem(FLASH_MIGRATION_KEY, '1');
+    } catch {
+        // localStorage unavailable (private mode, etc.) — skip migration.
+    }
+}


### PR DESCRIPTION
Migrate Synapse's default Flash usage from the gemini-3-flash-preview
to the GA gemini-3.5-flash model (announced May 2026):

- geminiClient: DEFAULT_GEMINI_MODEL -> gemini-3.5-flash; refresh the
  quota-error guidance to suggest the GA model.
- SettingsModal: add Gemini 3.5 Flash as the recommended current default,
  demote Gemini 3 Flash (preview) to the legacy section, keep all older
  models selectable. Strong/Pro default unchanged.
- modelMigration: new one-shot, sentinel-gated migration that moves
  existing GEMINI_MODEL / GEMINI_FAST_MODEL selections off superseded
  Flash ids (3-flash-preview, 2.5-flash) to 3.5 Flash, leaving Pro and
  Flash-Lite picks untouched. Wired into App startup.
- errors: reword model_not_found into a clear access-guard message; no
  silent fallback to an older model.
- tests: cover the default constant, migration behavior, and the
  access-guard message.

https://claude.ai/code/session_01ByJgG87smN379M7pXfmtnv