### PR TITLE
Add responsive PRD generation progress timeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,8 +229,50 @@ pipeline; do not reintroduce per-component `onMouseUp` selection logic.
 `index.html` carries `viewport-fit=cover` so safe-area insets resolve on
 notched devices.
 
-### Progress UI (`src/components/GenerationProgress.tsx`)
+### PRD progress timeline (`src/components/progress/`)
 
+The PRD generation path renders a single **responsive** `ProgressTimeline`
+card (used on both mobile and desktop — there is no separate mobile/desktop
+component). It is driven directly by the live `prdSectionStatus` store slice
+(not by parsing the `prdProgress` message log):
+
+- **`buildGenerationSteps.ts`** — pure adapter. `computeWaves()` groups the
+  10 pipeline sections (`DEFAULT_PRD_SECTIONS`) into **dependency waves**
+  (topological levels): a single-section wave is a sequential row, a
+  multi-section wave is a "Running concurrently" group whose children are the
+  parallel sections (labeled `2A`, `2B`, …). This is purely graph-derived, so
+  it supports arbitrary graphs, multiple concurrent groups, and any step
+  count. Overlays live status/timing/model onto the static waves;
+  `formatModelName()` renders the actual configured Gemini id (e.g.
+  `gemini-3-flash-preview` → "Gemini 3 Flash (preview)") — no hardcoded model
+  names. `summarizeSteps()` derives the header count/percent/status.
+- **`ProgressTimeline.tsx`** / `TimelineStep.tsx` / `ConcurrentGroup.tsx` —
+  presentation. Status icons (completed/in-progress/failed/pending), an
+  always-visible model chip, and explicitly-labeled times (`Actual:`/`Est.
+  ~`/`Elapsed:`). A 1s ticker injects live `Elapsed:` from `startedAt`.
+  Mobile collapses per-step detail behind chevrons and shows a `View full
+  history >` link (navigates to the History stage); desktop shows
+  description/model/status/est/actual/retry and concurrent groups without
+  expansion, plus inline `[Current Run] [History]` tabs (History renders the
+  `prdProgress` message log inline). Failed steps stay expanded with a red
+  `Run again` button.
+- **Single-section retry** (`src/lib/services/prdSectionRetry.ts`) —
+  `regeneratePrdSection()` re-runs **only** a failed section using the
+  current PRD as upstream context, shallow-overlays the new slice onto the
+  existing `StructuredPRD` (sections own disjoint top-level fields), and the
+  caller (`ProjectWorkspace.handleRetrySection`) writes it back via
+  `updateSpineStructuredPRD` — every other section stays intact. The shared
+  `parseSectionJson()` helper (in `progressivePrdGeneration.ts`) is reused by
+  both the DAG worker and the retry path. `SECTION_DESCRIPTIONS` (next to
+  `SECTION_TITLES` in `prdSectionPrompts.ts`) supplies the row descriptions.
+
+The card is shown while `isPRDActivelyGenerating || hasFailedSection`, so a
+partial-failure run (which returns a partial PRD without setting
+`generationError`) keeps its Run again affordance visible.
+
+### Other-flow progress UI (`src/components/GenerationProgress.tsx`)
+
+The mockup / artifact / consolidation flows still use `GenerationProgress`.
 Long-running LLM operations show a stages panel. The component supports
 three drive modes, in priority order:
 

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -12,8 +12,9 @@ import {
     buildRestrictedSafetyReview,
     buildSafetyReviewMarkdown,
 } from '../lib/safety';
-import { GenerationProgress } from './GenerationProgress';
-import { PRD_GENERATION_STAGES, PRD_REGENERATION_STAGES } from './generationStages';
+import { ProgressTimeline } from './progress/ProgressTimeline';
+import { buildGenerationSteps } from './progress/buildGenerationSteps';
+import { regeneratePrdSection } from '../lib/services/prdSectionRetry';
 import { SelectableSpine } from './SelectableSpine';
 import { BranchList } from './BranchList';
 import { ConsolidationModal } from './ConsolidationModal';
@@ -30,6 +31,7 @@ import { FeedbackItemsList } from './FeedbackItemsList';
 import { BranchCanvas } from './BranchCanvas';
 import { artifactJobController } from '../lib/services/artifactJobController';
 import { SECTION_TITLES } from '../lib/prompts/prdSectionPrompts';
+import type { SectionId } from '../lib/schemas/prdSchemas';
 import type { Branch, PipelineStage, FeedbackItem } from '../types';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
 
@@ -51,6 +53,7 @@ export function ProjectWorkspace() {
     const [showNavOverflow, setShowNavOverflow] = useState(false);
     const [isExportOpen, setIsExportOpen] = useState(false);
     const [isSnapshotsOpen, setIsSnapshotsOpen] = useState(false);
+    const [retryingStepId, setRetryingStepId] = useState<string | null>(null);
     const overflowRef = useRef<HTMLDivElement>(null);
     const overflowButtonRef = useRef<HTMLButtonElement>(null);
     const overflowMenuRef = useRef<HTMLDivElement>(null);
@@ -127,6 +130,15 @@ export function ProjectWorkspace() {
         (s) => s && s.status !== 'complete' && s.status !== 'error',
     );
     const isPRDActivelyGenerating = isPRDGenerating || sectionsStillRunning;
+
+    // A settled run can still hold a failed section (the pipeline returns a
+    // partial PRD without setting generationError). Keep the progress timeline
+    // — and its Run again affordance — visible while any section is in error.
+    const hasFailedSection = !!prdSectionStatus && Object.values(prdSectionStatus).some(
+        (s) => s && s.status === 'error',
+    );
+    const showProgressTimeline = isPRDActivelyGenerating || hasFailedSection;
+    const timelineSteps = buildGenerationSteps(prdSectionStatus ?? {});
 
     // Human-friendly version label
     const getVersionLabel = (spineId: string) => {
@@ -241,6 +253,47 @@ export function ProjectWorkspace() {
             }
         } finally {
             setIsGenerating(false);
+        }
+    };
+
+    // Re-run a single failed section, merging the new slice back into the
+    // current spine's PRD while leaving every other section intact.
+    const handleRetrySection = async (sectionId: string) => {
+        if (!projectId || !activeSpine?.structuredPRD || isOldVersion || retryingStepId) return;
+        const sourcePrompt = activeSpine.promptText;
+        const id = sectionId as SectionId;
+        const title = SECTION_TITLES[id] ?? sectionId;
+        try {
+            setRetryingStepId(sectionId);
+            appendPrdProgress(projectId, `↻ Retrying ${title}…`);
+            const { structuredPRD, markdown, model, ms } = await regeneratePrdSection(
+                id,
+                sourcePrompt,
+                activeSpine.structuredPRD,
+                {
+                    platform: project?.platform,
+                    onSectionStatus: (sid, update) => setSectionStatus(projectId, sid, update),
+                },
+            );
+            updateSpineStructuredPRD(projectId, activeSpine.id, structuredPRD, markdown, {
+                sourcePrompt,
+                model,
+            });
+            if (id === 'product_basics' && (structuredPRD.productName || structuredPRD.productCategory)) {
+                updateProjectProductMetadata(projectId, {
+                    productName: structuredPRD.productName,
+                    productCategory: structuredPRD.productCategory,
+                });
+            }
+            appendPrdProgress(projectId, `✓ ${title} · ${(ms / 1000).toFixed(1)}s`);
+        } catch (e) {
+            // onSectionStatus already marked the section 'error', so the Run
+            // again button stays visible. Surface the message in the log.
+            const err = normalizeError(e);
+            console.error('[PRD section retry failed]', err.raw);
+            appendPrdProgress(projectId, `✕ ${title} failed`);
+        } finally {
+            setRetryingStepId(null);
         }
     };
 
@@ -462,32 +515,16 @@ export function ProjectWorkspace() {
 
                                 {activeSpine ? (
                                     <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-6 md:p-10 mb-8">
-                                        {/* Regeneration progress overlay */}
-                                        {isGenerating && (
+                                        {/* PRD generation progress timeline (initial gen, regen, or a
+                                            settled run with a failed section awaiting retry). */}
+                                        {(isGenerating || showProgressTimeline) && (
                                             <div className="mb-6">
-                                                <GenerationProgress
-                                                    stages={PRD_REGENERATION_STAGES}
-                                                    variant="foundation"
-                                                    title="Regenerating PRD"
-                                                    subtitle="Creating a fresh draft from your original prompt"
-                                                    history={prdProgress?.messages}
-                                                    sectionStatus={prdSectionStatus}
-                                                    sectionTitles={SECTION_TITLES}
-                                                />
-                                            </div>
-                                        )}
-
-                                        {/* Initial generation progress */}
-                                        {!isGenerating && isPRDActivelyGenerating && (
-                                            <div className="mb-6">
-                                                <GenerationProgress
-                                                    stages={PRD_GENERATION_STAGES}
-                                                    variant="foundation"
-                                                    title="Building your PRD"
-                                                    subtitle="Transforming your product vision into a structured requirements document"
-                                                    history={prdProgress?.messages}
-                                                    sectionStatus={prdSectionStatus}
-                                                    sectionTitles={SECTION_TITLES}
+                                                <ProgressTimeline
+                                                    steps={timelineSteps}
+                                                    messages={prdProgress?.messages}
+                                                    onRetryStep={handleRetrySection}
+                                                    retryingStepId={retryingStepId ?? undefined}
+                                                    onViewHistory={() => setPipelineStage('history')}
                                                 />
                                             </div>
                                         )}
@@ -607,14 +644,12 @@ export function ProjectWorkspace() {
                                     </div>
                                 ) : (
                                     <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-6 md:p-10 mb-8">
-                                        <GenerationProgress
-                                            stages={PRD_GENERATION_STAGES}
-                                            variant="foundation"
-                                            title="Building your PRD"
-                                            subtitle="Transforming your product vision into a structured requirements document"
-                                            history={prdProgress?.messages}
-                                            sectionStatus={prdSectionStatus}
-                                            sectionTitles={SECTION_TITLES}
+                                        <ProgressTimeline
+                                            steps={timelineSteps}
+                                            messages={prdProgress?.messages}
+                                            onRetryStep={handleRetrySection}
+                                            retryingStepId={retryingStepId ?? undefined}
+                                            onViewHistory={() => setPipelineStage('history')}
                                         />
                                         <div className="mt-6 space-y-4 animate-pulse">
                                             <div className="h-5 bg-neutral-100 rounded w-2/5" />

--- a/src/components/progress/ConcurrentGroup.tsx
+++ b/src/components/progress/ConcurrentGroup.tsx
@@ -1,0 +1,75 @@
+import { Info } from 'lucide-react';
+import type { GenerationStep } from './types';
+import { StatusIcon, StepBody } from './TimelineStep';
+
+/**
+ * A dependency wave that runs in parallel. Rendered as a dashed container with
+ * branch connectors so the parallelism reads visually before any text. Children
+ * are leaf sections labeled "2A", "2B", … and each carries its own status,
+ * model chip, timing, and retry affordance.
+ */
+export function ConcurrentGroup({
+    group,
+    isDesktop,
+    expandedIds,
+    onToggle,
+    onRetry,
+    retryingStepId,
+    isLast,
+}: {
+    group: GenerationStep;
+    isDesktop: boolean;
+    expandedIds: Set<string>;
+    onToggle: (id: string) => void;
+    onRetry?: (sectionId: string) => void;
+    retryingStepId?: string;
+    isLast?: boolean;
+}) {
+    const children = group.children ?? [];
+    return (
+        <div className="flex gap-3">
+            <div className="flex flex-col items-center shrink-0">
+                <StatusIcon status={group.status} />
+                {!isLast && <span className="w-px flex-1 bg-neutral-200 mt-1" />}
+            </div>
+            <div className={`${isLast ? 'pb-0' : 'pb-5'} flex-1 min-w-0`}>
+                <div className="rounded-xl border border-dashed border-indigo-300 bg-indigo-50/30 p-3">
+                    <div className="flex items-center gap-1.5 text-xs font-semibold text-indigo-700 mb-2">
+                        <Info size={13} className="shrink-0" />
+                        Running concurrently
+                    </div>
+                    <div>
+                        {children.map((child, i) => {
+                            const isLastChild = i === children.length - 1;
+                            return (
+                                <div key={child.id} className="flex gap-2">
+                                    <div className="relative w-5 shrink-0">
+                                        <span
+                                            className={`absolute left-0 top-0 w-px bg-indigo-200 ${isLastChild ? 'h-3' : 'h-full'}`}
+                                        />
+                                        <span className="absolute left-0 top-3 w-4 h-px bg-indigo-200" />
+                                    </div>
+                                    <div className={`${isLastChild ? '' : 'pb-3'} flex-1 min-w-0`}>
+                                        <div className="flex gap-2">
+                                            <div className="pt-0.5">
+                                                <StatusIcon status={child.status} size="sm" />
+                                            </div>
+                                            <StepBody
+                                                step={child}
+                                                isDesktop={isDesktop}
+                                                expanded={expandedIds.has(child.id)}
+                                                onToggle={() => onToggle(child.id)}
+                                                onRetry={onRetry}
+                                                retrying={retryingStepId === child.sectionId}
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/progress/ProgressTimeline.tsx
+++ b/src/components/progress/ProgressTimeline.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, ChevronRight, Check, CheckCircle2 } from 'lucide-react';
+import { useIsMobile } from '../../lib/useIsMobile';
+import type { GenerationStep, GenerationStepStatus } from './types';
+import { summarizeSteps } from './buildGenerationSteps';
+import { TimelineStep } from './TimelineStep';
+import { ConcurrentGroup } from './ConcurrentGroup';
+
+export type ProgressTimelineProps = {
+    steps: GenerationStep[];
+    /** Raw progress message log (oldest first) for the inline History view. */
+    messages?: string[];
+    onRetryStep?: (sectionId: string) => void;
+    retryingStepId?: string;
+    onViewHistory?: () => void;
+    title?: string;
+};
+
+const STATUS_PILL: Record<GenerationStepStatus, { label: string; cls: string }> = {
+    in_progress: { label: 'In progress', cls: 'bg-indigo-50 text-indigo-700' },
+    completed: { label: 'Completed', cls: 'bg-green-50 text-green-700' },
+    failed: { label: 'Failed', cls: 'bg-red-50 text-red-700' },
+    pending: { label: 'Pending', cls: 'bg-neutral-100 text-neutral-600' },
+};
+
+const hasActiveStep = (steps: GenerationStep[]): boolean =>
+    steps.some((s) =>
+        s.children?.length
+            ? s.children.some((c) => c.status === 'in_progress')
+            : s.status === 'in_progress',
+    );
+
+export function ProgressTimeline({
+    steps,
+    messages,
+    onRetryStep,
+    retryingStepId,
+    onViewHistory,
+    title = 'PRD Generation',
+}: ProgressTimelineProps) {
+    const isMobile = useIsMobile();
+    const isDesktop = !isMobile;
+    const [collapsed, setCollapsed] = useState(false);
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+    const [tab, setTab] = useState<'current' | 'history'>('current');
+    const [now, setNow] = useState(() => Date.now());
+
+    const active = hasActiveStep(steps);
+
+    // Live elapsed ticker — only runs while a step is in progress.
+    useEffect(() => {
+        if (!active) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [active]);
+
+    const summary = useMemo(() => summarizeSteps(steps), [steps]);
+
+    // Inject live elapsed seconds into in-progress leaves.
+    const displaySteps = useMemo(() => {
+        const withElapsed = (s: GenerationStep): GenerationStep =>
+            s.status === 'in_progress' && s.startedAt
+                ? { ...s, elapsedSeconds: Math.max(0, (now - s.startedAt) / 1000) }
+                : s;
+        return steps.map((s) =>
+            s.children?.length ? { ...s, children: s.children.map(withElapsed) } : withElapsed(s),
+        );
+    }, [steps, now]);
+
+    const toggle = (id: string) =>
+        setExpandedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id); else next.add(id);
+            return next;
+        });
+
+    const pill = STATUS_PILL[summary.status];
+
+    const renderTimeline = () => (
+        <div className="mt-4">
+            {displaySteps.map((step, i) => {
+                const isLast = i === displaySteps.length - 1;
+                return step.children?.length ? (
+                    <ConcurrentGroup
+                        key={step.id}
+                        group={step}
+                        isDesktop={isDesktop}
+                        expandedIds={expandedIds}
+                        onToggle={toggle}
+                        onRetry={onRetryStep}
+                        retryingStepId={retryingStepId}
+                        isLast={isLast}
+                    />
+                ) : (
+                    <TimelineStep
+                        key={step.id}
+                        step={step}
+                        isDesktop={isDesktop}
+                        expanded={expandedIds.has(step.id)}
+                        onToggle={() => toggle(step.id)}
+                        onRetry={onRetryStep}
+                        retrying={retryingStepId === step.sectionId}
+                        isLast={isLast}
+                    />
+                );
+            })}
+        </div>
+    );
+
+    const renderHistory = () => (
+        <div className="mt-4 space-y-1.5">
+            {(!messages || messages.length === 0) && (
+                <p className="text-sm text-neutral-400">No activity yet.</p>
+            )}
+            {messages?.map((m, i) => (
+                <div key={i} className="flex items-start gap-2 text-xs text-neutral-600">
+                    <Check size={13} className="text-neutral-300 mt-0.5 shrink-0" />
+                    <span className="break-words">{m}</span>
+                </div>
+            ))}
+        </div>
+    );
+
+    return (
+        <div className="rounded-2xl border border-neutral-200 bg-white shadow-sm p-4 sm:p-5">
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <h2 className="text-lg font-bold text-neutral-900">{title}</h2>
+                        <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${pill.cls}`}>
+                            {summary.status === 'in_progress' && (
+                                <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 animate-pulse" />
+                            )}
+                            {pill.label}
+                        </span>
+                    </div>
+                    <p className="text-sm text-neutral-500 mt-0.5">
+                        {summary.completed} of {summary.total} steps completed
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => setCollapsed((c) => !c)}
+                    aria-label={collapsed ? 'Expand' : 'Collapse'}
+                    className="shrink-0 rounded-lg border border-neutral-200 text-neutral-500 hover:bg-neutral-50 p-1.5 transition"
+                >
+                    {collapsed ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
+                </button>
+            </div>
+
+            {/* Progress bar */}
+            <div className="flex items-center gap-3 mt-3">
+                <div className="flex-1 h-2 rounded-full bg-neutral-100 overflow-hidden">
+                    <div
+                        className={`h-full rounded-full transition-all duration-700 ${summary.status === 'failed' ? 'bg-red-400' : 'bg-indigo-600'}`}
+                        style={{ width: `${summary.percent}%` }}
+                    />
+                </div>
+                <span className="text-sm font-semibold text-neutral-700 tabular-nums shrink-0">
+                    {summary.percent}%
+                </span>
+            </div>
+
+            {!collapsed && (
+                <>
+                    {/* Desktop inline tabs */}
+                    {isDesktop && (
+                        <div className="flex items-center gap-1 mt-4 border-b border-neutral-100">
+                            {(['current', 'history'] as const).map((t) => (
+                                <button
+                                    key={t}
+                                    type="button"
+                                    onClick={() => setTab(t)}
+                                    className={`text-sm font-medium px-3 py-1.5 -mb-px border-b-2 transition ${tab === t ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-neutral-500 hover:text-neutral-700'}`}
+                                >
+                                    {t === 'current' ? 'Current Run' : 'History'}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+
+                    {isDesktop && tab === 'history' ? renderHistory() : renderTimeline()}
+
+                    {/* Footer */}
+                    <div className="flex items-center justify-between mt-5 pt-3 border-t border-neutral-100">
+                        <button
+                            type="button"
+                            onClick={onViewHistory}
+                            className="inline-flex items-center gap-1 text-sm font-medium text-neutral-600 hover:text-neutral-900 transition"
+                        >
+                            View full history
+                            <ChevronRight size={15} />
+                        </button>
+                        <span className="inline-flex items-center gap-1.5 text-xs text-neutral-400">
+                            Auto-save on
+                            <CheckCircle2 size={14} className="text-green-500" />
+                        </span>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/components/progress/TimelineStep.tsx
+++ b/src/components/progress/TimelineStep.tsx
@@ -1,0 +1,194 @@
+import { Check, X, RefreshCcw, ChevronDown, ChevronUp, Sparkles } from 'lucide-react';
+import type { GenerationStep, GenerationStepStatus } from './types';
+
+const roundEst = (s?: number) => (s == null ? null : `~${Math.round(s)}s`);
+const fixed = (s?: number) => (s == null ? null : `${s.toFixed(1)}s`);
+
+// ─── Status icon ─────────────────────────────────────────────────────────────
+
+export function StatusIcon({ status, size = 'md' }: { status: GenerationStepStatus; size?: 'sm' | 'md' }) {
+    const dim = size === 'sm' ? 'w-5 h-5' : 'w-6 h-6';
+    const icon = size === 'sm' ? 11 : 13;
+    if (status === 'completed') {
+        return (
+            <span className={`${dim} shrink-0 rounded-full bg-indigo-600 text-white flex items-center justify-center`}>
+                <Check size={icon} strokeWidth={3} />
+            </span>
+        );
+    }
+    if (status === 'failed') {
+        return (
+            <span className={`${dim} shrink-0 rounded-full bg-red-500 text-white flex items-center justify-center`}>
+                <X size={icon} strokeWidth={3} />
+            </span>
+        );
+    }
+    if (status === 'in_progress') {
+        return (
+            <span className={`${dim} shrink-0 rounded-full border-2 border-indigo-500 flex items-center justify-center`}>
+                <span className="w-2 h-2 rounded-full bg-indigo-500 animate-pulse" />
+            </span>
+        );
+    }
+    return <span className={`${dim} shrink-0 rounded-full border-2 border-neutral-300 bg-white`} />;
+}
+
+// ─── Model chip ──────────────────────────────────────────────────────────────
+
+export function ModelChip({ model }: { model: string }) {
+    if (!model) return null;
+    return (
+        <span className="inline-flex items-center gap-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium px-2 py-0.5 whitespace-nowrap">
+            <Sparkles size={11} className="shrink-0" />
+            {model}
+        </span>
+    );
+}
+
+// ─── Time / status block ─────────────────────────────────────────────────────
+
+function TimeBlock({ step }: { step: GenerationStep }) {
+    const lines: Array<{ text: string; cls?: string }> = [];
+    if (step.status === 'completed') {
+        const a = fixed(step.actualSeconds);
+        if (a) lines.push({ text: `Actual: ${a}` });
+    } else if (step.status === 'in_progress') {
+        lines.push({ text: 'In progress', cls: 'text-indigo-600 font-medium' });
+        const est = roundEst(step.estimatedSeconds);
+        if (est) lines.push({ text: `Est. ${est}`, cls: 'text-neutral-400' });
+        if (step.elapsedSeconds != null) {
+            lines.push({ text: `Elapsed: ${Math.round(step.elapsedSeconds)}s`, cls: 'text-neutral-500' });
+        }
+    } else if (step.status === 'failed') {
+        lines.push({ text: 'Failed', cls: 'text-red-600 font-medium' });
+        const est = roundEst(step.estimatedSeconds);
+        if (est) lines.push({ text: `Est. ${est}`, cls: 'text-neutral-400' });
+        const a = fixed(step.actualSeconds);
+        if (a) lines.push({ text: `Actual: ${a}`, cls: 'text-neutral-500' });
+    } else {
+        lines.push({ text: 'Pending', cls: 'text-neutral-400' });
+        const est = roundEst(step.estimatedSeconds);
+        if (est) lines.push({ text: `Est. ${est}`, cls: 'text-neutral-400' });
+    }
+    return (
+        <div className="text-right text-xs leading-tight shrink-0 min-w-[72px]">
+            {lines.map((l, i) => (
+                <div key={i} className={l.cls ?? 'text-neutral-600'}>{l.text}</div>
+            ))}
+        </div>
+    );
+}
+
+// ─── Step body (shared by sequential rows and concurrent children) ───────────
+
+export function StepBody({
+    step,
+    isDesktop,
+    expanded,
+    onToggle,
+    onRetry,
+    retrying,
+}: {
+    step: GenerationStep;
+    isDesktop: boolean;
+    expanded: boolean;
+    onToggle: () => void;
+    onRetry?: (sectionId: string) => void;
+    retrying?: boolean;
+}) {
+    // Failed steps stay expanded so the error + retry are always discoverable.
+    const showDetails = isDesktop || expanded || step.status === 'failed';
+    const canToggle = !isDesktop && step.status !== 'failed';
+
+    return (
+        <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold text-neutral-800">
+                            <span className="text-neutral-400 font-medium mr-1.5">{step.label}.</span>
+                            {step.title}
+                        </span>
+                    </div>
+                    {showDetails && step.description && (
+                        <p className="text-xs text-neutral-500 mt-0.5">{step.description}</p>
+                    )}
+                    <div className="mt-1.5">
+                        <ModelChip model={step.modelName} />
+                    </div>
+                </div>
+                <div className="flex items-start gap-1.5">
+                    <TimeBlock step={step} />
+                    {canToggle && (
+                        <button
+                            type="button"
+                            onClick={onToggle}
+                            aria-label={expanded ? 'Collapse step' : 'Expand step'}
+                            className="text-neutral-400 hover:text-neutral-600 p-0.5 shrink-0"
+                        >
+                            {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {step.status === 'failed' && (
+                <div className="mt-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2">
+                    {step.errorMessage && (
+                        <p className="text-xs text-red-700 break-words mb-2">{step.errorMessage}</p>
+                    )}
+                    {step.canRetry && step.sectionId && onRetry && (
+                        <button
+                            type="button"
+                            onClick={() => onRetry(step.sectionId!)}
+                            disabled={retrying}
+                            className="inline-flex items-center gap-1.5 rounded-lg border border-red-300 text-red-600 hover:bg-red-100 text-sm font-medium px-3 py-1.5 transition disabled:opacity-50"
+                        >
+                            <RefreshCcw size={14} className={retrying ? 'animate-spin' : ''} />
+                            {retrying ? 'Retrying…' : 'Run again'}
+                        </button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ─── Top-level sequential timeline row ───────────────────────────────────────
+
+export function TimelineStep({
+    step,
+    isDesktop,
+    expanded,
+    onToggle,
+    onRetry,
+    retrying,
+    isLast,
+}: {
+    step: GenerationStep;
+    isDesktop: boolean;
+    expanded: boolean;
+    onToggle: () => void;
+    onRetry?: (sectionId: string) => void;
+    retrying?: boolean;
+    isLast?: boolean;
+}) {
+    return (
+        <div className="flex gap-3">
+            <div className="flex flex-col items-center shrink-0">
+                <StatusIcon status={step.status} />
+                {!isLast && <span className="w-px flex-1 bg-neutral-200 mt-1" />}
+            </div>
+            <div className={isLast ? 'pb-0 flex-1 min-w-0' : 'pb-5 flex-1 min-w-0'}>
+                <StepBody
+                    step={step}
+                    isDesktop={isDesktop}
+                    expanded={expanded}
+                    onToggle={onToggle}
+                    onRetry={onRetry}
+                    retrying={retrying}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/progress/__tests__/ProgressTimeline.test.tsx
+++ b/src/components/progress/__tests__/ProgressTimeline.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProgressTimeline } from '../ProgressTimeline';
+import { buildGenerationSteps, type SectionStatusMap } from '../buildGenerationSteps';
+
+const MODELS = { fastModel: 'gemini-3-flash-preview', strongModel: 'gemini-3-pro-preview' };
+
+function mockMatchMedia(matches: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+}
+
+// A run with a completed, an in-progress, and a failed section.
+const status: SectionStatusMap = {
+    product_basics: { tier: 'fast', status: 'complete', ms: 5800 },
+    grounding: { tier: 'fast', status: 'complete', ms: 3100 },
+    product_thesis: { tier: 'strong', status: 'generating', startedAt: Date.now() - 6000 },
+    metrics_scope: { tier: 'fast', status: 'error', ms: 9200, error: 'Model timeout exceeded' },
+};
+
+const steps = () => buildGenerationSteps(status, MODELS);
+
+afterEach(() => {
+    // @ts-expect-error allow removing the stub between tests
+    delete window.matchMedia;
+    vi.restoreAllMocks();
+});
+
+describe('ProgressTimeline — desktop', () => {
+    it('shows labeled times, model chips, and no ambiguous tier suffixes', () => {
+        mockMatchMedia(false);
+        render(<ProgressTimeline steps={steps()} onRetryStep={vi.fn()} />);
+
+        // explicit time labels
+        expect(screen.getAllByText(/Actual:/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Est\./).length).toBeGreaterThan(0);
+        expect(screen.getByText('Failed')).toBeInTheDocument();
+        // appears both in the header pill and the in-progress step's time block
+        expect(screen.getAllByText('In progress').length).toBeGreaterThan(0);
+
+        // model chips always visible
+        expect(screen.getAllByText(/Gemini/).length).toBeGreaterThan(0);
+
+        // no "(Pro)" / "(Flash)" in any title
+        expect(document.body.textContent).not.toMatch(/\(Pro\)/);
+        expect(document.body.textContent).not.toMatch(/\(Flash\)/);
+    });
+
+    it('does not render a green "Completed" pill for completed steps', () => {
+        mockMatchMedia(false);
+        render(<ProgressTimeline steps={steps()} onRetryStep={vi.fn()} />);
+        // Header status is "In progress" here, and completed rows use "Actual:"
+        expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+    });
+
+    it('shows a Run again button for the failed step', () => {
+        mockMatchMedia(false);
+        const onRetryStep = vi.fn();
+        render(<ProgressTimeline steps={steps()} onRetryStep={onRetryStep} />);
+        const btn = screen.getByText('Run again');
+        expect(btn).toBeInTheDocument();
+        btn.click();
+        expect(onRetryStep).toHaveBeenCalledWith('metrics_scope');
+    });
+});
+
+describe('ProgressTimeline — mobile', () => {
+    it('exposes the full-history link and keeps the failed retry visible', () => {
+        mockMatchMedia(true);
+        const onViewHistory = vi.fn();
+        render(<ProgressTimeline steps={steps()} onRetryStep={vi.fn()} onViewHistory={onViewHistory} />);
+
+        const link = screen.getByText('View full history');
+        link.click();
+        expect(onViewHistory).toHaveBeenCalled();
+
+        // failed steps stay expanded on mobile too
+        expect(screen.getByText('Run again')).toBeInTheDocument();
+    });
+});

--- a/src/components/progress/__tests__/buildGenerationSteps.test.ts
+++ b/src/components/progress/__tests__/buildGenerationSteps.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+    computeWaves,
+    buildGenerationSteps,
+    summarizeSteps,
+    formatModelName,
+    flattenLeaves,
+    type SectionStatusMap,
+} from '../buildGenerationSteps';
+import type { PrdSectionTemplate } from '../../../lib/services/progressivePrdGeneration';
+
+const MODELS = { fastModel: 'gemini-3-flash-preview', strongModel: 'gemini-3-pro-preview' };
+
+describe('formatModelName', () => {
+    it('renders preview ids with a friendly suffix', () => {
+        expect(formatModelName('gemini-3-flash-preview')).toBe('Gemini 3 Flash (preview)');
+        expect(formatModelName('gemini-3-pro-preview')).toBe('Gemini 3 Pro (preview)');
+    });
+    it('keeps version numbers and capitalizes tiers', () => {
+        expect(formatModelName('gemini-1.5-flash')).toBe('Gemini 1.5 Flash');
+        expect(formatModelName('gemini-2.0-pro')).toBe('Gemini 2.0 Pro');
+    });
+    it('strips a models/ prefix and handles empty input', () => {
+        expect(formatModelName('models/gemini-2.0-flash')).toBe('Gemini 2.0 Flash');
+        expect(formatModelName(undefined)).toBe('Gemini');
+        expect(formatModelName('')).toBe('Gemini');
+    });
+});
+
+describe('computeWaves (default DAG)', () => {
+    it('groups the 10 sections into dependency waves', () => {
+        const waves = computeWaves();
+        expect(waves.map((w) => w.length)).toEqual([1, 2, 1, 3, 1, 2]);
+        expect(waves[0][0].id).toBe('product_basics');
+        expect(waves[1].map((s) => s.id)).toEqual(['product_thesis', 'grounding']);
+        expect(waves[3].map((s) => s.id)).toEqual(['data_model', 'ux_loops', 'metrics_scope']);
+        expect(waves[5].map((s) => s.id)).toEqual(['quality_risks', 'implementation_plan']);
+    });
+});
+
+describe('computeWaves (arbitrary graph — future-proofing)', () => {
+    it('supports multiple concurrent groups of arbitrary shape', () => {
+        const sections = [
+            { id: 'product_basics', title: 'A', order: 1, risk: 'low', estimatedSeconds: 5 },
+            { id: 'product_thesis', title: 'B', order: 2, risk: 'high', estimatedSeconds: 5, dependencies: ['product_basics'] },
+            { id: 'grounding', title: 'C', order: 3, risk: 'low', estimatedSeconds: 5, dependencies: ['product_basics'] },
+            { id: 'features', title: 'D', order: 4, risk: 'high', estimatedSeconds: 5, dependencies: ['product_thesis'] },
+            { id: 'data_model', title: 'E', order: 5, risk: 'high', estimatedSeconds: 5, dependencies: ['product_thesis'] },
+        ] as PrdSectionTemplate[];
+        const waves = computeWaves(sections);
+        expect(waves.map((w) => w.length)).toEqual([1, 2, 2]);
+    });
+});
+
+describe('buildGenerationSteps', () => {
+    it('builds sequential rows and concurrent groups with labels', () => {
+        const steps = buildGenerationSteps({}, MODELS);
+        expect(steps).toHaveLength(6);
+        expect(steps[0].sectionId).toBe('product_basics');
+        expect(steps[0].label).toBe('1');
+        expect(steps[0].executionMode).toBe('sequential');
+
+        const group = steps[1];
+        expect(group.executionMode).toBe('concurrent');
+        expect(group.title).toBe('Running concurrently');
+        expect(group.children?.map((c) => c.label)).toEqual(['2A', '2B']);
+        expect(steps[3].children?.map((c) => c.label)).toEqual(['4A', '4B', '4C']);
+    });
+
+    it('falls back to the tier model when no live model is present', () => {
+        const steps = buildGenerationSteps({}, MODELS);
+        // product_basics is a fast/low-risk section
+        expect(steps[0].modelName).toBe('Gemini 3 Flash (preview)');
+        // product_thesis (first child of wave 2) is a strong/high-risk section
+        expect(steps[1].children?.[0].modelName).toBe('Gemini 3 Pro (preview)');
+    });
+
+    it('maps live status, timing, model, and error onto steps', () => {
+        const status: SectionStatusMap = {
+            product_basics: { tier: 'fast', status: 'complete', ms: 5800, model: 'gemini-2.0-flash' },
+            product_thesis: { tier: 'strong', status: 'generating', startedAt: Date.now() },
+            metrics_scope: { tier: 'fast', status: 'error', ms: 9200, error: 'Model timeout exceeded' },
+        };
+        const steps = buildGenerationSteps(status, MODELS);
+
+        const basics = steps[0];
+        expect(basics.status).toBe('completed');
+        expect(basics.actualSeconds).toBeCloseTo(5.8);
+        expect(basics.modelName).toBe('Gemini 2.0 Flash'); // live model overrides tier default
+
+        const thesis = steps[1].children?.[0];
+        expect(thesis?.status).toBe('in_progress');
+
+        const metrics = steps[3].children?.find((c) => c.sectionId === 'metrics_scope');
+        expect(metrics?.status).toBe('failed');
+        expect(metrics?.canRetry).toBe(true);
+        expect(metrics?.errorMessage).toBe('Model timeout exceeded');
+        expect(metrics?.actualSeconds).toBeCloseTo(9.2);
+    });
+});
+
+describe('summarizeSteps', () => {
+    it('counts completed leaves and derives overall status', () => {
+        const status: SectionStatusMap = {
+            product_basics: { tier: 'fast', status: 'complete' },
+            grounding: { tier: 'fast', status: 'complete' },
+            product_thesis: { tier: 'strong', status: 'generating' },
+        };
+        const steps = buildGenerationSteps(status, MODELS);
+        const summary = summarizeSteps(steps);
+        expect(summary.total).toBe(10);
+        expect(summary.completed).toBe(2);
+        expect(summary.percent).toBe(20);
+        expect(summary.status).toBe('in_progress');
+    });
+
+    it('reports failed when a section errors and none are running', () => {
+        const status: SectionStatusMap = {
+            metrics_scope: { tier: 'fast', status: 'error', error: 'boom' },
+        };
+        const steps = buildGenerationSteps(status, MODELS);
+        expect(summarizeSteps(steps).status).toBe('failed');
+    });
+
+    it('flattenLeaves returns all 10 leaf sections', () => {
+        const steps = buildGenerationSteps({}, MODELS);
+        expect(flattenLeaves(steps)).toHaveLength(10);
+    });
+});

--- a/src/components/progress/__tests__/buildGenerationSteps.test.ts
+++ b/src/components/progress/__tests__/buildGenerationSteps.test.ts
@@ -19,6 +19,7 @@ describe('formatModelName', () => {
     it('keeps version numbers and capitalizes tiers', () => {
         expect(formatModelName('gemini-1.5-flash')).toBe('Gemini 1.5 Flash');
         expect(formatModelName('gemini-2.0-pro')).toBe('Gemini 2.0 Pro');
+        expect(formatModelName('gemini-3.5-flash')).toBe('Gemini 3.5 Flash');
     });
     it('strips a models/ prefix and handles empty input', () => {
         expect(formatModelName('models/gemini-2.0-flash')).toBe('Gemini 2.0 Flash');

--- a/src/components/progress/buildGenerationSteps.ts
+++ b/src/components/progress/buildGenerationSteps.ts
@@ -1,0 +1,210 @@
+import type { SectionId } from '../../lib/schemas/prdSchemas';
+import { getFastModel, getStrongModel } from '../../lib/geminiClient';
+import {
+    DEFAULT_PRD_SECTIONS,
+    selectModelTier,
+    type PrdSectionTemplate,
+} from '../../lib/services/progressivePrdGeneration';
+import { SECTION_TITLES, SECTION_DESCRIPTIONS } from '../../lib/prompts/prdSectionPrompts';
+import type { PrdSectionStatusEntry } from '../../store/slices/prdProgressSlice';
+import type { GenerationStep, GenerationStepStatus } from './types';
+
+export type SectionStatusMap = Partial<Record<SectionId, PrdSectionStatusEntry | undefined>>;
+
+// ─── Model name formatting ───────────────────────────────────────────────────
+
+const SUFFIX_WORDS = new Set(['preview', 'exp', 'experimental', 'latest']);
+
+/**
+ * Render a raw Gemini model id as a human-friendly label, e.g.
+ * `gemini-3-flash-preview` → "Gemini 3 Flash (preview)",
+ * `gemini-1.5-pro` → "Gemini 1.5 Pro". Derives entirely from the configured id
+ * so no model name is ever hardcoded.
+ */
+export const formatModelName = (raw?: string): string => {
+    if (!raw || !raw.trim()) return 'Gemini';
+    let id = raw.trim();
+    if (id.startsWith('models/')) id = id.slice('models/'.length);
+
+    const parts = id.split('-').filter(Boolean);
+    const main: string[] = [];
+    const suffixes: string[] = [];
+    for (const p of parts) {
+        if (SUFFIX_WORDS.has(p.toLowerCase())) suffixes.push(p.toLowerCase());
+        else main.push(p);
+    }
+
+    const titled = main.map((p, i) => {
+        if (i === 0 && p.toLowerCase() === 'gemini') return 'Gemini';
+        if (/^[0-9]/.test(p)) return p; // version numbers stay as-is (1.5, 2.0, 3)
+        return p.charAt(0).toUpperCase() + p.slice(1);
+    });
+
+    let label = titled.join(' ');
+    if (suffixes.length) label += ` (${suffixes.join(' ')})`;
+    return label || raw;
+};
+
+// ─── Dependency waves (topological levels) ──────────────────────────────────
+
+/**
+ * Group sections into dependency "waves": a wave is the set of sections at the
+ * same topological depth (level = 1 + max(level of dependencies)). Sections in
+ * the same wave can run concurrently. Purely graph-derived, so it supports
+ * arbitrary dependency graphs, multiple concurrent groups, and any step count.
+ * Within a wave, sections are ordered by their declared `order` for stability.
+ */
+export const computeWaves = (
+    sections: PrdSectionTemplate[] = DEFAULT_PRD_SECTIONS,
+): PrdSectionTemplate[][] => {
+    const byId = new Map(sections.map((s) => [s.id, s]));
+    const levelCache = new Map<string, number>();
+
+    const levelOf = (id: string, seen: Set<string> = new Set()): number => {
+        if (levelCache.has(id)) return levelCache.get(id)!;
+        if (seen.has(id)) return 0; // cycle guard
+        seen.add(id);
+        const section = byId.get(id as SectionId);
+        const deps = section?.dependencies ?? [];
+        const level = deps.length === 0
+            ? 1
+            : 1 + Math.max(...deps.map((d) => levelOf(d, seen)));
+        levelCache.set(id, level);
+        return level;
+    };
+
+    const waves = new Map<number, PrdSectionTemplate[]>();
+    for (const s of sections) {
+        const lvl = levelOf(s.id);
+        if (!waves.has(lvl)) waves.set(lvl, []);
+        waves.get(lvl)!.push(s);
+    }
+
+    return [...waves.keys()]
+        .sort((a, b) => a - b)
+        .map((lvl) => waves.get(lvl)!.sort((a, b) => a.order - b.order));
+};
+
+// ─── Status mapping ──────────────────────────────────────────────────────────
+
+const mapStatus = (s?: PrdSectionStatusEntry['status']): GenerationStepStatus => {
+    if (s === 'complete') return 'completed';
+    if (s === 'error') return 'failed';
+    if (s === 'generating' || s === 'queued' || s === 'refining') return 'in_progress';
+    return 'pending';
+};
+
+const groupStatus = (children: GenerationStep[]): GenerationStepStatus => {
+    if (children.some((c) => c.status === 'failed')) return 'failed';
+    if (children.some((c) => c.status === 'in_progress')) return 'in_progress';
+    if (children.length > 0 && children.every((c) => c.status === 'completed')) return 'completed';
+    return 'pending';
+};
+
+const COLUMN_LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+// ─── Step builder ────────────────────────────────────────────────────────────
+
+export type BuildOptions = {
+    sections?: PrdSectionTemplate[];
+    fastModel?: string;
+    strongModel?: string;
+};
+
+const buildLeaf = (
+    template: PrdSectionTemplate,
+    label: string,
+    status: SectionStatusMap,
+    fastModel: string,
+    strongModel: string,
+    executionMode: 'sequential' | 'concurrent',
+): GenerationStep => {
+    const entry = status[template.id];
+    const stepStatus = mapStatus(entry?.status);
+    const tier = selectModelTier(template.risk);
+    const modelName = formatModelName(entry?.model ?? (tier === 'fast' ? fastModel : strongModel));
+    return {
+        id: template.id,
+        sectionId: template.id,
+        label,
+        title: SECTION_TITLES[template.id],
+        description: SECTION_DESCRIPTIONS[template.id],
+        status: stepStatus,
+        modelName,
+        estimatedSeconds: entry?.estimatedSeconds ?? template.estimatedSeconds,
+        actualSeconds: entry?.ms != null ? entry.ms / 1000 : undefined,
+        startedAt: entry?.startedAt,
+        errorMessage: entry?.error,
+        canRetry: stepStatus === 'failed',
+        executionMode,
+    };
+};
+
+/**
+ * Build the timeline tree from live section status. Single-section waves become
+ * sequential rows; multi-section waves become a synthetic "Running concurrently"
+ * group whose children are the parallel sections (labeled "2A", "2B", …).
+ */
+export const buildGenerationSteps = (
+    status: SectionStatusMap = {},
+    opts: BuildOptions = {},
+): GenerationStep[] => {
+    const sections = opts.sections ?? DEFAULT_PRD_SECTIONS;
+    const fastModel = opts.fastModel ?? getFastModel();
+    const strongModel = opts.strongModel ?? getStrongModel();
+    const waves = computeWaves(sections);
+
+    return waves.map((wave, waveIdx) => {
+        const number = String(waveIdx + 1);
+        if (wave.length === 1) {
+            return buildLeaf(wave[0], number, status, fastModel, strongModel, 'sequential');
+        }
+        const children = wave.map((template, childIdx) =>
+            buildLeaf(
+                template,
+                `${number}${COLUMN_LABELS[childIdx] ?? childIdx + 1}`,
+                status,
+                fastModel,
+                strongModel,
+                'concurrent',
+            ),
+        );
+        return {
+            id: `wave-${number}`,
+            label: number,
+            title: 'Running concurrently',
+            description: '',
+            status: groupStatus(children),
+            modelName: '',
+            executionMode: 'concurrent',
+            children,
+        };
+    });
+};
+
+// ─── Aggregate selectors ─────────────────────────────────────────────────────
+
+export const flattenLeaves = (steps: GenerationStep[]): GenerationStep[] =>
+    steps.flatMap((s) => (s.children?.length ? s.children : [s]));
+
+export type TimelineSummary = {
+    completed: number;
+    total: number;
+    percent: number;
+    status: GenerationStepStatus;
+};
+
+export const summarizeSteps = (steps: GenerationStep[]): TimelineSummary => {
+    const leaves = flattenLeaves(steps);
+    const total = leaves.length;
+    const completed = leaves.filter((l) => l.status === 'completed').length;
+    const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+    let status: GenerationStepStatus;
+    if (total > 0 && completed === total) status = 'completed';
+    else if (leaves.some((l) => l.status === 'in_progress')) status = 'in_progress';
+    else if (leaves.some((l) => l.status === 'failed')) status = 'failed';
+    else status = 'in_progress'; // all pending — generation is starting up
+
+    return { completed, total, percent, status };
+};

--- a/src/components/progress/types.ts
+++ b/src/components/progress/types.ts
@@ -1,0 +1,31 @@
+import type { SectionId } from '../../lib/schemas/prdSchemas';
+
+export type GenerationStepStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+
+/**
+ * One node in the PRD generation timeline. A node is either a leaf section or a
+ * synthetic concurrent group (`executionMode: 'concurrent'`) whose `children`
+ * are the parallel leaf sections. Times are in seconds; `actualSeconds` is the
+ * measured wall-clock duration, `elapsedSeconds` is the live counter while a
+ * step runs.
+ */
+export type GenerationStep = {
+    /** Stable id — the SectionId for leaves, or a synthetic id for groups. */
+    id: string;
+    /** Display label e.g. "1", "2", "2A". */
+    label: string;
+    title: string;
+    description: string;
+    status: GenerationStepStatus;
+    modelName: string;
+    estimatedSeconds?: number;
+    elapsedSeconds?: number;
+    actualSeconds?: number;
+    startedAt?: number;
+    errorMessage?: string;
+    canRetry?: boolean;
+    children?: GenerationStep[];
+    executionMode?: 'sequential' | 'concurrent';
+    /** Present on leaf rows that map to a real pipeline section (retry target). */
+    sectionId?: SectionId;
+};

--- a/src/lib/prompts/prdSectionPrompts.ts
+++ b/src/lib/prompts/prdSectionPrompts.ts
@@ -267,3 +267,21 @@ export const SECTION_TITLES: Record<SectionId, string> = {
     metrics_scope: 'Metrics & Scope',
     implementation_plan: 'Implementation Plan',
 };
+
+/**
+ * Short, human-readable descriptions for each PRD section, used by the
+ * generation progress timeline UI. Kept terse (one clause) so timeline rows
+ * stay scannable on mobile.
+ */
+export const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
+    product_basics: 'Defining the core problem and target users',
+    product_thesis: 'Creating the product thesis and value proposition',
+    grounding: 'Identifying domain entities and primary actions',
+    features: 'Specifying core features and capabilities',
+    data_model: 'Designing the data model and entities',
+    ux_loops: 'Mapping key user flows and journeys',
+    architecture: 'Outlining the technical architecture',
+    quality_risks: 'Assessing risks and quality concerns',
+    metrics_scope: 'Defining success metrics and project scope',
+    implementation_plan: 'Assembling the implementation roadmap',
+};

--- a/src/lib/services/prdSectionRetry.ts
+++ b/src/lib/services/prdSectionRetry.ts
@@ -1,0 +1,109 @@
+// Single-section PRD retry. Re-runs exactly one failed section using the
+// already-completed PRD as upstream context, then overlays the new slice onto
+// the existing StructuredPRD. Keeps every other section's content intact — the
+// full DAG pipeline is never re-run.
+
+import { callGemini } from '../geminiClient';
+import { getFastModel, getStrongModel } from '../geminiClient';
+import type { StructuredPRD, ProjectPlatform } from '../../types';
+import { type SectionId, SECTION_SCHEMAS } from '../schemas/prdSchemas';
+import { buildSectionPrompt } from '../prompts/prdSectionPrompts';
+import { renderPremiumMarkdown } from './prdMarkdownRenderer';
+import {
+    DEFAULT_PRD_SECTIONS,
+    selectModelTier,
+    parseSectionJson,
+} from './progressivePrdGeneration';
+import type { SectionStatusUpdate } from './progressivePrdPipeline';
+
+export type RetrySectionResult = {
+    structuredPRD: StructuredPRD;
+    markdown: string;
+    model: string;
+    ms: number;
+};
+
+export type RetrySectionOptions = {
+    platform?: ProjectPlatform;
+    signal?: AbortSignal;
+    onSectionStatus?: (sectionId: SectionId, update: SectionStatusUpdate) => void;
+};
+
+/**
+ * Re-run a single PRD section and merge the result back into `currentPRD`.
+ *
+ * Sections own disjoint top-level StructuredPRD fields, so a shallow overlay
+ * (`{ ...currentPRD, ...parsed }`) replaces only this section's fields while
+ * preserving every other section. Throws if the section returns unparseable
+ * JSON or the request fails; the caller's `onSectionStatus` is updated to
+ * `error` before the throw so the progress UI can keep its retry affordance.
+ */
+export const regeneratePrdSection = async (
+    sectionId: SectionId,
+    promptText: string,
+    currentPRD: StructuredPRD,
+    options: RetrySectionOptions = {},
+): Promise<RetrySectionResult> => {
+    const { platform, signal, onSectionStatus } = options;
+
+    const template = DEFAULT_PRD_SECTIONS.find((s) => s.id === sectionId);
+    if (!template) {
+        throw new Error(`Unknown PRD section: ${sectionId}`);
+    }
+
+    const tier = selectModelTier(template.risk);
+    const uiTier = tier === 'fast' ? 'fast' : 'strong';
+    const model = tier === 'fast' ? getFastModel() : getStrongModel();
+
+    onSectionStatus?.(sectionId, {
+        tier: uiTier,
+        status: 'generating',
+        model,
+        estimatedSeconds: template.estimatedSeconds,
+    });
+
+    const start = performance.now();
+    try {
+        const { system, user } = buildSectionPrompt(sectionId, {
+            idea: promptText,
+            platform,
+            upstream: currentPRD,
+        });
+
+        const raw = await callGemini(
+            '',
+            `${system}\n\n${user}`,
+            {
+                responseMimeType: 'application/json',
+                responseSchema: SECTION_SCHEMAS[sectionId],
+                model,
+                maxOutputTokens: 8192,
+                temperature: 0.4,
+                topP: 0.9,
+            },
+            signal,
+        );
+
+        const parsed = parseSectionJson(raw);
+        if (!parsed) {
+            throw new Error(`Section "${sectionId}" returned unparseable JSON`);
+        }
+
+        const structuredPRD = { ...currentPRD, ...parsed } as StructuredPRD;
+        const markdown = renderPremiumMarkdown(structuredPRD);
+        const ms = performance.now() - start;
+
+        onSectionStatus?.(sectionId, { tier: uiTier, status: 'complete', ms });
+
+        return { structuredPRD, markdown, model, ms };
+    } catch (e) {
+        const ms = performance.now() - start;
+        onSectionStatus?.(sectionId, {
+            tier: uiTier,
+            status: 'error',
+            ms,
+            error: e instanceof Error ? e.message : 'Unknown error',
+        });
+        throw e;
+    }
+};

--- a/src/lib/services/progressivePrdGeneration.ts
+++ b/src/lib/services/progressivePrdGeneration.ts
@@ -133,6 +133,29 @@ export const applyAiUpdate = (section: PrdSectionJob, content: string): PrdSecti
     };
 };
 
+/**
+ * Parse a section's raw JSON response, applying truncation repair as a
+ * fallback. Per-section maxOutputTokens is bounded (8192) so complex sections
+ * like `features` can hit MAX_TOKENS and end mid-string. Returns `null` when
+ * the response is unparseable even after repair. Shared by the DAG worker and
+ * the single-section retry path so both stay in sync.
+ */
+export const parseSectionJson = (raw: string): Partial<StructuredPRD> | null => {
+    try {
+        return JSON.parse(raw) as Partial<StructuredPRD>;
+    } catch {
+        const { text: repairedText, repaired } = repairTruncatedJson(raw);
+        if (repaired) {
+            try {
+                return JSON.parse(repairedText) as Partial<StructuredPRD>;
+            } catch {
+                return null;
+            }
+        }
+        return null;
+    }
+};
+
 export const makeJsonProvider = (): ModelProvider => ({
     async generateText({ prompt, model, schema }) {
         return callGemini('', prompt, {
@@ -297,35 +320,15 @@ export async function generateProgressivePrd(params: {
         try {
             const raw = await provider.generateText({ prompt: `${system}\n\n${user}`, model, schema });
 
-            // Parse with truncation repair fallback. Per-section
-            // maxOutputTokens is bounded (8192) so complex sections like
-            // `features` can hit MAX_TOKENS and end mid-string. Try repair
-            // before giving up.
-            let parsed: Partial<StructuredPRD> | null = null;
-            let parseError: string | undefined;
-            try {
-                parsed = JSON.parse(raw) as Partial<StructuredPRD>;
-            } catch (parseErr) {
-                const { text: repairedText, repaired } = repairTruncatedJson(raw);
-                if (repaired) {
-                    try {
-                        parsed = JSON.parse(repairedText) as Partial<StructuredPRD>;
-                        console.warn(`[prd] section "${section.id}" recovered via JSON truncation repair`);
-                    } catch {
-                        parsed = null;
-                    }
-                }
-                if (!parsed) {
-                    parseError = parseErr instanceof Error ? parseErr.message : String(parseErr);
-                }
-            }
+            // Parse with truncation repair fallback (shared helper).
+            const parsed = parseSectionJson(raw);
 
             // Treat an unparsable response as a section failure: dropping
             // it silently while still firing `section_completed` would
             // mark the grid green with empty data and quietly omit the
             // section from the merged PRD.
             if (!parsed) {
-                throw new Error(`Section "${section.id}" returned unparseable JSON: ${parseError ?? 'unknown parse error'}`);
+                throw new Error(`Section "${section.id}" returned unparseable JSON`);
             }
 
             results[section.id] = parsed;


### PR DESCRIPTION
Replace the compact PRD progress card with a responsive ProgressTimeline
that surfaces real per-step execution metadata from the prdSectionStatus
store slice:

- Vertical step timeline driven by all 10 pipeline sections, with
  concurrent groups derived from the dependency DAG (topological waves).
- Always-visible Gemini model chips (actual configured model, no hardcoded
  names) and explicitly-labeled times (Actual / Est. ~ / Elapsed).
- Single-section retry: Run again re-runs only the failed section and
  merges it back into the existing PRD, leaving other sections intact.
- Mobile collapses detail behind chevrons with a "View full history" link;
  desktop shows full detail and inline Current Run / History tabs.

GenerationProgress is kept for the mockup/artifact/consolidation flows.

https://claude.ai/code/session_01DC7TfETQpggZEbk6Frqa4p