### PR TITLE
Rename header 'PRD' tab to 'Project' for nav clarity

### DIFF
--- a/src/components/PipelineStageBar.tsx
+++ b/src/components/PipelineStageBar.tsx
@@ -7,10 +7,10 @@ interface PipelineStageBarProps {
     hasPRD: boolean;
 }
 
-const stages: { key: PipelineStage; label: string; icon: typeof FileText }[] = [
-    { key: 'prd', label: 'PRD', icon: FileText },
-    { key: 'workspace', label: 'Workspace', icon: Package },
-    { key: 'history', label: 'History', icon: Clock },
+const stages: { key: PipelineStage; label: string; description: string; icon: typeof FileText }[] = [
+    { key: 'prd', label: 'Project', description: 'The editable PRD and source of truth for downstream artifacts', icon: FileText },
+    { key: 'workspace', label: 'Workspace', description: 'Where you work through generated artifacts', icon: Package },
+    { key: 'history', label: 'History', description: 'Chronological timeline of changes', icon: Clock },
 ];
 
 export function PipelineStageBar({ currentStage, onStageChange, hasPRD }: PipelineStageBarProps) {
@@ -40,6 +40,8 @@ export function PipelineStageBar({ currentStage, onStageChange, hasPRD }: Pipeli
                         key={stage.key}
                         onClick={() => enabled && onStageChange(stage.key)}
                         disabled={!enabled}
+                        title={stage.description}
+                        aria-label={`${stage.label}: ${stage.description}`}
                         className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition ${
                             active
                                 ? 'bg-indigo-600 text-white'


### PR DESCRIPTION
The top-nav 'PRD' tab collided conceptually with the 'PRD' entry in the
Workspace hamburger artifact panel, making the two navigation systems look
redundant. Rename the header tab label to 'Project' (keeping the document
icon, since it still links to the PRD) and add tooltip/aria-label
descriptions to clarify each tab's purpose. The internal 'prd' stage value
and the PRD artifact naming are unchanged.

https://claude.ai/code/session_015Pux2gY7nTy4nziUDiS53w