### PR TITLE
Add optional preflight clarification mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,10 @@ otherwise have nothing in common — keep that distinction in mind:
     `componentInventoryParse.ts` round-trips all these fields through
     markdown.
   - `branchService.ts` — branch consolidation back into the spine.
+  - `preflightService.ts` — optional pre-PRD clarification (see "Preflight
+    clarification" below). `generatePreflightQuestions()` (safety-gated) and
+    `generatePreflightSummary()`; both inject transports for tests and degrade
+    to fallbacks (generic question set / local recap) on non-safety failure.
   - `artifactJobController.ts` — concurrency control for artifact bundle
     generation.
 - **`prompts/prdPrompts.ts`** — strategy system instruction; the
@@ -153,6 +157,41 @@ request…").
   (`SafetyClassification`, `SafetyClassificationResult`, `SpineSafetyReview`)
   live in `src/types`; the safety module re-exports them.
 
+### Preflight clarification (`src/lib/services/preflightService.ts`, `src/components/preflight/`)
+
+An **optional** pre-PRD step. After entering an idea on `HomePage`, a
+`PreflightModeChoice` sheet offers **Generate Immediately** (unchanged path),
+**Quick** (5 questions), or **Deep** (10 questions). Quick/Deep create the
+project + spine, seed a `PreflightSession` via `initPreflightSession`, and
+navigate to `/p/:projectId` **without** starting PRD generation.
+
+- **State lives on the spine** — `SpineVersion.preflightSession`
+  (`PreflightMode`/`PreflightQuestion`/`PreflightStatus`/`PreflightSession` in
+  `src/types`), persisted with `spineVersions` (resumable across refresh; no
+  `partialize` change). Store actions are on `spineSlice`
+  (`initPreflightSession`, `setPreflightQuestions`, `setPreflightAnswer`,
+  `setPreflightIndex`, `setPreflightSummary`, `completePreflightSession`,
+  `setPreflightError`).
+- **Hosted in the workspace.** `ProjectWorkspace` renders `PreflightView`
+  (one question per card, progress, Skip/Back/Next, pinned safe-area CTA,
+  AI-generated summary → Edit answers / Generate PRD) instead of the PRD/
+  progress view while `preflightSession` exists, is not `completed`, has no
+  `structuredPRD`, and isn't `blocked`.
+- **Safety runs first.** `generatePreflightQuestions()` calls
+  `classifyProjectSafety()` before producing any questions — a `disallowed`
+  idea throws `SafetyBlockedError`, which `PreflightView` persists as a blocked
+  `safetyReview` so the existing `SafetyReviewView` shows and no questions/PRD
+  are produced. Non-safety failures fall back to a generic question set
+  (flagged `usedFallback`) / a deterministic local summary, never blocking.
+- **PRD integration.** Generation goes through the shared
+  `src/lib/runPrdGeneration.ts` helper (used by both HomePage and
+  `PreflightView`). On **Generate PRD**, `completePreflightSession` runs, then
+  `generateStructuredPRD` is called with an `options.preflight`
+  (`PreflightContext`) — answered/skipped responses + summary/assumptions/
+  unknowns. `prdService` appends `buildClarificationPromptBlock()` (the
+  authoritative-intent instruction; skipped → open unknowns) to the prompt
+  **after** the safety gate, so every section receives it via `ctx.idea`.
+
 ### State (`src/store/`)
 
 `useProjectStore` is one Zustand store composed from 8 slices in
@@ -180,7 +219,13 @@ persist. `onRehydrateStorage` migrates legacy `currentStage` values
 ### Pipeline flow
 
 ```
-User prompt → HomePage.handleCreateProject() → generateStructuredPRD()
+User prompt → HomePage.handleCreateProject() → PreflightModeChoice
+              ↓ (Generate Immediately) ──────────────┐
+              ↓ (Quick / Deep)                        │
+              PreflightView: questions → answers →     │
+              summary → Generate PRD                   │
+              ↓                                        ↓
+              runPrdGeneration() → generateStructuredPRD()
               ↓
               Pass A streams structured JSON → onPartial paints draft
               ↓

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -4,14 +4,10 @@ import { useProjectStore } from '../store/projectStore';
 import { Settings, List, Plus, ArrowUp, Sparkles, Smartphone, Monitor, Loader2, Compass } from 'lucide-react';
 import { SettingsModal } from './SettingsModal';
 import { ProjectDrawer } from './ProjectDrawer';
-import { normalizeError, userMessage } from '../lib/errors';
-import {
-    SafetyBlockedError,
-    buildBlockedSafetyReview,
-    buildRestrictedSafetyReview,
-    buildSafetyReviewMarkdown,
-} from '../lib/safety';
-import type { ProjectPlatform } from '../types';
+import { PreflightModeChoice } from './preflight/PreflightModeChoice';
+import { runPrdGeneration } from '../lib/runPrdGeneration';
+import { normalizeError } from '../lib/errors';
+import type { ProjectPlatform, PreflightMode } from '../types';
 import { useAuthStore } from '../store/authStore';
 import { useToastStore } from '../store/toastStore';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
@@ -45,7 +41,7 @@ const EXAMPLE_PROMPTS = [
 ];
 
 export function HomePage() {
-    const { createProject, loadDemoProject } = useProjectStore();
+    const { createProject, initPreflightSession, loadDemoProject } = useProjectStore();
     const navigate = useNavigate();
     const user = useAuthStore((s) => s.user);
 
@@ -83,118 +79,42 @@ export function HomePage() {
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
     const [isEnhancing, setIsEnhancing] = useState(false);
+    const [isChoosingMode, setIsChoosingMode] = useState(false);
 
     const fileInputRef = useRef<HTMLInputElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    const handleCreateProject = async () => {
+    // Step 1: validate input + API key, then present the start-mode choice.
+    const handleCreateProject = () => {
         if (!projectName.trim() || !promptText.trim()) return;
 
         const apiKey = localStorage.getItem('GEMINI_API_KEY');
         if (!apiKey) { setIsSettingsOpen(true); return; }
 
-        const { projectId, spineId } = createProject(projectName.trim(), promptText.trim(), platform);
-        navigate(`/p/${projectId}`);
+        setIsChoosingMode(true);
+    };
 
+    // Step 2a: Generate Immediately — existing behavior, unchanged flow.
+    const startImmediateGeneration = () => {
         const sourcePrompt = promptText.trim();
+        const { projectId, spineId } = createProject(projectName.trim(), sourcePrompt, platform);
+        navigate(`/p/${projectId}`);
+        void runPrdGeneration({ projectId, spineId, sourcePrompt, platform });
+    };
 
-        // Reset transient progress state for this project — a fresh run starts
-        // with a clean event log so the workspace progress panel doesn't show
-        // stale messages from a prior generation.
-        useProjectStore.getState().clearPrdProgress(projectId);
-        useProjectStore.getState().clearSectionStatus(projectId);
+    // Step 2b: Quick/Deep — seed a preflight session and hand off to the
+    // workspace clarification flow. No PRD is generated yet.
+    const startPreflight = (mode: 'quick' | 'deep') => {
+        const sourcePrompt = promptText.trim();
+        const { projectId, spineId } = createProject(projectName.trim(), sourcePrompt, platform);
+        initPreflightSession(projectId, spineId, mode, sourcePrompt);
+        navigate(`/p/${projectId}`);
+    };
 
-        import('../lib/llmProvider').then(({ generateStructuredPRD }) => {
-            generateStructuredPRD(
-                sourcePrompt,
-                {
-                    onProgress: (message) => {
-                        useProjectStore.getState().appendPrdProgress(projectId, message);
-                    },
-                    onSectionStatus: (sectionId, update) => {
-                        useProjectStore.getState().setSectionStatus(projectId, sectionId, update);
-                    },
-                    // Progressive render: paint the Pass A draft as soon as it
-                    // lands so the user isn't staring at a placeholder for the
-                    // full 30–60s pipeline.
-                    onPartial: ({ structuredPRD, markdown }) => {
-                        useProjectStore.getState().updateSpineStructuredPRD(
-                            projectId,
-                            spineId,
-                            structuredPRD,
-                            markdown,
-                            { sourcePrompt },
-                        );
-                        if (structuredPRD.productName || structuredPRD.productCategory) {
-                            useProjectStore.getState().updateProjectProductMetadata(projectId, {
-                                productName: structuredPRD.productName,
-                                productCategory: structuredPRD.productCategory,
-                            });
-                        }
-                    },
-                    // Final result: persist the rendered markdown plus
-                    // generation metadata. Single-pass mode no longer
-                    // produces quality scores.
-                    onResult: ({ structuredPRD, markdown, generationMeta, model }) => {
-                        useProjectStore.getState().updateSpineStructuredPRD(
-                            projectId,
-                            spineId,
-                            structuredPRD,
-                            markdown,
-                            {
-                                sourcePrompt,
-                                generationMeta,
-                                model,
-                                prdVersion: generationMeta.schemaVersion,
-                            },
-                        );
-                    },
-                    // allowed_with_restrictions: record the verdict so the PRD
-                    // renders with a Safety Boundaries card. (allowed records
-                    // nothing; disallowed never reaches here — it throws.)
-                    onSafety: (safety) => {
-                        if (safety.classification === 'allowed_with_restrictions') {
-                            useProjectStore.getState().setSpineSafetyReview(
-                                projectId,
-                                spineId,
-                                buildRestrictedSafetyReview(safety),
-                            );
-                        }
-                    },
-                },
-                platform,
-            ).catch((e) => {
-                // Disallowed requests hard-stop here: store a blocked Safety
-                // Review (which shows the dedicated screen and gates downstream
-                // generation) instead of a generic generation error.
-                if (e instanceof SafetyBlockedError) {
-                    useProjectStore.getState().setSpineSafetyReview(
-                        projectId,
-                        spineId,
-                        buildBlockedSafetyReview(e.result),
-                        buildSafetyReviewMarkdown(e.result),
-                    );
-                    return;
-                }
-                const err = normalizeError(e);
-                console.error('[PRD generation failed]', err.raw);
-                useProjectStore.getState().setSpineError(projectId, spineId, {
-                    message: userMessage(err),
-                    category: err.category,
-                    timestamp: err.timestamp,
-                    raw: err.raw,
-                });
-            });
-        }).catch((e) => {
-            const err = normalizeError(e);
-            console.error('[Module load failed]', err.raw);
-            useProjectStore.getState().setSpineError(projectId, spineId, {
-                message: 'Failed to load generation module. Try refreshing the page.',
-                category: err.category,
-                timestamp: err.timestamp,
-                raw: err.raw,
-            });
-        });
+    const handleChooseMode = (mode: PreflightMode) => {
+        setIsChoosingMode(false);
+        if (mode === 'none') startImmediateGeneration();
+        else startPreflight(mode);
     };
 
     const handleEnhance = async () => {
@@ -461,6 +381,12 @@ export function HomePage() {
             </div>
 
             {/* Modals & Drawers */}
+            {isChoosingMode && (
+                <PreflightModeChoice
+                    onChoose={handleChooseMode}
+                    onClose={() => setIsChoosingMode(false)}
+                />
+            )}
             {isSettingsOpen && <SettingsModal onClose={() => setIsSettingsOpen(false)} />}
             <ProjectDrawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)} />
         </div>

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -23,6 +23,7 @@ import { PipelineStageBar } from './PipelineStageBar';
 import { StructuredPRDView } from './StructuredPRDView';
 import { SafetyReviewView } from './SafetyReviewView';
 import { SafetyBoundariesCard } from './SafetyBoundariesCard';
+import { PreflightView } from './preflight/PreflightView';
 import { ArtifactWorkspace } from './ArtifactWorkspace';
 import { HistoryView } from './HistoryView';
 import { ExportModal } from './ExportModal';
@@ -139,6 +140,14 @@ export function ProjectWorkspace() {
     );
     const showProgressTimeline = isPRDActivelyGenerating || hasFailedSection;
     const timelineSteps = buildGenerationSteps(prdSectionStatus ?? {});
+
+    // Optional preflight clarification: while a non-completed session exists and
+    // no PRD has been produced (and the request isn't blocked), the workspace
+    // hosts the clarification flow instead of the PRD/progress view.
+    const showPreflight = !!activeSpine?.preflightSession
+        && !activeSpine.preflightSession.completed
+        && !activeSpine.structuredPRD
+        && activeSpine.safetyReview?.status !== 'blocked';
 
     // Human-friendly version label
     const getVersionLabel = (spineId: string) => {
@@ -505,7 +514,15 @@ export function ProjectWorkspace() {
 
                     <div className="max-w-4xl mx-auto mt-4">
                         {/* PRD Stage */}
-                        {pipelineStage === 'prd' && (
+                        {pipelineStage === 'prd' && showPreflight && activeSpine && (
+                            <PreflightView
+                                projectId={projectId}
+                                spineId={activeSpine.id}
+                                session={activeSpine.preflightSession!}
+                                platform={project?.platform}
+                            />
+                        )}
+                        {pipelineStage === 'prd' && !showPreflight && (
                             <>
                                 {/* Feedback items from mockups/artifacts */}
                                 <FeedbackItemsList

--- a/src/components/preflight/PreflightModeChoice.tsx
+++ b/src/components/preflight/PreflightModeChoice.tsx
@@ -1,0 +1,93 @@
+import { Zap, MessagesSquare, Compass, X } from 'lucide-react';
+import type { PreflightMode } from '../../types';
+
+interface PreflightModeChoiceProps {
+    onChoose: (mode: PreflightMode) => void;
+    onClose: () => void;
+}
+
+const OPTIONS: {
+    mode: PreflightMode;
+    icon: typeof Zap;
+    title: string;
+    subtitle: string;
+    detail: string;
+}[] = [
+    {
+        mode: 'none',
+        icon: Zap,
+        title: 'Generate Immediately',
+        subtitle: 'Fastest',
+        detail: 'Skip clarification and generate the PRD straight from your idea.',
+    },
+    {
+        mode: 'quick',
+        icon: MessagesSquare,
+        title: 'Quick Clarification',
+        subtitle: '5 questions',
+        detail: 'Answer 5 targeted questions so the PRD captures your intent.',
+    },
+    {
+        mode: 'deep',
+        icon: Compass,
+        title: 'Deep Discovery',
+        subtitle: '10 questions',
+        detail: 'Answer 10 questions for the most tailored, thorough PRD.',
+    },
+];
+
+/**
+ * Post-idea choice: how to start. Generate Immediately preserves the existing
+ * behavior; Quick/Deep enter the preflight clarification flow. Responsive —
+ * centered dialog on desktop, full-width bottom sheet on mobile.
+ */
+export function PreflightModeChoice({ onChoose, onClose }: PreflightModeChoiceProps) {
+    return (
+        <div
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-end sm:items-center justify-center z-50"
+            onClick={onClose}
+        >
+            <div
+                className="bg-neutral-900 border border-white/10 rounded-t-3xl sm:rounded-3xl w-full sm:max-w-lg max-h-[90vh] overflow-y-auto"
+                style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between px-6 pt-6 pb-2">
+                    <h2 className="text-lg font-semibold text-white">How would you like to start?</h2>
+                    <button
+                        onClick={onClose}
+                        className="p-2 -mr-2 text-neutral-400 hover:text-white rounded-lg transition"
+                        aria-label="Cancel"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+                <p className="px-6 text-sm text-neutral-400 mb-4">
+                    A few quick questions can sharpen the PRD. This step is optional.
+                </p>
+                <div className="px-4 pb-5 space-y-2">
+                    {OPTIONS.map(({ mode, icon: Icon, title, subtitle, detail }) => (
+                        <button
+                            key={mode}
+                            onClick={() => onChoose(mode)}
+                            className="w-full text-left flex items-start gap-4 p-4 min-h-[64px] rounded-2xl border border-white/10 bg-white/[0.03] hover:bg-white/[0.07] hover:border-indigo-500/50 transition group"
+                        >
+                            <div className="shrink-0 w-10 h-10 rounded-xl bg-indigo-500/15 text-indigo-300 flex items-center justify-center group-hover:bg-indigo-500/25 transition">
+                                <Icon size={18} />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2">
+                                    <span className="font-medium text-white">{title}</span>
+                                    <span className="text-xs text-indigo-300/80 bg-indigo-500/10 px-2 py-0.5 rounded-full">
+                                        {subtitle}
+                                    </span>
+                                </div>
+                                <p className="text-sm text-neutral-400 mt-0.5">{detail}</p>
+                            </div>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/preflight/PreflightView.tsx
+++ b/src/components/preflight/PreflightView.tsx
@@ -1,0 +1,389 @@
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, ChevronLeft, ChevronRight, SkipForward, Sparkles, Info, Pencil } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import {
+    generatePreflightQuestions,
+    generatePreflightSummary,
+    type PreflightContext,
+} from '../../lib/llmProvider';
+import { runPrdGeneration } from '../../lib/runPrdGeneration';
+import {
+    SafetyBlockedError,
+    buildBlockedSafetyReview,
+    buildSafetyReviewMarkdown,
+} from '../../lib/safety';
+import type { PreflightSession, ProjectPlatform } from '../../types';
+
+interface PreflightViewProps {
+    projectId: string;
+    spineId: string;
+    session: PreflightSession;
+    platform?: ProjectPlatform;
+}
+
+/** Build the PRD-generation context from a (completed) clarification session. */
+const toPreflightContext = (session: PreflightSession): PreflightContext => ({
+    mode: session.mode,
+    clarificationResponses: session.questions.map((q) => {
+        const skipped = !!q.skipped || !q.answer || !q.answer.trim();
+        return {
+            question: q.question,
+            answer: skipped ? null : q.answer!.trim(),
+            skipped,
+            intent: q.intent,
+        };
+    }),
+    summary: session.summary,
+    assumptions: session.assumptions,
+    unknowns: session.unknowns,
+});
+
+/**
+ * Optional preflight clarification flow, hosted in the workspace. Generates
+ * idea-specific questions, collects answers one at a time, shows a summary, and
+ * hands off to PRD generation. Mobile-first: one question per card, large tap
+ * targets, a pinned bottom action bar with safe-area insets.
+ */
+export function PreflightView({ projectId, spineId, session, platform }: PreflightViewProps) {
+    const {
+        setPreflightQuestions,
+        setPreflightAnswer,
+        setPreflightIndex,
+        setPreflightSummary,
+        completePreflightSession,
+        setSpineSafetyReview,
+    } = useProjectStore();
+
+    const [isWorking, setIsWorking] = useState(false);
+    const generationStarted = useRef(false);
+
+    const mode = session.mode === 'deep' ? 'deep' : 'quick';
+    const total = session.questions.length;
+
+    // Generate questions once when the session is first opened.
+    useEffect(() => {
+        if (session.status !== 'awaiting_questions' || generationStarted.current) return;
+        generationStarted.current = true;
+        let cancelled = false;
+        (async () => {
+            try {
+                const { questions, usedFallback } = await generatePreflightQuestions(
+                    session.originalIdea,
+                    mode,
+                );
+                if (cancelled) return;
+                setPreflightQuestions(projectId, spineId, questions, usedFallback);
+            } catch (e) {
+                if (cancelled) return;
+                if (e instanceof SafetyBlockedError) {
+                    // Disallowed idea — stop the flow and show the Safety Review.
+                    setSpineSafetyReview(
+                        projectId,
+                        spineId,
+                        buildBlockedSafetyReview(e.result),
+                        buildSafetyReviewMarkdown(e.result),
+                    );
+                } else {
+                    console.error('[preflight] unexpected question generation error', e);
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [session.status, session.originalIdea, mode, projectId, spineId, setPreflightQuestions, setSpineSafetyReview]);
+
+    // ---- Loading state: generating questions --------------------------------
+    if (session.status === 'awaiting_questions' || total === 0) {
+        return (
+            <PreflightShell>
+                <div className="flex flex-col items-center justify-center py-16 text-center">
+                    <Loader2 size={28} className="animate-spin text-indigo-500 mb-4" />
+                    <p className="font-medium text-neutral-700">Preparing your clarification questions…</p>
+                    <p className="text-sm text-neutral-500 mt-1">
+                        Tailoring {mode === 'deep' ? '10' : '5'} questions to your idea.
+                    </p>
+                </div>
+            </PreflightShell>
+        );
+    }
+
+    // ---- Summary step -------------------------------------------------------
+    if (session.status === 'summary') {
+        return (
+            <PreflightShell>
+                <PreflightSummaryStep
+                    session={session}
+                    isWorking={isWorking}
+                    onEdit={() => setPreflightIndex(projectId, spineId, 0)}
+                    onGenerate={() => {
+                        completePreflightSession(projectId, spineId);
+                        void runPrdGeneration({
+                            projectId,
+                            spineId,
+                            sourcePrompt: session.originalIdea,
+                            platform,
+                            preflight: toPreflightContext(session),
+                        });
+                    }}
+                />
+            </PreflightShell>
+        );
+    }
+
+    // ---- Answering one question at a time -----------------------------------
+    const index = Math.min(session.currentQuestionIndex, total - 1);
+    const question = session.questions[index];
+    const isLast = index === total - 1;
+
+    const advance = () => {
+        if (isLast) {
+            // Move to the summary; generate it from the answers.
+            setIsWorking(true);
+            (async () => {
+                const summary = await generatePreflightSummary(session.originalIdea, session.questions);
+                setPreflightSummary(projectId, spineId, summary);
+                setIsWorking(false);
+            })();
+        } else {
+            setPreflightIndex(projectId, spineId, index + 1);
+        }
+    };
+
+    const commitAndAdvance = (answer: string, skipped: boolean) => {
+        setPreflightAnswer(projectId, spineId, question.id, answer, skipped);
+        advance();
+    };
+
+    return (
+        <PreflightShell>
+            <QuestionCard
+                key={question.id}
+                index={index}
+                total={total}
+                question={question.question}
+                intent={question.intent}
+                initialAnswer={question.answer ?? ''}
+                usedFallback={!!session.usedFallback}
+                isWorking={isWorking}
+                canGoBack={index > 0}
+                isLast={isLast}
+                onBack={(draft) => {
+                    setPreflightAnswer(projectId, spineId, question.id, draft, draft.trim() === '');
+                    setPreflightIndex(projectId, spineId, index - 1);
+                }}
+                onSkip={() => commitAndAdvance('', true)}
+                onNext={(draft) => commitAndAdvance(draft, draft.trim() === '')}
+            />
+        </PreflightShell>
+    );
+}
+
+// --- Presentational pieces ---------------------------------------------------
+
+function PreflightShell({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-6 md:p-10 mb-8">
+            {children}
+        </div>
+    );
+}
+
+interface QuestionCardProps {
+    index: number;
+    total: number;
+    question: string;
+    intent?: string;
+    initialAnswer: string;
+    usedFallback: boolean;
+    isWorking: boolean;
+    canGoBack: boolean;
+    isLast: boolean;
+    onBack: (draft: string) => void;
+    onSkip: () => void;
+    onNext: (draft: string) => void;
+}
+
+function QuestionCard({
+    index,
+    total,
+    question,
+    intent,
+    initialAnswer,
+    usedFallback,
+    isWorking,
+    canGoBack,
+    isLast,
+    onBack,
+    onSkip,
+    onNext,
+}: QuestionCardProps) {
+    // Local draft, seeded from the stored answer. Card is keyed by question id
+    // so this remounts (and reseeds) on every navigation.
+    const [draft, setDraft] = useState(initialAnswer);
+    const progress = Math.round(((index + 1) / total) * 100);
+
+    return (
+        <div className="flex flex-col min-h-[60vh] md:min-h-0">
+            {/* Progress header */}
+            <div className="mb-6">
+                <div className="flex items-center justify-between text-sm mb-2">
+                    <span className="font-medium text-indigo-600">
+                        Question {index + 1} of {total}
+                    </span>
+                    <span className="text-neutral-400">{progress}%</span>
+                </div>
+                <div className="h-1.5 w-full bg-neutral-100 rounded-full overflow-hidden">
+                    <div
+                        className="h-full bg-indigo-500 rounded-full transition-all duration-300"
+                        style={{ width: `${progress}%` }}
+                    />
+                </div>
+                {usedFallback && (
+                    <p className="mt-3 text-xs text-amber-600 flex items-center gap-1.5">
+                        <Info size={12} /> Using default clarification questions.
+                    </p>
+                )}
+            </div>
+
+            {/* Question + answer (grows to push the action bar down on mobile) */}
+            <div className="flex-1">
+                <h2 className="text-xl md:text-2xl font-semibold text-neutral-900 leading-snug">{question}</h2>
+                {intent && <p className="mt-2 text-sm text-neutral-500">{intent}</p>}
+                <textarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    autoFocus
+                    placeholder="Type your answer… or skip this question."
+                    className="mt-5 w-full min-h-[140px] rounded-xl border border-neutral-300 bg-neutral-50 px-4 py-3 text-[15px] leading-relaxed text-neutral-800 placeholder-neutral-400 focus:outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-100 resize-none"
+                />
+            </div>
+
+            {/* Action bar — pinned near the bottom with safe-area inset */}
+            <div
+                className="sticky bottom-0 mt-6 flex items-center gap-3 bg-white/95 backdrop-blur pt-4 border-t border-neutral-100"
+                style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 0.25rem)' }}
+            >
+                <button
+                    onClick={() => onBack(draft)}
+                    disabled={!canGoBack || isWorking}
+                    className="inline-flex items-center gap-1.5 px-4 py-3 min-h-[44px] rounded-xl text-sm font-medium text-neutral-600 hover:bg-neutral-100 transition disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                    <ChevronLeft size={16} /> Back
+                </button>
+                <button
+                    onClick={onSkip}
+                    disabled={isWorking}
+                    className="inline-flex items-center gap-1.5 px-4 py-3 min-h-[44px] rounded-xl text-sm font-medium text-neutral-500 hover:bg-neutral-100 transition disabled:opacity-50"
+                >
+                    <SkipForward size={16} /> Skip
+                </button>
+                <div className="flex-1" />
+                <button
+                    onClick={() => onNext(draft)}
+                    disabled={isWorking}
+                    className="inline-flex items-center gap-1.5 px-6 py-3 min-h-[44px] rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 transition disabled:opacity-60"
+                >
+                    {isWorking ? (
+                        <>
+                            <Loader2 size={16} className="animate-spin" /> Summarizing…
+                        </>
+                    ) : isLast ? (
+                        <>
+                            Review <ChevronRight size={16} />
+                        </>
+                    ) : (
+                        <>
+                            Next <ChevronRight size={16} />
+                        </>
+                    )}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+interface PreflightSummaryStepProps {
+    session: PreflightSession;
+    isWorking: boolean;
+    onEdit: () => void;
+    onGenerate: () => void;
+}
+
+function PreflightSummaryStep({ session, onEdit, onGenerate }: PreflightSummaryStepProps) {
+    // Render the summary as scannable bullet lines.
+    const summaryLines = (session.summary ?? '')
+        .split('\n')
+        .map((l) => l.replace(/^[-•*]\s*/, '').trim())
+        .filter(Boolean);
+
+    return (
+        <div>
+            <div className="flex items-center gap-2 mb-1">
+                <Sparkles size={18} className="text-indigo-500" />
+                <h2 className="text-xl font-semibold text-neutral-900">Here&apos;s what I learned</h2>
+            </div>
+            <p className="text-sm text-neutral-500 mb-5">
+                Review before generating the PRD. You can edit any answer.
+            </p>
+
+            {summaryLines.length > 0 && (
+                <ul className="space-y-2 mb-6">
+                    {summaryLines.map((line, i) => (
+                        <li key={i} className="flex gap-2.5 text-[15px] text-neutral-700">
+                            <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-400" />
+                            <span className="leading-relaxed">{line}</span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {session.assumptions && session.assumptions.length > 0 && (
+                <SummaryGroup title="Assumptions" items={session.assumptions} tone="neutral" />
+            )}
+            {session.unknowns && session.unknowns.length > 0 && (
+                <SummaryGroup title="Open questions" items={session.unknowns} tone="amber" />
+            )}
+
+            <div
+                className="sticky bottom-0 mt-8 flex items-center gap-3 bg-white/95 backdrop-blur pt-4 border-t border-neutral-100"
+                style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 0.25rem)' }}
+            >
+                <button
+                    onClick={onEdit}
+                    className="inline-flex items-center gap-1.5 px-4 py-3 min-h-[44px] rounded-xl text-sm font-medium text-neutral-600 hover:bg-neutral-100 transition"
+                >
+                    <Pencil size={15} /> Edit answers
+                </button>
+                <div className="flex-1" />
+                <button
+                    onClick={onGenerate}
+                    className="inline-flex items-center gap-1.5 px-6 py-3 min-h-[44px] rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 transition"
+                >
+                    <Sparkles size={16} /> Generate PRD
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function SummaryGroup({ title, items, tone }: { title: string; items: string[]; tone: 'neutral' | 'amber' }) {
+    return (
+        <div className="mb-5">
+            <h3
+                className={`text-xs font-bold uppercase tracking-wider mb-2 ${
+                    tone === 'amber' ? 'text-amber-600' : 'text-neutral-400'
+                }`}
+            >
+                {title}
+            </h3>
+            <ul className="space-y-1.5">
+                {items.map((item, i) => (
+                    <li key={i} className="text-sm text-neutral-600 leading-relaxed">
+                        {item}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/lib/__tests__/preflightPrompts.test.ts
+++ b/src/lib/__tests__/preflightPrompts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildClarificationPromptBlock,
+    fallbackQuestionsFor,
+    formatAnswersForSummary,
+    QUESTION_COUNT,
+    type PreflightContext,
+} from '../prompts/preflightPrompts';
+import type { PreflightQuestion } from '../../types';
+
+describe('buildClarificationPromptBlock', () => {
+    const ctx: PreflightContext = {
+        mode: 'quick',
+        clarificationResponses: [
+            { question: 'Who is the primary user?', answer: 'Independent musicians', skipped: false },
+            { question: 'How is it monetized?', answer: null, skipped: true },
+        ],
+        summary: '- Target users are independent musicians.',
+        assumptions: ['Mobile-first'],
+        unknowns: ['Monetization undecided'],
+    };
+
+    it('includes the authoritative-intent instruction verbatim', () => {
+        const block = buildClarificationPromptBlock(ctx);
+        expect(block).toContain('Treat answered clarification responses as authoritative intent');
+        expect(block).toContain('If a question was skipped, do not invent certainty');
+    });
+
+    it('includes answered responses', () => {
+        const block = buildClarificationPromptBlock(ctx);
+        expect(block).toContain('Who is the primary user?');
+        expect(block).toContain('Independent musicians');
+    });
+
+    it('marks skipped questions as open unknowns rather than fabricating answers', () => {
+        const block = buildClarificationPromptBlock(ctx);
+        expect(block).toContain('How is it monetized?');
+        expect(block).toContain('skipped — treat as an open unknown');
+    });
+
+    it('includes summary, assumptions, and unknowns when present', () => {
+        const block = buildClarificationPromptBlock(ctx);
+        expect(block).toContain('Target users are independent musicians');
+        expect(block).toContain('Mobile-first');
+        expect(block).toContain('Monetization undecided');
+    });
+});
+
+describe('fallback question sets', () => {
+    it('provides exactly the right counts per mode', () => {
+        expect(QUESTION_COUNT.quick).toBe(5);
+        expect(QUESTION_COUNT.deep).toBe(10);
+        expect(fallbackQuestionsFor('quick')).toHaveLength(5);
+        expect(fallbackQuestionsFor('deep')).toHaveLength(10);
+    });
+});
+
+describe('formatAnswersForSummary', () => {
+    it('renders answered and skipped questions distinctly', () => {
+        const questions: PreflightQuestion[] = [
+            { id: 'q1', question: 'Who is the user?', answer: 'Musicians', skipped: false },
+            { id: 'q2', question: 'Monetization?', skipped: true },
+        ];
+        const text = formatAnswersForSummary('A songwriting app', questions);
+        expect(text).toContain('A songwriting app');
+        expect(text).toContain('Answer: Musicians');
+        expect(text).toContain('Answer: (skipped)');
+    });
+});

--- a/src/lib/__tests__/preflightService.test.ts
+++ b/src/lib/__tests__/preflightService.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+    generatePreflightQuestions,
+    generatePreflightSummary,
+    type PreflightTransport,
+} from '../services/preflightService';
+import type { SafetyTransport } from '../safety';
+import type { PreflightQuestion } from '../../types';
+
+// Safety transport stubs (mirror classifyProjectSafety's injection pattern).
+const allowSafety: SafetyTransport = async () =>
+    JSON.stringify({
+        classification: 'allowed',
+        confidence: 'high',
+        detectedConcerns: [],
+        userFacingReason: '',
+        safeAlternatives: [],
+    });
+
+const disallowSafety: SafetyTransport = async () =>
+    JSON.stringify({
+        classification: 'disallowed',
+        confidence: 'high',
+        detectedConcerns: ['credential theft'],
+        userFacingReason: 'This enables credential theft.',
+        safeAlternatives: [],
+    });
+
+const questionsTransport = (n: number): PreflightTransport => async () =>
+    JSON.stringify({
+        questions: Array.from({ length: n }, (_, i) => ({
+            question: `Generated question ${i + 1}?`,
+            intent: `intent ${i + 1}`,
+        })),
+    });
+
+describe('generatePreflightQuestions', () => {
+    it('generates 5 idea-specific questions in quick mode', async () => {
+        const { questions, usedFallback } = await generatePreflightQuestions('A meal planning app', 'quick', {
+            safetyTransport: allowSafety,
+            transport: questionsTransport(5),
+        });
+        expect(questions).toHaveLength(5);
+        expect(usedFallback).toBe(false);
+        expect(questions[0].question).toContain('Generated question 1');
+        expect(questions.map((q) => q.id)).toEqual(['q1', 'q2', 'q3', 'q4', 'q5']);
+    });
+
+    it('generates 10 questions in deep mode', async () => {
+        const { questions } = await generatePreflightQuestions('A drone inspection platform', 'deep', {
+            safetyTransport: allowSafety,
+            transport: questionsTransport(10),
+        });
+        expect(questions).toHaveLength(10);
+    });
+
+    it('caps over-produced questions to the requested count', async () => {
+        const { questions } = await generatePreflightQuestions('idea', 'quick', {
+            safetyTransport: allowSafety,
+            transport: questionsTransport(12),
+        });
+        expect(questions).toHaveLength(5);
+    });
+
+    it('throws SafetyBlockedError before producing questions for a disallowed idea', async () => {
+        await expect(
+            generatePreflightQuestions('Build a keylogger that steals passwords', 'quick', {
+                safetyTransport: disallowSafety,
+                // This transport would throw if ever reached — proving questions
+                // are never generated for a disallowed idea.
+                transport: async () => {
+                    throw new Error('question generation must not run for disallowed ideas');
+                },
+            }),
+        ).rejects.toMatchObject({ name: 'SafetyBlockedError' });
+    });
+
+    it('falls back to the generic set on a non-safety generation failure', async () => {
+        const { questions, usedFallback } = await generatePreflightQuestions('idea', 'quick', {
+            safetyTransport: allowSafety,
+            transport: async () => {
+                throw new Error('model unavailable');
+            },
+        });
+        expect(usedFallback).toBe(true);
+        expect(questions).toHaveLength(5);
+        expect(questions[0].question).toBe('Who is the primary user?');
+    });
+
+    it('uses the 10-question fallback set in deep mode', async () => {
+        const { questions, usedFallback } = await generatePreflightQuestions('idea', 'deep', {
+            safetyTransport: allowSafety,
+            transport: async () => '{"questions": []}',
+        });
+        expect(usedFallback).toBe(true);
+        expect(questions).toHaveLength(10);
+    });
+});
+
+describe('generatePreflightSummary', () => {
+    const questions: PreflightQuestion[] = [
+        { id: 'q1', question: 'Who is the primary user?', answer: 'Independent musicians', skipped: false },
+        { id: 'q2', question: 'How is it monetized?', skipped: true },
+    ];
+
+    it('returns the AI summary, assumptions, and unknowns', async () => {
+        const transport: PreflightTransport = async () =>
+            JSON.stringify({
+                summary: '- Target users are independent musicians.',
+                assumptions: ['Mobile-first experience'],
+                unknowns: ['Monetization not decided'],
+            });
+        const result = await generatePreflightSummary('A songwriting app', questions, { transport });
+        expect(result.summary).toContain('independent musicians');
+        expect(result.assumptions).toContain('Mobile-first experience');
+        expect(result.unknowns).toContain('Monetization not decided');
+    });
+
+    it('falls back to a local recap and treats skipped questions as unknowns', async () => {
+        const result = await generatePreflightSummary('A songwriting app', questions, {
+            transport: async () => {
+                throw new Error('model unavailable');
+            },
+        });
+        expect(result.summary).toContain('Independent musicians');
+        // The skipped question becomes an open unknown, not fabricated certainty.
+        expect(result.unknowns).toContain('How is it monetized?');
+    });
+});

--- a/src/lib/llmProvider.ts
+++ b/src/lib/llmProvider.ts
@@ -2,5 +2,12 @@
 export { callGeminiStream, type StreamCallbacks, type ProviderOptions } from './geminiClient';
 export { consolidateBranch, replyInBranch, type ConsolidationResult, type ConsolidationScope } from './services/branchService';
 export { generateStructuredPRD, structuredPRDToMarkdown, enhancePrompt } from './services/prdService';
+export {
+    generatePreflightQuestions,
+    generatePreflightSummary,
+    type PreflightQuestionsResult,
+    type PreflightSummaryResult,
+} from './services/preflightService';
+export type { PreflightContext } from './prompts/preflightPrompts';
 export { generateMockup, type ParseResult as MockupParseResult } from './services/mockupService';
 export { generateCoreArtifact, refineCoreArtifact } from './services/coreArtifactService';

--- a/src/lib/prompts/preflightPrompts.ts
+++ b/src/lib/prompts/preflightPrompts.ts
@@ -1,0 +1,131 @@
+// Prompts and fallbacks for the optional preflight clarification step.
+//
+// The authoritative safety guardrail is the code-level classifier
+// (classifyProjectSafety), which the preflight service runs BEFORE generating
+// any questions. SAFETY_OVERRIDE is prepended here as defense-in-depth so the
+// model never produces questions that help specify harmful intent.
+
+import { SAFETY_OVERRIDE } from './prdPrompts';
+import type { PreflightMode, PreflightQuestion } from '../../types';
+
+/** Number of questions per mode. */
+export const QUESTION_COUNT: Record<Exclude<PreflightMode, 'none'>, number> = {
+    quick: 5,
+    deep: 10,
+};
+
+// System instruction for question generation. The model returns exactly N
+// idea-specific questions — no generic boilerplate.
+export const buildQuestionSystemInstruction = (count: number): string => `${SAFETY_OVERRIDE}
+
+You are a senior product strategist running a fast, focused discovery interview before a Product Requirements Document is written. You receive a plain-language product idea. Generate exactly ${count} clarifying questions tailored specifically to THIS idea.
+
+Rules:
+- Generate exactly ${count} questions. No more, no fewer.
+- Each question must be specific to the stated idea — never generic filler that would apply to any product.
+- Cover the highest-leverage unknowns first. Draw from: target users, the core problem, user goals, MVP scope, key workflows, success criteria, constraints, differentiation, technical expectations, and — only when relevant to this idea — monetization/business model and safety/compliance concerns.
+- One clear question per item. Keep each question to a single sentence a non-technical founder can answer.
+- For each question, include a short "intent" (≤ 12 words) explaining why it matters.
+- Do not ask the user to write the PRD; ask for decisions and facts that inform it.
+- Do not number the questions or add commentary.
+
+Return only the JSON object matching the schema.`;
+
+// System instruction for summary generation. Produces a concise, scannable
+// recap plus derived assumptions and open unknowns.
+export const SUMMARY_SYSTEM_INSTRUCTION = `${SAFETY_OVERRIDE}
+
+You are a senior product strategist. You receive a product idea and the user's answers to a set of clarifying questions (some may be skipped). Produce a brief recap that will seed PRD generation.
+
+Rules:
+- "summary": 4-7 short, scannable bullet-style sentences capturing what was learned. Lead each with the concrete decision or fact. No marketing language, no hedging.
+- "assumptions": reasonable assumptions you are making where the user gave partial or no answer. State them plainly; do not invent certainty the user did not express.
+- "unknowns": questions the user skipped or left genuinely undecided, phrased as open items for the PRD's open-questions/assumptions handling.
+- Treat answered questions as authoritative user intent. Never contradict an explicit answer.
+- Be concise. Do not restate the questions verbatim.
+
+Return only the JSON object matching the schema.`;
+
+// Generic fallback question sets, used only when AI question generation fails.
+// These are the exact sets specified in the product brief.
+export const FALLBACK_QUESTIONS_5: { question: string; intent: string }[] = [
+    { question: 'Who is the primary user?', intent: 'Anchors the whole product to a real audience.' },
+    { question: 'What problem are they trying to solve?', intent: 'Defines the core job to be done.' },
+    { question: 'What should the MVP absolutely include?', intent: 'Sets the must-have scope.' },
+    { question: 'What should be excluded from the first version?', intent: 'Keeps the MVP shippable.' },
+    { question: 'How will you know the product is successful?', intent: 'Defines success criteria.' },
+];
+
+export const FALLBACK_QUESTIONS_10: { question: string; intent: string }[] = [
+    ...FALLBACK_QUESTIONS_5,
+    { question: 'What are the most important user workflows?', intent: 'Drives screen and flow design.' },
+    { question: 'Are there any technical constraints?', intent: 'Shapes architecture decisions.' },
+    { question: 'Are there any privacy, safety, or compliance concerns?', intent: 'Surfaces guardrails early.' },
+    { question: 'What makes this different from existing solutions?', intent: 'Clarifies differentiation.' },
+    { question: 'What assumptions should the PRD make if details are unknown?', intent: 'Guides assumption handling.' },
+];
+
+export const fallbackQuestionsFor = (mode: Exclude<PreflightMode, 'none'>) =>
+    mode === 'deep' ? FALLBACK_QUESTIONS_10 : FALLBACK_QUESTIONS_5;
+
+/** Shape of the clarification context forwarded into PRD generation. */
+export interface PreflightContext {
+    mode: PreflightMode;
+    clarificationResponses: {
+        question: string;
+        answer: string | null;
+        skipped: boolean;
+        intent?: string;
+    }[];
+    summary?: string;
+    assumptions?: string[];
+    unknowns?: string[];
+}
+
+/**
+ * Build the clarification block appended to the PRD prompt. Includes the
+ * authoritative-intent instruction (verbatim from the product brief) so the
+ * generator treats answers as intent and skipped questions as unknowns rather
+ * than fabricating certainty.
+ */
+export const buildClarificationPromptBlock = (ctx: PreflightContext): string => {
+    const lines: string[] = [];
+    lines.push('## Preflight Clarification');
+    lines.push(
+        'The user optionally completed a preflight clarification step. Treat answered clarification responses as authoritative intent. Use them to resolve ambiguity in the PRD. If a question was skipped, do not invent certainty. Instead, make a reasonable assumption and include it in the assumptions or open questions section where appropriate.',
+    );
+
+    if (ctx.clarificationResponses.length > 0) {
+        lines.push('\nClarification responses:');
+        for (const r of ctx.clarificationResponses) {
+            if (r.skipped || !r.answer || !r.answer.trim()) {
+                lines.push(`- Q: ${r.question}\n  A: (skipped — treat as an open unknown)`);
+            } else {
+                lines.push(`- Q: ${r.question}\n  A: ${r.answer.trim()}`);
+            }
+        }
+    }
+
+    if (ctx.summary && ctx.summary.trim()) {
+        lines.push(`\nSummary of intent:\n${ctx.summary.trim()}`);
+    }
+    if (ctx.assumptions && ctx.assumptions.length > 0) {
+        lines.push(`\nAssumptions to carry into the PRD:\n${ctx.assumptions.map((a) => `- ${a}`).join('\n')}`);
+    }
+    if (ctx.unknowns && ctx.unknowns.length > 0) {
+        lines.push(`\nOpen unknowns (do not fabricate answers):\n${ctx.unknowns.map((u) => `- ${u}`).join('\n')}`);
+    }
+
+    return lines.join('\n');
+};
+
+/** Format question/answer pairs for the summary prompt. */
+export const formatAnswersForSummary = (idea: string, questions: PreflightQuestion[]): string => {
+    const qa = questions
+        .map((q, i) => {
+            const answered = !q.skipped && q.answer && q.answer.trim();
+            return `${i + 1}. ${q.question}\n   Answer: ${answered ? q.answer!.trim() : '(skipped)'}`;
+        })
+        .join('\n');
+    return `Product idea:\n${idea}\n\nClarification Q&A:\n${qa}`;
+};

--- a/src/lib/runPrdGeneration.ts
+++ b/src/lib/runPrdGeneration.ts
@@ -1,0 +1,134 @@
+// Shared entry point for kicking off PRD generation against an existing spine.
+// Used by both the "Generate Immediately" path (HomePage) and the preflight
+// clarification path (PreflightView) so there is exactly one generation flow
+// with one set of store callbacks and error handling.
+
+import { useProjectStore } from '../store/projectStore';
+import { normalizeError, userMessage } from './errors';
+import {
+    SafetyBlockedError,
+    buildBlockedSafetyReview,
+    buildRestrictedSafetyReview,
+    buildSafetyReviewMarkdown,
+} from './safety';
+import type { ProjectPlatform } from '../types';
+import type { PreflightContext } from './llmProvider';
+
+export interface RunPrdGenerationParams {
+    projectId: string;
+    spineId: string;
+    /** The original user idea. Safety is classified on this text. */
+    sourcePrompt: string;
+    platform?: ProjectPlatform;
+    /** Optional preflight clarification context to inject into the prompt. */
+    preflight?: PreflightContext;
+}
+
+/**
+ * Runs PRD generation for a spine and wires the streaming results back into the
+ * store. Resolves when generation settles (success or handled failure); never
+ * rejects — disallowed/blocked and generation errors are persisted on the spine
+ * exactly as the prior inline call sites did.
+ */
+export async function runPrdGeneration({
+    projectId,
+    spineId,
+    sourcePrompt,
+    platform,
+    preflight,
+}: RunPrdGenerationParams): Promise<void> {
+    const store = useProjectStore.getState();
+    // Fresh run starts with a clean event log.
+    store.clearPrdProgress(projectId);
+    store.clearSectionStatus(projectId);
+
+    let generateStructuredPRD;
+    try {
+        ({ generateStructuredPRD } = await import('./llmProvider'));
+    } catch (e) {
+        const err = normalizeError(e);
+        console.error('[Module load failed]', err.raw);
+        useProjectStore.getState().setSpineError(projectId, spineId, {
+            message: 'Failed to load generation module. Try refreshing the page.',
+            category: err.category,
+            timestamp: err.timestamp,
+            raw: err.raw,
+        });
+        return;
+    }
+
+    try {
+        await generateStructuredPRD(
+            sourcePrompt,
+            {
+                preflight,
+                onProgress: (message) => {
+                    useProjectStore.getState().appendPrdProgress(projectId, message);
+                },
+                onSectionStatus: (sectionId, update) => {
+                    useProjectStore.getState().setSectionStatus(projectId, sectionId, update);
+                },
+                // Progressive render: paint the draft as soon as each section lands.
+                onPartial: ({ structuredPRD, markdown }) => {
+                    useProjectStore.getState().updateSpineStructuredPRD(
+                        projectId,
+                        spineId,
+                        structuredPRD,
+                        markdown,
+                        { sourcePrompt },
+                    );
+                    if (structuredPRD.productName || structuredPRD.productCategory) {
+                        useProjectStore.getState().updateProjectProductMetadata(projectId, {
+                            productName: structuredPRD.productName,
+                            productCategory: structuredPRD.productCategory,
+                        });
+                    }
+                },
+                onResult: ({ structuredPRD, markdown, generationMeta, model }) => {
+                    useProjectStore.getState().updateSpineStructuredPRD(
+                        projectId,
+                        spineId,
+                        structuredPRD,
+                        markdown,
+                        {
+                            sourcePrompt,
+                            generationMeta,
+                            model,
+                            prdVersion: generationMeta.schemaVersion,
+                        },
+                    );
+                },
+                onSafety: (safety) => {
+                    if (safety.classification === 'allowed_with_restrictions') {
+                        useProjectStore.getState().setSpineSafetyReview(
+                            projectId,
+                            spineId,
+                            buildRestrictedSafetyReview(safety),
+                        );
+                    }
+                },
+            },
+            platform,
+        );
+    } catch (e) {
+        // Disallowed requests hard-stop: store a blocked Safety Review (which
+        // shows the dedicated screen and gates downstream generation).
+        if (e instanceof SafetyBlockedError) {
+            useProjectStore.getState().setSpineSafetyReview(
+                projectId,
+                spineId,
+                buildBlockedSafetyReview(e.result),
+                buildSafetyReviewMarkdown(e.result),
+            );
+            return;
+        }
+        const err = normalizeError(e);
+        console.error('[PRD generation failed]', err.raw);
+        useProjectStore.getState().setSpineError(projectId, spineId, {
+            message: userMessage(err),
+            category: err.category,
+            timestamp: err.timestamp,
+            raw: err.raw,
+        });
+    }
+}

--- a/src/lib/schemas/preflightSchemas.ts
+++ b/src/lib/schemas/preflightSchemas.ts
@@ -1,0 +1,35 @@
+// Gemini JSON-mode schemas for the optional preflight clarification step.
+// Mirrors the style of safetySchemas.ts (uppercase types, required fields).
+
+// Question generation: the model returns an array of idea-specific clarifying
+// questions, each with a short "why this matters" intent line.
+export const preflightQuestionsSchema = {
+    type: "OBJECT",
+    properties: {
+        questions: {
+            type: "ARRAY",
+            items: {
+                type: "OBJECT",
+                properties: {
+                    question: { type: "STRING" },
+                    intent: { type: "STRING" },
+                },
+                required: ["question"],
+            },
+        },
+    },
+    required: ["questions"],
+};
+
+// Summary generation: a concise scannable recap plus derived assumptions and
+// open unknowns (skipped questions feed unknowns/assumptions, never fake
+// certainty).
+export const preflightSummarySchema = {
+    type: "OBJECT",
+    properties: {
+        summary: { type: "STRING" },
+        assumptions: { type: "ARRAY", items: { type: "STRING" } },
+        unknowns: { type: "ARRAY", items: { type: "STRING" } },
+    },
+    required: ["summary", "assumptions", "unknowns"],
+};

--- a/src/lib/services/prdService.ts
+++ b/src/lib/services/prdService.ts
@@ -8,6 +8,7 @@ import type { SectionId } from '../schemas/prdSchemas';
 import type { SectionStatusUpdate } from './progressivePrdPipeline';
 import { classifyProjectSafety, SafetyBlockedError, buildRestrictionDirective } from '../safety';
 import type { SafetyClassificationResult } from '../safety';
+import { buildClarificationPromptBlock, type PreflightContext } from '../prompts/preflightPrompts';
 
 export const enhancePrompt = async (rawPrompt: string): Promise<string> => {
     const system = `You are a senior product consultant. The user has written a rough product idea. Expand it into a clear, grounded product description that will support a high-quality PRD.
@@ -49,6 +50,14 @@ export const generateStructuredPRD = async (
          * pipeline hard-stops.
          */
         onSafety?: (result: SafetyClassificationResult) => void;
+        /**
+         * Optional preflight clarification context. When present (and
+         * `mode !== 'none'`), the answered/skipped responses and summary are
+         * appended to the prompt forwarded to every section, with an
+         * instruction to treat answers as authoritative intent and skipped
+         * questions as open unknowns.
+         */
+        preflight?: PreflightContext;
     },
     platform?: ProjectPlatform,
 ): Promise<StructuredPRD> => {
@@ -66,10 +75,17 @@ export const generateStructuredPRD = async (
 
     // For allowed_with_restrictions, constrain generation by appending a
     // binding directive to the prompt forwarded to every section.
-    const effectivePrompt =
+    const withRestrictions =
         safety.classification === 'allowed_with_restrictions'
             ? `${promptText}\n\n${buildRestrictionDirective(safety)}`
             : promptText;
+
+    // Append preflight clarification context (kept AFTER the safety gate so a
+    // disallowed idea can never reach this point).
+    const effectivePrompt =
+        options?.preflight && options.preflight.mode !== 'none'
+            ? `${withRestrictions}\n\n${buildClarificationPromptBlock(options.preflight)}`
+            : withRestrictions;
 
     options?.onStatus?.('Generating structured PRD with Gemini...');
 

--- a/src/lib/services/preflightService.ts
+++ b/src/lib/services/preflightService.ts
@@ -1,0 +1,185 @@
+// Optional preflight clarification: AI-generated discovery questions and a
+// pre-PRD summary. Safety is classified BEFORE any questions are generated —
+// a disallowed idea throws SafetyBlockedError and no questions are produced.
+//
+// Both calls degrade gracefully: question generation falls back to a generic
+// set on non-safety failure, and summary generation falls back to a
+// deterministic local recap, so the user is never blocked from continuing.
+
+import { callGemini, type JsonModeConfig } from '../geminiClient';
+import { classifyProjectSafety, SafetyBlockedError, type SafetyTransport } from '../safety';
+import { preflightQuestionsSchema, preflightSummarySchema } from '../schemas/preflightSchemas';
+import { repairTruncatedJson } from '../jsonRepair';
+import {
+    buildQuestionSystemInstruction,
+    SUMMARY_SYSTEM_INSTRUCTION,
+    QUESTION_COUNT,
+    fallbackQuestionsFor,
+    formatAnswersForSummary,
+} from '../prompts/preflightPrompts';
+import type { PreflightMode, PreflightQuestion } from '../../types';
+
+/** Injectable transport so tests can run without hitting the network. */
+export type PreflightTransport = (
+    system: string,
+    prompt: string,
+    jsonMode: JsonModeConfig,
+) => Promise<string>;
+
+const defaultTransport: PreflightTransport = (system, prompt, jsonMode) =>
+    callGemini(system, prompt, jsonMode);
+
+export interface PreflightServiceOptions {
+    signal?: AbortSignal;
+    /** Transport for the question/summary generation call. */
+    transport?: PreflightTransport;
+    /** Transport forwarded to the safety classifier (tests). */
+    safetyTransport?: SafetyTransport;
+}
+
+export interface PreflightQuestionsResult {
+    questions: PreflightQuestion[];
+    usedFallback: boolean;
+}
+
+const asStringArray = (value: unknown): string[] =>
+    Array.isArray(value)
+        ? value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+        : [];
+
+const parseJson = (raw: string): unknown => {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        const { text, repaired } = repairTruncatedJson(raw);
+        if (!repaired) return null;
+        try {
+            return JSON.parse(text);
+        } catch {
+            return null;
+        }
+    }
+};
+
+const fallbackQuestions = (mode: Exclude<PreflightMode, 'none'>): PreflightQuestion[] =>
+    fallbackQuestionsFor(mode).map((q, i) => ({
+        id: `q${i + 1}`,
+        question: q.question,
+        intent: q.intent,
+    }));
+
+/**
+ * Generate idea-specific clarification questions for the chosen mode. Runs the
+ * safety gate first: a `disallowed` verdict throws SafetyBlockedError before
+ * any questions are produced. On a non-safety failure, returns the generic
+ * fallback set with `usedFallback: true`.
+ */
+export const generatePreflightQuestions = async (
+    idea: string,
+    mode: Exclude<PreflightMode, 'none'>,
+    opts?: PreflightServiceOptions,
+): Promise<PreflightQuestionsResult> => {
+    // Safety gate — identical chokepoint to PRD generation, run up front.
+    const safety = await classifyProjectSafety(idea, {
+        signal: opts?.signal,
+        transport: opts?.safetyTransport,
+    });
+    if (safety.classification === 'disallowed') {
+        throw new SafetyBlockedError(safety);
+    }
+
+    const count = QUESTION_COUNT[mode];
+    const transport = opts?.transport ?? defaultTransport;
+
+    try {
+        const raw = await transport(buildQuestionSystemInstruction(count), idea, {
+            responseMimeType: 'application/json',
+            responseSchema: preflightQuestionsSchema,
+            temperature: 0.5,
+            topP: 0.95,
+            maxOutputTokens: 2048,
+        });
+        const parsed = parseJson(raw) as { questions?: unknown[] } | null;
+        const rawQuestions = Array.isArray(parsed?.questions) ? parsed!.questions : [];
+
+        const questions: PreflightQuestion[] = rawQuestions
+            .map((q, i): PreflightQuestion | null => {
+                const obj = q as Record<string, unknown>;
+                const question = typeof obj?.question === 'string' ? obj.question.trim() : '';
+                if (!question) return null;
+                const intent = typeof obj?.intent === 'string' ? obj.intent.trim() : undefined;
+                return { id: `q${i + 1}`, question, intent };
+            })
+            .filter((q): q is PreflightQuestion => q !== null)
+            // Never exceed the requested count, even if the model over-produces.
+            .slice(0, count);
+
+        if (questions.length === 0) {
+            return { questions: fallbackQuestions(mode), usedFallback: true };
+        }
+        // Top up with fallbacks if the model under-produced, keeping unique ids.
+        if (questions.length < count) {
+            const extras = fallbackQuestions(mode)
+                .slice(questions.length)
+                .map((q, i) => ({ ...q, id: `q${questions.length + i + 1}` }));
+            return { questions: [...questions, ...extras], usedFallback: false };
+        }
+        return { questions, usedFallback: false };
+    } catch (e) {
+        console.warn('[preflight] question generation failed; using fallback set', e);
+        return { questions: fallbackQuestions(mode), usedFallback: true };
+    }
+};
+
+export interface PreflightSummaryResult {
+    summary: string;
+    assumptions: string[];
+    unknowns: string[];
+}
+
+/** Deterministic local recap used when summary generation fails. */
+const localSummary = (questions: PreflightQuestion[]): PreflightSummaryResult => {
+    const answered = questions.filter((q) => !q.skipped && q.answer && q.answer.trim());
+    const skipped = questions.filter((q) => q.skipped || !q.answer || !q.answer.trim());
+    return {
+        summary: answered.length
+            ? answered.map((q) => `- ${q.question} → ${q.answer!.trim()}`).join('\n')
+            : 'No clarification answers were provided.',
+        assumptions: [],
+        unknowns: skipped.map((q) => q.question),
+    };
+};
+
+/**
+ * Summarize the clarification answers into a concise recap plus derived
+ * assumptions and unknowns. Falls back to a deterministic local recap on
+ * failure so the flow never blocks.
+ */
+export const generatePreflightSummary = async (
+    idea: string,
+    questions: PreflightQuestion[],
+    opts?: PreflightServiceOptions,
+): Promise<PreflightSummaryResult> => {
+    const transport = opts?.transport ?? defaultTransport;
+    try {
+        const raw = await transport(SUMMARY_SYSTEM_INSTRUCTION, formatAnswersForSummary(idea, questions), {
+            responseMimeType: 'application/json',
+            responseSchema: preflightSummarySchema,
+            temperature: 0.3,
+            topP: 0.9,
+            maxOutputTokens: 1536,
+        });
+        const parsed = parseJson(raw) as Record<string, unknown> | null;
+        if (!parsed || typeof parsed.summary !== 'string' || !parsed.summary.trim()) {
+            return localSummary(questions);
+        }
+        return {
+            summary: parsed.summary.trim(),
+            assumptions: asStringArray(parsed.assumptions),
+            unknowns: asStringArray(parsed.unknowns),
+        };
+    } catch (e) {
+        console.warn('[preflight] summary generation failed; using local recap', e);
+        return localSummary(questions);
+    }
+};

--- a/src/store/__tests__/preflightSession.test.ts
+++ b/src/store/__tests__/preflightSession.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import type { PreflightQuestion } from '../../types';
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+    localStorage.clear();
+});
+
+const setup = () => {
+    const store = useProjectStore.getState();
+    const { projectId, spineId } = store.createProject('Test', 'A songwriting app');
+    return { projectId, spineId };
+};
+
+const session = (projectId: string) =>
+    useProjectStore.getState().getLatestSpine(projectId)?.preflightSession;
+
+describe('preflight session store actions', () => {
+    it('round-trips init → questions → answer(skip) → summary → complete', () => {
+        const { projectId, spineId } = setup();
+        const store = useProjectStore.getState();
+
+        store.initPreflightSession(projectId, spineId, 'quick', 'A songwriting app');
+        expect(session(projectId)).toMatchObject({
+            mode: 'quick',
+            status: 'awaiting_questions',
+            completed: false,
+            currentQuestionIndex: 0,
+        });
+
+        const questions: PreflightQuestion[] = [
+            { id: 'q1', question: 'Who is the user?' },
+            { id: 'q2', question: 'Monetization?' },
+        ];
+        store.setPreflightQuestions(projectId, spineId, questions, false);
+        expect(session(projectId)?.status).toBe('answering');
+        expect(session(projectId)?.questions).toHaveLength(2);
+
+        store.setPreflightAnswer(projectId, spineId, 'q1', 'Musicians', false);
+        store.setPreflightAnswer(projectId, spineId, 'q2', '', true);
+        const qs = session(projectId)!.questions;
+        expect(qs.find((q) => q.id === 'q1')?.answer).toBe('Musicians');
+        expect(qs.find((q) => q.id === 'q2')?.skipped).toBe(true);
+
+        store.setPreflightSummary(projectId, spineId, {
+            summary: '- Users are musicians.',
+            assumptions: ['Mobile-first'],
+            unknowns: ['Monetization undecided'],
+        });
+        expect(session(projectId)).toMatchObject({
+            status: 'summary',
+            summary: '- Users are musicians.',
+        });
+        expect(session(projectId)?.unknowns).toContain('Monetization undecided');
+
+        store.completePreflightSession(projectId, spineId);
+        expect(session(projectId)).toMatchObject({ completed: true, status: 'completed' });
+    });
+
+    it('re-enters answering when editing from the summary', () => {
+        const { projectId, spineId } = setup();
+        const store = useProjectStore.getState();
+        store.initPreflightSession(projectId, spineId, 'quick', 'idea');
+        store.setPreflightQuestions(projectId, spineId, [
+            { id: 'q1', question: 'Q1' },
+            { id: 'q2', question: 'Q2' },
+        ]);
+        store.setPreflightSummary(projectId, spineId, { summary: 's', assumptions: [], unknowns: [] });
+        expect(session(projectId)?.status).toBe('summary');
+
+        store.setPreflightIndex(projectId, spineId, 0);
+        expect(session(projectId)?.status).toBe('answering');
+        expect(session(projectId)?.currentQuestionIndex).toBe(0);
+    });
+
+    it('persists the session on the spine (survives serialization)', () => {
+        const { projectId, spineId } = setup();
+        useProjectStore.getState().initPreflightSession(projectId, spineId, 'deep', 'idea');
+        const serialized = JSON.stringify(useProjectStore.getState().spineVersions);
+        const restored = JSON.parse(serialized);
+        expect(restored[projectId][0].preflightSession.mode).toBe('deep');
+    });
+});

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type {
     SpineVersion, HistoryEvent, StructuredPRD,
     QualityScores, GenerationMeta, SpineSafetyReview,
+    PreflightSession,
 } from '../../types';
 import type { ProjectState, SpineGenerationMetaInput } from '../types';
 
@@ -19,7 +20,27 @@ export type SpineSlice = {
     updateProjectProductMetadata: ProjectState['updateProjectProductMetadata'];
     setSpineError: ProjectState['setSpineError'];
     setSpineSafetyReview: ProjectState['setSpineSafetyReview'];
+    initPreflightSession: ProjectState['initPreflightSession'];
+    setPreflightQuestions: ProjectState['setPreflightQuestions'];
+    setPreflightAnswer: ProjectState['setPreflightAnswer'];
+    setPreflightIndex: ProjectState['setPreflightIndex'];
+    setPreflightSummary: ProjectState['setPreflightSummary'];
+    completePreflightSession: ProjectState['completePreflightSession'];
+    setPreflightError: ProjectState['setPreflightError'];
 };
+
+// Update a single spine's preflight session in place. No-op when the spine has
+// no session yet (except init, which seeds one). Keeps the verbose
+// map-over-spines pattern used throughout this slice.
+const patchPreflight = (
+    spines: SpineVersion[],
+    spineId: string,
+    patch: (prev: PreflightSession) => PreflightSession,
+): SpineVersion[] =>
+    spines.map((s) => {
+        if (s.id !== spineId || !s.preflightSession) return s;
+        return { ...s, preflightSession: patch(s.preflightSession) };
+    });
 
 export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = (set, get) => ({
     spineVersions: {},
@@ -94,6 +115,112 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
                 }
             };
         });
+    },
+
+    // --- Preflight clarification --------------------------------------------
+    initPreflightSession: (projectId, spineId, mode, originalIdea) => {
+        set((state) => {
+            const projectSpines = state.spineVersions[projectId] || [];
+            const updatedSpines = projectSpines.map((s) =>
+                s.id === spineId
+                    ? {
+                        ...s,
+                        preflightSession: {
+                            mode,
+                            originalIdea,
+                            questions: [],
+                            currentQuestionIndex: 0,
+                            status: 'awaiting_questions' as const,
+                            completed: false,
+                        },
+                    }
+                    : s,
+            );
+            return { spineVersions: { ...state.spineVersions, [projectId]: updatedSpines } };
+        });
+    },
+
+    setPreflightQuestions: (projectId, spineId, questions, usedFallback) => {
+        set((state) => ({
+            spineVersions: {
+                ...state.spineVersions,
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
+                    ...prev,
+                    questions,
+                    usedFallback: usedFallback ?? false,
+                    status: 'answering',
+                    error: undefined,
+                })),
+            },
+        }));
+    },
+
+    setPreflightAnswer: (projectId, spineId, questionId, answer, skipped) => {
+        set((state) => ({
+            spineVersions: {
+                ...state.spineVersions,
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
+                    ...prev,
+                    questions: prev.questions.map((q) =>
+                        q.id === questionId ? { ...q, answer, skipped } : q,
+                    ),
+                })),
+            },
+        }));
+    },
+
+    setPreflightIndex: (projectId, spineId, index) => {
+        set((state) => ({
+            spineVersions: {
+                ...state.spineVersions,
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
+                    ...prev,
+                    currentQuestionIndex: Math.max(0, index),
+                    // Returning to the questions from the summary re-enters answering.
+                    status: prev.status === 'summary' && index < prev.questions.length ? 'answering' : prev.status,
+                })),
+            },
+        }));
+    },
+
+    setPreflightSummary: (projectId, spineId, { summary, assumptions, unknowns }) => {
+        set((state) => ({
+            spineVersions: {
+                ...state.spineVersions,
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
+                    ...prev,
+                    summary,
+                    assumptions,
+                    unknowns,
+                    status: 'summary',
+                })),
+            },
+        }));
+    },
+
+    completePreflightSession: (projectId, spineId) => {
+        set((state) => ({
+            spineVersions: {
+                ...state.spineVersions,
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
+                    ...prev,
+                    completed: true,
+                    status: 'completed',
+                })),
+            },
+        }));
+    },
+
+    setPreflightError: (projectId, spineId, message) => {
+        set((state) => ({
+            spineVersions: {
+                ...state.spineVersions,
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
+                    ...prev,
+                    error: message ?? undefined,
+                })),
+            },
+        }));
     },
 
     updateStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,6 +5,7 @@ import type {
     SourceRef, FeedbackItem, FeedbackType, FeedbackStatus, StalenessState,
     ArtifactSlotKey, ProjectJobState, SlotState,
     QualityScores, GenerationMeta, SpineSafetyReview,
+    PreflightMode, PreflightQuestion,
 } from '../types';
 import type { SectionId } from '../lib/schemas/prdSchemas';
 
@@ -83,6 +84,15 @@ export interface ProjectState {
         review: SpineSafetyReview,
         responseText?: string,
     ) => void;
+
+    // --- Preflight clarification (persisted on the spine; resumable) ---
+    initPreflightSession: (projectId: string, spineId: string, mode: PreflightMode, originalIdea: string) => void;
+    setPreflightQuestions: (projectId: string, spineId: string, questions: PreflightQuestion[], usedFallback?: boolean) => void;
+    setPreflightAnswer: (projectId: string, spineId: string, questionId: string, answer: string, skipped: boolean) => void;
+    setPreflightIndex: (projectId: string, spineId: string, index: number) => void;
+    setPreflightSummary: (projectId: string, spineId: string, summary: { summary: string; assumptions: string[]; unknowns: string[] }) => void;
+    completePreflightSession: (projectId: string, spineId: string) => void;
+    setPreflightError: (projectId: string, spineId: string, message: string | null) => void;
 
     // --- Artifact System Actions ---
     createArtifact: (projectId: string, type: ArtifactType, title: string, subtype?: CoreArtifactSubtype) => { artifactId: string };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -303,6 +303,42 @@ export type SpineSafetyReview = {
     reviewedAt: number;
 };
 
+// --- Preflight clarification (optional pre-PRD interview) ---
+// When the user opts into Quick (5) or Deep (10) clarification, Synapse
+// generates idea-specific questions, collects answers one at a time, shows a
+// summary, then feeds the responses into PRD generation as authoritative
+// intent. State lives on the spine so progress is resumable across refresh.
+// Absent `preflightSession` = the legacy/"Generate Immediately" path.
+export type PreflightMode = 'none' | 'quick' | 'deep';
+
+export type PreflightQuestion = {
+    id: string;
+    question: string;
+    intent?: string; // short "why this matters" line shown under the question
+    answer?: string;
+    skipped?: boolean;
+};
+
+export type PreflightStatus =
+    | 'awaiting_questions' // questions not yet generated
+    | 'answering' // user is working through the questions
+    | 'summary' // all questions answered/skipped; reviewing the summary
+    | 'completed'; // PRD generation has been kicked off
+
+export type PreflightSession = {
+    mode: PreflightMode;
+    originalIdea: string;
+    questions: PreflightQuestion[];
+    currentQuestionIndex: number;
+    status: PreflightStatus;
+    completed: boolean;
+    summary?: string;
+    assumptions?: string[];
+    unknowns?: string[];
+    usedFallback?: boolean; // questions came from the generic fallback set
+    error?: string; // non-blocking question/summary generation error
+};
+
 export type SpineVersion = {
     id: string; // e.g. "v1", "v2"
     projectId: string;
@@ -312,6 +348,7 @@ export type SpineVersion = {
     isLatest: boolean;
     isFinal: boolean;
     structuredPRD?: StructuredPRD;
+    preflightSession?: PreflightSession;
     generationError?: {
         message: string;
         category: string;


### PR DESCRIPTION
Introduce an optional step between idea entry and PRD generation: users
can choose Generate Immediately (unchanged), Quick Clarification (5
questions), or Deep Discovery (10 questions). Quick/Deep generate
idea-specific questions, collect answers one at a time, show a summary,
then feed the responses into PRD generation as authoritative intent.

- Data model: PreflightSession on SpineVersion (optional, resumable,
  backward-compatible); store actions on spineSlice.
- LLM layer: preflightService (safety-gated question + summary
  generation, with generic fallbacks), preflightPrompts, preflightSchemas.
- PRD integration: generateStructuredPRD gains an options.preflight that
  injects a clarification block (authoritative-intent instruction;
  skipped questions -> open unknowns) after the safety gate. Shared
  runPrdGeneration helper used by both HomePage and the preflight flow.
- UI: PreflightModeChoice sheet on HomePage; mobile-first PreflightView
  hosted in the workspace (one question per card, progress, Skip/Back/
  Next, summary with Edit answers / Generate PRD).
- Safety: disallowed ideas show the existing Safety Review before any
  questions are generated.
- Tests for question generation (5/10/cap/fallback/blocked), summary,
  prompt injection, and the store session lifecycle. CLAUDE.md updated.

https://claude.ai/code/session_01WyHCBXCBwrYATPzfBtdagm