### PR TITLE
Fix preflight summary dropping answered questions and stale edits

### DIFF
--- a/src/components/preflight/PreflightView.tsx
+++ b/src/components/preflight/PreflightView.tsx
@@ -136,23 +136,25 @@ export function PreflightView({ projectId, spineId, session, platform }: Preflig
     const question = session.questions[index];
     const isLast = index === total - 1;
 
-    const advance = () => {
-        if (isLast) {
-            // Move to the summary; generate it from the answers.
-            setIsWorking(true);
-            (async () => {
-                const summary = await generatePreflightSummary(session.originalIdea, session.questions);
-                setPreflightSummary(projectId, spineId, summary);
-                setIsWorking(false);
-            })();
-        } else {
-            setPreflightIndex(projectId, spineId, index + 1);
-        }
-    };
-
     const commitAndAdvance = (answer: string, skipped: boolean) => {
         setPreflightAnswer(projectId, spineId, question.id, answer, skipped);
-        advance();
+        if (!isLast) {
+            setPreflightIndex(projectId, spineId, index + 1);
+            return;
+        }
+        // Move to the summary; generate it from the answers. The store update
+        // above is async and not yet reflected in `session`, so apply the
+        // just-committed answer locally — otherwise the final question is read
+        // as skipped and misfiled under "Open questions".
+        const updatedQuestions = session.questions.map((q) =>
+            q.id === question.id ? { ...q, answer, skipped } : q,
+        );
+        setIsWorking(true);
+        (async () => {
+            const summary = await generatePreflightSummary(session.originalIdea, updatedQuestions);
+            setPreflightSummary(projectId, spineId, summary);
+            setIsWorking(false);
+        })();
     };
 
     return (

--- a/src/lib/__tests__/preflightPrompts.test.ts
+++ b/src/lib/__tests__/preflightPrompts.test.ts
@@ -4,6 +4,7 @@ import {
     fallbackQuestionsFor,
     formatAnswersForSummary,
     QUESTION_COUNT,
+    SUMMARY_SYSTEM_INSTRUCTION,
     type PreflightContext,
 } from '../prompts/preflightPrompts';
 import type { PreflightQuestion } from '../../types';
@@ -52,6 +53,12 @@ describe('fallback question sets', () => {
         expect(QUESTION_COUNT.deep).toBe(10);
         expect(fallbackQuestionsFor('quick')).toHaveLength(5);
         expect(fallbackQuestionsFor('deep')).toHaveLength(10);
+    });
+});
+
+describe('SUMMARY_SYSTEM_INSTRUCTION', () => {
+    it('instructs the model never to file answered questions as unknowns', () => {
+        expect(SUMMARY_SYSTEM_INSTRUCTION).toContain('must NEVER appear in unknowns');
     });
 });
 

--- a/src/lib/prompts/preflightPrompts.ts
+++ b/src/lib/prompts/preflightPrompts.ts
@@ -40,7 +40,7 @@ You are a senior product strategist. You receive a product idea and the user's a
 Rules:
 - "summary": 4-7 short, scannable bullet-style sentences capturing what was learned. Lead each with the concrete decision or fact. No marketing language, no hedging.
 - "assumptions": reasonable assumptions you are making where the user gave partial or no answer. State them plainly; do not invent certainty the user did not express.
-- "unknowns": questions the user skipped or left genuinely undecided, phrased as open items for the PRD's open-questions/assumptions handling.
+- "unknowns": ONLY questions whose answer is "(skipped)" or genuinely left undecided, phrased as open items for the PRD's open-questions/assumptions handling. A question that has any real answer must NEVER appear in unknowns.
 - Treat answered questions as authoritative user intent. Never contradict an explicit answer.
 - Be concise. Do not restate the questions verbatim.
 

--- a/src/store/__tests__/preflightSession.test.ts
+++ b/src/store/__tests__/preflightSession.test.ts
@@ -74,12 +74,35 @@ describe('preflight session store actions', () => {
             { id: 'q1', question: 'Q1' },
             { id: 'q2', question: 'Q2' },
         ]);
-        store.setPreflightSummary(projectId, spineId, { summary: 's', assumptions: [], unknowns: [] });
+        store.setPreflightSummary(projectId, spineId, {
+            summary: 's',
+            assumptions: ['a'],
+            unknowns: ['u'],
+        });
         expect(session(projectId)?.status).toBe('summary');
 
         store.setPreflightIndex(projectId, spineId, 0);
         expect(session(projectId)?.status).toBe('answering');
         expect(session(projectId)?.currentQuestionIndex).toBe(0);
+        // The stale summary is invalidated so it can't be shown out of date.
+        expect(session(projectId)?.summary).toBeUndefined();
+        expect(session(projectId)?.assumptions).toBeUndefined();
+        expect(session(projectId)?.unknowns).toBeUndefined();
+    });
+
+    it('keeps the summary intact when navigating between questions (not from summary)', () => {
+        const { projectId, spineId } = setup();
+        const store = useProjectStore.getState();
+        store.initPreflightSession(projectId, spineId, 'quick', 'idea');
+        store.setPreflightQuestions(projectId, spineId, [
+            { id: 'q1', question: 'Q1' },
+            { id: 'q2', question: 'Q2' },
+        ]);
+        // status is 'answering' here, not 'summary' — back/next navigation
+        // must not wipe any derived fields.
+        store.setPreflightIndex(projectId, spineId, 1);
+        expect(session(projectId)?.status).toBe('answering');
+        expect(session(projectId)?.currentQuestionIndex).toBe(1);
     });
 
     it('persists the session on the spine (survives serialization)', () => {

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -173,12 +173,20 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
-                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => ({
-                    ...prev,
-                    currentQuestionIndex: Math.max(0, index),
+                [projectId]: patchPreflight(state.spineVersions[projectId] || [], spineId, (prev) => {
                     // Returning to the questions from the summary re-enters answering.
-                    status: prev.status === 'summary' && index < prev.questions.length ? 'answering' : prev.status,
-                })),
+                    const reentering = prev.status === 'summary' && index < prev.questions.length;
+                    return {
+                        ...prev,
+                        currentQuestionIndex: Math.max(0, index),
+                        status: reentering ? 'answering' : prev.status,
+                        // Re-entering invalidates the prior summary; it will be
+                        // regenerated from the edited answers, never shown stale.
+                        ...(reentering
+                            ? { summary: undefined, assumptions: undefined, unknowns: undefined }
+                            : {}),
+                    };
+                }),
             },
         }));
     },


### PR DESCRIPTION
The preflight clarification summary generated open-questions/unknowns from a
stale snapshot of the answers, and editing answers left the prior summary in
place. Two root causes:

- PreflightView.commitAndAdvance generated the summary from the render-time
  session.questions closure, which did not yet include the answer just
  committed for the final question (Zustand update is async). The final answer
  read as "(skipped)" and was misfiled under "Open questions". Build the
  up-to-date questions array locally before generating.

- setPreflightIndex flipped summary -> answering on "Edit answers" but left the
  old summary/assumptions/unknowns on the session, so editing showed degraded,
  out-of-date content. Clear those derived fields when re-entering answering
  from the summary so the next generation is unambiguous.

Also tighten SUMMARY_SYSTEM_INSTRUCTION so an answered question can never be
filed under unknowns (defense-in-depth). Adds store + prompt tests.