### PR TITLE
Add explicit mobile selection mode for PRD refinement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,9 +288,26 @@ pipeline; do not reintroduce per-component `onMouseUp` selection logic.
   drag-handle route, which never fires a matching `mouseup`). Validates
   against a `containerRef`; a *collapsing* selection never auto-dismisses
   an open dialog (focusing the mobile input collapses the native range) —
-  dismissal is explicit via `clear()`.
+  dismissal is explicit via `clear()`. Supports a **`manualCommit`** mode
+  (the mobile path): instead of surfacing a valid selection immediately, it
+  only *tracks* it (exposed as `pendingText`) and waits for an explicit
+  `commit()` to surface it as `selection`. This stops the Synapse action
+  sheet from popping on the first selected word and fighting the native iOS
+  Copy/Look Up/Translate toolbar. Desktop (`manualCommit` omitted/false) is
+  unchanged — selections surface instantly.
 - **`src/lib/useIsMobile.ts`** — `matchMedia` hook at the Tailwind `md`
   breakpoint (jsdom-safe).
+- **`src/components/MobileSelectionToolbar.tsx`** — mobile-only control that
+  drives the manual-commit flow. **Idle:** a pinned "Select text to edit"
+  button (until tapped, the PRD is plain readable text with untouched native
+  iOS selection — the hook is `enabled: false`). **Active:** a persistent
+  footer ("Select text, then tap Edit selection") echoing `pendingText`, with
+  **Edit selection** (→ `commit()`) and **Cancel** (→ exit mode + `clear()`).
+  Both renderers wire it identically: `mobileSelectMode` state gates the hook
+  via `enabled: … && (!isMobile || mobileSelectMode)` and
+  `manualCommit: isMobile && mobileSelectMode`, and the toolbar is hidden while
+  the action sheet (or, in `StructuredPRDView`, an inline edit) is open. Mode
+  resets on dismiss / successful branch.
 - **`src/components/SelectionActionDialog.tsx`** — shared presentation:
   desktop = floating popover anchored to the selection rect; mobile =
   bottom sheet with `env(safe-area-inset-*)` insets and ≥44px tap

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Replace**, spawning a threaded branch scoped to just that passage.
   unified PRD iteration (local or document-wide scope).
 - **Touch-first** — the same highlight → action pipeline works with mouse,
   pen, and mobile long-press; the dialog is a floating popover on desktop and
-  a safe-area bottom sheet on mobile.
+  a safe-area bottom sheet on mobile. On phones, an explicit **Select text to
+  edit** mode lets you adjust the native selection to a full phrase before
+  tapping **Edit selection** — so the action sheet never fights the iOS
+  selection toolbar.
 
 <img width="100%" alt="Refine a passage — Clarify / Expand / Specify / Alternative / Replace dialog and threaded branch" src="public/screenshots/tour-refine.png" />
 

--- a/src/components/MobileSelectionToolbar.tsx
+++ b/src/components/MobileSelectionToolbar.tsx
@@ -1,0 +1,92 @@
+interface MobileSelectionToolbarProps {
+    /** Whether selection mode is active (footer shown) or idle (entry button). */
+    active: boolean;
+    /** Whether a selection is currently tracked (enables "Edit selection"). */
+    hasSelection: boolean;
+    /** Text of the tracked selection, echoed back to the user. */
+    pendingText: string | null;
+    /** Enter selection mode. */
+    onActivate: () => void;
+    /** Commit the tracked selection → open the Synapse action sheet. */
+    onEdit: () => void;
+    /** Leave selection mode and drop any tracked selection. */
+    onCancel: () => void;
+}
+
+/**
+ * Mobile-only control that fronts the PRD highlight → branch gesture.
+ *
+ * The problem it solves: on iPhone, surfacing the Synapse action sheet on the
+ * first selected word collides with the native iOS Copy / Look Up / Translate
+ * toolbar and leaves no room to drag the selection handles out to a full
+ * phrase. So on mobile the selection pipeline runs in *manual-commit* mode and
+ * this toolbar drives an explicit two-step flow:
+ *
+ *  - **Idle** → a single pinned "Select text to edit" button. Until tapped, the
+ *    PRD is plain readable text and native iOS selection is untouched.
+ *  - **Active** → a persistent footer. The user adjusts the native selection
+ *    freely, then taps "Edit selection" to open the existing action sheet.
+ *
+ * Presentation only — all state lives in the parent renderer; it mirrors the
+ * dark, safe-area-inset bottom-sheet aesthetic of `SelectionActionDialog`.
+ */
+export function MobileSelectionToolbar({
+    active,
+    hasSelection,
+    pendingText,
+    onActivate,
+    onEdit,
+    onCancel,
+}: MobileSelectionToolbarProps) {
+    if (!active) {
+        return (
+            <div className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]">
+                <button
+                    type="button"
+                    onClick={onActivate}
+                    className="min-h-[44px] rounded-full bg-indigo-600 px-5 text-sm font-medium text-white shadow-lg transition hover:bg-indigo-700 active:bg-indigo-800"
+                >
+                    Select text to edit
+                </button>
+            </div>
+        );
+    }
+
+    const preview =
+        pendingText && pendingText.length > 40 ? `${pendingText.slice(0, 40)}…` : pendingText;
+
+    return (
+        <div
+            role="toolbar"
+            aria-label="Mobile text selection"
+            className="fixed inset-x-0 bottom-0 z-40 flex flex-col gap-2 border-t border-neutral-700 bg-neutral-900 p-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] shadow-2xl"
+        >
+            <div className="text-xs text-neutral-400">
+                {preview ? (
+                    <>
+                        <span className="font-semibold text-neutral-300">Selected:</span> "{preview}"
+                    </>
+                ) : (
+                    'Select text, then tap Edit selection'
+                )}
+            </div>
+            <div className="flex gap-2">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="min-h-[44px] flex-1 rounded-lg border border-neutral-700 bg-neutral-800 px-3 text-sm font-medium text-neutral-200 transition hover:bg-neutral-700 active:bg-neutral-600"
+                >
+                    Cancel
+                </button>
+                <button
+                    type="button"
+                    onClick={onEdit}
+                    disabled={!hasSelection}
+                    className="min-h-[44px] flex-[2] rounded-lg bg-indigo-600 px-3 text-sm font-medium text-white transition hover:bg-indigo-700 active:bg-indigo-800 disabled:opacity-50"
+                >
+                    Edit selection
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/SelectableSpine.tsx
+++ b/src/components/SelectableSpine.tsx
@@ -5,7 +5,9 @@ import Mark from 'mark.js';
 import { useProjectStore } from '../store/projectStore';
 import { replyInBranch } from '../lib/llmProvider';
 import { useSelectionPopover } from '../lib/useSelectionPopover';
+import { useIsMobile } from '../lib/useIsMobile';
 import { SelectionActionDialog } from './SelectionActionDialog';
+import { MobileSelectionToolbar } from './MobileSelectionToolbar';
 import { Callout } from './prd/Callout';
 
 interface SelectableSpineProps {
@@ -21,10 +23,17 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
     const spineRef = useRef<HTMLDivElement>(null);
     const { createBranch, addBranchMessage, branches } = useProjectStore();
 
+    // On mobile the selection sheet would collide with the native iOS toolbar,
+    // so we gate it behind an explicit "Select text to edit" mode (see
+    // MobileSelectionToolbar). Desktop is unchanged.
+    const isMobile = useIsMobile();
+    const [mobileSelectMode, setMobileSelectMode] = useState(false);
+
     // Shared, touch-aware selection pipeline (mouse + pointer + selectionchange).
-    const { selection, clear } = useSelectionPopover({
+    const { selection, pendingText, commit, clear } = useSelectionPopover({
         containerRef: spineRef,
-        enabled: !readOnly,
+        enabled: !readOnly && (!isMobile || mobileSelectMode),
+        manualCommit: isMobile && mobileSelectMode,
     });
 
     // Get active branches for this spine to highlight their anchors
@@ -56,6 +65,7 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
     const dismiss = () => {
         clear();
         setIntent('');
+        setMobileSelectMode(false);
     };
 
     // Single branch-creation path shared by the typed-intent form (desktop) and
@@ -73,6 +83,7 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
             // Clear selection UI immediately
             clear();
             setIntent('');
+            setMobileSelectMode(false);
 
             const response = await replyInBranch({ anchorText, intent: userIntent, threadHistory: [] });
             addBranchMessage(projectId, branchId, 'assistant', response);
@@ -125,6 +136,22 @@ export function SelectableSpine({ projectId, spineVersionId, text, readOnly }: S
                     onSubmit={handleSubmit}
                     onQuickAction={handleQuickAction}
                     onDismiss={dismiss}
+                />
+            )}
+
+            {/* Mobile-only: explicit selection mode so the iOS toolbar and the
+                Synapse action sheet don't fight. Hidden while the sheet is open. */}
+            {isMobile && !readOnly && !selection && (
+                <MobileSelectionToolbar
+                    active={mobileSelectMode}
+                    hasSelection={!!pendingText}
+                    pendingText={pendingText}
+                    onActivate={() => setMobileSelectMode(true)}
+                    onEdit={commit}
+                    onCancel={() => {
+                        setMobileSelectMode(false);
+                        clear();
+                    }}
                 />
             )}
         </div>

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -5,7 +5,9 @@ import { useProjectStore } from '../store/projectStore';
 import { structuredPRDToMarkdown, replyInBranch, generateStructuredPRD } from '../lib/llmProvider';
 import { FeatureCard } from './FeatureCard';
 import { useSelectionPopover } from '../lib/useSelectionPopover';
+import { useIsMobile } from '../lib/useIsMobile';
 import { SelectionActionDialog } from './SelectionActionDialog';
+import { MobileSelectionToolbar } from './MobileSelectionToolbar';
 import { v4 as uuidv4 } from 'uuid';
 import type { StructuredPRD, Feature } from '../types';
 import {
@@ -58,11 +60,18 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const contentRef = useRef<HTMLDivElement>(null);
 
+    // On mobile, gate selection behind an explicit "Select text to edit" mode so
+    // the Synapse sheet doesn't collide with the native iOS toolbar. Desktop is
+    // unchanged.
+    const isMobile = useIsMobile();
+    const [mobileSelectMode, setMobileSelectMode] = useState(false);
+
     // Shared, touch-aware selection pipeline. Disabled while inline-editing a
     // section so the textarea selection doesn't open the branch dialog.
-    const { selection, clear } = useSelectionPopover({
+    const { selection, pendingText, commit, clear } = useSelectionPopover({
         containerRef: contentRef,
-        enabled: !readOnly && !editingSection,
+        enabled: !readOnly && !editingSection && (!isMobile || mobileSelectMode),
+        manualCommit: isMobile && mobileSelectMode,
     });
 
     // Get active branches for this spine to highlight their anchors.
@@ -120,6 +129,7 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
     const dismiss = () => {
         clear();
         setIntent('');
+        setMobileSelectMode(false);
     };
 
     // Single branch-creation path shared by the typed-intent form (desktop) and
@@ -133,6 +143,7 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
             const { branchId } = createBranch(projectId, spineId, anchorText, userIntent);
             clear();
             setIntent('');
+            setMobileSelectMode(false);
             const response = await replyInBranch({ anchorText, intent: userIntent, threadHistory: [] });
             addBranchMessage(projectId, branchId, 'assistant', response);
         } finally {
@@ -637,6 +648,23 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     onSubmit={handleSubmit}
                     onQuickAction={handleQuickAction}
                     onDismiss={dismiss}
+                />
+            )}
+
+            {/* Mobile-only: explicit selection mode so the iOS toolbar and the
+                Synapse action sheet don't fight. Hidden while the sheet is open
+                or while inline-editing a section. */}
+            {isMobile && !readOnly && !editingSection && !selection && (
+                <MobileSelectionToolbar
+                    active={mobileSelectMode}
+                    hasSelection={!!pendingText}
+                    pendingText={pendingText}
+                    onActivate={() => setMobileSelectMode(true)}
+                    onEdit={commit}
+                    onCancel={() => {
+                        setMobileSelectMode(false);
+                        clear();
+                    }}
                 />
             )}
         </div>

--- a/src/components/__tests__/MobileSelectionToolbar.test.tsx
+++ b/src/components/__tests__/MobileSelectionToolbar.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MobileSelectionToolbar } from '../MobileSelectionToolbar';
+
+function renderToolbar(
+    overrides: Partial<React.ComponentProps<typeof MobileSelectionToolbar>> = {},
+) {
+    const props = {
+        active: false,
+        hasSelection: false,
+        pendingText: null,
+        onActivate: vi.fn(),
+        onEdit: vi.fn(),
+        onCancel: vi.fn(),
+        ...overrides,
+    };
+    return { props, ...render(<MobileSelectionToolbar {...props} />) };
+}
+
+describe('MobileSelectionToolbar', () => {
+    it('shows the entry button when inactive and activates on tap', () => {
+        const { props } = renderToolbar({ active: false });
+
+        const button = screen.getByRole('button', { name: 'Select text to edit' });
+        expect(screen.queryByRole('toolbar')).toBeNull();
+
+        fireEvent.click(button);
+        expect(props.onActivate).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the footer with hint when active and no selection yet', () => {
+        renderToolbar({ active: true, hasSelection: false });
+
+        expect(screen.getByRole('toolbar')).toBeInTheDocument();
+        expect(screen.getByText('Select text, then tap Edit selection')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Edit selection' })).toBeDisabled();
+    });
+
+    it('echoes the tracked selection and enables Edit selection', () => {
+        const { props } = renderToolbar({
+            active: true,
+            hasSelection: true,
+            pendingText: 'provides',
+        });
+
+        expect(screen.getByText(/Selected:/)).toBeInTheDocument();
+        expect(screen.getByText(/"provides"/)).toBeInTheDocument();
+
+        const edit = screen.getByRole('button', { name: 'Edit selection' });
+        expect(edit).toBeEnabled();
+        fireEvent.click(edit);
+        expect(props.onEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels out of selection mode', () => {
+        const { props } = renderToolbar({ active: true, hasSelection: true, pendingText: 'x' });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(props.onCancel).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/__tests__/useSelectionPopover.test.ts
+++ b/src/lib/__tests__/useSelectionPopover.test.ts
@@ -135,6 +135,88 @@ describe('useSelectionPopover', () => {
         expect(result.current.selection?.text).toBe('PRD');
     });
 
+    describe('manual-commit (mobile) mode', () => {
+        it('tracks but does not surface a selection until commit()', () => {
+            const node = container.firstChild;
+            vi.spyOn(window, 'getSelection').mockReturnValue(
+                makeFakeSelection({ text: 'world', node }),
+            );
+
+            const { result } = renderHook(() =>
+                useSelectionPopover({ containerRef: ref, enabled: true, manualCommit: true }),
+            );
+
+            act(() => {
+                document.dispatchEvent(new Event('selectionchange'));
+                vi.advanceTimersByTime(300);
+            });
+
+            // The action sheet must NOT auto-open — only the pending text is set.
+            expect(result.current.selection).toBeNull();
+            expect(result.current.pendingText).toBe('world');
+
+            act(() => {
+                result.current.commit();
+            });
+
+            expect(result.current.selection?.text).toBe('world');
+        });
+
+        it('commit() is a no-op when nothing is tracked', () => {
+            const { result } = renderHook(() =>
+                useSelectionPopover({ containerRef: ref, enabled: true, manualCommit: true }),
+            );
+
+            act(() => {
+                result.current.commit();
+            });
+
+            expect(result.current.selection).toBeNull();
+        });
+
+        it('clear() resets the tracked pending selection', () => {
+            const node = container.firstChild;
+            vi.spyOn(window, 'getSelection').mockReturnValue(
+                makeFakeSelection({ text: 'PRD', node }),
+            );
+
+            const { result } = renderHook(() =>
+                useSelectionPopover({ containerRef: ref, enabled: true, manualCommit: true }),
+            );
+
+            act(() => {
+                document.dispatchEvent(new Event('pointerup'));
+                vi.advanceTimersByTime(20);
+            });
+            expect(result.current.pendingText).toBe('PRD');
+
+            act(() => {
+                result.current.clear();
+            });
+            expect(result.current.pendingText).toBeNull();
+            expect(result.current.selection).toBeNull();
+        });
+
+        it('surfaces immediately when manualCommit is false (desktop regression guard)', () => {
+            const node = container.firstChild;
+            vi.spyOn(window, 'getSelection').mockReturnValue(
+                makeFakeSelection({ text: 'PRD', node }),
+            );
+
+            const { result } = renderHook(() =>
+                useSelectionPopover({ containerRef: ref, enabled: true, manualCommit: false }),
+            );
+
+            act(() => {
+                document.dispatchEvent(new Event('pointerup'));
+                vi.advanceTimersByTime(20);
+            });
+
+            expect(result.current.selection?.text).toBe('PRD');
+            expect(result.current.pendingText).toBeNull();
+        });
+    });
+
     it('clears when disabled', () => {
         const node = container.firstChild;
         vi.spyOn(window, 'getSelection').mockReturnValue(

--- a/src/lib/useSelectionPopover.ts
+++ b/src/lib/useSelectionPopover.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import {
     getSelectionInfo,
     isValidSelection,
@@ -10,6 +10,16 @@ interface UseSelectionPopoverOptions {
     containerRef: RefObject<HTMLElement | null>;
     /** When false, no listeners are attached and no selection is surfaced. */
     enabled: boolean;
+    /**
+     * Manual-commit (mobile) mode. When true, a valid selection is *tracked*
+     * (exposed via `pendingText`) but is **not** surfaced as `selection` until
+     * `commit()` is called. This is what lets the user finish dragging the
+     * native iOS selection handles to a full phrase before the Synapse action
+     * sheet opens — instead of it popping on the first selected word and
+     * fighting the iOS Copy/Look Up toolbar. When false (desktop), a valid
+     * selection is surfaced immediately as before.
+     */
+    manualCommit?: boolean;
     /** Debounce (ms) for the `selectionchange` path — the mobile route. */
     selectionChangeDelay?: number;
     /** Delay (ms) after `pointerup` before reading the selection. */
@@ -18,6 +28,14 @@ interface UseSelectionPopoverOptions {
 
 interface UseSelectionPopoverResult {
     selection: SelectionInfo | null;
+    /**
+     * In manual-commit mode, the text of the latest tracked-but-uncommitted
+     * selection (for the mobile toolbar to echo). `null` when nothing is
+     * tracked or in immediate (desktop) mode.
+     */
+    pendingText: string | null;
+    /** Surface the tracked selection (manual-commit mode). No-op otherwise. */
+    commit: () => void;
     /** Imperatively dismiss the dialog and drop the native selection. */
     clear: () => void;
 }
@@ -48,16 +66,31 @@ interface UseSelectionPopoverResult {
 export function useSelectionPopover({
     containerRef,
     enabled,
+    manualCommit = false,
     selectionChangeDelay = 300,
     pointerUpDelay = 10,
 }: UseSelectionPopoverOptions): UseSelectionPopoverResult {
     const [selection, setSelection] = useState<SelectionInfo | null>(null);
+    // The latest valid selection tracked but not yet surfaced (manual-commit
+    // mode). A ref so `commit()` reads the freshest value without re-binding,
+    // mirrored into state so the toolbar re-renders as the selection grows.
+    const pendingRef = useRef<SelectionInfo | null>(null);
+    const [pendingText, setPendingText] = useState<string | null>(null);
 
     const clear = useCallback(() => {
         setSelection(null);
+        pendingRef.current = null;
+        setPendingText(null);
         if (typeof window !== 'undefined') {
             window.getSelection()?.removeAllRanges();
         }
+    }, []);
+
+    // Surface the tracked selection (manual-commit mode). Reads the tracked
+    // value rather than `window.getSelection()` so a button tap that collapses
+    // the native range can't lose the selection.
+    const commit = useCallback(() => {
+        if (pendingRef.current) setSelection(pendingRef.current);
     }, []);
 
     useEffect(() => {
@@ -72,7 +105,15 @@ export function useSelectionPopover({
             const sel = window.getSelection();
             if (isValidSelection(sel, containerRef.current)) {
                 const info = getSelectionInfo(sel);
-                if (info) setSelection(info);
+                if (info) {
+                    if (manualCommit) {
+                        // Track only — opening the action sheet waits for commit().
+                        pendingRef.current = info;
+                        setPendingText(info.text);
+                    } else {
+                        setSelection(info);
+                    }
+                }
             }
             // Invalid/collapsed selection: keep whatever is open. Dismissal is
             // explicit (see the dialog), which is what keeps mobile usable.
@@ -97,9 +138,14 @@ export function useSelectionPopover({
             document.removeEventListener('pointerup', onPointerUp);
             document.removeEventListener('selectionchange', onSelectionChange);
         };
-    }, [enabled, containerRef, selectionChangeDelay, pointerUpDelay]);
+    }, [enabled, manualCommit, containerRef, selectionChangeDelay, pointerUpDelay]);
 
     // Gate the surfaced value on `enabled` so toggling read-only / entering an
     // inline edit hides the dialog without a setState-in-effect.
-    return { selection: enabled ? selection : null, clear };
+    return {
+        selection: enabled ? selection : null,
+        pendingText: enabled ? pendingText : null,
+        commit,
+        clear,
+    };
 }


### PR DESCRIPTION
On mobile the PRD action sheet opened on the first selected word, colliding
with the native iOS selection toolbar and leaving no room to drag the
selection handles out to a full phrase.

Add a manual-commit mode to useSelectionPopover: on mobile a valid selection
is tracked (pendingText) but not surfaced until commit(). A new shared
MobileSelectionToolbar fronts an explicit two-step flow — Select text to edit
-> adjust native selection -> Edit selection -> existing action sheet. Both
PRD renderers wire it identically; desktop behavior is unchanged.