### PR TITLE
Improve post-finalize workspace UX: Assets tab, auto-open panel, transition state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,12 +261,32 @@ User prompt → HomePage.handleCreateProject() → PreflightModeChoice
                    ConsolidationModal). Selection → action dialog runs
                    through the shared touch-aware pipeline (see "PRD
                    highlight → branch selection pipeline" below).
-  Workspace stage: ArtifactsView (bundle/individual gen, refine, validate)
+  Assets stage:    ArtifactWorkspace (bundle/individual gen, refine, validate)
                    + MockupsView (platform/fidelity/scope config)
                    + MarkupImageView (MarkupImageSpec → SVG via
-                   MarkupImageRenderer)
+                   MarkupImageRenderer). The `'workspace'` pipeline stage is
+                   labeled **"Assets"** in `PipelineStageBar` (label-only; the
+                   stage key/route is still `workspace`).
   History stage:   HistoryView — chronological timeline with diffs
 ```
+
+### Post-finalization transition (Mark Final → Assets)
+
+Marking a spine final must not dump the user back on something that looks like
+the PRD again. `ProjectWorkspace.handleToggleFinal` (on the finalize edge)
+starts artifact generation and shows `FinalizationSuccessModal` ("PRD
+Finalized" — *being created* vs *ready*, keyed off an `assetsReady` presence
+check of the 7 core artifacts + mockups) **without** switching stage. Its
+**Open Assets** action (`handleOpenAssets`) switches `currentStage` to
+`workspace` and arms a one-shot `finalizeAutoOpen` flag passed to
+`ArtifactWorkspace` as `autoOpenIntent`. `ArtifactWorkspace` consumes it once
+(via `onAutoOpenConsumed`): it auto-selects the first **non-PRD** artifact —
+preferring `done`, then `generating`, then `queued`, else the first slot in
+`CORE_ARTIFACT_DISPLAY_ORDER` (data_model → … → prompt_pack, then mockups) — and
+opens the mobile drawer (`useIsMobile`-gated, so it never reopens after the user
+closes it; desktop keeps the persistent side rail). While the overall run is in
+flight, an idle slot renders a centered `BuildAssetsLoading` ("Creating your
+build assets…") instead of an empty state.
 
 ### PRD highlight → branch selection pipeline
 

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -6,6 +6,7 @@ import {
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useProjectStore } from '../store/projectStore';
+import { useIsMobile } from '../lib/useIsMobile';
 import { artifactJobController } from '../lib/services/artifactJobController';
 import { CORE_ARTIFACT_DISPLAY_ORDER, getArtifactMeta } from '../lib/coreArtifactPipeline';
 import { ArtifactContentRenderer } from './renderers';
@@ -26,6 +27,12 @@ interface ArtifactWorkspaceProps {
     prdContent: string;
     structuredPRD: StructuredPRD;
     projectPlatform?: ProjectPlatform;
+    // One-shot signal that the user just arrived here by finalizing the PRD.
+    // When true, the panel auto-selects the first meaningful non-PRD artifact
+    // and opens the mobile drawer; consumed exactly once via onAutoOpenConsumed
+    // so closing the drawer never triggers a reopen.
+    autoOpenIntent?: boolean;
+    onAutoOpenConsumed?: () => void;
 }
 
 type WorkspaceSelection = 'prd' | ArtifactSlotKey;
@@ -73,7 +80,9 @@ function statusLabel(status: GenerationStatus): string {
 
 export function ArtifactWorkspace({
     projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
+    autoOpenIntent, onAutoOpenConsumed,
 }: ArtifactWorkspaceProps) {
+    const isMobile = useIsMobile();
     const {
         getArtifacts, getPreferredVersion, getArtifactStaleness, getJob, getProject,
         updateArtifactVersionMetadata,
@@ -129,6 +138,25 @@ export function ArtifactWorkspace({
         if (key === 'prd') return undefined;
         return job?.slots[key]?.error;
     };
+
+    // Post-finalization auto-open. Runs once each time the parent arms
+    // autoOpenIntent: pick the first meaningful non-PRD artifact (prefer one
+    // that's already done, else generating, else queued, else the first slot
+    // in display order) so the user never lands on the PRD again, and open the
+    // mobile drawer so the asset list is visible. Consumed immediately so a
+    // user who closes the drawer is never re-interrupted.
+    useEffect(() => {
+        if (!autoOpenIntent) return;
+        const candidates = slotMetas.map(s => s.key).filter(k => k !== 'prd');
+        const firstWith = (s: GenerationStatus) => candidates.find(k => slotStatusFor(k) === s);
+        const pick = firstWith('done') ?? firstWith('generating') ?? firstWith('queued') ?? candidates[0];
+        if (pick) setSelected(pick);
+        if (isMobile) setMobileSidebarOpen(true);
+        onAutoOpenConsumed?.();
+        // slotStatusFor/slotMetas are stable for this purpose; we intentionally
+        // react only to the intent flag flipping on.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [autoOpenIntent]);
 
     // Derived counts for the right-rail header.
     const allKeys = slotMetas.map(s => s.key);
@@ -217,6 +245,14 @@ export function ArtifactWorkspace({
                     </div>
                 </div>
             );
+        }
+
+        // Idle while the overall run is still in flight means this slot hasn't
+        // started yet (e.g. cleared job, or waiting behind the concurrency
+        // limit). Show the global "creating your build assets" state rather
+        // than a bare "Not generated yet" so the workspace never looks empty.
+        if (status === 'idle' && isActive) {
+            return <BuildAssetsLoading />;
         }
 
         // status === 'done' or 'idle' — try to render the existing artifact.
@@ -570,6 +606,20 @@ function RightRail({
                 )}
             </div>
         </aside>
+    );
+}
+
+function BuildAssetsLoading() {
+    return (
+        <div className="max-w-lg mx-auto text-center py-16">
+            <Loader2 size={32} className="mx-auto mb-4 text-indigo-500 animate-spin" />
+            <h3 className="text-lg font-semibold text-neutral-900">Creating your build assets…</h3>
+            <p className="text-sm text-neutral-500 mt-2 leading-relaxed">
+                We&apos;re generating your data model, user flows, screen inventory, components,
+                design system, implementation plan, prompt pack, and mockups. Each appears in
+                the panel as it&apos;s ready.
+            </p>
+        </div>
     );
 }
 

--- a/src/components/FinalizationSuccessModal.tsx
+++ b/src/components/FinalizationSuccessModal.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import { CheckCircle2, ArrowRight, Loader2 } from 'lucide-react';
+
+interface FinalizationSuccessModalProps {
+    // True once every build asset already has a generated version (e.g. the
+    // user re-finalized a spine whose artifacts were generated earlier).
+    // Drives the "ready" vs "being created" copy.
+    assetsReady: boolean;
+    onOpenAssets: () => void;
+    onClose: () => void;
+}
+
+/**
+ * Post-finalization transition. Shown immediately after the user marks a PRD
+ * as final so the change is unmistakable: the PRD is locked, build assets are
+ * underway, and the next action is to review them. "Open Assets" navigates to
+ * the Assets view, opens the artifact panel, and selects the first non-PRD
+ * artifact (handled by the parent).
+ */
+export function FinalizationSuccessModal({
+    assetsReady, onOpenAssets, onClose,
+}: FinalizationSuccessModalProps) {
+    // Escape closes the modal (without navigating) — the PRD stays final.
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [onClose]);
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+            onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="finalize-success-title"
+        >
+            <div
+                className="bg-white text-neutral-900 rounded-2xl shadow-2xl w-full max-w-md p-8 text-center"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="mx-auto w-14 h-14 rounded-full bg-green-100 flex items-center justify-center mb-5">
+                    <CheckCircle2 size={30} className="text-green-600" />
+                </div>
+                <h2 id="finalize-success-title" className="text-xl font-bold mb-2">
+                    PRD Finalized
+                </h2>
+                <p className="text-neutral-600 text-sm mb-6 flex items-center justify-center gap-1.5">
+                    {assetsReady ? (
+                        'Your build assets are ready.'
+                    ) : (
+                        <>
+                            <Loader2 size={14} className="text-indigo-500 animate-spin shrink-0" />
+                            Your build assets are being created.
+                        </>
+                    )}
+                </p>
+                <button
+                    type="button"
+                    onClick={onOpenAssets}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-xl transition"
+                >
+                    Open Assets
+                    <ArrowRight size={16} />
+                </button>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="mt-3 w-full px-4 py-2 text-sm text-neutral-500 hover:text-neutral-700 transition"
+                >
+                    Stay on the PRD
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/PipelineStageBar.tsx
+++ b/src/components/PipelineStageBar.tsx
@@ -9,7 +9,7 @@ interface PipelineStageBarProps {
 
 const stages: { key: PipelineStage; label: string; description: string; icon: typeof FileText }[] = [
     { key: 'prd', label: 'Project', description: 'The editable PRD and source of truth for downstream artifacts', icon: FileText },
-    { key: 'workspace', label: 'Workspace', description: 'Where you work through generated artifacts', icon: Package },
+    { key: 'workspace', label: 'Assets', description: 'Generated build assets — data model, flows, screens, components, and more', icon: Package },
     { key: 'history', label: 'History', description: 'Chronological timeline of changes', icon: Clock },
 ];
 

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -25,6 +25,8 @@ import { SafetyReviewView } from './SafetyReviewView';
 import { SafetyBoundariesCard } from './SafetyBoundariesCard';
 import { PreflightView } from './preflight/PreflightView';
 import { ArtifactWorkspace } from './ArtifactWorkspace';
+import { FinalizationSuccessModal } from './FinalizationSuccessModal';
+import { CORE_ARTIFACT_DISPLAY_ORDER } from '../lib/coreArtifactPipeline';
 import { HistoryView } from './HistoryView';
 import { ExportModal } from './ExportModal';
 import { SnapshotsPanel } from './SnapshotsPanel';
@@ -39,7 +41,7 @@ import { DEMO_PROJECT_ID } from '../data/demoProject';
 export function ProjectWorkspace() {
     const { projectId } = useParams<{ projectId: string }>();
     const navigate = useNavigate();
-    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, markSpineFinal, setProjectStage, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus } = useProjectStore();
+    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, markSpineFinal, setProjectStage, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, getArtifacts, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus } = useProjectStore();
     const prdProgress = useProjectStore((s) => (projectId ? s.prdProgress[projectId] : undefined));
     const prdSectionStatus = useProjectStore((s) => (projectId ? s.prdSectionStatus[projectId] : undefined));
     const [isGenerating, setIsGenerating] = useState(false);
@@ -55,6 +57,12 @@ export function ProjectWorkspace() {
     const [isExportOpen, setIsExportOpen] = useState(false);
     const [isSnapshotsOpen, setIsSnapshotsOpen] = useState(false);
     const [retryingStepId, setRetryingStepId] = useState<string | null>(null);
+    // Post-finalization transition. `showFinalizeSuccess` drives the success
+    // modal shown immediately after Mark Final; `finalizeAutoOpen` is the
+    // one-shot intent handed to ArtifactWorkspace so it auto-opens the panel
+    // and selects the first non-PRD artifact on arrival from finalize.
+    const [showFinalizeSuccess, setShowFinalizeSuccess] = useState(false);
+    const [finalizeAutoOpen, setFinalizeAutoOpen] = useState(false);
     const overflowRef = useRef<HTMLDivElement>(null);
     const overflowButtonRef = useRef<HTMLButtonElement>(null);
     const overflowMenuRef = useRef<HTMLDivElement>(null);
@@ -315,6 +323,18 @@ export function ProjectWorkspace() {
         setIsBranchesVisible(true);
     };
 
+    // True once every build asset (the 7 core artifacts + mockups) already has
+    // a generated version — i.e. nothing is left to create. Drives the success
+    // modal's "ready" vs "being created" copy. Cheap presence check; safe to
+    // run each render.
+    const assetsReady = !!activeSpine?.structuredPRD && (() => {
+        const coreReady = CORE_ARTIFACT_DISPLAY_ORDER.every(meta =>
+            getArtifacts(projectId, 'core_artifact').some(a => a.subtype === meta.subtype && a.currentVersionId),
+        );
+        const mockupReady = getArtifacts(projectId, 'mockup').some(a => a.currentVersionId);
+        return coreReady && mockupReady;
+    })();
+
     const handleToggleFinal = () => {
         if (!projectId || !activeSpine) return;
         // Blocked spines can never advance to the workspace / artifact stage.
@@ -323,7 +343,10 @@ export function ProjectWorkspace() {
         markSpineFinal(projectId, activeSpine.id, next);
         if (!next) return;
 
-        setProjectStage(projectId, 'workspace');
+        // Kick off artifact generation immediately so assets are underway
+        // while the success modal is visible. We deliberately do NOT switch
+        // to the Assets stage yet — the modal owns the transition, and its
+        // "Open Assets" action performs the navigation + panel auto-open.
         if (activeSpine.structuredPRD && projectId !== DEMO_PROJECT_ID) {
             artifactJobController.startAll({
                 projectId,
@@ -333,6 +356,17 @@ export function ProjectWorkspace() {
                 projectPlatform: project?.platform,
             });
         }
+        setShowFinalizeSuccess(true);
+    };
+
+    // "Open Assets" from the success modal: navigate to the Assets stage and
+    // arm the one-shot auto-open intent so ArtifactWorkspace opens the panel
+    // and selects the first non-PRD artifact instead of defaulting to the PRD.
+    const handleOpenAssets = () => {
+        if (!projectId) return;
+        setShowFinalizeSuccess(false);
+        setFinalizeAutoOpen(true);
+        setProjectStage(projectId, 'workspace');
     };
 
     const handleExport = () => {
@@ -453,6 +487,13 @@ export function ProjectWorkspace() {
                 </div>
             </div>
 
+            {showFinalizeSuccess && (
+                <FinalizationSuccessModal
+                    assetsReady={assetsReady}
+                    onOpenAssets={handleOpenAssets}
+                    onClose={() => setShowFinalizeSuccess(false)}
+                />
+            )}
             {isSettingsOpen && <SettingsModal onClose={() => setIsSettingsOpen(false)} />}
             {isExportOpen && projectId && <ExportModal projectId={projectId} onClose={() => setIsExportOpen(false)} />}
             {isSnapshotsOpen && projectId && (
@@ -495,6 +536,8 @@ export function ProjectWorkspace() {
                         prdContent={activeSpine.responseText}
                         structuredPRD={activeSpine.structuredPRD}
                         projectPlatform={project?.platform}
+                        autoOpenIntent={finalizeAutoOpen}
+                        onAutoOpenConsumed={() => setFinalizeAutoOpen(false)}
                     />
                 ) : (
                 <>


### PR DESCRIPTION
- Rename the 'Workspace' pipeline tab to 'Assets' (label-only; stage key
  unchanged).
- Show a FinalizationSuccessModal after Mark Final ('PRD Finalized' — being
  created vs ready) that starts artifact generation and owns the transition.
- Its 'Open Assets' action navigates to Assets and arms a one-shot
  autoOpenIntent so ArtifactWorkspace auto-selects the first non-PRD artifact
  (prefer done > generating > queued > first slot) instead of defaulting to
  the PRD, and opens the mobile drawer (gated by useIsMobile so it never
  reopens after the user closes it).
- Add a centered 'Creating your build assets…' state for idle slots while the
  run is in flight.
- Update CLAUDE.md pipeline-flow and add a post-finalization section.