### PR TITLE
Optimize PRD generation as a dependency-graph pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,35 @@ otherwise have nothing in common — keep that distinction in mind:
 
 - **`services/`** — one file per AI feature. Importing through the
   `llmProvider.ts` barrel keeps legacy call sites stable.
-  - `prdService.ts` + `prdPipeline.ts` — PRD generation. Pipeline is now
-    **single-pass**: Pass A streams a structured PRD (Gemini JSON mode with
-    `prdSchemas.structuredPRDSchema`) with the quality rubric baked into
-    the system prompt; markdown is rendered deterministically from the
-    JSON via `prdMarkdownRenderer.ts`. The legacy multi-pass scoring +
-    revision passes were removed — old projects in localStorage retain
-    their saved `qualityScores`, but no new generation writes them.
+  - `prdService.ts` → `progressivePrdPipeline.ts` → `progressivePrdGeneration.ts`
+    — PRD generation runs as a **dependency-graph (DAG) pipeline**, not in
+    document order. `DEFAULT_PRD_SECTIONS` (10 schema-aligned sections in
+    `progressivePrdGeneration.ts`) each declare `dependencies` that are **true
+    data dependencies only** — a section lists another solely when it consumes
+    that section's output as prompt context. `runDag()` runs every section whose
+    deps are satisfied concurrently, under separate per-tier concurrency caps
+    (`maxFastConcurrency` / `maxStrongConcurrency`); low-risk sections use the
+    fast (Flash) model, high-risk the strong (Pro) model. `validateGraph()` runs
+    first and throws on unknown-dependency references or cycles (Kahn's
+    algorithm) so a broken graph fails loudly instead of silently dropping
+    sections. Each section emits a typed slice of `StructuredPRD`; slices are
+    merged deterministically (`prdSectionMerge.ts`, disjoint top-level fields)
+    and markdown is rendered via `prdMarkdownRenderer.ts`. Do **not** re-add
+    edges to sequence sections by document position — only by real data flow.
+    The legacy multi-pass scoring + revision passes were removed — old projects
+    in localStorage retain their saved `qualityScores`, but no new generation
+    writes them.
+    - **Optional final consistency review** (`prdConsistencyReview.ts`): off by
+      default (one extra fast-model call). When enabled (localStorage
+      `synapse-prd-consistency-review === 'true'`, threaded through as
+      `enableConsistencyReview`), it reconciles terminology / names /
+      contradictions across the merged PRD. It **merges over the original**
+      (omitted fields preserved) and a **detail-loss guard** discards any
+      revision that would shrink/empty a key content array; on apply it sets
+      `generationMeta.revised` and adds a `consistency_review` pass record.
+    - **Observability** (`prdGenerationLog.ts`): structured, debug-gated logs
+      (`synapse-prd-debug` / `?prddebug`) for queued/started/completed/failed,
+      retry, run summary, model, est-vs-actual, and `surface` (mobile/web).
   - `mockupService.ts` + `mockupImageService.ts` — mockup HTML and image
     generation.
   - `coreArtifactService.ts` — the 7 core artifact types
@@ -318,10 +340,19 @@ component). It is driven directly by the live `prdSectionStatus` store slice
   `formatModelName()` renders the actual configured Gemini id (e.g.
   `gemini-3-flash-preview` → "Gemini 3 Flash (preview)") — no hardcoded model
   names. `summarizeSteps()` derives the header count/percent/status.
+  The executor emits a `section_ready` event when a section's deps are
+  satisfied, so the grid distinguishes two waiting states: **`pending`** =
+  waiting on dependencies (shows "Waits on: …"), **`queued`** = deps satisfied,
+  waiting for a free concurrency slot. `mapStatus()` keeps these distinct;
+  leaves also carry `dependsOn` (resolved to titles) and `retryCount`.
 - **`ProgressTimeline.tsx`** / `TimelineStep.tsx` / `ConcurrentGroup.tsx` —
-  presentation. Status icons (completed/in-progress/failed/pending), an
-  always-visible model chip, and explicitly-labeled times (`Actual:`/`Est.
-  ~`/`Elapsed:`). A 1s ticker injects live `Elapsed:` from `startedAt`.
+  presentation. Status icons (completed/in-progress/queued/failed/pending — the
+  amber `queued` ring is distinct from the plain `pending` ring), an
+  always-visible (truncating) model chip, a "Retried ×N" badge, and
+  explicitly-labeled times (`Actual:`/`Est. ~`/`Elapsed:`). A 1s ticker injects
+  live `Elapsed:` from `startedAt` (re-stamped on each `generating` transition,
+  so retries show fresh elapsed). Responsive rules (`min-w-0`, truncation, no
+  `whitespace-nowrap` on the model chip) keep narrow screens from overlapping.
   Mobile collapses per-step detail behind chevrons and shows a `View full
   history >` link (navigates to the History stage); desktop shows
   description/model/status/est/actual/retry and concurrent groups without

--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ the PRD prompt as authoritative intent.
 
 <img width="100%" alt="PRD generation progress timeline — sections generated wave by wave" src="public/screenshots/tour-spec.png" />
 
-The PRD is generated as structured JSON in a single streaming pass, and a live
-**progress timeline** shows exactly what's happening: the ten PRD sections are
-grouped into dependency *waves*, with independent sections rendered as
-"running concurrently" groups. Each step shows its status, the actual Gemini
-model in use, and elapsed/estimated timing. A failed section can be re-run on
-its own without touching the rest of the document.
+The PRD is generated as structured JSON by a **dependency-graph pipeline**:
+the ten sections run concurrently the moment their inputs are ready — they are
+never sequenced just because they appear later in the document. A live
+**progress timeline** shows exactly what's happening: sections are grouped into
+dependency *waves*, with independent sections rendered as "running
+concurrently" groups, and each step shows whether it's waiting on dependencies,
+queued for a free slot, or running — alongside the actual Gemini model in use
+and elapsed/estimated timing. A failed section can be re-run on its own without
+touching the rest of the document.
 
 You get back a structured PRD with vision, target users, core problems,
 features (with priority, acceptance criteria, and dependencies), architecture,

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -275,13 +275,24 @@ export function ProjectWorkspace() {
         try {
             setRetryingStepId(sectionId);
             appendPrdProgress(projectId, `↻ Retrying ${title}…`);
+            // Carry the incremented retry count through this run so the progress
+            // UI can show a "Retried ×N" badge. Computed once from the current
+            // entry and stamped on the first ('generating') status emission.
+            const nextRetryCount = (prdSectionStatus?.[id]?.retryCount ?? 0) + 1;
+            let retryCountStamped = false;
             const { structuredPRD, markdown, model, ms } = await regeneratePrdSection(
                 id,
                 sourcePrompt,
                 activeSpine.structuredPRD,
                 {
                     platform: project?.platform,
-                    onSectionStatus: (sid, update) => setSectionStatus(projectId, sid, update),
+                    onSectionStatus: (sid, update) => {
+                        const enriched = !retryCountStamped
+                            ? { ...update, retryCount: nextRetryCount }
+                            : update;
+                        if (!retryCountStamped) retryCountStamped = true;
+                        setSectionStatus(projectId, sid, enriched);
+                    },
                 },
             );
             updateSpineStructuredPRD(projectId, activeSpine.id, structuredPRD, markdown, {

--- a/src/components/progress/ProgressTimeline.tsx
+++ b/src/components/progress/ProgressTimeline.tsx
@@ -20,6 +20,7 @@ const STATUS_PILL: Record<GenerationStepStatus, { label: string; cls: string }> 
     in_progress: { label: 'In progress', cls: 'bg-indigo-50 text-indigo-700' },
     completed: { label: 'Completed', cls: 'bg-green-50 text-green-700' },
     failed: { label: 'Failed', cls: 'bg-red-50 text-red-700' },
+    queued: { label: 'Queued', cls: 'bg-amber-50 text-amber-700' },
     pending: { label: 'Pending', cls: 'bg-neutral-100 text-neutral-600' },
 };
 

--- a/src/components/progress/TimelineStep.tsx
+++ b/src/components/progress/TimelineStep.tsx
@@ -30,6 +30,15 @@ export function StatusIcon({ status, size = 'md' }: { status: GenerationStepStat
             </span>
         );
     }
+    if (status === 'queued') {
+        // Dependencies satisfied, waiting for a free slot — distinct from the
+        // plain "pending (waiting on deps)" ring.
+        return (
+            <span className={`${dim} shrink-0 rounded-full border-2 border-amber-400 flex items-center justify-center`}>
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+            </span>
+        );
+    }
     return <span className={`${dim} shrink-0 rounded-full border-2 border-neutral-300 bg-white`} />;
 }
 
@@ -38,9 +47,9 @@ export function StatusIcon({ status, size = 'md' }: { status: GenerationStepStat
 export function ModelChip({ model }: { model: string }) {
     if (!model) return null;
     return (
-        <span className="inline-flex items-center gap-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium px-2 py-0.5 whitespace-nowrap">
+        <span className="inline-flex items-center gap-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium px-2 py-0.5 max-w-full min-w-0">
             <Sparkles size={11} className="shrink-0" />
-            {model}
+            <span className="truncate">{model}</span>
         </span>
     );
 }
@@ -65,8 +74,12 @@ function TimeBlock({ step }: { step: GenerationStep }) {
         if (est) lines.push({ text: `Est. ${est}`, cls: 'text-neutral-400' });
         const a = fixed(step.actualSeconds);
         if (a) lines.push({ text: `Actual: ${a}`, cls: 'text-neutral-500' });
+    } else if (step.status === 'queued') {
+        lines.push({ text: 'Queued', cls: 'text-amber-600 font-medium' });
+        const est = roundEst(step.estimatedSeconds);
+        if (est) lines.push({ text: `Est. ${est}`, cls: 'text-neutral-400' });
     } else {
-        lines.push({ text: 'Pending', cls: 'text-neutral-400' });
+        lines.push({ text: 'Waiting', cls: 'text-neutral-400' });
         const est = roundEst(step.estimatedSeconds);
         if (est) lines.push({ text: `Est. ${est}`, cls: 'text-neutral-400' });
     }
@@ -104,16 +117,26 @@ export function StepBody({
         <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                         <span className="text-sm font-semibold text-neutral-800">
                             <span className="text-neutral-400 font-medium mr-1.5">{step.label}.</span>
                             {step.title}
                         </span>
+                        {step.retryCount != null && step.retryCount > 0 && (
+                            <span className="inline-flex items-center rounded-full bg-amber-100 text-amber-700 text-[10px] font-semibold px-1.5 py-0.5">
+                                Retried ×{step.retryCount}
+                            </span>
+                        )}
                     </div>
                     {showDetails && step.description && (
                         <p className="text-xs text-neutral-500 mt-0.5">{step.description}</p>
                     )}
-                    <div className="mt-1.5">
+                    {(step.status === 'pending' || step.status === 'queued') && step.dependsOn && step.dependsOn.length > 0 && (
+                        <p className="text-xs text-neutral-400 mt-0.5 break-words">
+                            {step.status === 'queued' ? 'Ready — waiting for a slot' : `Waits on: ${step.dependsOn.join(', ')}`}
+                        </p>
+                    )}
+                    <div className="mt-1.5 min-w-0">
                         <ModelChip model={step.modelName} />
                     </div>
                 </div>

--- a/src/components/progress/__tests__/buildGenerationSteps.test.ts
+++ b/src/components/progress/__tests__/buildGenerationSteps.test.ts
@@ -31,11 +31,11 @@ describe('formatModelName', () => {
 describe('computeWaves (default DAG)', () => {
     it('groups the 10 sections into dependency waves', () => {
         const waves = computeWaves();
-        expect(waves.map((w) => w.length)).toEqual([1, 2, 1, 3, 1, 2]);
+        expect(waves.map((w) => w.length)).toEqual([1, 3, 4, 1, 1]);
         expect(waves[0][0].id).toBe('product_basics');
-        expect(waves[1].map((s) => s.id)).toEqual(['product_thesis', 'grounding']);
-        expect(waves[3].map((s) => s.id)).toEqual(['data_model', 'ux_loops', 'metrics_scope']);
-        expect(waves[5].map((s) => s.id)).toEqual(['quality_risks', 'implementation_plan']);
+        expect(waves[1].map((s) => s.id)).toEqual(['product_thesis', 'grounding', 'features']);
+        expect(waves[2].map((s) => s.id)).toEqual(['data_model', 'ux_loops', 'quality_risks', 'metrics_scope']);
+        expect(waves[4].map((s) => s.id)).toEqual(['implementation_plan']);
     });
 });
 
@@ -56,7 +56,7 @@ describe('computeWaves (arbitrary graph — future-proofing)', () => {
 describe('buildGenerationSteps', () => {
     it('builds sequential rows and concurrent groups with labels', () => {
         const steps = buildGenerationSteps({}, MODELS);
-        expect(steps).toHaveLength(6);
+        expect(steps).toHaveLength(5);
         expect(steps[0].sectionId).toBe('product_basics');
         expect(steps[0].label).toBe('1');
         expect(steps[0].executionMode).toBe('sequential');
@@ -64,8 +64,8 @@ describe('buildGenerationSteps', () => {
         const group = steps[1];
         expect(group.executionMode).toBe('concurrent');
         expect(group.title).toBe('Running concurrently');
-        expect(group.children?.map((c) => c.label)).toEqual(['2A', '2B']);
-        expect(steps[3].children?.map((c) => c.label)).toEqual(['4A', '4B', '4C']);
+        expect(group.children?.map((c) => c.label)).toEqual(['2A', '2B', '2C']);
+        expect(steps[2].children?.map((c) => c.label)).toEqual(['3A', '3B', '3C', '3D']);
     });
 
     it('falls back to the tier model when no live model is present', () => {
@@ -92,11 +92,36 @@ describe('buildGenerationSteps', () => {
         const thesis = steps[1].children?.[0];
         expect(thesis?.status).toBe('in_progress');
 
-        const metrics = steps[3].children?.find((c) => c.sectionId === 'metrics_scope');
+        const metrics = steps[2].children?.find((c) => c.sectionId === 'metrics_scope');
         expect(metrics?.status).toBe('failed');
         expect(metrics?.canRetry).toBe(true);
         expect(metrics?.errorMessage).toBe('Model timeout exceeded');
         expect(metrics?.actualSeconds).toBeCloseTo(9.2);
+    });
+
+    it('maps the queued status distinctly from pending and in_progress', () => {
+        const status: SectionStatusMap = {
+            product_basics: { tier: 'fast', status: 'complete' },
+            // deps satisfied, waiting for a slot
+            product_thesis: { tier: 'strong', status: 'queued' },
+        };
+        const steps = buildGenerationSteps(status, MODELS);
+        const thesis = steps[1].children?.find((c) => c.sectionId === 'product_thesis');
+        expect(thesis?.status).toBe('queued');
+        // grounding has no status entry → still pending (waiting on deps)
+        const grounding = steps[1].children?.find((c) => c.sectionId === 'grounding');
+        expect(grounding?.status).toBe('pending');
+    });
+
+    it('carries dependsOn (resolved to titles) and retryCount onto leaves', () => {
+        const status: SectionStatusMap = {
+            features: { tier: 'strong', status: 'error', error: 'boom', retryCount: 2 },
+        };
+        const steps = buildGenerationSteps(status, MODELS);
+        const features = steps[1].children?.find((c) => c.sectionId === 'features');
+        expect(features?.retryCount).toBe(2);
+        // features depends on product_basics — resolved to its section title.
+        expect(features?.dependsOn).toContain('Product Basics');
     });
 });
 

--- a/src/components/progress/buildGenerationSteps.ts
+++ b/src/components/progress/buildGenerationSteps.ts
@@ -90,13 +90,17 @@ export const computeWaves = (
 const mapStatus = (s?: PrdSectionStatusEntry['status']): GenerationStepStatus => {
     if (s === 'complete') return 'completed';
     if (s === 'error') return 'failed';
-    if (s === 'generating' || s === 'queued' || s === 'refining') return 'in_progress';
+    if (s === 'generating' || s === 'refining') return 'in_progress';
+    // 'queued' = dependencies satisfied, waiting for a concurrency slot — kept
+    // distinct from 'pending' (waiting on deps) so the UI can label them apart.
+    if (s === 'queued') return 'queued';
     return 'pending';
 };
 
 const groupStatus = (children: GenerationStep[]): GenerationStepStatus => {
     if (children.some((c) => c.status === 'failed')) return 'failed';
     if (children.some((c) => c.status === 'in_progress')) return 'in_progress';
+    if (children.some((c) => c.status === 'queued')) return 'queued';
     if (children.length > 0 && children.every((c) => c.status === 'completed')) return 'completed';
     return 'pending';
 };
@@ -123,6 +127,9 @@ const buildLeaf = (
     const stepStatus = mapStatus(entry?.status);
     const tier = selectModelTier(template.risk);
     const modelName = formatModelName(entry?.model ?? (tier === 'fast' ? fastModel : strongModel));
+    // Resolve dependency ids to human titles for the "Waits on:" hint.
+    const depIds = entry?.dependsOn ?? template.dependencies ?? [];
+    const dependsOn = depIds.map((d) => SECTION_TITLES[d] ?? d);
     return {
         id: template.id,
         sectionId: template.id,
@@ -137,6 +144,8 @@ const buildLeaf = (
         errorMessage: entry?.error,
         canRetry: stepStatus === 'failed',
         executionMode,
+        dependsOn,
+        retryCount: entry?.retryCount,
     };
 };
 

--- a/src/components/progress/types.ts
+++ b/src/components/progress/types.ts
@@ -1,6 +1,12 @@
 import type { SectionId } from '../../lib/schemas/prdSchemas';
 
-export type GenerationStepStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+/**
+ * - `pending`     — waiting on dependencies (an upstream section isn't done)
+ * - `queued`      — dependencies satisfied, waiting for a free concurrency slot
+ * - `in_progress` — model call running
+ * - `completed` / `failed` — settled
+ */
+export type GenerationStepStatus = 'pending' | 'queued' | 'in_progress' | 'completed' | 'failed';
 
 /**
  * One node in the PRD generation timeline. A node is either a leaf section or a
@@ -28,4 +34,8 @@ export type GenerationStep = {
     executionMode?: 'sequential' | 'concurrent';
     /** Present on leaf rows that map to a real pipeline section (retry target). */
     sectionId?: SectionId;
+    /** Titles of the sections this step waits on (shown while pending). */
+    dependsOn?: string[];
+    /** Number of manual retries applied to this section (badge when > 0). */
+    retryCount?: number;
 };

--- a/src/lib/__tests__/prdConsistencyReview.test.ts
+++ b/src/lib/__tests__/prdConsistencyReview.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { reviewPrdConsistency } from '../services/prdConsistencyReview';
+import type { StructuredPRD, Feature } from '../../types';
+
+const makeFeatures = (n: number): Feature[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `f${i + 1}`,
+    name: `Feature ${i + 1}`,
+    description: `desc ${i + 1}`,
+    userValue: `value ${i + 1}`,
+    complexity: 'low' as const,
+  }));
+
+const basePrd = (): StructuredPRD => ({
+  vision: 'A vision',
+  targetUsers: ['users a', 'users b'],
+  coreProblem: 'the problem',
+  features: makeFeatures(6),
+  architecture: 'arch',
+  risks: ['r1', 'r2'],
+  productName: 'MyApp',
+});
+
+describe('reviewPrdConsistency', () => {
+  it('applies a revision that preserves detail', async () => {
+    const original = basePrd();
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: { ...original, productName: 'MyApp (canonical)' },
+        changeLog: 'Normalized product name across sections.',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(transport).toHaveBeenCalledOnce();
+    expect(result.applied).toBe(true);
+    expect(result.prd.productName).toBe('MyApp (canonical)');
+    expect(result.prd.features).toHaveLength(6);
+    expect(result.changeLog).toMatch(/normalized/i);
+  });
+
+  it('discards a revision that drops substantive detail (guard)', async () => {
+    const original = basePrd();
+    // Model returns only 2 of 6 features — a lossy "summary".
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, features: makeFeatures(2) }, changeLog: 'shortened' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    // Original is returned untouched.
+    expect(result.prd.features).toHaveLength(6);
+  });
+
+  it('merges over the original so omitted fields are preserved', async () => {
+    const original = basePrd();
+    // Model omits features entirely (returns only a tweaked vision).
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { vision: 'Sharper vision' }, changeLog: 'tightened vision' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(true);
+    expect(result.prd.vision).toBe('Sharper vision');
+    expect(result.prd.features).toHaveLength(6); // preserved via merge
+  });
+
+  it('returns the original (no-op) when the response is unparseable', async () => {
+    const original = basePrd();
+    const transport = vi.fn(async () => 'not json');
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.prd).toEqual(original);
+  });
+});

--- a/src/lib/__tests__/progressivePrdGeneration.test.ts
+++ b/src/lib/__tests__/progressivePrdGeneration.test.ts
@@ -5,7 +5,43 @@ import {
   generateProgressivePrd,
   makeSkeletonJobs,
   selectModelTier,
+  validateGraph,
+  type PrdSectionTemplate,
 } from '../services/progressivePrdGeneration';
+
+const baseConfig = {
+  fastModel: 'fast',
+  strongModel: 'strong',
+  maxFastConcurrency: 4,
+  maxStrongConcurrency: 3,
+  enableRefinementPass: false,
+};
+
+/**
+ * Provider that tracks peak simultaneous in-flight calls and lets each call's
+ * resolution be deferred, so concurrency can be asserted deterministically.
+ */
+const makeConcurrencyProvider = (delayMs = 5) => {
+  let inFlight = 0;
+  let peak = 0;
+  const order: string[] = [];
+  return {
+    get peak() { return peak; },
+    order,
+    provider: {
+      async generateText(input: { prompt: string; model: string; schema: object }) {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        // Record which section by matching the unique "<id> slice" marker in the prompt.
+        const marker = DEFAULT_PRD_SECTIONS.find(s => input.prompt.includes(`${s.id} slice`));
+        if (marker) order.push(marker.id);
+        await new Promise(r => setTimeout(r, delayMs));
+        inFlight--;
+        return '{}';
+      },
+    },
+  };
+};
 
 describe('progressive PRD generation', () => {
   it('routes low risk tasks to fast tier', () => {
@@ -182,5 +218,122 @@ describe('progressive PRD generation', () => {
 
     expect(jobs.product_thesis.status).toBe('error');
     expect(jobs.features.status).toBe('complete');
+  });
+
+  // ─── DAG executor hardening ────────────────────────────────────────────────
+
+  it('runs independent sections concurrently (peak concurrency > 1)', async () => {
+    const tracker = makeConcurrencyProvider(10);
+    // product_thesis and grounding are both independent (depend only on
+    // product_basics) so after basics they should overlap.
+    const sections = [
+      DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_basics')!,
+      DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_thesis')!,
+      DEFAULT_PRD_SECTIONS.find(s => s.id === 'grounding')!,
+    ];
+    await generateProgressivePrd({
+      prompt: 'concurrent test',
+      provider: tracker.provider,
+      sections,
+      config: baseConfig,
+    });
+    expect(tracker.peak).toBeGreaterThan(1);
+  });
+
+  it('respects the per-tier max concurrency limit', async () => {
+    const tracker = makeConcurrencyProvider(10);
+    // 4 independent fast sections, but a fast cap of 2 → peak must be ≤ 2.
+    const sections: PrdSectionTemplate[] = ['a', 'b', 'c', 'd'].map((id, i) => ({
+      id: id as PrdSectionTemplate['id'],
+      title: id,
+      order: i + 1,
+      risk: 'low',
+      estimatedSeconds: 1,
+    }));
+    await generateProgressivePrd({
+      prompt: 'cap test',
+      provider: tracker.provider,
+      sections,
+      config: { ...baseConfig, maxFastConcurrency: 2 },
+    });
+    expect(tracker.peak).toBeLessThanOrEqual(2);
+  });
+
+  it('detects circular dependencies and throws', () => {
+    const cyclic: PrdSectionTemplate[] = [
+      { id: 'a' as PrdSectionTemplate['id'], title: 'a', order: 1, risk: 'low', estimatedSeconds: 1, dependencies: ['b' as PrdSectionTemplate['id']] },
+      { id: 'b' as PrdSectionTemplate['id'], title: 'b', order: 2, risk: 'low', estimatedSeconds: 1, dependencies: ['a' as PrdSectionTemplate['id']] },
+    ];
+    expect(() => validateGraph(cyclic)).toThrow(/circular dependency/i);
+  });
+
+  it('rejects a dependency referencing an unknown section', () => {
+    const broken: PrdSectionTemplate[] = [
+      { id: 'a' as PrdSectionTemplate['id'], title: 'a', order: 1, risk: 'low', estimatedSeconds: 1, dependencies: ['ghost' as PrdSectionTemplate['id']] },
+    ];
+    expect(() => validateGraph(broken)).toThrow(/unknown section/i);
+  });
+
+  it('a failed section does not block an unrelated independent branch', async () => {
+    const provider = {
+      async generateText(input: { prompt: string; model: string; schema: object }) {
+        if (input.prompt.includes('product_thesis slice')) throw new Error('boom');
+        return '{}';
+      },
+    };
+    // product_thesis and grounding are independent siblings (both depend only on
+    // product_basics). product_thesis failing must not stop grounding.
+    const sections = [
+      DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_basics')!,
+      DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_thesis')!,
+      DEFAULT_PRD_SECTIONS.find(s => s.id === 'grounding')!,
+    ];
+    const { jobs } = await generateProgressivePrd({
+      prompt: 'isolation test',
+      provider,
+      sections,
+      config: baseConfig,
+    });
+    expect(jobs.product_thesis.status).toBe('error');
+    expect(jobs.grounding.status).toBe('complete');
+  });
+
+  it('captures per-section start and completion timestamps', async () => {
+    const provider = { async generateText() { return '{}'; } };
+    const { jobs } = await generateProgressivePrd({
+      prompt: 'timing test',
+      provider,
+      sections: [DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_basics')!],
+      config: baseConfig,
+    });
+    expect(jobs.product_basics.startedAt).toBeTruthy();
+    expect(jobs.product_basics.completedAt).toBeTruthy();
+  });
+
+  it('emits section_ready before section_started for each section', async () => {
+    const provider = { async generateText() { return '{}'; } };
+    const events: Array<{ type: string; sectionId?: string }> = [];
+    await generateProgressivePrd({
+      prompt: 'transition test',
+      provider,
+      sections: [
+        DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_basics')!,
+        DEFAULT_PRD_SECTIONS.find(s => s.id === 'product_thesis')!,
+      ],
+      config: baseConfig,
+      onEvent: (e) => {
+        if (e.type === 'section_ready' || e.type === 'section_started' || e.type === 'section_completed') {
+          events.push({ type: e.type, sectionId: (e as { sectionId?: string }).sectionId });
+        }
+      },
+    });
+    for (const id of ['product_basics', 'product_thesis']) {
+      const readyIdx = events.findIndex(e => e.type === 'section_ready' && e.sectionId === id);
+      const startedIdx = events.findIndex(e => e.type === 'section_started' && e.sectionId === id);
+      const completedIdx = events.findIndex(e => e.type === 'section_completed' && e.sectionId === id);
+      expect(readyIdx).toBeGreaterThanOrEqual(0);
+      expect(startedIdx).toBeGreaterThan(readyIdx);
+      expect(completedIdx).toBeGreaterThan(startedIdx);
+    }
   });
 });

--- a/src/lib/runPrdGeneration.ts
+++ b/src/lib/runPrdGeneration.ts
@@ -13,6 +13,21 @@ import {
 } from './safety';
 import type { ProjectPlatform } from '../types';
 import type { PreflightContext } from './llmProvider';
+import { detectSurface } from './services/prdGenerationLog';
+
+/**
+ * Read the opt-in consistency-review flag from localStorage. Default OFF —
+ * enabling adds a final reconciliation model call. Wrapped in try/catch for
+ * non-browser contexts.
+ */
+const consistencyReviewEnabled = (): boolean => {
+    try {
+        return typeof localStorage !== 'undefined'
+            && localStorage.getItem('synapse-prd-consistency-review') === 'true';
+    } catch {
+        return false;
+    }
+};
 
 export interface RunPrdGenerationParams {
     projectId: string;
@@ -62,6 +77,8 @@ export async function runPrdGeneration({
             sourcePrompt,
             {
                 preflight,
+                enableConsistencyReview: consistencyReviewEnabled(),
+                surface: detectSurface(),
                 onProgress: (message) => {
                     useProjectStore.getState().appendPrdProgress(projectId, message);
                 },

--- a/src/lib/services/prdConsistencyReview.ts
+++ b/src/lib/services/prdConsistencyReview.ts
@@ -1,0 +1,147 @@
+// Optional final consistency-review pass for the parallel PRD pipeline.
+//
+// Because sections are generated concurrently (and some without seeing each
+// other's output), the merged document can carry small inconsistencies:
+// drifting product/feature names, contradictory scope statements, duplicated
+// points, or uneven terminology. This pass runs ONE fast-model call over the
+// fully-merged PRD and asks the model to reconcile those issues WITHOUT
+// removing substantive detail.
+//
+// It is OFF by default in the pipeline (it adds a model call). Two safety
+// properties make it safe to enable:
+//   1. It MERGES the revision over the original, so any field the model omits
+//      is preserved (never dropped).
+//   2. A detail-loss guard discards the entire revision if it would shrink or
+//      empty any key content array — a defensive backstop against a model that
+//      "summarizes" instead of reconciling.
+
+import { callGemini, getFastModel } from '../geminiClient';
+import type { StructuredPRD } from '../../types';
+import { repairTruncatedJson } from '../jsonRepair';
+import { structuredPRDSchema } from '../schemas/prdSchemas';
+
+// Wrapper schema: the model returns the corrected PRD plus a one-line change
+// note. Fields absent from structuredPRDSchema (e.g. implementationPlan) are
+// simply not revised — they are preserved via the merge-over-original below.
+const reviewResponseSchema = {
+    type: 'OBJECT',
+    properties: {
+        prd: structuredPRDSchema,
+        changeLog: { type: 'STRING' },
+    },
+    required: ['prd'],
+};
+
+export type ConsistencyReviewTransport = (input: {
+    prompt: string;
+    model: string;
+}) => Promise<string>;
+
+export interface ReviewOptions {
+    /** Injectable transport for tests; defaults to a fast-model JSON call. */
+    transport?: ConsistencyReviewTransport;
+    signal?: AbortSignal;
+}
+
+export interface ReviewResult {
+    /** The PRD to use downstream (revised when `applied`, else the original). */
+    prd: StructuredPRD;
+    /** Whether the revision passed the guards and was merged in. */
+    applied: boolean;
+    /** Short human-readable note about what changed (model-provided, optional). */
+    changeLog?: string;
+}
+
+const SYSTEM = `You are a meticulous product editor performing a final consistency pass on a Product Requirements Document. The PRD was assembled from independently-generated sections, so it may contain inconsistencies.
+
+Reconcile ONLY the following, and change nothing else:
+- terminology and phrasing used inconsistently across sections,
+- the product name and feature names (make every reference identical),
+- contradictory or overlapping scope / assumption statements,
+- duplicated points expressed in different sections,
+- obvious factual contradictions between sections.
+
+HARD RULES:
+- Do NOT remove or summarize substantive detail. Preserve every feature, entity, user loop, page, risk, metric, and plan item. Array lengths must not shrink.
+- Do NOT invent new features, entities, or scope.
+- Preserve the exact JSON shape and all field names of the input.
+- Return ONLY a JSON object with two keys: "prd" (the full corrected PRD, same shape as the input) and "changeLog" (a one-sentence summary of what you reconciled, or "No changes needed").`;
+
+const buildPrompt = (prd: StructuredPRD): string =>
+    `${SYSTEM}\n\nHere is the PRD JSON to review:\n\n${JSON.stringify(prd)}`;
+
+const defaultTransport: ConsistencyReviewTransport = ({ prompt, model }) =>
+    callGemini('', prompt, {
+        responseMimeType: 'application/json',
+        responseSchema: reviewResponseSchema,
+        model,
+        maxOutputTokens: 8192,
+        temperature: 0.2,
+        topP: 0.9,
+    });
+
+const len = (v: unknown): number => (Array.isArray(v) ? v.length : 0);
+
+/**
+ * Detail-loss guard. Returns true when `revised` would lose substantive content
+ * relative to `original` — any non-empty key array dropping below 70% of its
+ * original length (or emptied entirely). Such a revision is discarded.
+ */
+const losesDetail = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const arrays: Array<keyof StructuredPRD> = [
+        'features', 'targetUsers', 'risks', 'userLoops', 'uxPages',
+        'successMetrics', 'assumptions', 'domainEntities', 'risksDetailed',
+        'nonFunctionalRequirements', 'constraints',
+    ];
+    for (const key of arrays) {
+        const before = len(original[key]);
+        if (before === 0) continue;
+        const after = len(revised[key]);
+        if (after === 0 || after < Math.ceil(before * 0.7)) return true;
+    }
+    // Nested entity list inside the rich data model.
+    const beforeEntities = original.richDataModel?.entities?.length ?? 0;
+    if (beforeEntities > 0) {
+        const afterEntities = revised.richDataModel?.entities?.length ?? 0;
+        if (afterEntities === 0 || afterEntities < Math.ceil(beforeEntities * 0.7)) return true;
+    }
+    return false;
+};
+
+const parse = (raw: string): { prd?: Partial<StructuredPRD>; changeLog?: string } | null => {
+    const tryParse = (s: string) => {
+        try {
+            return JSON.parse(s) as { prd?: Partial<StructuredPRD>; changeLog?: string };
+        } catch {
+            return null;
+        }
+    };
+    return tryParse(raw) ?? tryParse(repairTruncatedJson(raw).text);
+};
+
+/**
+ * Run the consistency-review pass. On any failure, ambiguity, or detail-loss
+ * the original PRD is returned with `applied: false` — this is a best-effort
+ * polish, never a gate.
+ */
+export const reviewPrdConsistency = async (
+    prd: StructuredPRD,
+    options: ReviewOptions = {},
+): Promise<ReviewResult> => {
+    const transport = options.transport ?? defaultTransport;
+    const raw = await transport({ prompt: buildPrompt(prd), model: getFastModel() });
+
+    const parsed = parse(raw);
+    if (!parsed?.prd) {
+        return { prd, applied: false };
+    }
+
+    // Merge over the original so any omitted field is preserved.
+    const revised: StructuredPRD = { ...prd, ...parsed.prd };
+
+    if (losesDetail(prd, revised)) {
+        return { prd, applied: false, changeLog: 'discarded: detail-loss guard tripped' };
+    }
+
+    return { prd: revised, applied: true, changeLog: parsed.changeLog };
+};

--- a/src/lib/services/prdGenerationLog.ts
+++ b/src/lib/services/prdGenerationLog.ts
@@ -1,0 +1,84 @@
+// Structured, low-noise observability for the PRD DAG pipeline. Emits one
+// machine-readable record per lifecycle event (queued / started / completed /
+// failed / dependency-satisfied / retry / run summary) so a generation run can
+// be reconstructed from the console without scattering ad-hoc console.log
+// calls through the orchestration code.
+//
+// Logging is OFF by default (it would flood the console for every run) and is
+// enabled by either:
+//   - localStorage 'synapse-prd-debug' === 'true', or
+//   - a `?prddebug` query param (handy for shareable repro links).
+// All access is wrapped in try/catch so this never throws in non-browser
+// (test/SSR) contexts.
+
+export type PrdLogSurface = 'mobile' | 'web';
+
+export type PrdLogEvent =
+    | 'run_started'
+    | 'section_queued'
+    | 'section_started'
+    | 'section_completed'
+    | 'section_failed'
+    | 'dependency_satisfied'
+    | 'retry_triggered'
+    | 'consistency_review'
+    | 'run_completed';
+
+export interface PrdLogRecord {
+    event: PrdLogEvent;
+    sectionId?: string;
+    model?: string;
+    tier?: 'fast' | 'strong';
+    estimatedSeconds?: number;
+    actualSeconds?: number;
+    retryCount?: number;
+    surface?: PrdLogSurface;
+    totalMs?: number;
+    detail?: string;
+    error?: string;
+}
+
+const isDebugEnabled = (): boolean => {
+    try {
+        if (typeof localStorage !== 'undefined' && localStorage.getItem('synapse-prd-debug') === 'true') {
+            return true;
+        }
+        if (typeof window !== 'undefined' && window.location?.search?.includes('prddebug')) {
+            return true;
+        }
+    } catch {
+        // Non-browser context — stay silent.
+    }
+    return false;
+};
+
+/**
+ * Emit a structured PRD-generation log record. No-op unless debug logging is
+ * enabled. Uses `console.debug` so it stays out of the way of real warnings.
+ */
+export const logPrd = (record: PrdLogRecord): void => {
+    if (!isDebugEnabled()) return;
+    try {
+        // Single-line, grep-friendly prefix + structured payload.
+        console.debug(`[prd:${record.event}]`, { t: Date.now(), ...record });
+    } catch {
+        // Never let logging break generation.
+    }
+};
+
+/**
+ * Best-effort detection of the rendering surface for log context. Returns
+ * 'mobile' below the Tailwind `md` breakpoint (767px), 'web' otherwise, and
+ * undefined when there is no window (tests/SSR).
+ */
+export const detectSurface = (): PrdLogSurface | undefined => {
+    try {
+        if (typeof window === 'undefined') return undefined;
+        if (typeof window.matchMedia === 'function') {
+            return window.matchMedia('(max-width: 767px)').matches ? 'mobile' : 'web';
+        }
+        return window.innerWidth <= 767 ? 'mobile' : 'web';
+    } catch {
+        return undefined;
+    }
+};

--- a/src/lib/services/prdService.ts
+++ b/src/lib/services/prdService.ts
@@ -58,6 +58,10 @@ export const generateStructuredPRD = async (
          * questions as open unknowns.
          */
         preflight?: PreflightContext;
+        /** Run the optional final consistency-review pass (default false). */
+        enableConsistencyReview?: ProgressivePrdPipelineOptions['enableConsistencyReview'];
+        /** Rendering surface for observability logs. */
+        surface?: ProgressivePrdPipelineOptions['surface'];
     },
     platform?: ProjectPlatform,
 ): Promise<StructuredPRD> => {
@@ -97,6 +101,8 @@ export const generateStructuredPRD = async (
             onProgress: options?.onProgress,
             onSectionStatus: options?.onSectionStatus,
             signal: options?.signal,
+            enableConsistencyReview: options?.enableConsistencyReview,
+            surface: options?.surface,
         },
         platform,
     );

--- a/src/lib/services/progressivePrdGeneration.ts
+++ b/src/lib/services/progressivePrdGeneration.ts
@@ -67,7 +67,11 @@ export type ModelProvider = {
 
 export type ProgressiveEvent =
     | { type: 'session_started'; sections: PrdSectionJob[] }
-    | { type: 'section_queued'; sectionId: string }
+    // Emitted by the executor the moment a section's dependencies are all
+    // satisfied and it enters the ready queue. The section may still wait for a
+    // free concurrency slot before `section_started` fires, so this maps to the
+    // "queued — waiting for a slot" UI state (distinct from "waiting on deps").
+    | { type: 'section_ready'; sectionId: string }
     | { type: 'section_started'; sectionId: string; modelTier: ModelTier; model: string }
     | { type: 'section_completed'; sectionId: string; content: string; confidence?: number }
     | { type: 'section_refining'; sectionId: string }
@@ -80,15 +84,30 @@ export type ProgressiveEvent =
 // is merged client-side into the final document. Fast (Flash) sections run
 // independently; strong (Pro) sections depend on earlier results.
 
+// Dependencies are TRUE data dependencies only — a section lists another only
+// when it actually consumes that section's output as prompt context. Sections
+// are NOT sequenced just because they appear later in the document. Earlier
+// revisions over-constrained the graph (e.g. `features` waited on the slow
+// `product_thesis`, and `quality_risks` waited on the full architecture chain),
+// which serialized the two heaviest early calls and delayed fan-out. The graph
+// below relaxes those spurious edges so independent work overlaps. Prompt
+// builders degrade gracefully (via `missingNote()`) when an upstream field they
+// reference is not a declared dependency, so dropping an edge never breaks a
+// section — it just lets it start sooner.
 export const DEFAULT_PRD_SECTIONS: PrdSectionTemplate[] = [
     { id: 'product_basics',       title: SECTION_TITLES.product_basics,       order: 1,  risk: 'low',  estimatedSeconds: 8 },
     { id: 'product_thesis',       title: SECTION_TITLES.product_thesis,       order: 2,  risk: 'high', estimatedSeconds: 25, dependencies: ['product_basics'] },
     { id: 'grounding',            title: SECTION_TITLES.grounding,            order: 3,  risk: 'low',  estimatedSeconds: 10, dependencies: ['product_basics'] },
-    { id: 'features',             title: SECTION_TITLES.features,             order: 4,  risk: 'high', estimatedSeconds: 35, dependencies: ['product_basics', 'product_thesis'] },
+    // features depends on product_basics only — it runs in parallel with the
+    // slow product_thesis call instead of waiting behind it.
+    { id: 'features',             title: SECTION_TITLES.features,             order: 4,  risk: 'high', estimatedSeconds: 35, dependencies: ['product_basics'] },
     { id: 'data_model',           title: SECTION_TITLES.data_model,           order: 5,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'grounding'] },
-    { id: 'ux_loops',             title: SECTION_TITLES.ux_loops,             order: 6,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'product_thesis'] },
+    // ux_loops only truly needs the feature set; thesis is incidental context.
+    { id: 'ux_loops',             title: SECTION_TITLES.ux_loops,             order: 6,  risk: 'high', estimatedSeconds: 25, dependencies: ['features'] },
     { id: 'architecture',         title: SECTION_TITLES.architecture,         order: 7,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'data_model'] },
-    { id: 'quality_risks',        title: SECTION_TITLES.quality_risks,        order: 8,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features', 'architecture'] },
+    // quality_risks is derivable from the feature set; it no longer waits on the
+    // long architecture chain.
+    { id: 'quality_risks',        title: SECTION_TITLES.quality_risks,        order: 8,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features'] },
     { id: 'metrics_scope',        title: SECTION_TITLES.metrics_scope,        order: 9,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features'] },
     { id: 'implementation_plan',  title: SECTION_TITLES.implementation_plan,  order: 10, risk: 'high', estimatedSeconds: 30, dependencies: ['features', 'data_model', 'architecture'] },
 ];
@@ -169,6 +188,49 @@ export const makeJsonProvider = (): ModelProvider => ({
     },
 });
 
+// ─── Graph validation ─────────────────────────────────────────────────────────
+// Run before execution so a malformed graph fails fast and loudly instead of
+// silently deadlocking (sections that never run would be quietly dropped from
+// the merged PRD). Detects (a) dependencies referencing unknown section ids and
+// (b) circular dependencies (Kahn's algorithm — if fewer than all nodes can be
+// topologically processed, a cycle exists).
+export const validateGraph = (sections: PrdSectionTemplate[]): void => {
+    const ids = new Set(sections.map(s => s.id));
+    const inDegree: Record<string, number> = {};
+    const dependents: Record<string, string[]> = {};
+    for (const s of sections) {
+        inDegree[s.id] = 0;
+        dependents[s.id] = [];
+    }
+    for (const s of sections) {
+        for (const dep of (s.dependencies ?? [])) {
+            if (!ids.has(dep)) {
+                throw new Error(
+                    `Invalid PRD section graph: "${s.id}" depends on unknown section "${dep}"`,
+                );
+            }
+            inDegree[s.id]++;
+            dependents[dep].push(s.id);
+        }
+    }
+
+    const queue: string[] = sections.filter(s => inDegree[s.id] === 0).map(s => s.id);
+    let processed = 0;
+    while (queue.length > 0) {
+        const id = queue.shift()!;
+        processed++;
+        for (const dep of dependents[id]) {
+            if (--inDegree[dep] === 0) queue.push(dep);
+        }
+    }
+    if (processed < sections.length) {
+        const cyclic = sections.filter(s => inDegree[s.id] > 0).map(s => s.id);
+        throw new Error(
+            `Circular dependency detected in PRD section graph among: ${cyclic.join(', ')}`,
+        );
+    }
+};
+
 // ─── DAG executor ────────────────────────────────────────────────────────────
 // Runs sections respecting dependency ordering with separate per-tier
 // concurrency caps. Each section receives the already-merged partial PRD from
@@ -176,13 +238,20 @@ export const makeJsonProvider = (): ModelProvider => ({
 //
 // `results` is passed in by reference from the caller so both the worker and
 // buildUpstream share the same source of truth for completed section values.
+//
+// `onReady` fires when a section's dependencies are all satisfied and it enters
+// the ready queue (it may still wait for a free concurrency slot before the
+// worker actually starts it).
 
 async function runDag(
     sections: PrdSectionTemplate[],
     config: ProgressiveGenerationConfig,
     results: Record<string, Partial<StructuredPRD> | null>,
     worker: (section: PrdSectionTemplate, upstream: Partial<StructuredPRD>) => Promise<void>,
+    onReady?: (sectionId: string) => void,
 ): Promise<void> {
+    validateGraph(sections);
+
     const sectionMap = Object.fromEntries(sections.map(s => [s.id, s]));
 
     // Build the dependency graph.
@@ -206,6 +275,8 @@ async function runDag(
     const strongMax = config.maxStrongConcurrency;
 
     const ready: PrdSectionTemplate[] = sections.filter(s => (s.dependencies?.length ?? 0) === 0);
+    // Sections with no dependencies are ready immediately (awaiting only a slot).
+    for (const s of ready) onReady?.(s.id);
 
     // Notification gate: resolves whenever a section completes so the outer
     // loop can re-evaluate what's now runnable.
@@ -225,7 +296,10 @@ async function runDag(
         settled.add(sectionId);
         for (const depId of dependents[sectionId]) {
             inDegree[depId]--;
-            if (inDegree[depId] === 0) ready.push(sectionMap[depId]);
+            if (inDegree[depId] === 0) {
+                ready.push(sectionMap[depId]);
+                onReady?.(depId);
+            }
         }
         notifyTick();
     };
@@ -265,7 +339,14 @@ async function runDag(
         }
 
         const allIdle = fastRunning === 0 && strongRunning === 0;
-        if (!dispatched && allIdle) break; // deadlock guard (should not happen)
+        if (!dispatched && allIdle) {
+            // Nothing running and nothing dispatchable while sections remain
+            // unsettled — only possible with a cyclic/broken graph, which
+            // validateGraph should have rejected. Fail loudly rather than
+            // silently dropping the unreachable sections from the PRD.
+            const stuck = sections.filter(s => !settled.has(s.id)).map(s => s.id);
+            throw new Error(`PRD DAG deadlock: unreachable sections ${stuck.join(', ')}`);
+        }
         if (!dispatched || (ready.length > 0 && (fastRunning >= fastMax || strongRunning >= strongMax))) {
             await waitForTick();
         }
@@ -298,9 +379,6 @@ export async function generateProgressivePrd(params: {
 
     const worker = async (section: PrdSectionTemplate, upstream: Partial<StructuredPRD>) => {
         const job = jobs[section.id];
-        job.status = 'queued';
-        params.onEvent?.({ type: 'section_queued', sectionId: section.id });
-
         const tier = selectModelTier(section.risk);
         const model = selectModelForTier(tier, params.config);
         const schema = SECTION_SCHEMAS[section.id];
@@ -380,7 +458,13 @@ export async function generateProgressivePrd(params: {
         }
     };
 
-    await runDag(sections, params.config, results, worker);
+    await runDag(
+        sections,
+        params.config,
+        results,
+        worker,
+        (sectionId) => params.onEvent?.({ type: 'section_ready', sectionId }),
+    );
 
     params.onEvent?.({ type: 'session_completed' });
     return { jobs, results };

--- a/src/lib/services/progressivePrdPipeline.ts
+++ b/src/lib/services/progressivePrdPipeline.ts
@@ -7,6 +7,8 @@ import { getFastModel, getStrongModel } from '../geminiClient';
 import { generateProgressivePrd, DEFAULT_PRD_SECTIONS, selectModelTier } from './progressivePrdGeneration';
 import { parseSectionResults, mergeSectionsToStructuredPrd } from './prdSectionMerge';
 import { renderPremiumMarkdown } from './prdMarkdownRenderer';
+import { reviewPrdConsistency } from './prdConsistencyReview';
+import { logPrd, type PrdLogSurface } from './prdGenerationLog';
 import type { PrdPipelineOptions, PrdPipelineResult } from './prdPipeline';
 import type { StructuredPRD, GenerationPassRecord } from '../../types';
 import type { SectionId } from '../schemas/prdSchemas';
@@ -22,6 +24,8 @@ export type SectionStatusUpdate = {
     error?: string;
     /** Rough wall-clock estimate (seconds) shown in the progress UI. */
     estimatedSeconds?: number;
+    /** Section ids this section depends on (for the "Waits on:" hint). */
+    dependsOn?: SectionId[];
 };
 
 export interface ProgressivePrdPipelineOptions extends PrdPipelineOptions {
@@ -30,14 +34,24 @@ export interface ProgressivePrdPipelineOptions extends PrdPipelineOptions {
      * per-section grid UI in prdProgressSlice.
      */
     onSectionStatus?: (sectionId: SectionId, update: SectionStatusUpdate) => void;
+    /**
+     * When true, run a final cross-section consistency-review pass after the
+     * DAG completes. Default false — the deterministic merge is the fast path;
+     * the review adds one extra model call. See prdConsistencyReview.ts.
+     */
+    enableConsistencyReview?: boolean;
+    /** Rendering surface, attached to structured logs for observability. */
+    surface?: PrdLogSurface;
 }
+
+const SECTION_BY_ID = Object.fromEntries(DEFAULT_PRD_SECTIONS.map(s => [s.id, s]));
 
 export const runProgressivePrdPipeline = async (
     promptText: string,
     options: ProgressivePrdPipelineOptions = {},
     platform?: ProjectPlatform,
 ): Promise<PrdPipelineResult> => {
-    const { onStatus, onPartial, onProgress, onSectionStatus, signal } = options;
+    const { onStatus, onPartial, onProgress, onSectionStatus, signal, enableConsistencyReview, surface } = options;
 
     const fastModel = getFastModel();
     const strongModel = getStrongModel();
@@ -51,6 +65,7 @@ export const runProgressivePrdPipeline = async (
 
     onStatus?.('Starting progressive PRD generation…');
     onProgress?.('Sending request to model…');
+    logPrd({ event: 'run_started', surface, model: `${fastModel} / ${strongModel}` });
 
     const { jobs, results } = await generateProgressivePrd({
         prompt: promptText,
@@ -79,13 +94,42 @@ export const runProgressivePrdPipeline = async (
             }
         },
         onEvent: (event) => {
-            if (event.type === 'section_started') {
+            if (event.type === 'session_started') {
+                // Seed the grid: every section starts 'pending' (waiting on deps)
+                // with its dependency list and estimate so the UI can render the
+                // full plan immediately.
+                for (const section of DEFAULT_PRD_SECTIONS) {
+                    onSectionStatus?.(section.id, {
+                        tier: selectModelTier(section.risk) === 'fast' ? 'fast' : 'strong',
+                        status: 'pending',
+                        estimatedSeconds: section.estimatedSeconds,
+                        dependsOn: section.dependencies ?? [],
+                    });
+                }
+            } else if (event.type === 'section_ready') {
+                // Dependencies satisfied — now waiting only for a concurrency slot.
+                const section = SECTION_BY_ID[event.sectionId];
+                const tier = section ? selectModelTier(section.risk) : 'strong';
+                logPrd({ event: 'section_queued', sectionId: event.sectionId, surface });
+                onSectionStatus?.(event.sectionId as SectionId, {
+                    tier: tier === 'fast' ? 'fast' : 'strong',
+                    status: 'queued',
+                });
+            } else if (event.type === 'section_started') {
                 sectionStarts[event.sectionId] = performance.now();
-                const startedSection = DEFAULT_PRD_SECTIONS.find(s => s.id === event.sectionId);
+                const startedSection = SECTION_BY_ID[event.sectionId];
                 const tierLabel = event.modelTier === 'fast' ? 'Flash' : 'Pro';
                 const estimate = startedSection?.estimatedSeconds;
                 const estimateSuffix = estimate ? ` · ~${estimate}s` : '';
                 onProgress?.(`Generating ${startedSection?.title ?? event.sectionId} (${tierLabel}${estimateSuffix})…`);
+                logPrd({
+                    event: 'section_started',
+                    sectionId: event.sectionId,
+                    tier: event.modelTier === 'fast' ? 'fast' : 'strong',
+                    model: event.model,
+                    estimatedSeconds: estimate,
+                    surface,
+                });
                 onSectionStatus?.(event.sectionId as SectionId, {
                     tier: event.modelTier === 'fast' ? 'fast' : 'strong',
                     status: 'generating',
@@ -94,9 +138,17 @@ export const runProgressivePrdPipeline = async (
                 });
             } else if (event.type === 'section_completed') {
                 const ms = performance.now() - (sectionStarts[event.sectionId] ?? overallStart);
-                const section = DEFAULT_PRD_SECTIONS.find(s => s.id === event.sectionId);
+                const section = SECTION_BY_ID[event.sectionId];
                 const tier = section ? selectModelTier(section.risk) : 'strong';
                 onProgress?.(`✓ ${section?.title ?? event.sectionId} (${tier === 'fast' ? 'Flash' : 'Pro'}) · ${(ms / 1000).toFixed(1)}s`);
+                logPrd({
+                    event: 'section_completed',
+                    sectionId: event.sectionId,
+                    tier: tier === 'fast' ? 'fast' : 'strong',
+                    estimatedSeconds: section?.estimatedSeconds,
+                    actualSeconds: ms / 1000,
+                    surface,
+                });
                 onSectionStatus?.(event.sectionId as SectionId, {
                     tier: tier === 'fast' ? 'fast' : 'strong',
                     status: 'complete',
@@ -105,8 +157,16 @@ export const runProgressivePrdPipeline = async (
                 passes.push({ stage: event.sectionId, ms, ok: true });
             } else if (event.type === 'section_error') {
                 const ms = performance.now() - (sectionStarts[event.sectionId] ?? overallStart);
-                const section = DEFAULT_PRD_SECTIONS.find(s => s.id === event.sectionId);
+                const section = SECTION_BY_ID[event.sectionId];
                 const tier = section ? selectModelTier(section.risk) : 'strong';
+                logPrd({
+                    event: 'section_failed',
+                    sectionId: event.sectionId,
+                    tier: tier === 'fast' ? 'fast' : 'strong',
+                    actualSeconds: ms / 1000,
+                    error: event.error,
+                    surface,
+                });
                 onSectionStatus?.(event.sectionId as SectionId, {
                     tier: tier === 'fast' ? 'fast' : 'strong',
                     status: 'error',
@@ -115,7 +175,7 @@ export const runProgressivePrdPipeline = async (
                 });
                 passes.push({ stage: event.sectionId, ms, ok: false });
             } else if (event.type === 'section_refining') {
-                const section = DEFAULT_PRD_SECTIONS.find(s => s.id === event.sectionId);
+                const section = SECTION_BY_ID[event.sectionId];
                 const tier = section ? selectModelTier(section.risk) : 'strong';
                 onSectionStatus?.(event.sectionId as SectionId, {
                     tier: tier === 'fast' ? 'fast' : 'strong',
@@ -128,11 +188,40 @@ export const runProgressivePrdPipeline = async (
     onProgress?.('Merging sections…');
 
     const sectionResults = parseSectionResults(results);
-    const structuredPRD = mergeSectionsToStructuredPrd(sectionResults);
-    const markdown = renderPremiumMarkdown(structuredPRD);
+    let structuredPRD = mergeSectionsToStructuredPrd(sectionResults);
 
     const allJobs = Object.values(jobs);
     const failedSections = allJobs.filter(j => j.status === 'error');
+
+    // Optional final consistency-review pass. Reconciles terminology, names,
+    // duplicates, and contradictions introduced by parallel generation. Skipped
+    // by default (extra model call) and never runs when every section failed
+    // (handled below) or on a heavily-degraded partial. Guarded against detail
+    // loss inside reviewPrdConsistency — a lossy revision is discarded.
+    let reviewed = false;
+    if (enableConsistencyReview && failedSections.length === 0) {
+        onProgress?.('Reviewing for consistency…');
+        const reviewStart = performance.now();
+        try {
+            const review = await reviewPrdConsistency(structuredPRD, { signal });
+            const reviewMs = performance.now() - reviewStart;
+            reviewed = review.applied;
+            if (review.applied) structuredPRD = review.prd;
+            passes.push({ stage: 'consistency_review', ms: reviewMs, ok: true });
+            logPrd({
+                event: 'consistency_review',
+                actualSeconds: reviewMs / 1000,
+                detail: review.applied ? (review.changeLog || 'applied') : 'discarded (no-op or detail-loss guard)',
+                surface,
+            });
+        } catch (e) {
+            // A review failure must never fail the whole generation — keep the
+            // deterministically-merged PRD.
+            console.warn('[prd] consistency review failed; keeping merged PRD.', e);
+        }
+    }
+
+    const markdown = renderPremiumMarkdown(structuredPRD);
 
     // If every section errored, the merged PRD is just stub fields — that's
     // not a "successful" result, it's a total outage (auth/quota/network).
@@ -154,6 +243,12 @@ export const runProgressivePrdPipeline = async (
     }
 
     const totalMs = performance.now() - overallStart;
+    logPrd({
+        event: 'run_completed',
+        totalMs,
+        surface,
+        detail: `${allJobs.length - failedSections.length}/${allJobs.length} sections ok${reviewed ? ', consistency-reviewed' : ''}`,
+    });
 
     return {
         structuredPRD,
@@ -161,7 +256,7 @@ export const runProgressivePrdPipeline = async (
         generationMeta: {
             passes,
             totalMs,
-            revised: false,
+            revised: reviewed,
             schemaVersion: PRD_SCHEMA_VERSION,
         },
         model: `${fastModel} / ${strongModel}`,

--- a/src/store/slices/prdProgressSlice.ts
+++ b/src/store/slices/prdProgressSlice.ts
@@ -9,6 +9,13 @@ export interface PrdProgressEntry {
 
 export interface PrdSectionStatusEntry {
     tier: 'fast' | 'strong';
+    /**
+     * - `pending`    — waiting on dependencies (an upstream section is not done)
+     * - `queued`     — dependencies satisfied, waiting for a free concurrency slot
+     * - `generating` — model call in flight
+     * - `refining`   — optional confidence refinement pass
+     * - `complete` / `error` — settled
+     */
     status: 'pending' | 'queued' | 'generating' | 'complete' | 'error' | 'refining';
     model?: string;
     ms?: number;
@@ -17,6 +24,10 @@ export interface PrdSectionStatusEntry {
     estimatedSeconds?: number;
     /** Wall-clock start timestamp (ms) — set when status flips to 'generating'. */
     startedAt?: number;
+    /** Section ids this section depends on (for the progress UI "Waits on:" hint). */
+    dependsOn?: SectionId[];
+    /** Number of manual retries applied to this section. */
+    retryCount?: number;
 }
 
 export type PrdProgressSlice = {
@@ -78,9 +89,11 @@ export const createPrdProgressSlice: StateCreator<
             const current = state.prdSectionStatus[projectId] ?? {} as Record<SectionId, PrdSectionStatusEntry>;
             const existing = current[sectionId] ?? { tier: update.tier ?? 'strong', status: 'pending' };
             const merged: PrdSectionStatusEntry = { ...existing, ...update };
-            // Stamp wall-clock start the first time a section flips to 'generating'
-            // so the live elapsed counter has a stable origin across re-renders.
-            if (update.status === 'generating' && !merged.startedAt) {
+            // Stamp wall-clock start whenever a section (re)enters 'generating'
+            // so the live elapsed counter has a fresh origin — including on
+            // retry, where a stale startedAt would otherwise show a huge elapsed.
+            // The update itself can override (e.g. carry an explicit startedAt).
+            if (update.status === 'generating' && update.startedAt === undefined) {
                 merged.startedAt = Date.now();
             }
             return {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -8,6 +8,7 @@ import type {
     PreflightMode, PreflightQuestion,
 } from '../types';
 import type { SectionId } from '../lib/schemas/prdSchemas';
+import type { PrdSectionStatusEntry } from './slices/prdProgressSlice';
 
 export interface SpineGenerationMetaInput {
     sourcePrompt?: string;
@@ -153,20 +154,9 @@ export interface ProjectState {
     clearPrdProgress: (projectId: string) => void;
     getPrdProgress: (projectId: string) => { messages: string[]; updatedAt: number } | undefined;
 
-    // Per-section generation status grid (transient — excluded from persist)
-    prdSectionStatus: Record<string, Record<SectionId, {
-        tier: 'fast' | 'strong';
-        status: 'pending' | 'queued' | 'generating' | 'complete' | 'error' | 'refining';
-        model?: string;
-        ms?: number;
-        error?: string;
-    }> | undefined>;
-    setSectionStatus: (projectId: string, sectionId: SectionId, update: Partial<{
-        tier: 'fast' | 'strong';
-        status: 'pending' | 'queued' | 'generating' | 'complete' | 'error' | 'refining';
-        model?: string;
-        ms?: number;
-        error?: string;
-    }>) => void;
+    // Per-section generation status grid (transient — excluded from persist).
+    // Shape is the canonical PrdSectionStatusEntry from the slice.
+    prdSectionStatus: Record<string, Record<SectionId, PrdSectionStatusEntry> | undefined>;
+    setSectionStatus: (projectId: string, sectionId: SectionId, update: Partial<PrdSectionStatusEntry>) => void;
     clearSectionStatus: (projectId: string) => void;
 }


### PR DESCRIPTION
Convert the PRD section pipeline from implicit document-order sequencing to
explicit dependency-based execution, hardening the existing DAG executor and
making the progress model richer.

- Relax over-tight dependencies in DEFAULT_PRD_SECTIONS so independent work
  overlaps: `features` no longer waits on the slow `product_thesis`, and
  `quality_risks`/`ux_loops` drop spurious edges. Sections are now sequenced
  only by true data dependencies, never by position.
- Add validateGraph() (unknown-dependency + cycle detection via Kahn's
  algorithm) and replace the silent deadlock guard with a thrown error.
- Emit a `section_ready` executor event so the UI distinguishes "waiting on
  dependencies" (pending) from "waiting for a concurrency slot" (queued).
- Enrich per-section status with dependsOn and retryCount; restamp startedAt
  on each generating transition so retries show fresh elapsed.
- Add an optional final consistency-review pass (prdConsistencyReview.ts),
  default OFF, that merges over the original and discards detail-losing
  revisions via a guard.
- Add structured, debug-gated observability logging (prdGenerationLog.ts) with
  mobile/web surface context.
- Full progress-UI updates: distinct queued state + icon, "Waits on:" hint,
  "Retried xN" badge, and mobile overflow fixes (truncating model chip).
- Tests for concurrency, per-tier cap, cycle/unknown-dep detection, failure
  isolation, timing capture, state transitions, and the review pass; update
  wave-structure expectations for the relaxed graph.
- Sync CLAUDE.md and README to the DAG pipeline and new progress states.

https://claude.ai/code/session_013q1ac5soUT2cAEP9H8Mobi