### PR TITLE
feat(tour): make /tour a public, portfolio-ready standalone demo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,14 @@ page. It rebuilds six onboarding screens as native UI and teaches the workflow
 through interaction. All content is demo-only (`tourData.ts`); it never touches
 the Gemini pipeline, the `api/` backend, or the Zustand project store.
 
+**Public portfolio demo:** `/tour` and `/about` are deliberately **outside the
+auth gate** in `App.tsx` (no `RequireAuth`), so the tour is a standalone,
+linkable demo that exposes no user data or keys. SPA fallback to `index.html`
+on direct load/refresh is provided by `vercel.json` `rewrites` (Vercel) and
+`public/_redirects` (Netlify / compatible static hosts) — keep both in sync if
+routing changes. `TourPage.tsx`'s header carries Synapse branding + an "Open
+Synapse" CTA back to `/` so it reads as a product demo, not an internal page.
+
 - **Two modes, one source of truth.** `src/lib/useTourState.ts` is a
   `useReducer` (`tourReducer` + `initialTourState`, both exported for tests)
   holding `{ activeIndex, mode, direction }`. **Guided** mode (first-timers)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,43 @@ all from a single client-side workspace.
 
 ---
 
+## Live demo (portfolio-safe)
+
+The interactive product tour is a **public, standalone demo** you can link to
+directly from a portfolio or résumé:
+
+- **Public URL:** `https://<your-deployment>/tour` (alias: `/about`)
+- **No authentication** — the route is not behind the auth gate.
+- **Demo data only** — every screen renders local fixtures
+  (`src/components/tour/tourData.ts`). It never calls Gemini, never touches the
+  `api/` backend or the project store, and never reads or exposes an API key or
+  any user data.
+- **Deep-linkable** — open or refresh `/tour` directly; the SPA rewrite (see
+  [Deploying the tour](#deploying-the-tour-static-hosting)) serves
+  `index.html`, so there is no 404.
+- **Mobile-first** — responsive layout with swipe navigation and reduced-motion
+  support.
+
+### Paste-into-your-portfolio markdown
+
+```markdown
+### Synapse — AI-native product definition environment
+
+From a plain-language idea to a structured PRD, UI mockups, and downstream
+engineering artifacts — all in one client-side workspace.
+
+▶️ **[Try the interactive demo](https://<your-deployment>/tour)** ·
+📂 **[Source on GitHub](https://github.com/<you>/synapse)**
+
+*The demo runs entirely on local sample data — no sign-up, no API key, no
+backend calls.*
+```
+
+> Replace `<your-deployment>` with your live host (e.g. your Vercel URL) and
+> `<you>` with your GitHub username before publishing.
+
+---
+
 ## What it does
 
 A single prompt flows from a plain-language idea to a finalized blueprint and
@@ -271,6 +308,27 @@ at lower image quality.
 ```bash
 npm run build
 ```
+
+The build emits a fully static SPA to `dist/` — no server is required to serve
+the tour.
+
+### Deploying the tour (static hosting)
+
+Because Synapse is a client-side SPA, every host must fall back to
+`index.html` for unknown paths, or a direct load / refresh of `/tour` (or
+`/about`, `/p/:id`, `/privacy`) returns a 404. The repo ships the config for
+the common hosts:
+
+| Host | Config (already in repo) | Notes |
+| --- | --- | --- |
+| **Vercel** (recommended) | `vercel.json` → `rewrites` | The full app, including the recruiter-portal `api/` functions, deploys as-is. The negative-lookahead rewrite (`/((?!api/).*)`) keeps API routes server-side while sending everything else to `index.html`. |
+| **Netlify** | `public/_redirects` → `/*  /index.html  200` | Copied verbatim into `dist/` on build. Serves the static tour; the `api/` serverless functions are Vercel-specific. |
+| **GitHub Pages** | — | Static-only (no `api/`). Pages has no rewrite engine, so use the SPA fallback trick — copy `dist/index.html` to `dist/404.html` after build. If serving from a project subpath (`/<repo>/`), also set Vite's `base` accordingly. |
+
+**Recommendation:** deploy to **Vercel** — it's the configured target, supports
+the SPA rewrite and the backend functions, and serves `/tour` directly. For a
+**tour-only** portfolio link, Netlify or GitHub Pages also work since the tour
+needs no backend.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,9 +1,11 @@
 # Deployment
 
-Synapse is a fully static SPA. There are no server secrets, no managed
-database, and no serverless functions. Users bring their own Gemini API
-key, which is stored in their browser's `localStorage` via the in-app
-Settings modal.
+The Synapse product workspace is a fully client-side SPA: users bring their
+own Gemini API key, stored in their browser's `localStorage` (or the encrypted
+provider-key vault) via the in-app Settings modal. The public product tour at
+`/tour` needs no key at all — it runs on local demo data. A separate
+recruiter-portal sub-product adds Vercel serverless functions under `api/`
+(MongoDB-backed); those are Vercel-specific and unrelated to the tour.
 
 ## Local development
 
@@ -28,23 +30,43 @@ Projects and keys persist across reloads via `localStorage`.
 | `npm run test` | Vitest suite (jsdom environment) |
 | `npx tsc --noEmit` | Typecheck without emitting |
 
-## Vercel
+## Vercel (recommended)
 
-Deployment is a straight static upload. The entire configuration lives in
-`vercel.json`:
+Deployment configuration lives in `vercel.json`. The recruiter-portal backend
+runs as serverless functions under `api/`, so the SPA rewrite uses a
+negative-lookahead to leave `/api/*` server-side and send everything else to
+`index.html`:
 
 ```json
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }
 ```
 
-The single SPA rewrite makes React Router's client-side routes (`/about`,
-`/p/:projectId`) work on direct navigation and page refresh.
+That rewrite makes React Router's client-side routes — including the public,
+unauthenticated product tour at `/tour` (aliased `/about`), plus
+`/p/:projectId` and `/privacy` — resolve on direct navigation and page refresh
+instead of 404ing.
+
+## Static SPA routing on other hosts
+
+The product tour is a fully client-side, demo-data-only route, so it can be
+served from any static host as a portfolio link. Every host just needs an
+SPA fallback to `index.html`:
+
+- **Netlify** — `public/_redirects` (shipped in the repo) is copied into
+  `dist/` on build and provides `/*  /index.html  200`.
+- **GitHub Pages** — has no rewrite engine; after `npm run build`, copy
+  `dist/index.html` to `dist/404.html` so unknown paths still load the SPA. If
+  you serve from a project subpath (`https://<user>.github.io/<repo>/`), set
+  Vite's `base` to `/<repo>/` as well.
+
+Note the `api/` serverless functions are Vercel-specific — Netlify and GitHub
+Pages serve the static front end (including the tour) only.
 
 ### Environment variables
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,5 @@
+# SPA fallback for static hosts (Netlify and compatible).
+# Every non-asset path is served index.html so React Router can resolve
+# client-side routes — including /tour and /about — on direct load and refresh.
+# Vercel uses the equivalent "rewrites" rule in vercel.json instead.
+/*    /index.html   200

--- a/src/components/tour/TourPage.tsx
+++ b/src/components/tour/TourPage.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useEffect, type ComponentType } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { useTourState } from '../../lib/useTourState';
 import { useIsMobile } from '../../lib/useIsMobile';
@@ -62,22 +62,41 @@ export function TourPage() {
 
     return (
         <div className="flex h-[100dvh] flex-col bg-neutral-900 text-neutral-100">
-            {/* Header */}
+            {/* Header — branded so the tour reads as a product demo, not an
+                internal step-through. The wordmark and the "Open Synapse" CTA
+                both lead back to the live app. */}
             <header className="flex items-center justify-between gap-3 px-5 pt-[calc(env(safe-area-inset-top)+1rem)] sm:px-8">
-                <div className="flex items-center gap-2.5">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-600 text-lg font-bold text-white">
-                        {activeIndex + 1}
+                <div className="flex min-w-0 items-center gap-3">
+                    <Link
+                        to="/"
+                        aria-label="Synapse home"
+                        className="flex min-w-0 items-center gap-2.5 transition hover:opacity-90"
+                    >
+                        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-600 text-lg font-bold text-white">
+                            S
+                        </span>
+                        <span className="flex min-w-0 flex-col leading-tight">
+                            <span className="text-sm font-semibold text-white">Synapse</span>
+                            <span className="hidden truncate text-[11px] text-neutral-500 sm:block">
+                                From plain-language to product blueprint
+                            </span>
+                        </span>
+                    </Link>
+                    <span className="hidden items-center rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-200 md:inline-flex">
+                        Interactive demo
                     </span>
-                    <span className="text-sm text-neutral-500">/ {TOTAL_STEPS}</span>
                 </div>
                 <div className="flex items-center gap-3">
+                    <span className="hidden text-xs text-neutral-500 sm:inline" aria-hidden="true">
+                        {activeIndex + 1} / {TOTAL_STEPS}
+                    </span>
                     <ModeToggle mode={mode} onChange={(m) => dispatch({ type: 'SET_MODE', mode: m })} />
                     <button
                         type="button"
                         onClick={finish}
                         className="text-sm font-medium text-neutral-400 transition hover:text-white"
                     >
-                        Skip
+                        Open Synapse
                     </button>
                 </div>
             </header>


### PR DESCRIPTION
Audit + harden the interactive product tour so it works as a publicly
linkable portfolio demo with no auth and demo-only data.

- TourPage header: add Synapse branding (wordmark + "From plain-language
  to product blueprint" tagline + "Interactive demo" badge) and an
  "Open Synapse" CTA back to the app, so the route reads as a product
  demo instead of an internal step-through. Responsive: tagline/badge/
  step-count collapse on small screens.
- Add public/_redirects so non-Vercel static hosts (Netlify) serve
  index.html for /tour, /about, and the other SPA routes on direct load
  and refresh. Vercel already handles this via vercel.json rewrites.
- README: new "Live demo (portfolio-safe)" section with the public URL
  placeholder, paste-into-portfolio markdown snippet, and the
  unauthenticated/demo-data-only guarantees; plus a "Deploying the tour"
  table covering Vercel (recommended) / Netlify / GitHub Pages.
- docs/deployment.md: correct the stale SPA rewrite snippet to match the
  real negative-lookahead rule, note the api/ serverless functions, and
  document static-host SPA fallback for the tour.
- CLAUDE.md: document the tour's public-route guarantee and the dual SPA
  fallback (vercel.json + public/_redirects).

The tour touches no Gemini pipeline, api/ backend, or project/auth store
and makes zero API calls; verified the production build, /tour + /about
returning index.html (200) on direct load, lint, and the full test suite.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DuqEgdYHFb7SaEBGNS3rrD