### PR TITLE
fix(auth): resolve loginCount conflict in OAuth user upsert

### DIFF
--- a/api/_lib/__tests__/usersUpsert.test.js
+++ b/api/_lib/__tests__/usersUpsert.test.js
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression guard for the OAuth upsert. The mongodb server rejects an update
+// that touches the same field path in two operators (code 40,
+// "would create a conflict"). upsertOAuthUser previously seeded loginCount in
+// BOTH $setOnInsert and $inc, which blew up every OAuth sign-in once a live DB
+// was actually reachable. Assert the update never reintroduces that conflict.
+
+const runMongoAction = vi.fn();
+vi.mock('../db.js', () => ({ runMongoAction: (...a) => runMongoAction(...a) }));
+
+let upsertOAuthUser;
+
+beforeEach(async () => {
+  vi.resetModules();
+  runMongoAction.mockReset();
+  ({ upsertOAuthUser } = await import('../users.js'));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('upsertOAuthUser update shape', () => {
+  it('does not reference loginCount in more than one update operator', async () => {
+    // findUserByProvider (no existing user) then the updateOne upsert.
+    runMongoAction.mockResolvedValueOnce({ document: null }); // findUserByProvider
+    runMongoAction.mockResolvedValueOnce({ document: null }); // findAnyUserByEmail
+    runMongoAction.mockResolvedValueOnce({ matchedCount: 0, modifiedCount: 0, upsertedId: { _id: 'x' } });
+
+    await upsertOAuthUser({
+      authProvider: 'github',
+      providerUserId: '12345',
+      email: 'new@example.com',
+      name: 'New User',
+    });
+
+    const updateCall = runMongoAction.mock.calls.find(([action]) => action === 'updateOne');
+    expect(updateCall).toBeTruthy();
+    const [, payload] = updateCall;
+    const { update } = payload;
+
+    // loginCount may appear in $inc, but must NOT also be in $setOnInsert/$set.
+    const inInc = update.$inc && 'loginCount' in update.$inc;
+    const inSetOnInsert = update.$setOnInsert && 'loginCount' in update.$setOnInsert;
+    const inSet = update.$set && 'loginCount' in update.$set;
+
+    expect(inInc).toBe(true);
+    expect(inSetOnInsert).toBe(false);
+    expect(inSet).toBe(false);
+
+    // Collect every field path across all operators — no path may repeat.
+    const paths = [];
+    for (const op of ['$set', '$setOnInsert', '$inc']) {
+      if (update[op]) paths.push(...Object.keys(update[op]));
+    }
+    const dupes = paths.filter((p, i) => paths.indexOf(p) !== i);
+    expect(dupes).toEqual([]);
+  });
+});

--- a/api/_lib/users.js
+++ b/api/_lib/users.js
@@ -251,8 +251,11 @@ export async function upsertOAuthUser({
       $setOnInsert: {
         createdAt: now,
         firstLoginAt: now,
-        loginCount: 0,
       },
+      // $inc creates loginCount as 1 on insert and increments it on every
+      // subsequent login. Do NOT also seed loginCount via $setOnInsert — Mongo
+      // rejects the same field path in two update operators ("would create a
+      // conflict at 'loginCount'").
       $inc: { loginCount: 1 },
     },
     upsert: true,


### PR DESCRIPTION
## Summary

Follow-up to #151. With the MongoDB driver now connected, OAuth sign-in got far enough to actually write to the database — and surfaced a latent bug. Every GitHub/LinkedIn sign-in failed with:

```
MongoServerError: Updating the path 'loginCount' would create a conflict at 'loginCount' (code 40)
    at runMongoAction (api/_lib/db.js)
    at upsertOAuthUser (api/_lib/users.js:246)
```

`upsertOAuthUser` referenced `loginCount` in **two** update operators at once — `$setOnInsert: { loginCount: 0 }` **and** `$inc: { loginCount: 1 }`. MongoDB forbids the same field path in more than one operator in a single update. (This never fired before because the OAuth path never reached a live DB write — the retired Data API failed earlier.)

## Fix

Drop the redundant `loginCount: 0` from `$setOnInsert`. `$inc` already creates the field as `1` on insert and increments it on subsequent logins, so behavior is unchanged — minus the illegal conflict.

## Test

- New regression test (`api/_lib/__tests__/usersUpsert.test.js`) asserts no field path appears in more than one update operator (`$set` / `$setOnInsert` / `$inc`), so this can't silently come back.
- Full suite: **476 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TawKMScXUnToYCrTskjx2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TawKMScXUnToYCrTskjx2p)_