### PR TITLE
feat(auth): sign-out UI + clear local browser keys on logout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,15 @@ rules:
   `App.tsx` gate the workspace (the read-only `DEMO_PROJECT_ID` stays public).
   Every private API route resolves identity **only** through
   `api/_lib/requireUser.js` (verified session cookie) — never a client-supplied
-  id.
+  id. **Sign-out** is exposed in the `HomePage` header and the
+  `ProjectWorkspace` overflow menu; `authStore.logout()` clears the session
+  cookie, the in-memory provider session, and (via
+  `providerSession.clearLocalProviderKeys()`) the **un-namespaced** local
+  credential keys (`GEMINI_API_KEY`/`OPENAI_API_KEY`/`GITHUB_TOKEN`) so a
+  different account signing in on the same browser can't inherit them. Local
+  keys are cleared only on an **explicit** logout, not on passive "no session"
+  resolution. The header signed-in label derives from `user.authProvider`
+  (`HomePage.providerLabel`) — don't hardcode a provider name.
 - **Projects are namespaced per user in localStorage.** `userScope.ts` maps the
   active `userId` to the persist key (`createDebouncedStorage`'s `resolveName`
   override); `projectUserSync.applyProjectUser()` wipes in-memory state and

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useProjectStore } from '../store/projectStore';
-import { Settings, List, Plus, ArrowUp, Sparkles, Smartphone, Monitor, Loader2, Compass } from 'lucide-react';
+import { Settings, List, Plus, ArrowUp, Sparkles, Smartphone, Monitor, Loader2, Compass, LogOut } from 'lucide-react';
+import type { AuthProvider } from '../lib/recruiterApi';
 import { SettingsModal } from './SettingsModal';
 import { ProjectDrawer } from './ProjectDrawer';
 import { PreflightModeChoice } from './preflight/PreflightModeChoice';
@@ -11,6 +12,18 @@ import type { ProjectPlatform, PreflightMode } from '../types';
 import { useAuthStore } from '../store/authStore';
 import { useToastStore } from '../store/toastStore';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
+
+// Human-readable name for the account's sign-in method (the header used to
+// hardcode "via LinkedIn" regardless of the actual provider).
+function providerLabel(provider: AuthProvider | undefined): string {
+    switch (provider) {
+        case 'github': return 'GitHub';
+        case 'google': return 'Google';
+        case 'linkedin': return 'LinkedIn';
+        case 'email': return '';
+        default: return '';
+    }
+}
 
 const EXAMPLE_PROMPTS = [
     {
@@ -44,8 +57,28 @@ export function HomePage() {
     const { createProject, initPreflightSession, loadDemoProject } = useProjectStore();
     const navigate = useNavigate();
     const user = useAuthStore((s) => s.user);
+    const logout = useAuthStore((s) => s.logout);
 
     const [isLoadingDemo, setIsLoadingDemo] = useState(false);
+    const [isSigningOut, setIsSigningOut] = useState(false);
+
+    const handleSignOut = async () => {
+        if (isSigningOut) return;
+        setIsSigningOut(true);
+        try {
+            await logout();
+            // On success the auth store clears `user`, and the app's HomeRoute
+            // re-renders the LoginPage automatically — no manual navigation.
+        } catch (err) {
+            console.error('[handleSignOut] failed', err);
+            useToastStore.getState().addToast({
+                type: 'warning',
+                title: 'Sign out failed',
+                message: err instanceof Error ? err.message : 'Please try again.',
+            });
+            setIsSigningOut(false);
+        }
+    };
 
     const handleOpenDemo = async () => {
         if (isLoadingDemo) return;
@@ -188,7 +221,7 @@ export function HomePage() {
                 <div className="flex items-center gap-2">
                     {user && (
                         <div className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-200 text-sm">
-                            Signed in as {user.name} via LinkedIn
+                            Signed in as {user.name}{providerLabel(user.authProvider) ? ` via ${providerLabel(user.authProvider)}` : ''}
                         </div>
                     )}
                     <button
@@ -198,6 +231,16 @@ export function HomePage() {
                     >
                         <Settings size={18} />
                     </button>
+                    {user && (
+                        <button
+                            onClick={handleSignOut}
+                            disabled={isSigningOut}
+                            className="p-2.5 text-neutral-400 hover:text-white hover:bg-white/10 rounded-xl transition-all border border-white/5 hover:border-white/10 disabled:opacity-60 disabled:cursor-wait"
+                            title="Sign out"
+                        >
+                            {isSigningOut ? <Loader2 size={18} className="animate-spin" /> : <LogOut size={18} />}
+                        </button>
+                    )}
                     <button
                         onClick={() => setIsDrawerOpen(true)}
                         className="p-2.5 text-neutral-400 hover:text-white hover:bg-white/10 rounded-xl transition-all border border-white/5 hover:border-white/10"

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useProjectStore } from '../store/projectStore';
+import { useAuthStore } from '../store/authStore';
 import { ChevronLeft, RefreshCcw, LogOut, CheckCircle, Cloud, Download, Settings, ChevronDown, ChevronRight, PanelRightOpen, PanelRightClose, MoreHorizontal, Loader2, ArrowRight } from 'lucide-react';
 import { useState, useRef, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
@@ -41,6 +42,8 @@ import { DEMO_PROJECT_ID } from '../data/demoProject';
 export function ProjectWorkspace() {
     const { projectId } = useParams<{ projectId: string }>();
     const navigate = useNavigate();
+    const authUser = useAuthStore((s) => s.user);
+    const logout = useAuthStore((s) => s.logout);
     const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, markSpineFinal, setProjectStage, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, getArtifacts, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus } = useProjectStore();
     const prdProgress = useProjectStore((s) => (projectId ? s.prdProgress[projectId] : undefined));
     const prdSectionStatus = useProjectStore((s) => (projectId ? s.prdSectionStatus[projectId] : undefined));
@@ -561,6 +564,23 @@ export function ProjectWorkspace() {
                                     <LogOut size={14} />
                                     Abandon Session
                                 </button>
+                                {authUser && (
+                                    <button
+                                        onClick={async () => {
+                                            setShowNavOverflow(false);
+                                            try {
+                                                await logout();
+                                                // RequireAuth sends the now-signed-out user to "/".
+                                            } catch (err) {
+                                                console.error('[workspace sign out] failed', err);
+                                            }
+                                        }}
+                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition border-t border-white/5"
+                                    >
+                                        <LogOut size={14} className="text-neutral-500" />
+                                        Sign out
+                                    </button>
+                                )}
                             </div>,
                             document.body,
                         )}

--- a/src/lib/providerSession.ts
+++ b/src/lib/providerSession.ts
@@ -24,3 +24,29 @@ export function clearProviderSession(): void {
   setImageProviderConfigured(false);
   clearGeminiKey();
 }
+
+// localStorage keys holding credential material for the optional "local browser
+// keys" fallback. These are NOT user-namespaced (unlike projects), so they are
+// shared by anyone using the same browser profile. We wipe them on an explicit
+// sign-out so a different account signing in afterward never inherits the
+// previous user's keys. (The encrypted server vault is per-user and unaffected.)
+const LOCAL_CREDENTIAL_KEYS = [
+  'GEMINI_API_KEY',
+  'OPENAI_API_KEY',
+  'GITHUB_TOKEN',
+];
+
+/**
+ * Remove local-browser credential material from this browser. Called on an
+ * explicit logout only — not on passive "no session" resolution — so anonymous
+ * page loads don't wipe a user's offline fallback keys.
+ */
+export function clearLocalProviderKeys(): void {
+  try {
+    for (const key of LOCAL_CREDENTIAL_KEYS) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // localStorage unavailable (private mode, etc.) — nothing to clear.
+  }
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -7,7 +7,7 @@ import {
   signupWithEmail,
 } from '../lib/recruiterApi';
 import { applyProjectUser } from './projectUserSync';
-import { primeProviderSession, clearProviderSession } from '../lib/providerSession';
+import { primeProviderSession, clearProviderSession, clearLocalProviderKeys } from '../lib/providerSession';
 
 // Real authentication is ON by default. For local development without the
 // MongoDB/session backend running, opt into a bypass by setting
@@ -95,6 +95,10 @@ export const useAuthStore = create<AuthState>((set) => {
         return; // no-op in dev mode
       }
       await logoutRequest();
+      // Explicit sign-out: also wipe local-browser credential keys so the next
+      // account to sign in on this browser can't inherit them. The per-user
+      // encrypted server vault is unaffected (it's keyed by userId server-side).
+      clearLocalProviderKeys();
       setUser(null);
     },
   };


### PR DESCRIPTION
## Summary

Two issues raised after GitHub sign-in worked: (1) there was **no way to sign out**, and (2) a verification of per-user data isolation surfaced one gap in the **local-browser-keys** fallback.

## Isolation audit (what was verified)

- **Projects** — isolated per user. `userScope.ts` namespaces the persist key (`synapse-projects-storage::u:<userId>`); `projectUserSync.applyProjectUser()` wipes + rehydrates on every auth transition.
- **Encrypted server vault** (recommended key storage) — fully isolated. Per-`(userId, provider)` AES-256-GCM with owner-bound AAD; every `/api/provider-keys` call is gated by `requireUser` (session cookie only). Another account sees only its own keys; status returns masked `…last4` only.
- **Gap found:** the optional "Local browser keys" fields write raw `GEMINI_API_KEY`/`OPENAI_API_KEY`/`GITHUB_TOKEN` to localStorage **un-namespaced**, so on a shared browser a second account could inherit them.

## Changes

- **Sign Out** in the `HomePage` header and the `ProjectWorkspace` overflow menu (authenticated users only; the public demo is unaffected).
- `authStore.logout()` now also calls `providerSession.clearLocalProviderKeys()` to wipe the un-namespaced local credential keys on **explicit** sign-out (not on passive no-session loads). The per-user server vault is untouched.
- Fix the header label that hardcoded "via LinkedIn" → derives from `user.authProvider`.
- CLAUDE.md updated.

## Verification

`tsc --noEmit`, `eslint .` clean; **476 tests pass**; `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TawKMScXUnToYCrTskjx2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TawKMScXUnToYCrTskjx2p)_