### PR TITLE
Add OAuth redirect_uri debugging and logging

### DIFF
--- a/api/auth/[provider].js
+++ b/api/auth/[provider].js
@@ -53,6 +53,36 @@ export default async function handler(req, res) {
     const state = crypto.randomBytes(16).toString('hex');
     const authUrl = provider.createAuthUrl(config, state);
 
+    // Surface the redirect_uri in server logs so configuration mismatches
+    // ("The redirect_uri does not match the registered value") can be
+    // diagnosed by checking Vercel function logs.
+    console.log(
+      `[oauth init ${providerName}] redirect_uri=${config.redirectUri} baseUrl=${baseUrl}`,
+    );
+
+    // ?debug=1 short-circuits the redirect and returns the values Synapse
+    // would have sent to the provider. Hit /api/auth/<provider>?debug=1 to
+    // confirm what URL to register in the provider's developer portal.
+    // None of the returned fields are secret (clientId and redirect_uri are
+    // sent unencrypted to the provider in the normal flow).
+    if (req.query?.debug === '1') {
+      const envKey = `${providerName.toUpperCase()}_REDIRECT_URI`;
+      return json(res, 200, {
+        provider: providerName,
+        baseUrl,
+        redirectUri: config.redirectUri,
+        clientId: config.clientId,
+        scopes: config.scopes,
+        authUrl,
+        envOverride: Boolean(process.env[envKey]),
+        envOverrideKey: envKey,
+        hint:
+          `Register "redirectUri" above (exactly) as an authorized redirect URL ` +
+          `in the ${providerName} app, or set ${envKey} to a URL you have already ` +
+          `registered. Remove ?debug=1 to start the real OAuth flow.`,
+      });
+    }
+
     const secure = process.env.NODE_ENV === 'production';
     res.setHeader(
       'Set-Cookie',

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -122,6 +122,38 @@ developer console:
   callback URL
 - LinkedIn Developer Portal → App → Auth → Redirect URLs
 
+### Debugging "redirect_uri does not match the registered value"
+
+If the provider's OAuth page rejects the request with a redirect_uri
+mismatch, the `redirect_uri` Synapse generated does not exactly match the
+URL you registered in the provider's developer portal. Append `?debug=1`
+to the OAuth init endpoint to see the exact value Synapse would send,
+without starting the flow:
+
+```
+GET /api/auth/linkedin?debug=1
+GET /api/auth/google?debug=1
+GET /api/auth/github?debug=1
+```
+
+The response is JSON with `redirectUri`, the constructed `authUrl`,
+`baseUrl` (derived from the request's `x-forwarded-host`/`host`), and
+`envOverride` (whether `<PROVIDER>_REDIRECT_URI` is set in the
+environment). The same `redirect_uri` is also logged server-side on
+every real init (visible in Vercel function logs) as
+`[oauth init <provider>] redirect_uri=…`.
+
+Common causes:
+
+- **Vercel preview deployments** — each preview has its own
+  `*.vercel.app` host, and only the URLs you explicitly registered with
+  the provider are accepted. Either register the preview URL too, or set
+  `<PROVIDER>_REDIRECT_URI` to your canonical production URL so every
+  deployment sends the same value.
+- **Custom domain vs. `*.vercel.app`** — registering
+  `https://synapse.example.com/...` but visiting the raw Vercel URL.
+- **`www.` vs. apex domain**, or trailing slash differences.
+
 ## Account-linking policy
 
 If a user signs up with email `alex@example.com` and later tries to sign in

--- a/docs/linkedin-auth.md
+++ b/docs/linkedin-auth.md
@@ -51,3 +51,14 @@ Synapse requests only:
 - `email`
 
 No posting, messaging, or write scopes are requested.
+
+## Troubleshooting
+
+If LinkedIn's OAuth page rejects the request with **"The redirect_uri
+does not match the registered value"**, hit
+`GET /api/auth/linkedin?debug=1` to see the exact `redirect_uri` Synapse
+is sending, then register that URL in the LinkedIn Developer Portal
+under App → Auth → Authorized redirect URLs (or set
+`LINKEDIN_REDIRECT_URI` to one you have already registered). See the
+debugging section in [`docs/auth.md`](auth.md) for the full
+explanation.


### PR DESCRIPTION
## Summary

Add debugging tools and improved logging to help diagnose OAuth `redirect_uri` mismatches, a common configuration issue when registering OAuth apps with providers (Google, GitHub, LinkedIn).

## Changes

- **New debug endpoint** (`?debug=1`): Added a query parameter to OAuth init endpoints (`/api/auth/<provider>?debug=1`) that returns the exact `redirect_uri`, `authUrl`, `baseUrl`, and environment override status without starting the OAuth flow. This lets developers confirm their registered redirect URL matches what Synapse will send.

- **Server-side logging**: Every real OAuth init now logs the constructed `redirect_uri` and `baseUrl` to Vercel function logs, making it easy to spot mismatches by inspecting logs after a failed OAuth attempt.

- **Comprehensive debugging guide** (`docs/auth.md`): Added a new "Debugging redirect_uri does not match the registered value" section that explains:
  - How to use the `?debug=1` endpoint
  - What fields are returned and what they mean
  - Common causes (Vercel preview deployments, custom domain vs. `*.vercel.app`, `www.` vs. apex domain, trailing slashes)
  - How to set `<PROVIDER>_REDIRECT_URI` environment variable as a workaround

- **LinkedIn-specific troubleshooting** (`docs/linkedin-auth.md`): Added a troubleshooting section with a quick reference to the debug endpoint and link to the full explanation in `auth.md`.

## Implementation Details

- The debug response includes `provider`, `baseUrl`, `redirectUri`, `clientId`, `scopes`, `authUrl`, `envOverride` (boolean), `envOverrideKey`, and a helpful hint message.
- All returned fields are non-secret (clientId and redirect_uri are sent unencrypted to the provider in normal OAuth flow).
- The debug endpoint short-circuits the redirect and returns JSON instead of starting the OAuth flow.
- Logging uses the existing console.log infrastructure visible in Vercel function logs.

https://claude.ai/code/session_014s8BTWSsfzw4scwisj6kw1