### PR TITLE
Add orchestration metrics dashboard + real token capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ navigate to `/p/:projectId` **without** starting PRD generation.
 
 ### State (`src/store/`)
 
-`useProjectStore` is one Zustand store composed from 9 slices in
+`useProjectStore` is one Zustand store composed from 10 slices in
 `src/store/slices/`:
 
 - `projectSlice` — Project CRUD, current stage
@@ -296,6 +296,13 @@ navigate to `/p/:projectId` **without** starting PRD generation.
   (todo/in_progress/done) and `recordTaskExports` (attach created
   GitHub/Linear issue refs) drive progress tracking. **Persisted** — not
   stripped from localStorage.
+- `metricsSlice` — Persisted orchestration metrics (`WorkflowRun[]` keyed by
+  projectId, newest-first, capped at 50/project). `recordWorkflowRun` appends a
+  run; `getWorkflowRuns`/`getAllWorkflowRuns`/`clearWorkflowRuns` read/clear.
+  Append-only and **persisted** — the metric math lives in `src/lib/metrics/`
+  (pure) before a run is recorded. Cleaned up in `deleteProject` and included
+  in `emptyPersistedState()` (`projectUserSync.ts`). See "Orchestration metrics"
+  below.
 
 The store's `partialize` strips `jobs` and `prdProgress` so they don't
 persist. `onRehydrateStorage` migrates legacy `currentStage` values
@@ -685,6 +692,41 @@ Synapse" CTA back to `/` so it reads as a product demo, not an internal page.
   pieces in `components/`: `ScreenShell`, `GenerationStep`, `RefineMenu`,
   `ArtifactDrawer` (mobile bottom-sheet / desktop side-drawer, mirrors
   `SelectionActionDialog`'s responsive pattern), `NodeGraph`.
+
+### Orchestration metrics (`src/lib/metrics/`, `src/components/metrics/`)
+
+A measurable view of the concurrent multi-agent workflows. **Important context:
+PRD section generation was already genuinely concurrent** (the DAG executor —
+see the LLM layer) before this; the metrics layer makes that concurrency
+*visible*, it did not introduce it. See `docs/ORCHESTRATION_AND_METRICS.md`.
+
+- **Token capture.** `callGemini` reads Gemini's `usageMetadata` and surfaces it
+  via an optional `JsonModeConfig.onUsage` callback (callGemini still returns the
+  same `string` — no call site breaks). The PRD section worker threads it
+  through `ModelProvider.generateText` → `makeJsonProvider` and emits it on the
+  `section_completed` event. **New provider call sites that want token metrics
+  must forward `onUsage`.** (Artifact services don't yet — a documented TODO.)
+- **Pure metric math** (`src/lib/metrics/`, unit-tested, no store/LLM access):
+  `workflowMetrics.ts` (sequential estimate, actual runtime, speedup, max/avg
+  concurrency via interval sweep, critical path via memoized DFS),
+  `modelPricing.ts` (approximate per-model $/1M-token table → cost **estimates**,
+  surfaced as "est."), and `buildWorkflowRun.ts` (assembles a `WorkflowRun` from
+  per-node observations; derives `parallelGroupId` as a topological wave when not
+  supplied). Both pipelines feed `buildWorkflowRun` so PRD and artifact runs are
+  computed identically.
+- **Recording is decoupled + defensive.** `progressivePrdPipeline` accumulates
+  per-section node observations from the lifecycle events it already emits and
+  fires `onWorkflowRun(run)` once at completion (threaded through `prdService`);
+  `artifactJobController.executeJob` does the same for the artifact bundle.
+  Identity (projectId/projectName) is stamped at the call site
+  (`runPrdGeneration.ts`, `ProjectWorkspace.handleRegenerate`) before
+  `recordWorkflowRun`. **All run assembly is wrapped in try/catch — metrics can
+  never break a generation run.**
+- **Dashboard** at `/metrics` (auth-gated route in `App.tsx`, linked from the
+  Settings modal and the workspace overflow menu): `MetricsPage` (stable
+  `EMPTY_RUNS` selector fallback per the Selector-stability rule),
+  `MetricsOverviewCards`, `WorkflowRunsTable`, `WorkflowRunDetail` (Gantt bars +
+  node table). **No synthetic/demo data** — a fresh user sees an empty state.
 
 ### Domain types
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ You get back a structured PRD with vision, target users, core problems,
 features (with priority, acceptance criteria, and dependencies), architecture,
 metrics, risks, and non-functional requirements.
 
+That concurrency is **measured, not just claimed**. An **Orchestration
+Metrics** dashboard (`/metrics`, linked from Settings and the workspace menu)
+records each PRD generation and artifact-bundle run and shows real telemetry:
+sequential estimate vs. actual runtime, **parallel speedup** and time saved,
+max/average concurrency, critical path, per-section token usage, and estimated
+AI cost — with a per-run Gantt timeline that visualizes which agents ran in
+parallel. Cost figures are clearly labeled estimates; there's no synthetic
+data, so a fresh account shows an empty state until the first real run.
+
 ### 3. Refine specific parts of the document
 
 Highlight any passage and improve it without rewriting everything. A
@@ -358,6 +367,10 @@ needs no backend.
 - [`docs/AUTH_AND_PROVIDER_KEYS.md`](docs/AUTH_AND_PROVIDER_KEYS.md) — per-user
   projects, the encrypted BYO provider-key vault, server-side model routing,
   and the demo/recruiter mode
+- [`docs/ORCHESTRATION_AND_METRICS.md`](docs/ORCHESTRATION_AND_METRICS.md) —
+  how the concurrent multi-agent workflows run, the `/metrics` dashboard, and
+  what each metric means (sequential estimate vs. actual runtime, speedup,
+  concurrency, critical path, cost estimates)
 - [`docs/linkedin-auth.md`](docs/linkedin-auth.md) — LinkedIn OAuth setup,
   recruiter capture fields, and compliance note
 - [`docs/archive/`](docs/archive/) — historical design notes and audits

--- a/docs/ORCHESTRATION_AND_METRICS.md
+++ b/docs/ORCHESTRATION_AND_METRICS.md
@@ -1,0 +1,108 @@
+# Orchestration & Workflow Metrics
+
+This document describes how Synapse runs its multi-agent workflows
+concurrently and how the orchestration **Metrics** dashboard (`/metrics`)
+measures that concurrency.
+
+## TL;DR — was concurrency working before this change?
+
+**Yes.** PRD section generation was already genuinely concurrent before any of
+the metrics work. The earlier suspicion that it ran "sequentially despite the
+intended architecture" was not borne out by the code. What was missing was
+**measurement**, **token/cost capture**, and a **user-facing surface** — which
+is what this change adds. No generation behavior was rewritten.
+
+## How PRD generation runs (the evidence)
+
+PRD generation is a **dependency-graph (DAG) executor**, not document-order
+generation:
+
+- `src/lib/services/progressivePrdGeneration.ts` → `runDag()` builds the
+  dependency graph from `DEFAULT_PRD_SECTIONS` (10 schema-aligned sections),
+  validates it (Kahn's algorithm, rejects cycles/unknown deps), then dispatches
+  every section whose dependencies are satisfied **up to per-tier concurrency
+  caps**. In-flight section promises are collected and awaited together
+  (`await Promise.all(running)`); the loop unblocks on *any* completion
+  (`waitForTick`) to dispatch more. There is **no `await`-in-loop**
+  serialization.
+- Caps default to `maxFastConcurrency: 4` / `maxStrongConcurrency: 3`
+  (`progressivePrdPipeline.ts`). Low-risk sections use the fast (Flash) model,
+  high-risk the strong (Pro) model — each tier has an independent slot budget so
+  one tier's rate limit doesn't starve the other.
+- Dependencies are **true data dependencies only** (a section lists another
+  only when it consumes that section's output as prompt context), so the graph
+  fans out aggressively.
+
+Downstream artifacts are also concurrent: `artifactJobController.ts` runs the 7
+core artifacts in **dependency layers** (`CORE_CONCURRENCY_PER_PROJECT = 4`,
+`Promise.all` within each layer); the mockup runs after the core layers.
+
+Regression guard: `src/lib/__tests__/progressivePrdGeneration.test.ts` includes
+a wall-clock test that runs the full section graph through a fixed-delay
+provider and asserts the elapsed time is well under the sequential sum — it
+**fails if the DAG is ever accidentally serialized**.
+
+## What this change added
+
+1. **Real token capture.** `callGemini` now reads Gemini's `usageMetadata`
+   (`promptTokenCount` / `candidatesTokenCount` / `totalTokenCount`) and
+   surfaces it via an optional `onUsage` callback on `JsonModeConfig`. The PRD
+   section worker threads this through `ModelProvider.generateText` and emits it
+   on the `section_completed` event. (Artifact token capture is a TODO — see
+   `tasks/TODO.md`.)
+2. **A persisted `WorkflowRun` model** (`src/types/index.ts`) recorded per run
+   and stored in a new `metricsSlice` (`workflowRuns`, keyed by projectId, per
+   user, capped at 50/project).
+3. **Pure metric math** in `src/lib/metrics/` (`workflowMetrics.ts`,
+   `modelPricing.ts`, `buildWorkflowRun.ts`) — unit-tested.
+4. **A dashboard** at `/metrics` (`src/components/metrics/`): overview cards, a
+   recent-runs table, and a per-run Gantt + node table.
+
+Recording is fully decoupled and defensive: the pipeline assembles a
+`WorkflowRun` from the section lifecycle events it already emits and fires an
+`onWorkflowRun` callback; `runPrdGeneration.ts` / `ProjectWorkspace` stamp the
+project identity and persist it via `recordWorkflowRun`. Any error in metric
+assembly is swallowed — **metrics can never break a generation run**.
+
+## Metric definitions
+
+All timings are milliseconds, derived from per-node start/end timestamps.
+
+| Metric | Formula | Meaning |
+| --- | --- | --- |
+| **Sequential Estimate** | `Σ node.durationMs` | Hypothetical runtime if every node ran one-after-another. The baseline. |
+| **Actual Runtime** | `max(node.completedAt) − min(node.startedAt)` (or the explicit run window) | Real wall-clock time the run took. |
+| **Parallel Time Saved** | `sequentialEstimate − actualRuntime` (≥ 0) | Wall-clock time saved by running concurrently. |
+| **Speedup Ratio** | `sequentialEstimate ÷ actualRuntime` | e.g. 2.5× = finished 2.5× faster than serial. |
+| **Max Concurrency** | sweep-line peak overlap of node intervals | Most agents in flight at once. |
+| **Average Concurrency** | `totalNodeRuntime ÷ actualRuntime` | Average agents in flight over the run. |
+| **Critical Path** | longest dependency chain weighted by node duration | Theoretical runtime floor even with infinite concurrency. |
+| **Estimated Cost** | `Σ (inTok·inPrice + outTok·outPrice)` per node | Approximate USD from `modelPricing.ts`. **Estimate only.** |
+
+### Interpreting sequential estimate vs actual runtime
+
+The headline story is `Sequential Estimate` (what serial execution *would* have
+cost) versus `Actual Runtime` (what the concurrent executor *did* cost). Their
+ratio is the **Speedup**, and their difference is **Time Saved**. A speedup near
+1× means little overlap happened (e.g. a near-linear dependency chain, or only
+one section ran); a higher speedup means independent work genuinely fanned out.
+
+## Where to find it
+
+`/metrics` (auth-gated). Linked from the **Project Settings** modal ("Metrics")
+and the workspace overflow menu ("Orchestration Metrics"). The page shows an
+empty state until a real run is recorded — there is **no synthetic/demo data**.
+
+## Known limitations
+
+- **Artifact runs have no token data yet** (timing/concurrency only) — core
+  artifact services don't thread `onUsage`. Cost shows $0 for those nodes.
+- **Costs are estimates** from a static price table; they ignore context
+  caching, batch discounts, and provider rounding.
+- **Streaming first-token latency is not captured** (PRD sections use JSON mode,
+  not streaming, for the recorded path).
+- **No DAG-internal retry tracking** — `retryCount` reflects manual retries only.
+- Metrics are **client-side / per-browser** (localStorage), like the rest of the
+  PRD workspace; they are not aggregated server-side.
+
+See `tasks/TODO.md` for the follow-up backlog.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { LoginPage } from './components/LoginPage';
 import { ProjectWorkspace } from './components/ProjectWorkspace';
 import { DEMO_PROJECT_ID } from './data/demoProject';
 import { TourPage } from './components/tour/TourPage';
+import { MetricsPage } from './components/metrics/MetricsPage';
 import { PrivacyPolicyPage } from './components/PrivacyPolicyPage';
 import { RecruiterAdminPage } from './components/RecruiterAdminPage';
 import { GlobalErrorBoundary } from './components/GlobalErrorBoundary';
@@ -108,6 +109,14 @@ function App() {
           <Route path="/about" element={<TourPage />} />
           <Route path="/tour" element={<TourPage />} />
           <Route path="/p/:projectId" element={<ProjectRoute />} />
+          <Route
+            path="/metrics"
+            element={
+              <RequireAuth>
+                <MetricsPage />
+              </RequireAuth>
+            }
+          />
           <Route path="/privacy" element={<PrivacyPolicyPage />} />
           <Route path="/admin/recruiters" element={<RecruiterAdminPage />} />
         </Routes>

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -1,7 +1,7 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useProjectStore } from '../store/projectStore';
 import { useAuthStore } from '../store/authStore';
-import { ChevronLeft, RefreshCcw, LogOut, CheckCircle, Cloud, Download, Settings, ChevronDown, ChevronRight, PanelRightOpen, PanelRightClose, MoreHorizontal, Loader2, ArrowRight, History } from 'lucide-react';
+import { ChevronLeft, RefreshCcw, LogOut, CheckCircle, Cloud, Download, Settings, ChevronDown, ChevronRight, PanelRightOpen, PanelRightClose, MoreHorizontal, Loader2, ArrowRight, History, Activity } from 'lucide-react';
 import { useState, useRef, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
@@ -276,6 +276,13 @@ export function ProjectWorkspace() {
                 {
                     onProgress: (message) => appendPrdProgress(projectId, message),
                     onSectionStatus: (sectionId, update) => setSectionStatus(projectId, sectionId, update),
+                    onWorkflowRun: (run) => {
+                        useProjectStore.getState().recordWorkflowRun({
+                            ...run,
+                            projectId,
+                            projectName: project?.name,
+                        });
+                    },
                     onPartial: ({ structuredPRD, markdown }) => {
                         updateSpineStructuredPRD(
                             projectId,
@@ -598,6 +605,13 @@ export function ProjectWorkspace() {
                                 >
                                     <History size={14} className="text-indigo-400" />
                                     Version History
+                                </button>
+                                <button
+                                    onClick={() => { navigate('/metrics'); setShowNavOverflow(false); }}
+                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition border-b border-white/5"
+                                >
+                                    <Activity size={14} className="text-indigo-400" />
+                                    Orchestration Metrics
                                 </button>
                                 <button
                                     onClick={() => { setIsBranchesVisible(!isBranchesVisible); setShowNavOverflow(false); }}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase, Sparkles, Zap, Brain, Github } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase, Sparkles, Zap, Brain, Github, ChevronRight } from 'lucide-react';
 import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 import { ProviderKeysSection } from './settings/ProviderKeysSection';
 import {
@@ -109,6 +110,7 @@ function ModelRadio({
 }
 
 export function SettingsModal({ onClose }: SettingsModalProps) {
+    const navigate = useNavigate();
     const [apiKey, setApiKey] = useState(() => getLocalCredential(GEMINI_API_KEY) || '');
     const [projectId, setProjectId] = useState(() => localStorage.getItem('GEMINI_PROJECT_ID') || '');
     const [model, setModel] = useState(() => localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL);
@@ -422,6 +424,26 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                                 </div>
                             )}
                         </div>
+                    </div>
+
+                    {/* Orchestration Metrics link */}
+                    <div className="pt-4 border-t border-white/5">
+                        <button
+                            type="button"
+                            onClick={() => { onClose(); navigate('/metrics'); }}
+                            className="w-full bg-white/5 rounded-2xl p-4 flex items-center justify-between border border-white/5 hover:bg-white/10 transition-all text-left"
+                        >
+                            <div className="flex items-center gap-3">
+                                <div className="p-2 rounded-lg bg-indigo-500/10 text-indigo-400">
+                                    <Activity size={14} />
+                                </div>
+                                <div>
+                                    <p className="text-[10px] uppercase tracking-widest font-bold text-neutral-500 mb-0.5">Metrics</p>
+                                    <p className="text-xs text-neutral-300 font-medium">Orchestration & AI workflow telemetry</p>
+                                </div>
+                            </div>
+                            <ChevronRight size={16} className="text-neutral-500" />
+                        </button>
                     </div>
 
                     {/* Meta Info */}

--- a/src/components/__tests__/MetricsPage.test.tsx
+++ b/src/components/__tests__/MetricsPage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MetricsPage } from '../metrics/MetricsPage';
+import { useProjectStore } from '../../store/projectStore';
+import type { WorkflowRun } from '../../types';
+
+const sampleRun = (over: Partial<WorkflowRun> = {}): WorkflowRun => ({
+    id: 'run-1',
+    projectId: 'p1',
+    projectName: 'Recipe App',
+    workflowType: 'prd',
+    status: 'complete',
+    startedAt: 1_700_000_000_000,
+    completedAt: 1_700_000_072_000,
+    actualRuntimeMs: 72_000,
+    sequentialEstimateMs: 180_000,
+    parallelTimeSavedMs: 108_000,
+    speedupRatio: 2.5,
+    maxConcurrency: 4,
+    averageConcurrency: 2.4,
+    criticalPathMs: 40_000,
+    totalNodeRuntimeMs: 180_000,
+    totalInputTokens: 1200,
+    totalOutputTokens: 3400,
+    totalTokens: 4600,
+    estimatedCost: 0.0123,
+    retryCount: 0,
+    failureCount: 0,
+    nodeCount: 6,
+    parallelGroupCount: 3,
+    nodes: [
+        {
+            id: 'n1', nodeId: 'product_basics', nodeName: 'Product Basics', model: 'gemini-3-flash-preview',
+            provider: 'gemini', status: 'complete', dependencyIds: [], parallelGroupId: 0,
+            startedAt: 1_700_000_000_000, completedAt: 1_700_000_008_000, durationMs: 8000,
+            inputTokens: 200, outputTokens: 400, totalTokens: 600, estimatedCost: 0.001,
+        },
+    ],
+    ...over,
+});
+
+const reset = (runs: Record<string, WorkflowRun[]>) =>
+    useProjectStore.setState({ workflowRuns: runs });
+
+describe('MetricsPage', () => {
+    beforeEach(() => {
+        reset({});
+    });
+
+    it('renders an empty state when no runs exist', () => {
+        render(
+            <MemoryRouter>
+                <MetricsPage />
+            </MemoryRouter>,
+        );
+        expect(screen.getByText(/No workflow runs recorded yet/i)).toBeInTheDocument();
+    });
+
+    it('renders overview + run row when runs exist', () => {
+        reset({ p1: [sampleRun()] });
+        render(
+            <MemoryRouter>
+                <MetricsPage />
+            </MemoryRouter>,
+        );
+        // Overview headline + cards.
+        expect(screen.getByText(/Workflows Run/i)).toBeInTheDocument();
+        // Speedup shows up (overview headline and/or table).
+        expect(screen.getAllByText(/2\.5×/).length).toBeGreaterThan(0);
+        // The run's project name appears in the table.
+        expect(screen.getByText('Recipe App')).toBeInTheDocument();
+    });
+});

--- a/src/components/metrics/MetricsOverviewCards.tsx
+++ b/src/components/metrics/MetricsOverviewCards.tsx
@@ -1,0 +1,75 @@
+import type { WorkflowRun } from '../../types';
+import { successRate } from '../../lib/metrics/workflowMetrics';
+import {
+    formatConcurrency,
+    formatCost,
+    formatDuration,
+    formatPercent,
+    formatSpeedup,
+    formatTokens,
+} from './format';
+
+// Aggregate "at a glance" cards across every recorded workflow run. All values
+// are averages/totals over the provided runs — see workflowMetrics.ts for the
+// per-run math these roll up.
+
+interface Props {
+    runs: WorkflowRun[];
+}
+
+function avg(nums: number[]): number {
+    if (nums.length === 0) return 0;
+    return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+interface Card {
+    label: string;
+    value: string;
+    hint?: string;
+}
+
+export function MetricsOverviewCards({ runs }: Props) {
+    const totalRuntime = runs.reduce((s, r) => s + r.actualRuntimeMs, 0);
+    const totalSequential = runs.reduce((s, r) => s + r.sequentialEstimateMs, 0);
+    const totalTokens = runs.reduce((s, r) => s + r.totalTokens, 0);
+    const totalCost = runs.reduce((s, r) => s + r.estimatedCost, 0);
+
+    const cards: Card[] = [
+        { label: 'Workflows Run', value: `${runs.length}` },
+        { label: 'Avg Actual Runtime', value: formatDuration(avg(runs.map((r) => r.actualRuntimeMs))) },
+        { label: 'Avg Sequential Estimate', value: formatDuration(avg(runs.map((r) => r.sequentialEstimateMs))), hint: 'If sections ran one-by-one' },
+        { label: 'Avg Parallel Speedup', value: formatSpeedup(avg(runs.map((r) => r.speedupRatio))), hint: 'Sequential ÷ actual' },
+        { label: 'Avg Time Saved', value: formatDuration(avg(runs.map((r) => r.parallelTimeSavedMs))) },
+        { label: 'Avg Max Concurrency', value: formatConcurrency(avg(runs.map((r) => r.maxConcurrency))), hint: 'Peak agents in flight' },
+        { label: 'Success Rate', value: formatPercent(successRate(runs.map((r) => r.status))) },
+        { label: 'Total Tokens', value: formatTokens(totalTokens) },
+        { label: 'Estimated AI Cost', value: formatCost(totalCost), hint: 'Approximate' },
+    ];
+
+    // A headline "time saved overall" sentence — the single most resume-worthy
+    // number — derived from the totals rather than an average of ratios.
+    const overallSpeedup = totalRuntime > 0 ? totalSequential / totalRuntime : 1;
+
+    return (
+        <div className="space-y-4">
+            <div className="rounded-2xl border border-indigo-500/30 bg-indigo-500/10 p-5">
+                <p className="text-sm text-indigo-200">
+                    Across {runs.length} concurrent multi-agent run{runs.length === 1 ? '' : 's'}, parallel execution
+                    delivered an overall{' '}
+                    <span className="font-semibold text-white">{formatSpeedup(overallSpeedup)} speedup</span>
+                    {' '}— {formatDuration(totalSequential)} of sequential work completed in{' '}
+                    <span className="font-semibold text-white">{formatDuration(totalRuntime)}</span>.
+                </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-3">
+                {cards.map((c) => (
+                    <div key={c.label} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <p className="text-[11px] font-medium uppercase tracking-wide text-neutral-400">{c.label}</p>
+                        <p className="mt-1 text-2xl font-semibold text-white tabular-nums">{c.value}</p>
+                        {c.hint && <p className="mt-0.5 text-[11px] text-neutral-500">{c.hint}</p>}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/metrics/MetricsPage.tsx
+++ b/src/components/metrics/MetricsPage.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Activity, X } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import type { WorkflowRun } from '../../types';
+import { MetricsOverviewCards } from './MetricsOverviewCards';
+import { WorkflowRunsTable } from './WorkflowRunsTable';
+import { WorkflowRunDetail } from './WorkflowRunDetail';
+
+// Standalone, auth-gated orchestration Metrics dashboard (`/metrics`). Reads
+// persisted WorkflowRun history straight from the project store. Everything is
+// real, recorded data — there is no synthetic/demo fallback, so a fresh account
+// correctly shows an empty state rather than fabricated numbers.
+
+// Module-level stable empty fallback — a fresh `{}`/`[]` in a selector allocates
+// a new reference every render and trips React error #185 (see CLAUDE.md
+// "Selector stability rule").
+const EMPTY_RUNS: Record<string, WorkflowRun[]> = {};
+
+export function MetricsPage() {
+    const navigate = useNavigate();
+    const workflowRuns = useProjectStore((s) => s.workflowRuns ?? EMPTY_RUNS);
+    const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+
+    const runs = useMemo(
+        () => Object.values(workflowRuns).flat().sort((a, b) => b.startedAt - a.startedAt),
+        [workflowRuns],
+    );
+
+    const selected = useMemo(
+        () => runs.find((r) => r.id === selectedId),
+        [runs, selectedId],
+    );
+
+    return (
+        <div className="min-h-screen bg-neutral-950 text-white">
+            <header className="sticky top-0 z-10 border-b border-white/10 bg-neutral-950/80 backdrop-blur">
+                <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-4">
+                    <button
+                        onClick={() => navigate(-1)}
+                        className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-neutral-300 transition-colors hover:bg-white/5"
+                    >
+                        <ArrowLeft size={15} /> Back
+                    </button>
+                    <div className="flex items-center gap-2">
+                        <Activity size={18} className="text-indigo-400" />
+                        <h1 className="text-lg font-semibold">Orchestration Metrics</h1>
+                    </div>
+                </div>
+            </header>
+
+            <main className="mx-auto max-w-6xl space-y-8 px-4 py-8">
+                <p className="max-w-3xl text-sm text-neutral-400">
+                    Telemetry from Synapse's concurrent multi-agent workflows. PRD sections and downstream
+                    artifacts run on a dependency-aware DAG executor; these metrics show how much that
+                    parallelism actually saved versus running every step sequentially. Cost figures are
+                    estimates.
+                </p>
+
+                {runs.length === 0 ? (
+                    <EmptyState />
+                ) : (
+                    <>
+                        <MetricsOverviewCards runs={runs} />
+
+                        <section className="space-y-3">
+                            <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">
+                                Recent Workflow Runs
+                            </h2>
+                            <WorkflowRunsTable runs={runs} selectedId={selectedId} onSelect={(r) => setSelectedId(r.id)} />
+                            <p className="text-[11px] text-neutral-500">Select a run to inspect its node timeline.</p>
+                        </section>
+
+                        {selected && (
+                            <section className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">
+                                        Run Detail — {selected.projectName ?? 'Project'} ·{' '}
+                                        {selected.workflowType === 'prd' ? 'PRD Generation' : 'Artifact Bundle'}
+                                    </h2>
+                                    <button
+                                        onClick={() => setSelectedId(undefined)}
+                                        className="flex items-center gap-1 rounded-lg border border-white/10 px-2 py-1 text-xs text-neutral-400 hover:bg-white/5"
+                                    >
+                                        <X size={13} /> Close
+                                    </button>
+                                </div>
+                                <WorkflowRunDetail run={selected} />
+                            </section>
+                        )}
+                    </>
+                )}
+            </main>
+        </div>
+    );
+}
+
+function EmptyState() {
+    return (
+        <div className="rounded-2xl border border-dashed border-white/15 bg-white/5 p-10 text-center">
+            <Activity size={28} className="mx-auto text-neutral-600" />
+            <p className="mt-3 text-sm font-medium text-neutral-300">No workflow runs recorded yet</p>
+            <p className="mx-auto mt-1 max-w-md text-[13px] text-neutral-500">
+                Generate a PRD or build downstream artifacts and Synapse will record real orchestration
+                telemetry here — runtime, parallel speedup, concurrency, tokens, and estimated cost per run.
+            </p>
+        </div>
+    );
+}

--- a/src/components/metrics/WorkflowRunDetail.tsx
+++ b/src/components/metrics/WorkflowRunDetail.tsx
@@ -1,0 +1,147 @@
+import type { WorkflowNodeRun, WorkflowRun } from '../../types';
+import {
+    formatConcurrency,
+    formatCost,
+    formatDuration,
+    formatSpeedup,
+    formatTokens,
+} from './format';
+
+// Detail / Gantt view for a single workflow run. The horizontal bars are laid
+// out by normalizing each node's [startedAt, completedAt] against the run
+// window, so overlapping bars are a direct visual proof of concurrency. Below
+// the chart, a per-node table lists model / duration / tokens / cost / deps.
+
+interface Props {
+    run: WorkflowRun;
+}
+
+// A small palette indexed by parallel group so nodes in the same wave share a
+// hue and the eye can read "these ran together".
+const GROUP_COLORS = [
+    'bg-indigo-500',
+    'bg-sky-500',
+    'bg-violet-500',
+    'bg-teal-500',
+    'bg-amber-500',
+    'bg-rose-500',
+];
+
+function barColor(node: WorkflowNodeRun): string {
+    if (node.status === 'error') return 'bg-red-500';
+    const g = node.parallelGroupId ?? 0;
+    return GROUP_COLORS[g % GROUP_COLORS.length];
+}
+
+export function WorkflowRunDetail({ run }: Props) {
+    const runStart = run.startedAt;
+    const span = Math.max(1, run.completedAt - run.startedAt);
+    // Stable visual ordering: by start time, then by group.
+    const nodes = [...run.nodes].sort(
+        (a, b) => a.startedAt - b.startedAt || (a.parallelGroupId ?? 0) - (b.parallelGroupId ?? 0),
+    );
+
+    const consistencyMs = run.metadata?.consistencyReviewMs as number | undefined;
+
+    return (
+        <div className="space-y-5">
+            {/* Headline metrics for this run */}
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <Stat label="Actual Runtime" value={formatDuration(run.actualRuntimeMs)} />
+                <Stat label="Sequential Estimate" value={formatDuration(run.sequentialEstimateMs)} />
+                <Stat label="Parallel Speedup" value={formatSpeedup(run.speedupRatio)} accent />
+                <Stat label="Time Saved" value={formatDuration(run.parallelTimeSavedMs)} />
+                <Stat label="Max Concurrency" value={formatConcurrency(run.maxConcurrency)} />
+                <Stat label="Avg Concurrency" value={formatConcurrency(run.averageConcurrency)} />
+                <Stat label="Critical Path" value={formatDuration(run.criticalPathMs)} />
+                <Stat label="Est. Cost" value={formatCost(run.estimatedCost)} />
+            </div>
+
+            {/* Gantt */}
+            <div>
+                <h4 className="mb-2 text-sm font-semibold text-neutral-200">Timeline</h4>
+                <div className="space-y-1.5">
+                    {nodes.map((node) => {
+                        const leftPct = ((node.startedAt - runStart) / span) * 100;
+                        const widthPct = Math.max(1.5, (node.durationMs / span) * 100);
+                        return (
+                            <div key={node.id} className="flex items-center gap-2">
+                                <div className="w-32 shrink-0 truncate text-right text-[11px] text-neutral-400" title={node.nodeName}>
+                                    {node.nodeName}
+                                </div>
+                                <div className="relative h-5 flex-1 rounded bg-white/5">
+                                    <div
+                                        className={`absolute top-0 flex h-5 items-center rounded ${barColor(node)} px-1.5`}
+                                        style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+                                        title={`${node.nodeName} · ${formatDuration(node.durationMs)}`}
+                                    >
+                                        <span className="truncate text-[10px] font-medium text-white/90">
+                                            {formatDuration(node.durationMs)}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+                <p className="mt-2 text-[11px] text-neutral-500">
+                    Bars sharing a color ran in the same dependency wave (eligible to execute concurrently).
+                    {typeof consistencyMs === 'number' && ` Consistency review: ${formatDuration(consistencyMs)}.`}
+                </p>
+            </div>
+
+            {/* Node table */}
+            <div className="overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full min-w-[680px] text-left text-sm">
+                    <thead>
+                        <tr className="border-b border-white/10 text-[11px] uppercase tracking-wide text-neutral-400">
+                            <th className="px-3 py-2 font-medium">Node</th>
+                            <th className="px-3 py-2 font-medium">Model</th>
+                            <th className="px-3 py-2 font-medium">Wave</th>
+                            <th className="px-3 py-2 text-right font-medium">Duration</th>
+                            <th className="px-3 py-2 text-right font-medium">Tokens</th>
+                            <th className="px-3 py-2 text-right font-medium">Est. Cost</th>
+                            <th className="px-3 py-2 font-medium">Depends on</th>
+                            <th className="px-3 py-2 font-medium">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {nodes.map((node) => (
+                            <tr key={node.id} className="border-b border-white/5">
+                                <td className="px-3 py-2 text-neutral-200">{node.nodeName}</td>
+                                <td className="px-3 py-2 text-neutral-400">{node.model}</td>
+                                <td className="px-3 py-2 tabular-nums text-neutral-400">{(node.parallelGroupId ?? 0) + 1}</td>
+                                <td className="px-3 py-2 text-right tabular-nums text-white">{formatDuration(node.durationMs)}</td>
+                                <td className="px-3 py-2 text-right tabular-nums text-neutral-300">
+                                    {node.totalTokens !== undefined ? formatTokens(node.totalTokens) : '—'}
+                                </td>
+                                <td className="px-3 py-2 text-right tabular-nums text-neutral-300">
+                                    {node.estimatedCost ? formatCost(node.estimatedCost) : '—'}
+                                </td>
+                                <td className="px-3 py-2 text-[11px] text-neutral-500">
+                                    {node.dependencyIds.length ? node.dependencyIds.join(', ') : '—'}
+                                </td>
+                                <td className="px-3 py-2">
+                                    {node.status === 'error' ? (
+                                        <span className="text-red-300" title={node.errorMessage}>error</span>
+                                    ) : (
+                                        <span className="text-emerald-300">ok</span>
+                                    )}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+    return (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+            <p className="text-[10px] font-medium uppercase tracking-wide text-neutral-400">{label}</p>
+            <p className={`mt-0.5 text-lg font-semibold tabular-nums ${accent ? 'text-indigo-300' : 'text-white'}`}>{value}</p>
+        </div>
+    );
+}

--- a/src/components/metrics/WorkflowRunsTable.tsx
+++ b/src/components/metrics/WorkflowRunsTable.tsx
@@ -1,0 +1,82 @@
+import type { WorkflowRun } from '../../types';
+import {
+    formatConcurrency,
+    formatCost,
+    formatDuration,
+    formatSpeedup,
+    formatTimestamp,
+    formatTokens,
+} from './format';
+
+// Recent-runs table. Each row is a recorded WorkflowRun; clicking selects it
+// for the detail/Gantt view. Horizontally scrollable on narrow screens.
+
+interface Props {
+    runs: WorkflowRun[];
+    selectedId?: string;
+    onSelect: (run: WorkflowRun) => void;
+}
+
+const STATUS_STYLES: Record<WorkflowRun['status'], string> = {
+    complete: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30',
+    partial: 'bg-amber-500/10 text-amber-300 border-amber-500/30',
+    error: 'bg-red-500/10 text-red-300 border-red-500/30',
+};
+
+const TYPE_LABEL: Record<WorkflowRun['workflowType'], string> = {
+    prd: 'PRD Generation',
+    artifacts: 'Artifact Bundle',
+};
+
+export function WorkflowRunsTable({ runs, selectedId, onSelect }: Props) {
+    return (
+        <div className="overflow-x-auto rounded-2xl border border-white/10">
+            <table className="w-full min-w-[860px] text-left text-sm">
+                <thead>
+                    <tr className="border-b border-white/10 text-[11px] uppercase tracking-wide text-neutral-400">
+                        <th className="px-3 py-2 font-medium">When</th>
+                        <th className="px-3 py-2 font-medium">Project</th>
+                        <th className="px-3 py-2 font-medium">Type</th>
+                        <th className="px-3 py-2 font-medium">Status</th>
+                        <th className="px-3 py-2 text-right font-medium">Actual</th>
+                        <th className="px-3 py-2 text-right font-medium">Sequential</th>
+                        <th className="px-3 py-2 text-right font-medium">Speedup</th>
+                        <th className="px-3 py-2 text-right font-medium">Max&nbsp;Conc.</th>
+                        <th className="px-3 py-2 text-right font-medium">Tokens</th>
+                        <th className="px-3 py-2 text-right font-medium">Est.&nbsp;Cost</th>
+                        <th className="px-3 py-2 text-right font-medium">Retries</th>
+                        <th className="px-3 py-2 text-right font-medium">Fails</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {runs.map((r) => (
+                        <tr
+                            key={r.id}
+                            onClick={() => onSelect(r)}
+                            className={`cursor-pointer border-b border-white/5 transition-colors hover:bg-white/5 ${
+                                selectedId === r.id ? 'bg-indigo-500/10' : ''
+                            }`}
+                        >
+                            <td className="whitespace-nowrap px-3 py-2 text-neutral-300">{formatTimestamp(r.startedAt)}</td>
+                            <td className="px-3 py-2 text-neutral-200">{r.projectName ?? '—'}</td>
+                            <td className="whitespace-nowrap px-3 py-2 text-neutral-300">{TYPE_LABEL[r.workflowType]}</td>
+                            <td className="px-3 py-2">
+                                <span className={`inline-block rounded-full border px-2 py-0.5 text-[11px] capitalize ${STATUS_STYLES[r.status]}`}>
+                                    {r.status}
+                                </span>
+                            </td>
+                            <td className="px-3 py-2 text-right tabular-nums text-white">{formatDuration(r.actualRuntimeMs)}</td>
+                            <td className="px-3 py-2 text-right tabular-nums text-neutral-400">{formatDuration(r.sequentialEstimateMs)}</td>
+                            <td className="px-3 py-2 text-right tabular-nums font-semibold text-indigo-300">{formatSpeedup(r.speedupRatio)}</td>
+                            <td className="px-3 py-2 text-right tabular-nums text-neutral-300">{formatConcurrency(r.maxConcurrency)}</td>
+                            <td className="px-3 py-2 text-right tabular-nums text-neutral-300">{formatTokens(r.totalTokens)}</td>
+                            <td className="px-3 py-2 text-right tabular-nums text-neutral-300">{formatCost(r.estimatedCost)}</td>
+                            <td className="px-3 py-2 text-right tabular-nums text-neutral-400">{r.retryCount}</td>
+                            <td className="px-3 py-2 text-right tabular-nums text-neutral-400">{r.failureCount}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/components/metrics/format.ts
+++ b/src/components/metrics/format.ts
@@ -1,0 +1,61 @@
+// Small, pure display formatters for the Metrics dashboard. Kept separate so
+// the rendering components stay declarative and these can be unit-tested.
+
+/** Human-friendly duration from milliseconds: "320ms", "4.2s", "1m 12s". */
+export function formatDuration(ms: number): string {
+    if (!isFinite(ms) || ms < 0) return '—';
+    if (ms < 1000) return `${Math.round(ms)}ms`;
+    const totalSeconds = ms / 1000;
+    if (totalSeconds < 60) return `${totalSeconds.toFixed(1)}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = Math.round(totalSeconds % 60);
+    return `${minutes}m ${seconds}s`;
+}
+
+/** Speedup ratio as "2.5×". */
+export function formatSpeedup(ratio: number): string {
+    if (!isFinite(ratio) || ratio <= 0) return '—';
+    return `${ratio.toFixed(ratio >= 10 ? 0 : 1)}×`;
+}
+
+/** Compact token count: "812", "12.3k", "1.4M". */
+export function formatTokens(n: number): string {
+    if (!n) return '0';
+    if (n < 1000) return `${n}`;
+    if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+    return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+/** USD cost estimate: "$0.0123", "<$0.001", "$0.00". */
+export function formatCost(usd: number): string {
+    if (!usd) return '$0.00';
+    if (usd < 0.001) return '<$0.001';
+    if (usd < 1) return `$${usd.toFixed(4)}`;
+    return `$${usd.toFixed(2)}`;
+}
+
+/** Ratio 0–1 → "92%". */
+export function formatPercent(ratio: number): string {
+    if (!isFinite(ratio)) return '—';
+    return `${Math.round(ratio * 100)}%`;
+}
+
+/** Epoch ms → "Jun 27, 3:14 PM". */
+export function formatTimestamp(ms: number): string {
+    try {
+        return new Date(ms).toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+        });
+    } catch {
+        return '—';
+    }
+}
+
+/** Concurrency level like "2.4×" → here just a plain number to 1 decimal. */
+export function formatConcurrency(n: number): string {
+    if (!isFinite(n) || n <= 0) return '—';
+    return Number.isInteger(n) ? `${n}` : n.toFixed(1);
+}

--- a/src/lib/__tests__/progressivePrdGeneration.test.ts
+++ b/src/lib/__tests__/progressivePrdGeneration.test.ts
@@ -262,6 +262,29 @@ describe('progressive PRD generation', () => {
     expect(tracker.peak).toBeGreaterThan(1);
   });
 
+  it('completes the section graph in parallel wall-clock time (fails if serialized)', async () => {
+    // Run the real 10-section graph through a fixed-delay provider. Executed
+    // one-after-another this is 10×delay; the dependency-aware concurrent
+    // executor overlaps independent sections, so the measured wall-clock time
+    // must be well under the sequential sum. This is a direct regression guard
+    // against an accidental await-in-loop serialization of the DAG.
+    const delay = 20;
+    const tracker = makeConcurrencyProvider(delay);
+    const start = performance.now();
+    await generateProgressivePrd({
+      prompt: 'wall-clock test',
+      provider: tracker.provider,
+      sections: DEFAULT_PRD_SECTIONS,
+      config: baseConfig,
+    });
+    const elapsed = performance.now() - start;
+    const sequential = delay * DEFAULT_PRD_SECTIONS.length; // 200ms
+    // Multiple sections genuinely overlapped…
+    expect(tracker.peak).toBeGreaterThan(1);
+    // …and the run finished well under the sequential sum.
+    expect(elapsed).toBeLessThan(sequential * 0.7);
+  });
+
   it('respects the per-tier max concurrency limit', async () => {
     const tracker = makeConcurrencyProvider(10);
     // 4 independent fast sections, but a fast cap of 2 → peak must be ≤ 2.

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -23,6 +23,20 @@ export interface JsonModeConfig {
      * changing the global default.
      */
     model?: string;
+    /**
+     * Optional usage sink. When provided, it is invoked once with the token
+     * counts reported by Gemini's `usageMetadata` after a successful response.
+     * Purely observational (powers the orchestration Metrics dashboard) — the
+     * call still resolves to the response text, so no existing caller breaks.
+     */
+    onUsage?: (usage: GeminiTokenUsage) => void;
+}
+
+/** Token counts extracted from a Gemini response's `usageMetadata`. */
+export interface GeminiTokenUsage {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
 }
 
 export interface StreamCallbacks {
@@ -254,7 +268,10 @@ export const callGemini = async (systemInstruction: string, promptText: string, 
     }
 
     const watchdog = createWatchdog(GEMINI_TIMEOUT_MS, signal);
-    let data: { candidates?: Array<{ finishReason?: string; content?: { parts?: Array<{ text?: string }> } }> } | undefined;
+    let data: {
+        candidates?: Array<{ finishReason?: string; content?: { parts?: Array<{ text?: string }> } }>;
+        usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; totalTokenCount?: number };
+    } | undefined;
     try {
         const response = await fetchWithRetry(url, {
             method: 'POST',
@@ -287,6 +304,17 @@ export const callGemini = async (systemInstruction: string, promptText: string, 
     if (!text) {
         const reason = finishReason ? ` (finishReason: ${finishReason})` : '';
         throw new Error(`Gemini returned an empty response${reason}. Please try again.`);
+    }
+    // Surface token usage to any observer (Metrics dashboard). Gemini returns
+    // these on the top-level `usageMetadata`; absent on some error/partial
+    // responses, in which case we simply skip the callback.
+    if (jsonMode?.onUsage && data?.usageMetadata) {
+        const u = data.usageMetadata;
+        jsonMode.onUsage({
+            inputTokens: u.promptTokenCount ?? 0,
+            outputTokens: u.candidatesTokenCount ?? 0,
+            totalTokens: u.totalTokenCount ?? (u.promptTokenCount ?? 0) + (u.candidatesTokenCount ?? 0),
+        });
     }
     const durationMs = performance.now() - startTime;
     console.log(`[GEN] callGemini: ${durationMs.toFixed(0)}ms (${text.length} chars)`);

--- a/src/lib/metrics/__tests__/buildWorkflowRun.test.ts
+++ b/src/lib/metrics/__tests__/buildWorkflowRun.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkflowRun, computeParallelGroups, type NodeObservation } from '../buildWorkflowRun';
+
+const obs = (
+    nodeId: string,
+    start: number,
+    end: number,
+    extra: Partial<NodeObservation> = {},
+): NodeObservation => ({
+    nodeId,
+    nodeName: nodeId,
+    model: 'gemini-3-flash-preview',
+    status: 'complete',
+    startedAt: start,
+    completedAt: end,
+    ...extra,
+});
+
+describe('computeParallelGroups', () => {
+    it('assigns topological wave levels', () => {
+        const groups = computeParallelGroups([
+            { nodeId: 'a' },
+            { nodeId: 'b', dependencyIds: ['a'] },
+            { nodeId: 'c', dependencyIds: ['a'] },
+            { nodeId: 'd', dependencyIds: ['b', 'c'] },
+        ]);
+        expect(groups.get('a')).toBe(0);
+        expect(groups.get('b')).toBe(1);
+        expect(groups.get('c')).toBe(1);
+        expect(groups.get('d')).toBe(2);
+    });
+});
+
+describe('buildWorkflowRun', () => {
+    it('aggregates timings, tokens, cost and concurrency', () => {
+        const run = buildWorkflowRun({
+            projectId: 'p1',
+            projectName: 'Demo',
+            workflowType: 'prd',
+            startedAt: 1000,
+            completedAt: 1120,
+            nodes: [
+                obs('a', 1000, 1040, { inputTokens: 100, outputTokens: 200 }),
+                obs('b', 1040, 1120, { inputTokens: 50, outputTokens: 50, dependencyIds: ['a'] }),
+                obs('c', 1040, 1100, { inputTokens: 10, outputTokens: 10, dependencyIds: ['a'] }),
+            ],
+        });
+
+        expect(run.projectId).toBe('p1');
+        expect(run.workflowType).toBe('prd');
+        expect(run.nodeCount).toBe(3);
+        expect(run.status).toBe('complete');
+        // Sequential = 40 + 80 + 60 = 180; actual window = 120.
+        expect(run.sequentialEstimateMs).toBe(180);
+        expect(run.actualRuntimeMs).toBe(120);
+        expect(run.parallelTimeSavedMs).toBe(60);
+        // b and c overlap (both 1040..) → max concurrency 2.
+        expect(run.maxConcurrency).toBe(2);
+        expect(run.totalInputTokens).toBe(160);
+        expect(run.totalOutputTokens).toBe(260);
+        expect(run.totalTokens).toBe(420);
+        expect(run.estimatedCost).toBeGreaterThan(0);
+        // a is wave 0; b and c are wave 1 → 2 distinct groups.
+        expect(run.parallelGroupCount).toBe(2);
+    });
+
+    it('marks a run partial when some nodes error and error when all error', () => {
+        const partial = buildWorkflowRun({
+            projectId: 'p1',
+            workflowType: 'artifacts',
+            nodes: [obs('a', 0, 10), obs('b', 0, 10, { status: 'error' })],
+        });
+        expect(partial.status).toBe('partial');
+        expect(partial.failureCount).toBe(1);
+
+        const allFailed = buildWorkflowRun({
+            projectId: 'p1',
+            workflowType: 'artifacts',
+            nodes: [obs('a', 0, 10, { status: 'error' })],
+        });
+        expect(allFailed.status).toBe('error');
+    });
+});

--- a/src/lib/metrics/__tests__/workflowMetrics.test.ts
+++ b/src/lib/metrics/__tests__/workflowMetrics.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+    actualRuntimeMs,
+    averageConcurrency,
+    criticalPathMs,
+    maxConcurrency,
+    parallelTimeSavedMs,
+    sequentialEstimateMs,
+    speedupRatio,
+    successRate,
+    type MetricNode,
+} from '../workflowMetrics';
+
+// Helper to build a node with run-relative timings.
+const node = (id: string, start: number, end: number, deps: string[] = []): MetricNode => ({
+    nodeId: id,
+    startedAt: start,
+    completedAt: end,
+    durationMs: end - start,
+    dependencyIds: deps,
+});
+
+describe('workflowMetrics', () => {
+    describe('sequentialEstimateMs', () => {
+        it('sums all node durations', () => {
+            const nodes = [node('a', 0, 100), node('b', 0, 50), node('c', 0, 30)];
+            expect(sequentialEstimateMs(nodes)).toBe(180);
+        });
+        it('is 0 for no nodes', () => {
+            expect(sequentialEstimateMs([])).toBe(0);
+        });
+    });
+
+    describe('actualRuntimeMs', () => {
+        it('is max end minus min start', () => {
+            // 3 nodes overlapping; span is 0..120.
+            const nodes = [node('a', 0, 100), node('b', 20, 120), node('c', 10, 40)];
+            expect(actualRuntimeMs(nodes)).toBe(120);
+        });
+        it('is 0 for no nodes', () => {
+            expect(actualRuntimeMs([])).toBe(0);
+        });
+    });
+
+    describe('parallelTimeSavedMs / speedupRatio', () => {
+        it('computes saved time and ratio', () => {
+            // Example from the prompt: 180s sequential, 72s actual → 2.5×, 108s saved.
+            expect(parallelTimeSavedMs(180_000, 72_000)).toBe(108_000);
+            expect(speedupRatio(180_000, 72_000)).toBe(2.5);
+        });
+        it('clamps negative savings to 0', () => {
+            expect(parallelTimeSavedMs(50, 80)).toBe(0);
+        });
+        it('guards divide-by-zero', () => {
+            expect(speedupRatio(100, 0)).toBe(100);
+            expect(speedupRatio(0, 0)).toBe(1);
+        });
+    });
+
+    describe('maxConcurrency', () => {
+        it('finds the peak overlap from intervals', () => {
+            // a: 0..100, b: 10..40, c: 20..30 → at t=25 all three overlap → 3.
+            const nodes = [node('a', 0, 100), node('b', 10, 40), node('c', 20, 30)];
+            expect(maxConcurrency(nodes)).toBe(3);
+        });
+        it('counts back-to-back (touching) intervals as non-overlapping', () => {
+            const nodes = [node('a', 0, 50), node('b', 50, 100)];
+            expect(maxConcurrency(nodes)).toBe(1);
+        });
+        it('is 1 for a single node and 0 for none', () => {
+            expect(maxConcurrency([node('a', 0, 10)])).toBe(1);
+            expect(maxConcurrency([])).toBe(0);
+        });
+    });
+
+    describe('averageConcurrency', () => {
+        it('is total node runtime over actual runtime', () => {
+            // total node runtime 180, actual 100 → 1.8 average.
+            expect(averageConcurrency(180, 100)).toBe(1.8);
+        });
+        it('is 0 when actual runtime is 0', () => {
+            expect(averageConcurrency(180, 0)).toBe(0);
+        });
+    });
+
+    describe('criticalPathMs', () => {
+        it('follows the longest dependency chain weighted by duration', () => {
+            // a(10) → b(20) → d(40) = 70; c(5) is a side branch.
+            const nodes = [
+                node('a', 0, 10),
+                node('b', 0, 20, ['a']),
+                node('c', 0, 5, ['a']),
+                node('d', 0, 40, ['b', 'c']),
+            ];
+            // a + b + d = 10 + 20 + 40 = 70.
+            expect(criticalPathMs(nodes)).toBe(70);
+        });
+        it('falls back to the longest single node when there are no deps', () => {
+            const nodes = [node('a', 0, 30), node('b', 0, 80), node('c', 0, 10)];
+            expect(criticalPathMs(nodes)).toBe(80);
+        });
+        it('ignores unknown dependency ids', () => {
+            const nodes = [node('a', 0, 25, ['ghost'])];
+            expect(criticalPathMs(nodes)).toBe(25);
+        });
+    });
+
+    describe('successRate', () => {
+        it('counts complete and partial as successful', () => {
+            expect(successRate(['complete', 'partial', 'error', 'complete'])).toBe(0.75);
+        });
+        it('is 0 for no runs', () => {
+            expect(successRate([])).toBe(0);
+        });
+    });
+});

--- a/src/lib/metrics/buildWorkflowRun.ts
+++ b/src/lib/metrics/buildWorkflowRun.ts
@@ -1,0 +1,176 @@
+// Assembles a persisted WorkflowRun from a flat list of node observations.
+//
+// Both pipelines (PRD section DAG and the artifact-bundle controller) collect
+// the same per-node facts — when each node started/ended, which model ran it,
+// how many tokens it used, what it depended on — and hand them here. This is
+// the single place that turns those facts into the aggregate orchestration
+// metrics (speedup, concurrency, critical path, cost), so the PRD and artifact
+// dashboards stay consistent by construction.
+
+import { v4 as uuidv4 } from 'uuid';
+import type { WorkflowNodeRun, WorkflowRun, WorkflowType } from '../../types';
+import { estimateCost, providerForModel } from './modelPricing';
+import {
+    actualRuntimeMs,
+    averageConcurrency,
+    criticalPathMs,
+    maxConcurrency,
+    parallelTimeSavedMs,
+    sequentialEstimateMs,
+    speedupRatio,
+} from './workflowMetrics';
+
+/** Raw per-node observation supplied by a pipeline. Absolute epoch ms timings. */
+export interface NodeObservation {
+    nodeId: string;
+    nodeName: string;
+    agentName?: string;
+    model: string;
+    provider?: string;
+    status: 'complete' | 'error';
+    dependencyIds?: string[];
+    parallelGroupId?: number;
+    startedAt: number;
+    completedAt: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    retryCount?: number;
+    errorMessage?: string;
+}
+
+export interface BuildWorkflowRunInput {
+    projectId: string;
+    projectName?: string;
+    workflowType: WorkflowType;
+    /** Epoch ms when the overall run began (defaults to earliest node start). */
+    startedAt?: number;
+    /** Epoch ms when the overall run settled (defaults to latest node end). */
+    completedAt?: number;
+    nodes: NodeObservation[];
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * Assign each node a topological wave index (0 = no dependencies). Nodes that
+ * share a level are dependency-eligible to run concurrently, which is exactly
+ * what the "parallel group" column means in the dashboard. Used as a fallback
+ * when a pipeline does not already supply parallelGroupId. Unknown deps are
+ * ignored; cycles (shouldn't occur — the PRD graph is validated) resolve to 0.
+ */
+export function computeParallelGroups(
+    nodes: Array<{ nodeId: string; dependencyIds?: string[] }>,
+): Map<string, number> {
+    const byId = new Map(nodes.map((n) => [n.nodeId, n] as const));
+    const level = new Map<string, number>();
+    const visiting = new Set<string>();
+
+    const resolve = (id: string): number => {
+        const cached = level.get(id);
+        if (cached !== undefined) return cached;
+        const node = byId.get(id);
+        if (!node) return 0;
+        if (visiting.has(id)) return 0;
+        visiting.add(id);
+        let max = -1;
+        for (const dep of node.dependencyIds ?? []) {
+            if (byId.has(dep)) max = Math.max(max, resolve(dep));
+        }
+        visiting.delete(id);
+        const lvl = max + 1;
+        level.set(id, lvl);
+        return lvl;
+    };
+
+    for (const n of nodes) resolve(n.nodeId);
+    return level;
+}
+
+function toNodeRun(obs: NodeObservation, fallbackGroup?: number): WorkflowNodeRun {
+    const durationMs = Math.max(0, obs.completedAt - obs.startedAt);
+    const inputTokens = obs.inputTokens;
+    const outputTokens = obs.outputTokens;
+    const totalTokens =
+        obs.totalTokens ??
+        (inputTokens !== undefined || outputTokens !== undefined
+            ? (inputTokens ?? 0) + (outputTokens ?? 0)
+            : undefined);
+    const cost = estimateCost(obs.model, { inputTokens, outputTokens, totalTokens: totalTokens ?? 0 });
+    return {
+        id: uuidv4(),
+        nodeId: obs.nodeId,
+        nodeName: obs.nodeName,
+        agentName: obs.agentName,
+        provider: obs.provider ?? providerForModel(obs.model),
+        model: obs.model,
+        status: obs.status,
+        dependencyIds: obs.dependencyIds ?? [],
+        parallelGroupId: obs.parallelGroupId ?? fallbackGroup,
+        startedAt: obs.startedAt,
+        completedAt: obs.completedAt,
+        durationMs,
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        estimatedCost: cost,
+        retryCount: obs.retryCount,
+        errorMessage: obs.errorMessage,
+    };
+}
+
+export function buildWorkflowRun(input: BuildWorkflowRunInput): WorkflowRun {
+    const groups = computeParallelGroups(input.nodes);
+    const nodes = input.nodes.map((obs) => toNodeRun(obs, groups.get(obs.nodeId)));
+
+    const startedAt =
+        input.startedAt ?? (nodes.length ? Math.min(...nodes.map((n) => n.startedAt)) : Date.now());
+    const completedAt =
+        input.completedAt ?? (nodes.length ? Math.max(...nodes.map((n) => n.completedAt)) : startedAt);
+
+    const seqMs = sequentialEstimateMs(nodes);
+    // Prefer the explicit run window when given, else derive from the node span.
+    const actualMs = input.startedAt !== undefined && input.completedAt !== undefined
+        ? Math.max(0, completedAt - startedAt)
+        : actualRuntimeMs(nodes);
+
+    const failureCount = nodes.filter((n) => n.status === 'error').length;
+    const retryCount = nodes.reduce((sum, n) => sum + (n.retryCount ?? 0), 0);
+    const totalInputTokens = nodes.reduce((sum, n) => sum + (n.inputTokens ?? 0), 0);
+    const totalOutputTokens = nodes.reduce((sum, n) => sum + (n.outputTokens ?? 0), 0);
+    const totalTokens = nodes.reduce((sum, n) => sum + (n.totalTokens ?? 0), 0);
+    const estimatedCost = nodes.reduce((sum, n) => sum + (n.estimatedCost ?? 0), 0);
+    const groupIds = new Set(
+        nodes.map((n) => n.parallelGroupId).filter((g): g is number => g !== undefined),
+    );
+
+    const status: WorkflowRun['status'] =
+        failureCount === 0 ? 'complete' : failureCount === nodes.length ? 'error' : 'partial';
+
+    return {
+        id: uuidv4(),
+        projectId: input.projectId,
+        projectName: input.projectName,
+        workflowType: input.workflowType,
+        status,
+        startedAt,
+        completedAt,
+        actualRuntimeMs: actualMs,
+        sequentialEstimateMs: seqMs,
+        parallelTimeSavedMs: parallelTimeSavedMs(seqMs, actualMs),
+        speedupRatio: speedupRatio(seqMs, actualMs),
+        maxConcurrency: maxConcurrency(nodes),
+        averageConcurrency: averageConcurrency(seqMs, actualMs),
+        criticalPathMs: criticalPathMs(nodes),
+        totalNodeRuntimeMs: seqMs,
+        totalInputTokens,
+        totalOutputTokens,
+        totalTokens,
+        estimatedCost,
+        retryCount,
+        failureCount,
+        nodeCount: nodes.length,
+        parallelGroupCount: groupIds.size,
+        nodes,
+        metadata: input.metadata,
+    };
+}

--- a/src/lib/metrics/modelPricing.ts
+++ b/src/lib/metrics/modelPricing.ts
@@ -1,0 +1,59 @@
+// Approximate model pricing for the Metrics dashboard's cost ESTIMATES.
+//
+// These are list-price approximations (USD per 1,000,000 tokens), matched to a
+// model id by family keyword. They are deliberately surfaced as "est." in the
+// UI — they are NOT a billing source of truth and do not account for context
+// caching, batch discounts, or provider-specific rounding. Tune the table here
+// if Google/OpenAI pricing changes; nothing else needs to update.
+
+import type { TokenUsage } from '../../types';
+
+export interface ModelPrice {
+    /** USD per 1M input tokens. */
+    input: number;
+    /** USD per 1M output tokens. */
+    output: number;
+}
+
+/**
+ * Family keyword → price. Matched case-insensitively as a substring of the
+ * model id, most-specific first (so 'flash-lite' wins over 'flash').
+ */
+export const MODEL_PRICING: Array<{ match: string; price: ModelPrice }> = [
+    { match: 'flash-lite', price: { input: 0.10, output: 0.40 } },
+    { match: 'pro', price: { input: 1.25, output: 5.0 } },
+    { match: 'flash', price: { input: 0.30, output: 2.5 } },
+    { match: 'gpt-4', price: { input: 2.5, output: 10.0 } },
+];
+
+/** Fallback when no family matches — a mid Flash-tier estimate. */
+const DEFAULT_PRICE: ModelPrice = { input: 0.30, output: 2.5 };
+
+export function priceForModel(model: string): ModelPrice {
+    const id = (model || '').toLowerCase();
+    for (const { match, price } of MODEL_PRICING) {
+        if (id.includes(match)) return price;
+    }
+    return DEFAULT_PRICE;
+}
+
+/**
+ * Estimated USD cost of a single call. Returns 0 when no token usage is
+ * available (so a run with un-instrumented nodes simply shows $0 rather than a
+ * fabricated number).
+ */
+export function estimateCost(model: string, usage: Partial<TokenUsage> | undefined): number {
+    if (!usage) return 0;
+    const { input, output } = priceForModel(model);
+    const inTok = usage.inputTokens ?? 0;
+    const outTok = usage.outputTokens ?? 0;
+    return (inTok / 1_000_000) * input + (outTok / 1_000_000) * output;
+}
+
+/** Provider label inferred from a model id (for per-provider breakdowns). */
+export function providerForModel(model: string): string {
+    const id = (model || '').toLowerCase();
+    if (id.includes('gpt') || id.includes('openai') || id.includes('dall')) return 'openai';
+    if (id.includes('gemini')) return 'gemini';
+    return 'gemini';
+}

--- a/src/lib/metrics/workflowMetrics.ts
+++ b/src/lib/metrics/workflowMetrics.ts
@@ -1,0 +1,151 @@
+// Pure, dependency-free metric math for the orchestration Metrics dashboard.
+//
+// Everything here is derived from per-node timings, so the same functions work
+// for a PRD run (sections) or an artifact bundle (artifacts). No model calls,
+// no store access — just arithmetic over intervals — which keeps them trivially
+// unit-testable and is why the "did concurrency actually help?" numbers can be
+// trusted.
+//
+// All timestamps are milliseconds. `startedAt`/`completedAt` may be either
+// epoch ms or run-relative ms — every function here only uses *differences*, so
+// the origin does not matter as long as a single run is internally consistent.
+
+/** Minimal node shape the metric functions need. */
+export interface MetricNode {
+    nodeId: string;
+    startedAt: number;
+    completedAt: number;
+    durationMs: number;
+    dependencyIds?: string[];
+}
+
+/**
+ * Hypothetical one-after-another runtime: the sum of every node's own
+ * duration. This is the baseline the concurrent executor is compared against.
+ */
+export function sequentialEstimateMs(nodes: Pick<MetricNode, 'durationMs'>[]): number {
+    return nodes.reduce((sum, n) => sum + Math.max(0, n.durationMs), 0);
+}
+
+/** Total node runtime — identical math to the sequential estimate, named for clarity at call sites. */
+export const totalNodeRuntimeMs = sequentialEstimateMs;
+
+/**
+ * Wall-clock runtime of the run, derived from the node span:
+ * max(completedAt) − min(startedAt). Returns 0 for an empty run.
+ */
+export function actualRuntimeMs(nodes: Pick<MetricNode, 'startedAt' | 'completedAt'>[]): number {
+    if (nodes.length === 0) return 0;
+    let min = Infinity;
+    let max = -Infinity;
+    for (const n of nodes) {
+        if (n.startedAt < min) min = n.startedAt;
+        if (n.completedAt > max) max = n.completedAt;
+    }
+    return Math.max(0, max - min);
+}
+
+/** Time saved by running concurrently: sequential estimate − actual runtime (never negative). */
+export function parallelTimeSavedMs(sequentialMs: number, actualMs: number): number {
+    return Math.max(0, sequentialMs - actualMs);
+}
+
+/**
+ * Speedup ratio: sequential / actual. 1 means no benefit (or a single node);
+ * 2.5 means the run finished 2.5× faster than running each node in series.
+ * Guards divide-by-zero and rounds to 2 decimals.
+ */
+export function speedupRatio(sequentialMs: number, actualMs: number): number {
+    if (actualMs <= 0) return sequentialMs > 0 ? sequentialMs : 1;
+    return Math.round((sequentialMs / actualMs) * 100) / 100;
+}
+
+/**
+ * Peak number of nodes running at the same instant. Sweep-line over node
+ * start/end events: +1 on a start, −1 on an end, tracking the running max.
+ * Ends are processed before starts at the same timestamp so two strictly
+ * back-to-back nodes are not counted as overlapping.
+ */
+export function maxConcurrency(nodes: Pick<MetricNode, 'startedAt' | 'completedAt'>[]): number {
+    if (nodes.length === 0) return 0;
+    type Ev = { t: number; delta: number };
+    const events: Ev[] = [];
+    for (const n of nodes) {
+        // Skip zero/negative-width intervals — they cannot overlap with anything.
+        if (n.completedAt <= n.startedAt) {
+            events.push({ t: n.startedAt, delta: 1 });
+            events.push({ t: n.startedAt, delta: -1 });
+            continue;
+        }
+        events.push({ t: n.startedAt, delta: 1 });
+        events.push({ t: n.completedAt, delta: -1 });
+    }
+    // Sort by time; at a tie, ends (−1) before starts (+1).
+    events.sort((a, b) => (a.t - b.t) || (a.delta - b.delta));
+    let cur = 0;
+    let peak = 0;
+    for (const e of events) {
+        cur += e.delta;
+        if (cur > peak) peak = cur;
+    }
+    return peak;
+}
+
+/**
+ * Average number of nodes in flight over the run: total node runtime / actual
+ * runtime. Equivalent to the area under the concurrency curve divided by its
+ * width. Rounded to 2 decimals.
+ */
+export function averageConcurrency(totalRuntimeMs: number, actualMs: number): number {
+    if (actualMs <= 0) return 0;
+    return Math.round((totalRuntimeMs / actualMs) * 100) / 100;
+}
+
+/**
+ * Longest dependency chain through the graph, weighted by node duration. This
+ * is the theoretical floor on runtime: even with infinite concurrency the run
+ * cannot finish faster than its critical path.
+ *
+ * Computed by memoized DFS — for each node, its chain cost is its own duration
+ * plus the max chain cost of its dependencies. Unknown dependency ids are
+ * ignored (treated as no-ops). When no dependencies are recorded anywhere, the
+ * critical path collapses to the single longest node, which is the correct
+ * answer for a fully-parallel graph.
+ */
+export function criticalPathMs(nodes: MetricNode[]): number {
+    if (nodes.length === 0) return 0;
+    const byId = new Map<string, MetricNode>();
+    for (const n of nodes) byId.set(n.nodeId, n);
+
+    const memo = new Map<string, number>();
+    const visiting = new Set<string>();
+
+    const cost = (id: string): number => {
+        const node = byId.get(id);
+        if (!node) return 0;
+        const cached = memo.get(id);
+        if (cached !== undefined) return cached;
+        // Cycle guard (the PRD graph is validated acyclic upstream, but stay safe).
+        if (visiting.has(id)) return Math.max(0, node.durationMs);
+        visiting.add(id);
+        let depMax = 0;
+        for (const dep of node.dependencyIds ?? []) {
+            depMax = Math.max(depMax, cost(dep));
+        }
+        visiting.delete(id);
+        const total = Math.max(0, node.durationMs) + depMax;
+        memo.set(id, total);
+        return total;
+    };
+
+    let longest = 0;
+    for (const n of nodes) longest = Math.max(longest, cost(n.nodeId));
+    return longest;
+}
+
+/** Success rate of a set of runs (0–1), counting non-error runs as successful. */
+export function successRate(statuses: Array<'complete' | 'partial' | 'error'>): number {
+    if (statuses.length === 0) return 0;
+    const ok = statuses.filter((s) => s !== 'error').length;
+    return ok / statuses.length;
+}

--- a/src/lib/runPrdGeneration.ts
+++ b/src/lib/runPrdGeneration.ts
@@ -82,6 +82,16 @@ export async function runPrdGeneration({
                 preflight,
                 enableConsistencyReview: consistencyReviewEnabled(),
                 surface: detectSurface(),
+                onWorkflowRun: (run) => {
+                    // The pipeline doesn't know the project — stamp identity here
+                    // where we do, so the Metrics dashboard can group by project.
+                    const project = useProjectStore.getState().getProject(projectId);
+                    useProjectStore.getState().recordWorkflowRun({
+                        ...run,
+                        projectId,
+                        projectName: project?.name,
+                    });
+                },
                 onProgress: (message) => {
                     useProjectStore.getState().appendPrdProgress(projectId, message);
                 },

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -18,6 +18,8 @@ import {
     getArtifactMeta,
 } from '../coreArtifactPipeline';
 import { isAbortError } from '../concurrency';
+import { getStrongModel } from '../geminiClient';
+import { buildWorkflowRun, type NodeObservation } from '../metrics/buildWorkflowRun';
 import { buildAutoMockupSettings } from '../mockupDefaults';
 import { normalizeError } from '../errors';
 import { useMockupImageStore } from '../../store/mockupImageStore';
@@ -383,6 +385,13 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
 
     const generatedArtifacts: Partial<Record<CoreArtifactSubtype, string>> = {};
 
+    // Per-slot observations for the orchestration WorkflowRun (artifact bundle).
+    // Captures wall-clock start/end + dependency edges so the Metrics dashboard
+    // can show the layered concurrency / speedup of artifact generation. Token
+    // capture for artifacts is a known TODO (see tasks/TODO.md).
+    const artifactRunStart = Date.now();
+    const nodeObs: NodeObservation[] = [];
+
     // Seed `generatedArtifacts` from the store for any core slot already done
     // for this spine — later layers may consume them as dependency context.
     for (const meta of CORE_ARTIFACT_PIPELINE) {
@@ -402,10 +411,34 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
             const tasks = layer
                 .filter(meta => coreSubtypes.has(meta.subtype))
                 .map(meta => async () => {
+                    const startedAt = Date.now();
                     try {
                         await runCoreArtifactSlot(args, meta.subtype, signal, generatedArtifacts);
+                        nodeObs.push({
+                            nodeId: meta.subtype,
+                            nodeName: meta.title,
+                            agentName: 'Artifact Agent',
+                            model: getStrongModel(),
+                            provider: 'gemini',
+                            status: 'complete',
+                            dependencyIds: meta.dependsOn,
+                            startedAt,
+                            completedAt: Date.now(),
+                        });
                     } catch (e) {
                         if (isAbortError(e) || signal.aborted) return;
+                        nodeObs.push({
+                            nodeId: meta.subtype,
+                            nodeName: meta.title,
+                            agentName: 'Artifact Agent',
+                            model: getStrongModel(),
+                            provider: 'gemini',
+                            status: 'error',
+                            dependencyIds: meta.dependsOn,
+                            startedAt,
+                            completedAt: Date.now(),
+                            errorMessage: e instanceof Error ? e.message : 'Unknown error',
+                        });
                         recordError(projectId, meta.subtype, e);
                     }
                 });
@@ -424,7 +457,19 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
             try {
                 await corePromise;
                 if (signal.aborted) return;
+                const startedAt = Date.now();
                 await runMockupSlot(args, signal);
+                nodeObs.push({
+                    nodeId: 'mockup',
+                    nodeName: 'Mockup',
+                    agentName: 'Mockup Agent',
+                    model: getStrongModel(),
+                    provider: 'gemini',
+                    status: 'complete',
+                    dependencyIds: MOCKUP_DEPENDENCIES,
+                    startedAt,
+                    completedAt: Date.now(),
+                });
             } catch (e) {
                 if (isAbortError(e) || signal.aborted) return;
                 recordError(projectId, 'mockup', e);
@@ -437,6 +482,26 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
     if (signal.aborted) {
         useProjectStore.getState().markAllInterrupted(projectId);
         return;
+    }
+
+    // Record the artifact-bundle WorkflowRun for the Metrics dashboard. Wrapped
+    // so a metrics failure can never break artifact generation.
+    if (nodeObs.length > 0) {
+        try {
+            const project = useProjectStore.getState().getProject(projectId);
+            const run = buildWorkflowRun({
+                projectId,
+                projectName: project?.name,
+                workflowType: 'artifacts',
+                startedAt: artifactRunStart,
+                completedAt: Date.now(),
+                nodes: nodeObs,
+                metadata: { slots: slotKeys },
+            });
+            useProjectStore.getState().recordWorkflowRun(run);
+        } catch (e) {
+            console.warn('[artifactJobController] failed to record workflow metrics.', e);
+        }
     }
 
     const job = useProjectStore.getState().getJob(projectId);

--- a/src/lib/services/prdService.ts
+++ b/src/lib/services/prdService.ts
@@ -44,6 +44,12 @@ export const generateStructuredPRD = async (
         onSectionStatus?: (sectionId: SectionId, update: SectionStatusUpdate) => void;
         onResult?: (result: PrdPipelineResult) => void;
         /**
+         * Fired once at completion with the assembled orchestration WorkflowRun
+         * (per-section timings, tokens, concurrency/speedup metrics). Purely
+         * observational — feeds the Metrics dashboard.
+         */
+        onWorkflowRun?: ProgressivePrdPipelineOptions['onWorkflowRun'];
+        /**
          * Fired once the pre-generation safety classification completes, for
          * `allowed` and `allowed_with_restrictions` outcomes. `disallowed`
          * does NOT fire this — it throws `SafetyBlockedError` instead so the
@@ -103,6 +109,7 @@ export const generateStructuredPRD = async (
             signal: options?.signal,
             enableConsistencyReview: options?.enableConsistencyReview,
             surface: options?.surface,
+            onWorkflowRun: options?.onWorkflowRun,
         },
         platform,
     );

--- a/src/lib/services/progressivePrdGeneration.ts
+++ b/src/lib/services/progressivePrdGeneration.ts
@@ -61,8 +61,22 @@ export type ProgressiveGenerationConfig = {
     enableRefinementPass: boolean;
 };
 
+/** Token counts captured from a model call (observational; for metrics). */
+export type NodeTokenUsage = {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+};
+
 export type ModelProvider = {
-    generateText: (input: { prompt: string; model: string; schema: object; signal?: AbortSignal }) => Promise<string>;
+    generateText: (input: {
+        prompt: string;
+        model: string;
+        schema: object;
+        signal?: AbortSignal;
+        /** Optional sink for token usage — forwarded to the transport. */
+        onUsage?: (usage: NodeTokenUsage) => void;
+    }) => Promise<string>;
 };
 
 export type ProgressiveEvent =
@@ -73,7 +87,7 @@ export type ProgressiveEvent =
     // "queued — waiting for a slot" UI state (distinct from "waiting on deps").
     | { type: 'section_ready'; sectionId: string }
     | { type: 'section_started'; sectionId: string; modelTier: ModelTier; model: string }
-    | { type: 'section_completed'; sectionId: string; content: string; confidence?: number }
+    | { type: 'section_completed'; sectionId: string; content: string; confidence?: number; usage?: NodeTokenUsage }
     | { type: 'section_refining'; sectionId: string }
     | { type: 'section_refined'; sectionId: string; content: string; confidence?: number }
     | { type: 'section_error'; sectionId: string; error: string }
@@ -176,7 +190,7 @@ export const parseSectionJson = (raw: string): Partial<StructuredPRD> | null => 
 };
 
 export const makeJsonProvider = (): ModelProvider => ({
-    async generateText({ prompt, model, schema, signal }) {
+    async generateText({ prompt, model, schema, signal, onUsage }) {
         return callGemini('', prompt, {
             responseMimeType: 'application/json',
             responseSchema: schema,
@@ -184,6 +198,7 @@ export const makeJsonProvider = (): ModelProvider => ({
             maxOutputTokens: 8192,
             temperature: 0.4,
             topP: 0.9,
+            onUsage,
         }, signal);
     },
 });
@@ -395,8 +410,15 @@ export async function generateProgressivePrd(params: {
         };
         const { system, user } = buildSectionPrompt(section.id, ctx);
 
+        let usage: NodeTokenUsage | undefined;
         try {
-            const raw = await provider.generateText({ prompt: `${system}\n\n${user}`, model, schema, signal: params.signal });
+            const raw = await provider.generateText({
+                prompt: `${system}\n\n${user}`,
+                model,
+                schema,
+                signal: params.signal,
+                onUsage: (u) => { usage = u; },
+            });
 
             // Parse with truncation repair fallback (shared helper).
             const parsed = parseSectionJson(raw);
@@ -422,6 +444,7 @@ export async function generateProgressivePrd(params: {
                 sectionId: section.id,
                 content: updated.content,
                 confidence: updated.confidence,
+                usage,
             });
 
             if (params.config.enableRefinementPass && result.confidence < 0.72 && tier === 'fast') {

--- a/src/lib/services/progressivePrdPipeline.ts
+++ b/src/lib/services/progressivePrdPipeline.ts
@@ -10,9 +10,10 @@ import { renderPremiumMarkdown } from './prdMarkdownRenderer';
 import { reviewPrdConsistency } from './prdConsistencyReview';
 import { logPrd, type PrdLogSurface } from './prdGenerationLog';
 import type { PrdPipelineOptions, PrdPipelineResult } from './prdPipeline';
-import type { StructuredPRD, GenerationPassRecord } from '../../types';
+import type { StructuredPRD, GenerationPassRecord, WorkflowRun } from '../../types';
 import type { SectionId } from '../schemas/prdSchemas';
 import type { ProjectPlatform } from '../../types';
+import { buildWorkflowRun, type NodeObservation } from '../metrics/buildWorkflowRun';
 
 export const PRD_SCHEMA_VERSION = 2;
 
@@ -42,6 +43,17 @@ export interface ProgressivePrdPipelineOptions extends PrdPipelineOptions {
     enableConsistencyReview?: boolean;
     /** Rendering surface, attached to structured logs for observability. */
     surface?: PrdLogSurface;
+    /**
+     * Fired once at completion with the assembled orchestration WorkflowRun
+     * (per-section node timings + aggregate speedup/concurrency/cost metrics).
+     * Observational only — never affects generation. Errors thrown by the
+     * callback are swallowed so metrics can never break a PRD run.
+     */
+    onWorkflowRun?: (run: WorkflowRun) => void;
+    /** Project id stamped onto the WorkflowRun (for the metrics dashboard). */
+    projectId?: string;
+    /** Project name stamped onto the WorkflowRun (display only). */
+    projectName?: string;
 }
 
 const SECTION_BY_ID = Object.fromEntries(DEFAULT_PRD_SECTIONS.map(s => [s.id, s]));
@@ -51,11 +63,19 @@ export const runProgressivePrdPipeline = async (
     options: ProgressivePrdPipelineOptions = {},
     platform?: ProjectPlatform,
 ): Promise<PrdPipelineResult> => {
-    const { onStatus, onPartial, onProgress, onSectionStatus, signal, enableConsistencyReview, surface } = options;
+    const { onStatus, onPartial, onProgress, onSectionStatus, signal, enableConsistencyReview, surface,
+        onWorkflowRun, projectId, projectName } = options;
 
     const fastModel = getFastModel();
     const strongModel = getStrongModel();
     const overallStart = performance.now();
+    // Epoch anchor so the WorkflowRun carries absolute wall-clock timestamps
+    // (for the dashboard's date column + Gantt layout) while still using the
+    // monotonic performance clock for durations.
+    const runStartedAtEpoch = Date.now();
+    const nowEpoch = () => runStartedAtEpoch + (performance.now() - overallStart);
+    // Per-section observations accumulated for the orchestration WorkflowRun.
+    const nodeObs: Record<string, NodeObservation> = {};
     const passes: GenerationPassRecord[] = [];
 
     // Per-section start times for duration tracking.
@@ -117,6 +137,18 @@ export const runProgressivePrdPipeline = async (
                 });
             } else if (event.type === 'section_started') {
                 sectionStarts[event.sectionId] = performance.now();
+                const started = SECTION_BY_ID[event.sectionId];
+                nodeObs[event.sectionId] = {
+                    nodeId: event.sectionId,
+                    nodeName: started?.title ?? event.sectionId,
+                    agentName: 'PRD Section Agent',
+                    model: event.model,
+                    provider: 'gemini',
+                    status: 'complete',
+                    dependencyIds: started?.dependencies ?? [],
+                    startedAt: nowEpoch(),
+                    completedAt: nowEpoch(),
+                };
                 const startedSection = SECTION_BY_ID[event.sectionId];
                 const tierLabel = event.modelTier === 'fast' ? 'Flash' : 'Pro';
                 const estimate = startedSection?.estimatedSeconds;
@@ -138,6 +170,14 @@ export const runProgressivePrdPipeline = async (
                 });
             } else if (event.type === 'section_completed') {
                 const ms = performance.now() - (sectionStarts[event.sectionId] ?? overallStart);
+                const obs = nodeObs[event.sectionId];
+                if (obs) {
+                    obs.status = 'complete';
+                    obs.completedAt = nowEpoch();
+                    obs.inputTokens = event.usage?.inputTokens;
+                    obs.outputTokens = event.usage?.outputTokens;
+                    obs.totalTokens = event.usage?.totalTokens;
+                }
                 const section = SECTION_BY_ID[event.sectionId];
                 const tier = section ? selectModelTier(section.risk) : 'strong';
                 onProgress?.(`✓ ${section?.title ?? event.sectionId} (${tier === 'fast' ? 'Flash' : 'Pro'}) · ${(ms / 1000).toFixed(1)}s`);
@@ -157,6 +197,12 @@ export const runProgressivePrdPipeline = async (
                 passes.push({ stage: event.sectionId, ms, ok: true });
             } else if (event.type === 'section_error') {
                 const ms = performance.now() - (sectionStarts[event.sectionId] ?? overallStart);
+                const obs = nodeObs[event.sectionId];
+                if (obs) {
+                    obs.status = 'error';
+                    obs.completedAt = nowEpoch();
+                    obs.errorMessage = event.error;
+                }
                 const section = SECTION_BY_ID[event.sectionId];
                 const tier = section ? selectModelTier(section.risk) : 'strong';
                 logPrd({
@@ -199,14 +245,30 @@ export const runProgressivePrdPipeline = async (
     // (handled below) or on a heavily-degraded partial. Guarded against detail
     // loss inside reviewPrdConsistency — a lossy revision is discarded.
     let reviewed = false;
+    let consistencyMs: number | undefined;
     if (enableConsistencyReview && failedSections.length === 0) {
         onProgress?.('Reviewing for consistency…');
         const reviewStart = performance.now();
+        const reviewStartEpoch = nowEpoch();
         try {
             const review = await reviewPrdConsistency(structuredPRD, { signal });
             const reviewMs = performance.now() - reviewStart;
+            consistencyMs = reviewMs;
             reviewed = review.applied;
             if (review.applied) structuredPRD = review.prd;
+            // Record the consistency pass as a final, all-sections-dependent
+            // node so the Gantt shows it sequentially after the parallel wave.
+            nodeObs['consistency_review'] = {
+                nodeId: 'consistency_review',
+                nodeName: 'Consistency Review',
+                agentName: 'Consistency Agent',
+                model: getFastModel(),
+                provider: 'gemini',
+                status: 'complete',
+                dependencyIds: Object.keys(nodeObs),
+                startedAt: reviewStartEpoch,
+                completedAt: nowEpoch(),
+            };
             passes.push({ stage: 'consistency_review', ms: reviewMs, ok: true });
             logPrd({
                 event: 'consistency_review',
@@ -249,6 +311,29 @@ export const runProgressivePrdPipeline = async (
         surface,
         detail: `${allJobs.length - failedSections.length}/${allJobs.length} sections ok${reviewed ? ', consistency-reviewed' : ''}`,
     });
+
+    // Assemble + emit the orchestration WorkflowRun. Wrapped so a metrics bug
+    // can never surface as a generation failure.
+    if (onWorkflowRun) {
+        try {
+            const run = buildWorkflowRun({
+                projectId: projectId ?? 'unknown',
+                projectName,
+                workflowType: 'prd',
+                startedAt: runStartedAtEpoch,
+                completedAt: runStartedAtEpoch + totalMs,
+                nodes: Object.values(nodeObs),
+                metadata: {
+                    models: `${fastModel} / ${strongModel}`,
+                    consistencyReviewMs: consistencyMs,
+                    consistencyReviewed: reviewed,
+                },
+            });
+            onWorkflowRun(run);
+        } catch (e) {
+            console.warn('[prd] failed to assemble workflow metrics run.', e);
+        }
+    }
 
     return {
         structuredPRD,

--- a/src/store/__tests__/metricsSlice.test.ts
+++ b/src/store/__tests__/metricsSlice.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import type { WorkflowRun } from '../../types';
+
+const reset = () =>
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+        tasks: {},
+        workflowRuns: {},
+    });
+
+const run = (id: string, projectId: string, startedAt: number): WorkflowRun => ({
+    id,
+    projectId,
+    workflowType: 'prd',
+    status: 'complete',
+    startedAt,
+    completedAt: startedAt + 1000,
+    actualRuntimeMs: 1000,
+    sequentialEstimateMs: 2500,
+    parallelTimeSavedMs: 1500,
+    speedupRatio: 2.5,
+    maxConcurrency: 3,
+    averageConcurrency: 2.1,
+    criticalPathMs: 800,
+    totalNodeRuntimeMs: 2500,
+    totalInputTokens: 100,
+    totalOutputTokens: 200,
+    totalTokens: 300,
+    estimatedCost: 0.01,
+    retryCount: 0,
+    failureCount: 0,
+    nodeCount: 5,
+    parallelGroupCount: 3,
+    nodes: [],
+});
+
+describe('metricsSlice', () => {
+    beforeEach(() => {
+        reset();
+        localStorage.clear();
+    });
+
+    it('records runs newest-first per project', () => {
+        const s = useProjectStore.getState();
+        s.recordWorkflowRun(run('r1', 'p1', 1000));
+        s.recordWorkflowRun(run('r2', 'p1', 2000));
+        const runs = useProjectStore.getState().getWorkflowRuns('p1');
+        expect(runs.map(r => r.id)).toEqual(['r2', 'r1']);
+    });
+
+    it('aggregates all runs across projects newest-first', () => {
+        const s = useProjectStore.getState();
+        s.recordWorkflowRun(run('r1', 'p1', 1000));
+        s.recordWorkflowRun(run('r2', 'p2', 3000));
+        s.recordWorkflowRun(run('r3', 'p1', 2000));
+        const all = useProjectStore.getState().getAllWorkflowRuns();
+        expect(all.map(r => r.id)).toEqual(['r2', 'r3', 'r1']);
+    });
+
+    it('caps stored runs per project at 50', () => {
+        const s = useProjectStore.getState();
+        for (let i = 0; i < 60; i++) {
+            s.recordWorkflowRun(run(`r${i}`, 'p1', i));
+        }
+        const runs = useProjectStore.getState().getWorkflowRuns('p1');
+        expect(runs).toHaveLength(50);
+        // Newest kept (r59 first), oldest dropped (r0..r9 gone).
+        expect(runs[0].id).toBe('r59');
+        expect(runs.some(r => r.id === 'r0')).toBe(false);
+    });
+
+    it('clears runs for a project', () => {
+        const s = useProjectStore.getState();
+        s.recordWorkflowRun(run('r1', 'p1', 1000));
+        s.clearWorkflowRuns('p1');
+        expect(useProjectStore.getState().getWorkflowRuns('p1')).toHaveLength(0);
+    });
+
+    it('removes runs when the project is deleted', () => {
+        const s = useProjectStore.getState();
+        const { projectId } = s.createProject('Test', 'an idea');
+        useProjectStore.getState().recordWorkflowRun(run('r1', projectId, 1000));
+        expect(useProjectStore.getState().getWorkflowRuns(projectId)).toHaveLength(1);
+        useProjectStore.getState().deleteProject(projectId);
+        expect(useProjectStore.getState().getWorkflowRuns(projectId)).toHaveLength(0);
+    });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -12,6 +12,7 @@ import { createStalenessSlice } from './slices/stalenessSlice';
 import { createGenerationJobsSlice } from './slices/generationJobsSlice';
 import { createPrdProgressSlice } from './slices/prdProgressSlice';
 import { createTasksSlice } from './slices/tasksSlice';
+import { createMetricsSlice } from './slices/metricsSlice';
 import { markInterruptedGenerations } from './interruptedGeneration';
 
 export type { ProjectState } from './types';
@@ -28,6 +29,7 @@ export const useProjectStore = create<ProjectState>()(
             ...createGenerationJobsSlice(...a),
             ...createPrdProgressSlice(...a),
             ...createTasksSlice(...a),
+            ...createMetricsSlice(...a),
         }),
         {
             name: 'synapse-projects-storage',

--- a/src/store/projectUserSync.ts
+++ b/src/store/projectUserSync.ts
@@ -32,6 +32,7 @@ function emptyPersistedState() {
     artifactVersions: {},
     feedbackItems: {},
     tasks: {},
+    workflowRuns: {},
   };
 }
 

--- a/src/store/slices/metricsSlice.ts
+++ b/src/store/slices/metricsSlice.ts
@@ -1,0 +1,52 @@
+import type { StateCreator } from 'zustand';
+import type { WorkflowRun } from '../../types';
+import type { ProjectState } from '../types';
+
+// Persisted orchestration-metrics history. Each project keeps a capped, newest-
+// first list of WorkflowRun records (PRD generations and artifact bundles) so
+// the Metrics dashboard can show real speedup/concurrency/cost numbers across
+// sessions. This is a thin, append-only store — all the metric math happens in
+// `src/lib/metrics/` before a run reaches `recordWorkflowRun`.
+
+export type MetricsSlice = {
+    workflowRuns: Record<string, WorkflowRun[]>;
+    recordWorkflowRun: ProjectState['recordWorkflowRun'];
+    getWorkflowRuns: ProjectState['getWorkflowRuns'];
+    getAllWorkflowRuns: ProjectState['getAllWorkflowRuns'];
+    clearWorkflowRuns: ProjectState['clearWorkflowRuns'];
+};
+
+// Keep storage bounded — a busy project regenerating repeatedly should not grow
+// localStorage without limit. Newest runs are kept.
+const RUNS_PER_PROJECT_CAP = 50;
+
+export const createMetricsSlice: StateCreator<ProjectState, [], [], MetricsSlice> = (set, get) => ({
+    workflowRuns: {},
+
+    recordWorkflowRun: (run) => {
+        set((state) => {
+            const existing = state.workflowRuns[run.projectId] ?? [];
+            const next = [run, ...existing].slice(0, RUNS_PER_PROJECT_CAP);
+            return {
+                workflowRuns: { ...state.workflowRuns, [run.projectId]: next },
+            };
+        });
+    },
+
+    getWorkflowRuns: (projectId) => get().workflowRuns[projectId] ?? [],
+
+    getAllWorkflowRuns: () => {
+        const all = Object.values(get().workflowRuns).flat();
+        // Newest first across all projects.
+        return all.sort((a, b) => b.startedAt - a.startedAt);
+    },
+
+    clearWorkflowRuns: (projectId) => {
+        set((state) => {
+            if (!state.workflowRuns[projectId]) return state;
+            const next = { ...state.workflowRuns };
+            delete next[projectId];
+            return { workflowRuns: next };
+        });
+    },
+});

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -78,6 +78,8 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             delete newFeedbackItems[projectId];
             const newTasks = { ...state.tasks };
             delete newTasks[projectId];
+            const newWorkflowRuns = { ...state.workflowRuns };
+            delete newWorkflowRuns[projectId];
             return {
                 projects: newProjects,
                 spineVersions: newSpines,
@@ -87,6 +89,7 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
                 artifactVersions: newArtifactVersions,
                 feedbackItems: newFeedbackItems,
                 tasks: newTasks,
+                workflowRuns: newWorkflowRuns,
             };
         });
     },

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -7,6 +7,7 @@ import type {
     QualityScores, GenerationMeta, SpineSafetyReview,
     PreflightMode, PreflightQuestion,
     ProjectTask, TaskStatus, TaskExternalRef,
+    WorkflowRun,
 } from '../types';
 import type { ImplementationTask } from '../types/tasks';
 import type { SectionId } from '../lib/schemas/prdSchemas';
@@ -189,6 +190,15 @@ export interface ProjectState {
     ) => void;
     getTasks: (projectId: string) => ProjectTask[];
     getTasksForArtifact: (projectId: string, sourceArtifactId: string) => ProjectTask[];
+
+    // Orchestration metrics — persisted WorkflowRun history keyed by projectId.
+    // Records what the concurrent DAG executor actually achieved per run
+    // (runtime, speedup, concurrency, tokens, cost) for the Metrics dashboard.
+    workflowRuns: Record<string, WorkflowRun[]>;
+    recordWorkflowRun: (run: WorkflowRun) => void;
+    getWorkflowRuns: (projectId: string) => WorkflowRun[];
+    getAllWorkflowRuns: () => WorkflowRun[];
+    clearWorkflowRuns: (projectId: string) => void;
 
     // Staleness
     getArtifactStaleness: (projectId: string, artifactId: string) => StalenessState;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -280,6 +280,89 @@ export type GenerationMeta = {
     failedSections?: string[];
 };
 
+// --- Workflow orchestration metrics domain types ---
+//
+// A WorkflowRun captures one end-to-end multi-agent run (a PRD generation, or
+// a downstream-artifact bundle) so the Metrics dashboard can show how much the
+// concurrent DAG executor actually saved over a hypothetical sequential run.
+// All fields are derived deterministically from per-node start/end timings —
+// nothing here changes generation behavior. These are persisted (per user,
+// keyed by projectId) in `metricsSlice`; keep every field present so older
+// stored runs stay renderable.
+
+/** Token counts for a single model call. */
+export type TokenUsage = {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+};
+
+export type WorkflowType = 'prd' | 'artifacts';
+
+export type WorkflowNodeStatus = 'complete' | 'error';
+
+/** One agent/section call within a workflow run. */
+export type WorkflowNodeRun = {
+    id: string;
+    /** Stable key for the unit of work (e.g. a PRD section id or artifact slot). */
+    nodeId: string;
+    /** Human-readable label shown in the timeline. */
+    nodeName: string;
+    /** Optional logical agent name (e.g. 'PRD Section Agent'). */
+    agentName?: string;
+    provider: string;                       // 'gemini' | 'openai' | …
+    model: string;
+    status: WorkflowNodeStatus;
+    /** nodeIds this node consumed as upstream context (true data deps only). */
+    dependencyIds: string[];
+    /** Topological wave index — nodes sharing one are eligible to run together. */
+    parallelGroupId?: number;
+    /** Wall-clock ms relative to the run start (so detail views can lay out bars). */
+    startedAt: number;
+    completedAt: number;
+    durationMs: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    estimatedCost?: number;                 // USD, estimate (see modelPricing.ts)
+    retryCount?: number;
+    errorMessage?: string;
+};
+
+export type WorkflowRunStatus = 'complete' | 'partial' | 'error';
+
+/** Aggregate metrics for one multi-agent workflow run. */
+export type WorkflowRun = {
+    id: string;
+    projectId: string;
+    projectName?: string;
+    workflowType: WorkflowType;
+    status: WorkflowRunStatus;
+    /** Epoch ms when the run started / settled. */
+    startedAt: number;
+    completedAt: number;
+    actualRuntimeMs: number;
+    /** Σ node.durationMs — the hypothetical one-after-another runtime. */
+    sequentialEstimateMs: number;
+    parallelTimeSavedMs: number;
+    speedupRatio: number;
+    maxConcurrency: number;
+    averageConcurrency: number;
+    criticalPathMs: number;
+    totalNodeRuntimeMs: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalTokens: number;
+    estimatedCost: number;                  // USD, estimate
+    retryCount: number;
+    failureCount: number;
+    nodeCount: number;
+    parallelGroupCount: number;
+    nodes: WorkflowNodeRun[];
+    /** Free-form extras (e.g. consistency-review ms, model pair). */
+    metadata?: Record<string, unknown>;
+};
+
 // --- Safety guardrail domain types ---
 
 export type SafetyClassification =

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -1,0 +1,47 @@
+# TODO — Orchestration, Metrics & Cost Tracking
+
+Backlog from the orchestration-metrics work. Phase 1 (instrumentation +
+dashboard) is implemented; the items below are deferred follow-ups.
+
+## Orchestration / Parallelism TODOs
+
+- [ ] Make `maxFastConcurrency` / `maxStrongConcurrency` configurable from
+      Settings (currently constants in `progressivePrdPipeline.ts`). Surface as
+      an "advanced" control with sane defaults.
+- [ ] Auto-tune concurrency caps based on observed 429/rate-limit responses
+      (back off the per-tier cap on `RESOURCE_EXHAUSTED`, recover on success).
+- [ ] Consider overlapping the optional consistency-review pass with
+      independent downstream work where it's safe (today it's strictly after the
+      DAG).
+- [ ] Expose the artifact dependency layers' concurrency utilization the same
+      way the PRD waves are shown.
+
+## Metrics Dashboard TODOs
+
+- [ ] Per-provider / per-model cost + token breakdown cards.
+- [ ] Filter/sort the runs table (by project, type, date range, status).
+- [ ] Optional richer charts (concurrency-over-time curve, cost trend) — kept
+      out of Phase 1 to stay clean.
+- [ ] Export a run's metrics as JSON/CSV for the portfolio writeup.
+- [ ] A compact "last run" speedup badge in the workspace header that deep-links
+      to `/metrics`.
+
+## AI Cost Tracking TODOs
+
+- [ ] Thread `onUsage` through `coreArtifactService` / `generateCoreArtifact` so
+      **artifact** runs capture real tokens & cost (today only PRD runs do).
+- [ ] Capture OpenAI image-generation cost for mockups (per-image pricing, not
+      token-based) via `api/image/generate.js`.
+- [ ] Calibrate `modelPricing.ts` against real billing and add a "pricing as of
+      <date>" note; consider reading prices from a config rather than code.
+- [ ] Account for context caching / batch discounts in the estimate.
+
+## Workflow Reliability TODOs
+
+- [ ] Capture streaming first-token latency where streaming is used.
+- [ ] Track DAG-internal retries (transport-level `fetchWithRetry` attempts) and
+      surface `retryCount` per node — currently only manual retries count.
+- [ ] Optional server-side persistence/aggregation of `WorkflowRun`s (the PRD
+      workspace is client-only today, so metrics are per-browser).
+- [ ] Record interrupted/aborted runs as a distinct status instead of dropping
+      them.


### PR DESCRIPTION
Audit finding: PRD section generation was already genuinely concurrent
(DAG executor with per-tier caps, Promise.all), and the 7 core artifacts
run in parallel dependency layers. The gap was measurement, not concurrency.

This change instruments the existing concurrency and surfaces it:

- Capture real Gemini token usage: callGemini reads usageMetadata and
  exposes it via an optional JsonModeConfig.onUsage callback, threaded
  through ModelProvider/makeJsonProvider and emitted on section_completed.
- New pure metric libs (src/lib/metrics): workflowMetrics (sequential
  estimate, actual runtime, speedup, max/avg concurrency, critical path),
  modelPricing (estimated cost), buildWorkflowRun (assembles a WorkflowRun
  + topological parallel groups). Unit-tested.
- New WorkflowRun/WorkflowNodeRun domain types and a persisted metricsSlice
  (workflowRuns keyed by projectId, capped, per-user; cleaned up on
  deleteProject; in emptyPersistedState).
- Decoupled, defensive recording from both the PRD pipeline and the
  artifact controller (onWorkflowRun; metrics never break a generation run).
- Dedicated auth-gated /metrics dashboard: overview cards, recent-runs
  table, per-run Gantt + node table; empty state, no synthetic data.
  Linked from Settings and the workspace menu.
- Tests: metric math, concurrency wall-clock regression guard (fails if
  serialized), metricsSlice, MetricsPage empty + data states.
- Docs: docs/ORCHESTRATION_AND_METRICS.md, tasks/TODO.md, CLAUDE.md, README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HZXD6MB1VUEzzGbWTiJi8i