### PR TITLE
Carry user project name into the PRD as productName

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,19 @@ device-scoped and never syncs) and full design.
     The legacy multi-pass scoring + revision passes were removed — old projects
     in localStorage retain their saved `qualityScores`, but no new generation
     writes them.
+    - **User project name → `productName`.** The name the user types when
+      creating a project is threaded into generation as an optional
+      `projectName` (call site `runPrdGeneration`/`ProjectWorkspace.handleRegenerate`
+      → `generateStructuredPRD` → pipeline → `generateProgressivePrd` →
+      `SectionPromptContext.projectName`). The `product_basics` builder
+      (`prdSectionPrompts.ts`) makes it the **authoritative** `productName` so the
+      PRD (and every downstream artifact/mockup, which read `productName`) use the
+      name the user chose instead of one the model invents. A generic-placeholder
+      guard (`isMeaningfulProjectName` / `GENERIC_PROJECT_NAMES`: "untitled",
+      "test", "my app", …) drops names with no product intent so the model is
+      still free to coin one. `runPrdGeneration` reads the name from the store by
+      `projectId`; pass it explicitly from any new direct `generateStructuredPRD`
+      call site.
     - **Optional final consistency review** (`prdConsistencyReview.ts`): off by
       default (one extra fast-model call). When enabled (localStorage
       `synapse-prd-consistency-review === 'true'`, threaded through as

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -274,6 +274,7 @@ export function ProjectWorkspace() {
             await generateStructuredPRD(
                 sourcePrompt,
                 {
+                    projectName: project?.name,
                     onProgress: (message) => appendPrdProgress(projectId, message),
                     onSectionStatus: (sectionId, update) => setSectionStatus(projectId, sectionId, update),
                     onWorkflowRun: (run) => {

--- a/src/lib/__tests__/prdSectionPrompts.test.ts
+++ b/src/lib/__tests__/prdSectionPrompts.test.ts
@@ -47,6 +47,34 @@ describe('buildSectionPrompt', () => {
         });
         expect(system.toLowerCase()).toContain('mobile');
     });
+
+    it('forces the user-chosen project name as the productName in product_basics', () => {
+        const { user } = buildSectionPrompt('product_basics', {
+            idea: 'A budgeting app',
+            projectName: 'PennyWise',
+            upstream: {},
+        });
+        expect(user).toContain('PennyWise');
+        expect(user.toLowerCase()).toContain('authoritative');
+    });
+
+    it('ignores a generic placeholder project name', () => {
+        const { user } = buildSectionPrompt('product_basics', {
+            idea: 'A budgeting app',
+            projectName: 'Untitled Project',
+            upstream: {},
+        });
+        expect(user).not.toContain('Untitled Project');
+        expect(user.toLowerCase()).not.toContain('authoritative');
+    });
+
+    it('does not reference a project name when none is provided', () => {
+        const { user } = buildSectionPrompt('product_basics', {
+            idea: 'A budgeting app',
+            upstream: {},
+        });
+        expect(user.toLowerCase()).not.toContain('authoritative');
+    });
 });
 
 describe('SECTION_TITLES', () => {

--- a/src/lib/prompts/prdSectionPrompts.ts
+++ b/src/lib/prompts/prdSectionPrompts.ts
@@ -6,6 +6,30 @@ export type SectionPromptContext = {
     idea: string;
     platform?: ProjectPlatform;
     upstream: Partial<StructuredPRD>;
+    /**
+     * The name the user gave the project when creating it. When present and not
+     * a generic placeholder, it is treated as the authoritative product name so
+     * the generated PRD (and every downstream artifact/mockup) uses the name the
+     * user chose rather than one the model invents. Only `product_basics`
+     * consumes it (it owns `productName`).
+     */
+    projectName?: string;
+};
+
+// Generic project names users type to get past the required-name field carry no
+// product intent — "untitled", "test", "my app", "new project", etc. When the
+// name looks like one of these, we don't force it onto the PRD as the product
+// name; the model is free to coin a fitting one instead.
+const GENERIC_PROJECT_NAMES = new Set([
+    'untitled', 'untitled project', 'new project', 'project', 'my project',
+    'test', 'test project', 'demo', 'example', 'app', 'my app', 'new app',
+    'website', 'my website', 'web app', 'prototype', 'mvp', 'draft', 'temp',
+]);
+
+const isMeaningfulProjectName = (name: string | undefined): name is string => {
+    const trimmed = name?.trim();
+    if (!trimmed) return false;
+    return !GENERIC_PROJECT_NAMES.has(trimmed.toLowerCase());
 };
 
 const PLATFORM_NOTE: Record<ProjectPlatform, string> = {
@@ -41,15 +65,24 @@ const missingNote = (sectionName: string): string =>
 type SectionPrompt = { system: string; user: string };
 
 const builders: Record<SectionId, (ctx: SectionPromptContext) => SectionPrompt> = {
-    product_basics: (ctx) => ({
-        system: `${SHARED_PREAMBLE}
+    product_basics: (ctx) => {
+        const named = isMeaningfulProjectName(ctx.projectName);
+        const nameDirective = named
+            ? `\n\nThe user named this product "${ctx.projectName!.trim()}". Use this exact name as the productName — it is the authoritative product name. Do NOT invent a different one. (Only override it if it is clearly an offensive or unusable string.)`
+            : '';
+        const productNameInstruction = named
+            ? `productName (string — use the user's product name "${ctx.projectName!.trim()}" verbatim)`
+            : 'productName (string)';
+        return {
+            system: `${SHARED_PREAMBLE}
 
 You are generating the product_basics slice: productName, productCategory, executiveSummary, vision, targetUsers, coreProblem.
 ${ctx.platform ? PLATFORM_NOTE[ctx.platform] : ''}`,
-        user: `Product idea:\n${ctx.idea}
+            user: `Product idea:\n${ctx.idea}${nameDirective}
 
-Return JSON with: productName (string), productCategory (short label e.g. "B2C Marketplace"), executiveSummary (2–3 sentences), vision (1 aspirational sentence), targetUsers (3–5 specific user types as strings), coreProblem (the core pain solved — state the user's current workaround, why existing solutions fail, and the consequence of leaving it unsolved).`,
-    }),
+Return JSON with: ${productNameInstruction}, productCategory (short label e.g. "B2C Marketplace"), executiveSummary (2–3 sentences), vision (1 aspirational sentence), targetUsers (3–5 specific user types as strings), coreProblem (the core pain solved — state the user's current workaround, why existing solutions fail, and the consequence of leaving it unsolved).`,
+        };
+    },
 
     product_thesis: (ctx) => {
         const basics = pick(ctx.upstream, 'vision', 'coreProblem', 'targetUsers');

--- a/src/lib/runPrdGeneration.ts
+++ b/src/lib/runPrdGeneration.ts
@@ -53,6 +53,9 @@ export async function runPrdGeneration({
     preflight,
 }: RunPrdGenerationParams): Promise<void> {
     const store = useProjectStore.getState();
+    // The name the user gave the project is forwarded into generation so the
+    // PRD's productName reflects it (see prdSectionPrompts.product_basics).
+    const projectName = store.getProject(projectId)?.name;
     // Fresh run starts with a clean event log. Marking the spine 'running'
     // lets rehydration detect an interrupted run if the page is closed
     // mid-generation (see markInterruptedGenerations).
@@ -80,6 +83,7 @@ export async function runPrdGeneration({
             sourcePrompt,
             {
                 preflight,
+                projectName,
                 enableConsistencyReview: consistencyReviewEnabled(),
                 surface: detectSurface(),
                 onWorkflowRun: (run) => {

--- a/src/lib/services/prdService.ts
+++ b/src/lib/services/prdService.ts
@@ -68,6 +68,12 @@ export const generateStructuredPRD = async (
         enableConsistencyReview?: ProgressivePrdPipelineOptions['enableConsistencyReview'];
         /** Rendering surface for observability logs. */
         surface?: ProgressivePrdPipelineOptions['surface'];
+        /**
+         * The user-chosen project name. When meaningful (not a generic
+         * placeholder), it becomes the PRD's authoritative `productName` so the
+         * name the user typed carries through to the PRD and downstream assets.
+         */
+        projectName?: ProgressivePrdPipelineOptions['projectName'];
     },
     platform?: ProjectPlatform,
 ): Promise<StructuredPRD> => {
@@ -110,6 +116,7 @@ export const generateStructuredPRD = async (
             enableConsistencyReview: options?.enableConsistencyReview,
             surface: options?.surface,
             onWorkflowRun: options?.onWorkflowRun,
+            projectName: options?.projectName,
         },
         platform,
     );

--- a/src/lib/services/progressivePrdGeneration.ts
+++ b/src/lib/services/progressivePrdGeneration.ts
@@ -375,6 +375,8 @@ async function runDag(
 export async function generateProgressivePrd(params: {
     prompt: string;
     platform?: ProjectPlatform;
+    /** User-chosen project name, surfaced to product_basics as the productName. */
+    projectName?: string;
     config: ProgressiveGenerationConfig;
     provider?: ModelProvider;
     onEvent?: (event: ProgressiveEvent) => void;
@@ -407,6 +409,7 @@ export async function generateProgressivePrd(params: {
             idea: params.prompt,
             platform: params.platform,
             upstream,
+            projectName: params.projectName,
         };
         const { system, user } = buildSectionPrompt(section.id, ctx);
 

--- a/src/lib/services/progressivePrdPipeline.ts
+++ b/src/lib/services/progressivePrdPipeline.ts
@@ -90,6 +90,7 @@ export const runProgressivePrdPipeline = async (
     const { jobs, results } = await generateProgressivePrd({
         prompt: promptText,
         platform,
+        projectName,
         config: {
             fastModel,
             strongModel,


### PR DESCRIPTION
When creating a project the user supplies a project name, but it never
reached PRD generation — the model invented its own productName instead.
Thread the user-chosen name through the generation chain
(runPrdGeneration / ProjectWorkspace.handleRegenerate → generateStructuredPRD
→ pipeline → generateProgressivePrd → SectionPromptContext) so the
product_basics section uses it as the authoritative productName, which then
flows to downstream artifacts and mockups that read productName.

A generic-placeholder guard (untitled / test / my app / …) drops names with
no product intent so the model can still coin a fitting one.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019SYEdsPL8dngg47GKzPD1R