### PR TITLE
Fix demo restore wiping the source project's mockup images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,35 @@ otherwise have nothing in common — keep that distinction in mind:
    The old Atlas Data API REST gateway was retired by MongoDB (2025-09-30); the
    shim preserves the prior call/return shapes so call sites are unchanged.
 
+### Snapshots & the demo project (`src/lib/snapshotClient.ts`, `api/snapshots.js`)
+
+Owner-only project snapshots bundle a project's Zustand slice **plus its
+IndexedDB-backed mockup images** (base64 PNGs from `src/lib/mockupImageStore.ts`,
+keyed `versionId:screenId:quality` where `versionId` is the **artifact version
+id**) and push them to Vercel Blob behind a `SYNAPSE_OWNER_TOKEN` gate. Images
+are split out of the JSON envelope and shipped one request each so neither
+upload nor download crosses Vercel's ~4.5 MB cap. One snapshot can be pinned as
+**the demo** (`_demo.json` pointer + public `?demo=1` read); `loadDemoProject`
+restores it under the stable `DEMO_PROJECT_ID`.
+
+- **Restoring under a *different* project id MUST namespace the artifact version
+  ids** (`namespaceSnapshotForRestore` → `rewriteIds`), not just the project id.
+  Mockup images are keyed in IndexedDB by `versionId` with **no projectId in the
+  key**, so a demo restored from a real project's snapshot would otherwise share
+  version ids — and `restoreSnapshotAs`'s `deleteImagesForVersion()` would wipe
+  and re-tag the **source project's** images. Version ids are namespaced as
+  `${targetProjectId}:${versionId}` (deterministic → idempotent re-restores) and
+  each image's composite `key` is rebuilt from the remapped fields. Never restore
+  a snapshot under a foreign project id without this remap.
+- **`collectProjectImages` must not filter images by the stored `record.projectId`.**
+  A version id uniquely identifies its owning project, so collect by version id
+  only; filtering on a (possibly drifted) `projectId` tag is what silently
+  dropped mockup images from snapshots.
+- Note: user-uploaded Screen Inventory images
+  (`src/lib/screenInventoryImageStore.ts`, a separate IndexedDB store) are **not
+  yet** captured in snapshots, and `/api/projects` cross-device sync is
+  text-only (no images) — both are documented gaps, not bugs to "fix" silently.
+
 ### Server-side project storage (`api/projects.js`, `api/_lib/projectsStore.js`, `src/store/projectServerSync.ts`)
 
 PRD projects sync to a MongoDB `projects` collection so a signed-in user sees the

--- a/src/lib/__tests__/snapshotClient.test.ts
+++ b/src/lib/__tests__/snapshotClient.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { namespaceSnapshotForRestore } from '../snapshotClient';
+import type { SnapshotPayload } from '../snapshotClient';
+import type { MockupImageRecord } from '../../types';
+import { buildImageKey } from '../mockupImageStore';
+
+// Builds a minimal-but-realistic snapshot for a source project that has one
+// mockup artifact version with two AI image records. Only the fields the
+// namespacing logic reads are populated; the rest is cast away.
+const SOURCE_PROJECT_ID = 'aaaaaaaa-0000-4000-8000-000000000001';
+const VERSION_ID = 'bbbbbbbb-0000-4000-8000-000000000002';
+const DEMO_PROJECT_ID = '00000000-0000-4000-8000-000000000d01';
+
+const makeImage = (quality: MockupImageRecord['quality']): MockupImageRecord => ({
+    key: buildImageKey(VERSION_ID, 'screen-1', quality),
+    projectId: SOURCE_PROJECT_ID,
+    artifactId: 'artifact-1',
+    versionId: VERSION_ID,
+    screenId: 'screen-1',
+    dataUrl: `data:image/png;base64,${quality}`,
+    quality,
+    prompt: 'p',
+    generatedAt: 1,
+});
+
+const makeSnapshot = (): SnapshotPayload => ({
+    schemaVersion: 2,
+    manifest: {
+        id: 'snap-1', title: 't', projectName: 'n',
+        createdAt: '2026-01-01', schemaVersion: 2, imageCount: 2,
+    },
+    project: {
+        project: { id: SOURCE_PROJECT_ID },
+        spineVersions: [],
+        historyEvents: [],
+        branches: [],
+        artifacts: [],
+        // The version id is also referenced from a sourceRef to prove the
+        // remap is applied consistently across the bundle, not just on `.id`.
+        artifactVersions: [
+            {
+                id: VERSION_ID,
+                sourceRefs: [{ sourceType: 'spine', sourceArtifactVersionId: VERSION_ID }],
+            },
+        ],
+        feedbackItems: [],
+    } as unknown as SnapshotPayload['project'],
+    images: [makeImage('low'), makeImage('high')],
+});
+
+describe('namespaceSnapshotForRestore', () => {
+    it('namespaces the project id and every artifact version id under the target', () => {
+        const { bundle, images } = namespaceSnapshotForRestore(makeSnapshot(), DEMO_PROJECT_ID);
+
+        expect(bundle.project.id).toBe(DEMO_PROJECT_ID);
+        const av = bundle.artifactVersions[0] as { id: string; sourceRefs: Array<{ sourceArtifactVersionId: string }> };
+        const namespacedVersionId = `${DEMO_PROJECT_ID}:${VERSION_ID}`;
+        expect(av.id).toBe(namespacedVersionId);
+        // The same id referenced elsewhere in the bundle is remapped too.
+        expect(av.sourceRefs[0].sourceArtifactVersionId).toBe(namespacedVersionId);
+
+        for (const img of images) {
+            expect(img.versionId).toBe(namespacedVersionId);
+            expect(img.projectId).toBe(DEMO_PROJECT_ID);
+            // The composite key is rebuilt from the remapped fields.
+            expect(img.key).toBe(buildImageKey(namespacedVersionId, img.screenId, img.quality));
+        }
+    });
+
+    it('isolates restored images from the source project (no shared version ids)', () => {
+        const { images } = namespaceSnapshotForRestore(makeSnapshot(), DEMO_PROJECT_ID);
+        // None of the restored images reuse the source project's version id, so
+        // deleteImagesForVersion during restore can never touch the source's
+        // IndexedDB records.
+        expect(images.every((r) => r.versionId !== VERSION_ID)).toBe(true);
+    });
+
+    it('is a no-op remap when the target equals the snapshot project id', () => {
+        const snapshot = makeSnapshot();
+        const { bundle, images } = namespaceSnapshotForRestore(snapshot, SOURCE_PROJECT_ID);
+        // Same project id => restore over self, ids untouched.
+        expect(bundle).toBe(snapshot.project);
+        expect(images).toBe(snapshot.images);
+        expect(images[0].versionId).toBe(VERSION_ID);
+    });
+});

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -24,7 +24,7 @@ import type {
     Artifact, ArtifactVersion, FeedbackItem, MockupImageRecord,
 } from '../types';
 import { useProjectStore } from '../store/projectStore';
-import { listImagesForVersion, putImage, deleteImagesForVersion } from './mockupImageStore';
+import { buildImageKey, listImagesForVersion, putImage, deleteImagesForVersion } from './mockupImageStore';
 
 export const OWNER_TOKEN_KEY = 'synapse-owner-token';
 
@@ -131,13 +131,19 @@ export const collectProjectBundle = (projectId: string): SnapshotProjectBundle =
 // versions. The store keys artifactVersions by projectId, so the bundle's
 // version list already represents this project exhaustively. The IDB index
 // is keyed by versionId, so we walk that for each version.
+//
+// We deliberately do NOT filter on `record.projectId`. Artifact version ids
+// are unique per project (and the demo restore namespaces them — see
+// `namespaceSnapshotForRestore`), so a version id unambiguously identifies the
+// owning project. Filtering on the stored `projectId` used to silently drop
+// images whose tag had drifted (e.g. records left tagged with the demo project
+// id by the old restore path), which is exactly how snapshots ended up
+// "losing" mockup images.
 const collectProjectImages = async (bundle: SnapshotProjectBundle): Promise<MockupImageRecord[]> => {
     const out: MockupImageRecord[] = [];
     for (const v of bundle.artifactVersions) {
         const records = await listImagesForVersion(v.id);
-        for (const r of records) {
-            if (r.projectId === bundle.project.id) out.push(r);
-        }
+        out.push(...records);
     }
     return out;
 };
@@ -330,25 +336,70 @@ export const restoreSnapshot = async (snapshot: SnapshotPayload): Promise<string
     return projectId;
 };
 
-// Deep-clone a bundle while rewriting every string occurrence of `fromId` to
-// `toId`. We use this when restoring a snapshot as the demo project so the
-// project URL is stable across visitors (always /p/<DEMO_PROJECT_ID>) and
-// independent of whichever real project id was saved.
-const rewriteProjectId = <T,>(value: T, fromId: string, toId: string): T => {
+// Deep-clone a value while replacing every string that EXACTLY equals a key in
+// `idMap` with its mapped value. Exact-string matching (never substring) keeps
+// this safe to run over PRD prose / markdown — only standalone id fields are
+// rewritten, never an id that happens to appear inside a longer string.
+const rewriteIds = <T,>(value: T, idMap: Map<string, string>): T => {
     if (Array.isArray(value)) {
-        return value.map((v) => rewriteProjectId(v, fromId, toId)) as unknown as T;
+        return value.map((v) => rewriteIds(v, idMap)) as unknown as T;
     }
     if (value && typeof value === 'object') {
         const out: Record<string, unknown> = {};
         for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-            out[k] = rewriteProjectId(v, fromId, toId);
+            out[k] = rewriteIds(v, idMap);
         }
         return out as T;
     }
-    if (typeof value === 'string' && value === fromId) {
-        return toId as unknown as T;
+    if (typeof value === 'string' && idMap.has(value)) {
+        return idMap.get(value) as unknown as T;
     }
     return value;
+};
+
+// Produce a copy of a snapshot whose ids are namespaced under `targetProjectId`
+// so the restored project shares NO ids — and therefore no IndexedDB image
+// keys — with any real project already on this device.
+//
+// This is the crux of the "setting a project as demo wiped its mockup images"
+// bug. Mockup images are keyed in IndexedDB by `versionId` (the artifact
+// version id). The demo restore reuses the source project's bundle, so without
+// remapping, the demo and its source project reference the *same* artifact
+// version ids — and `restoreSnapshotAs` would `deleteImagesForVersion()` and
+// overwrite the source project's own images. Remapping every artifact version
+// id (and rebuilding each image's composite key) isolates the demo completely.
+//
+// Pure: no IndexedDB / store access, so it is unit-testable in isolation.
+export const namespaceSnapshotForRestore = (
+    snapshot: SnapshotPayload,
+    targetProjectId: string,
+): { bundle: SnapshotProjectBundle; images: MockupImageRecord[] } => {
+    const sourceId = snapshot.project.project.id;
+
+    const idMap = new Map<string, string>();
+    if (sourceId !== targetProjectId) {
+        idMap.set(sourceId, targetProjectId);
+        // Namespace every artifact version id deterministically so repeated
+        // restores are idempotent and never collide with a real project's
+        // bare-UUID version ids.
+        for (const v of snapshot.project.artifactVersions) {
+            if (v.id) idMap.set(v.id, `${targetProjectId}:${v.id}`);
+        }
+    }
+
+    if (idMap.size === 0) {
+        return { bundle: snapshot.project, images: snapshot.images };
+    }
+
+    const bundle = rewriteIds(snapshot.project, idMap);
+    const images = snapshot.images.map((record) => {
+        const next = rewriteIds(record, idMap);
+        // The composite `key` embeds the versionId, so rebuild it from the
+        // remapped fields rather than relying on exact-string replacement.
+        return { ...next, key: buildImageKey(next.versionId, next.screenId, next.quality) };
+    });
+
+    return { bundle, images };
 };
 
 // Restore a snapshot into the store under a fixed `targetProjectId` instead
@@ -359,21 +410,14 @@ export const restoreSnapshotAs = async (
     snapshot: SnapshotPayload,
     targetProjectId: string,
 ): Promise<string> => {
-    const sourceId = snapshot.project.project.id;
-    const remapped: SnapshotProjectBundle = sourceId === targetProjectId
-        ? snapshot.project
-        : rewriteProjectId(snapshot.project, sourceId, targetProjectId);
+    const { bundle: remapped, images } = namespaceSnapshotForRestore(snapshot, targetProjectId);
 
-    const versionIds = new Set(snapshot.images.map((r) => r.versionId));
+    const versionIds = new Set(images.map((r) => r.versionId));
     for (const vid of versionIds) {
         await deleteImagesForVersion(vid);
     }
-    for (const record of snapshot.images) {
-        // Image records also embed projectId, so remap before persisting.
-        const remappedRecord = sourceId === targetProjectId
-            ? record
-            : rewriteProjectId(record, sourceId, targetProjectId);
-        await putImage(remappedRecord);
+    for (const record of images) {
+        await putImage(record);
     }
 
     useProjectStore.setState((state) => ({


### PR DESCRIPTION
Mockup images live in IndexedDB keyed by versionId:screenId:quality with no
projectId in the key, where versionId is the artifact version id. Restoring a
snapshot under the stable DEMO_PROJECT_ID (loadDemoProject) only remapped the
project id, leaving artifact version ids unchanged. Since the demo and its
source project then shared version ids, restoreSnapshotAs's
deleteImagesForVersion() deleted and re-tagged the SOURCE project's images —
so a project "set as demo" lost its mockups, and collectProjectImages (which
filtered on the now-drifted record.projectId) silently dropped images from
future snapshots.

- namespaceSnapshotForRestore (pure, exported) namespaces every artifact
  version id as `${targetProjectId}:${versionId}` and rebuilds each image's
  composite key, isolating the demo's IndexedDB images from any real project.
- restoreSnapshotAs uses it; deletes/writes only the namespaced keys.
- collectProjectImages no longer filters by record.projectId — a version id
  uniquely identifies its project, and the filter is what dropped drifted
  images. This also recovers images for already-corrupted local state.
- Unit tests for the namespacing helper; CLAUDE.md documents the rule.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PFy3BGTbLzMhSZ6b3gMZSr