### PR TITLE
Route core artifacts to Fast/Expert model by complexity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,19 +257,37 @@ device-scoped and never syncs) and full design.
     generation.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
-    implementation_plan, prompt_pack, design_system). **Complexity-based model
-    routing (mirrors the PRD pipeline):** each subtype is tagged in
-    `CORE_ARTIFACT_COMPLEXITY` as `low`/`high`, and `selectArtifactModel()`
-    resolves a `high` artifact (screen_inventory, user_flows, data_model,
-    implementation_plan) to the Expert/Pro model (`getStrongModel`) and a `low`
-    artifact (component_inventory, design_system, prompt_pack) to the Fast/Flash
-    model (`getFastModel`) — both configured in Settings → "PRD Generation
-    Models" and shared with the PRD pipeline (when tier models are unset, both
-    resolvers fall back to the single "Intelligence Level" `GEMINI_MODEL`). The
-    resolved model is threaded into every generate **and** refine call, and
-    `artifactJobController` records that same per-subtype model in workflow
-    metrics (previously it always reported the strong model). Keep
+    implementation_plan, prompt_pack, design_system). **Per-artifact model
+    routing (`src/lib/artifactModelSettings.ts`):** the routing brain lives in
+    `artifactModelSettings.ts` (not coreArtifactService) so the Settings UI and
+    the generation pipeline share one source of truth. Each subtype is tagged in
+    `CORE_ARTIFACT_COMPLEXITY` (`low`/`high`); `getArtifactModel(subtype)`
+    resolves **(1)** an explicit per-artifact override (Settings → "Artifact
+    Generation Models", persisted as the `GEMINI_ARTIFACT_MODELS` JSON map),
+    else **(2)** the complexity recommendation — `high` (screen_inventory,
+    user_flows, data_model, implementation_plan) → Expert/Pro (`getStrongModel`),
+    `low` (component_inventory, design_system, prompt_pack) → Fast/Flash
+    (`getFastModel`), else **(3)** the tier fallback to the single Default model
+    (`getModel`) → `DEFAULT_GEMINI_MODEL`. `coreArtifactService.selectArtifactModel`
+    delegates to `getArtifactModel` and re-exports `CORE_ARTIFACT_COMPLEXITY` for
+    back-compat. Existing projects have no override key, so behaviour is
+    unchanged until the user picks a model (no migration). The resolved model is
+    threaded into every generate **and** refine call, and `artifactJobController`
+    records that same per-subtype model in workflow metrics. Keep
     `CORE_ARTIFACT_COMPLEXITY` in sync when adding a `CoreArtifactSubtype`.
+    **Mockups are image artifacts, not text:** `artifactModelSettings` also owns
+    the mockup **image source mode** (`getMockupImageMode`/`setMockupImageMode`,
+    `SYNAPSE_MOCKUP_IMAGE_MODE`: `gpt_image` | `user_uploaded`, default
+    `gpt_image`). `resolveMockupRender(mode, hasOpenAiKey)` decides per screen:
+    `user_uploaded` (or `gpt_image` with **no** OpenAI key — a non-silent forced
+    fallback) → the manual prompt+upload sheet (`MockupScreenUpload`, reusing the
+    IDB-backed `screenInventoryImageStore` keyed by the mockup version id);
+    otherwise the OpenAI gpt-image-2 generator (`MockupScreenImage`).
+    `MockupImageStatusChip` summarizes per-version status (AI-generated /
+    uploaded / awaiting). The Settings section is `settings/ArtifactModelsSection.tsx`
+    (PRD shown as expandable "Multi", text artifacts with Complex/Simple badges,
+    Mockups with an "Image Source" select); the model list is the shared
+    `src/lib/modelCatalog.ts`.
     Three of these
     (screen/data/component inventory) use Gemini JSON mode with schemas in
     `schemas/artifactSchemas.ts`, then convert to markdown via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,20 @@ device-scoped and never syncs) and full design.
     generation.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
-    implementation_plan, prompt_pack, design_system). Three of these
+    implementation_plan, prompt_pack, design_system). **Complexity-based model
+    routing (mirrors the PRD pipeline):** each subtype is tagged in
+    `CORE_ARTIFACT_COMPLEXITY` as `low`/`high`, and `selectArtifactModel()`
+    resolves a `high` artifact (screen_inventory, user_flows, data_model,
+    implementation_plan) to the Expert/Pro model (`getStrongModel`) and a `low`
+    artifact (component_inventory, design_system, prompt_pack) to the Fast/Flash
+    model (`getFastModel`) — both configured in Settings → "PRD Generation
+    Models" and shared with the PRD pipeline (when tier models are unset, both
+    resolvers fall back to the single "Intelligence Level" `GEMINI_MODEL`). The
+    resolved model is threaded into every generate **and** refine call, and
+    `artifactJobController` records that same per-subtype model in workflow
+    metrics (previously it always reported the strong model). Keep
+    `CORE_ARTIFACT_COMPLEXITY` in sync when adding a `CoreArtifactSubtype`.
+    Three of these
     (screen/data/component inventory) use Gemini JSON mode with schemas in
     `schemas/artifactSchemas.ts`, then convert to markdown via
     `structuredArtifactToMarkdown()` for storage; renderers in

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ and categorized component cards rather than raw markdown. Every artifact tracks
 refinement** ("add error states to each screen"), and surfaces **quality
 warnings** if the output looks truncated or malformed.
 
+Each artifact is routed to the right model by complexity — Flash for simpler
+artifacts, Pro for complex reasoning — and you can override the model **per
+artifact** in Settings → **Artifact Generation Models** (the PRD itself routes
+per-section). Sensible defaults mean you never have to touch it.
+
 #### Multi-fidelity UI mockups
 
 <img width="100%" alt="UI Mockups are one of the assets generated from the finalized PRD" src="public/screenshots/tour-assets.png" />
@@ -165,7 +170,12 @@ warnings** if the output looks truncated or malformed.
 Generate UI mockups directly from the finalized PRD with configurable platform
 (mobile / desktop), fidelity (wireframe / mid-fi / high-fi), and scope (single
 screen / multi-screen / key workflow). Every run is saved as a new version so
-you can diff iterations side-by-side.
+you can diff iterations side-by-side. Per-screen images come from one of two
+sources (chosen in Settings → **Artifact Generation Models → Mockups**): OpenAI
+`gpt-image-2`, or **your own uploads** — the latter shows a generated prompt for
+each screen (goal, layout, visual style, expected format) to guide what you
+create and upload. If GPT Image is selected without an OpenAI key, Synapse falls
+back to the upload sheet rather than failing silently.
 
 #### Integrated feedback loop
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synapse-prd",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,6 +4,16 @@ import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle
 import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 import { ProviderKeysSection } from './settings/ProviderKeysSection';
 import { ConnectedAccountsSection } from './settings/ConnectedAccountsSection';
+import { ArtifactModelsSection } from './settings/ArtifactModelsSection';
+import { MODEL_CATALOG, CURRENT_MODELS, LEGACY_MODELS, type ModelOption } from '../lib/modelCatalog';
+import {
+    getArtifactModelOverrides,
+    setArtifactModelOverrides,
+    getMockupImageMode,
+    setMockupImageMode,
+    type MockupImageMode,
+} from '../lib/artifactModelSettings';
+import type { CoreArtifactSubtype } from '../types';
 import {
     getLocalCredential,
     setLocalCredential,
@@ -19,62 +29,6 @@ const DEFAULT_STRONG_MODEL = 'gemini-3.1-pro-preview';
 interface SettingsModalProps {
     onClose: () => void;
 }
-
-/**
- * Model catalog. Order within each tier = display order in the UI. `current`
- * models render expanded; `legacy` models render inside a collapsed section.
- * The `id` is passed straight into the Gemini REST URL, so it must match what
- * Google's API accepts (see https://ai.google.dev/gemini-api/docs/models).
- */
-type ModelTier = 'current' | 'legacy';
-interface ModelOption {
-    id: string;
-    name: string;
-    description: string;
-    tier: ModelTier;
-}
-
-const MODEL_CATALOG: ModelOption[] = [
-    {
-        id: 'gemini-3.5-flash',
-        name: 'Gemini 3.5 Flash',
-        description: 'Recommended default. Latest GA Flash — frontier-class quality with full quotas.',
-        tier: 'current',
-    },
-    {
-        id: 'gemini-3.1-pro-preview',
-        name: 'Gemini 3.1 Pro',
-        description: 'Maximum reasoning power for the most complex PRDs.',
-        tier: 'current',
-    },
-    {
-        id: 'gemini-3.1-flash-lite-preview',
-        name: 'Gemini 3.1 Flash-Lite',
-        description: 'Cheapest option. Good for quick drafts and iteration.',
-        tier: 'current',
-    },
-    {
-        id: 'gemini-3-flash-preview',
-        name: 'Gemini 3 Flash',
-        description: 'Previous-generation Flash preview — prefer 3.5 Flash, which is GA.',
-        tier: 'legacy',
-    },
-    {
-        id: 'gemini-2.5-pro',
-        name: 'Gemini 2.5 Pro',
-        description: 'Previous-generation high-reasoning model.',
-        tier: 'legacy',
-    },
-    {
-        id: 'gemini-2.5-flash',
-        name: 'Gemini 2.5 Flash',
-        description: 'Previous-generation fast model. Often hits capacity limits — prefer 3.5 Flash.',
-        tier: 'legacy',
-    },
-];
-
-const CURRENT_MODELS = MODEL_CATALOG.filter((m) => m.tier === 'current');
-const LEGACY_MODELS = MODEL_CATALOG.filter((m) => m.tier === 'legacy');
 
 function ModelRadio({
     option,
@@ -120,6 +74,10 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     const [strongModel, setStrongModel] = useState(() => localStorage.getItem('GEMINI_STRONG_MODEL') || DEFAULT_STRONG_MODEL);
     const [githubToken, setGithubToken] = useState(() => getLocalCredential(GITHUB_TOKEN) || '');
     const [githubRepo, setGithubRepo] = useState(() => localStorage.getItem('GITHUB_DEFAULT_REPO') || '');
+    const [artifactOverrides, setArtifactOverrides] = useState<Partial<Record<CoreArtifactSubtype, string>>>(
+        () => getArtifactModelOverrides(),
+    );
+    const [mockupMode, setMockupMode] = useState<MockupImageMode>(() => getMockupImageMode());
 
     // Expand the legacy section automatically if the user is currently on a
     // legacy model — otherwise keep it collapsed to reduce visual noise.
@@ -134,6 +92,8 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         localStorage.setItem('GEMINI_MODEL', model);
         localStorage.setItem('GEMINI_FAST_MODEL', fastModel);
         localStorage.setItem('GEMINI_STRONG_MODEL', strongModel);
+        setArtifactModelOverrides(artifactOverrides);
+        setMockupImageMode(mockupMode);
         const trimmedProjectId = projectId.trim();
         if (trimmedProjectId) {
             localStorage.setItem('GEMINI_PROJECT_ID', trimmedProjectId);
@@ -369,6 +329,16 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                             </div>
                         </div>
                     </div>
+
+                    {/* Per-artifact model routing */}
+                    <ArtifactModelsSection
+                        fastModel={fastModel}
+                        strongModel={strongModel}
+                        overrides={artifactOverrides}
+                        onOverridesChange={setArtifactOverrides}
+                        mockupMode={mockupMode}
+                        onMockupModeChange={setMockupMode}
+                    />
 
                     {/* Model Selection */}
                     <div className="space-y-4">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -374,9 +374,17 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                     <div className="space-y-4">
                         <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
                             <Cpu size={14} className="text-indigo-400" />
-                            Intelligence Level
-                            <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Other features</span>
+                            Default model
+                            <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Refine & enhance</span>
                         </label>
+                        <p className="text-[11px] text-neutral-500 leading-relaxed -mt-1">
+                            Used for everything that isn't tiered above — the PRD refinement
+                            conversations (highlight &rarr; branch &rarr; consolidate) and the
+                            "Enhance" prompt helper. PRD sections and the core artifacts route
+                            automatically between the Fast and Expert models by complexity (see
+                            "PRD Generation Models"); this also acts as the fallback for those
+                            tiers when they're left unset.
+                        </p>
 
                         <div className="grid grid-cols-1 gap-3">
                             {CURRENT_MODELS.map((option) => (
@@ -463,8 +471,8 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                                 </div>
                             </div>
                             <div className="text-right">
-                                <p className="text-[10px] uppercase tracking-widest font-bold text-neutral-500 mb-0.5">V1.2.0-PRO</p>
-                                <p className="text-xs text-neutral-300 font-medium select-none">Build: 031626</p>
+                                <p className="text-[10px] uppercase tracking-widest font-bold text-neutral-500 mb-0.5">v{__APP_VERSION__}</p>
+                                <p className="text-xs text-neutral-300 font-medium select-none">Build: {__BUILD_DATE__}</p>
                             </div>
                         </div>
                     </div>

--- a/src/components/mockups/MockupImageStatusChip.tsx
+++ b/src/components/mockups/MockupImageStatusChip.tsx
@@ -1,0 +1,82 @@
+/**
+ * Compact summary of a mockup version's image status across all its screens.
+ * Reflects the requirement that the artifact shows whether mockups were
+ * generated automatically (OpenAI), uploaded manually, or are still awaiting
+ * user input. Reads both image stores (AI-generated in `mockupImageStore`,
+ * manual uploads in `screenInventoryImageStore`) keyed by the mockup version id.
+ */
+
+import { useEffect } from 'react';
+import { ImageUp, Sparkles, Clock, Images } from 'lucide-react';
+import type { MockupScreen } from '../../types';
+import { useMockupImageStore } from '../../store/mockupImageStore';
+import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
+import { buildScreenScopeKey } from '../../lib/mockupImageStore';
+import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
+
+interface Props {
+    versionId: string;
+    screens: MockupScreen[];
+}
+
+export function MockupImageStatusChip({ versionId, screens }: Props) {
+    const loadAi = useMockupImageStore((s) => s.loadForVersion);
+    const aiImages = useMockupImageStore((s) => s.images);
+    const loadUploads = useScreenInventoryImageStore((s) => s.loadForArtifactVersion);
+    const uploads = useScreenInventoryImageStore((s) => s.images);
+
+    useEffect(() => {
+        void loadAi(versionId);
+        void loadUploads(versionId);
+    }, [versionId, loadAi, loadUploads]);
+
+    if (screens.length === 0) return null;
+
+    let autoCount = 0;
+    let uploadCount = 0;
+    for (const screen of screens) {
+        const aiScope = buildScreenScopeKey(versionId, screen.id);
+        const hasAi = Object.keys(aiImages).some((k) => k.startsWith(aiScope));
+        const slug = slugifyScreenName(screen.name);
+        const hasUpload = Object.values(uploads).some(
+            (r) => r.artifactVersionId === versionId && r.screenSlug === slug && r.isPreferred,
+        );
+        if (hasUpload) uploadCount++;
+        else if (hasAi) autoCount++;
+    }
+
+    const total = screens.length;
+    const withImages = autoCount + uploadCount;
+
+    let label: string;
+    let Icon = Images;
+    let tone = 'border-neutral-200 bg-neutral-50 text-neutral-500';
+
+    if (withImages === 0) {
+        label = `Awaiting images · 0/${total}`;
+        Icon = Clock;
+        tone = 'border-amber-200 bg-amber-50 text-amber-700';
+    } else if (uploadCount === total) {
+        label = `Uploaded · ${total}/${total}`;
+        Icon = ImageUp;
+        tone = 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    } else if (autoCount === total) {
+        label = `AI-generated · ${total}/${total}`;
+        Icon = Sparkles;
+        tone = 'border-indigo-200 bg-indigo-50 text-indigo-700';
+    } else {
+        label = `Images · ${withImages}/${total}`;
+        Icon = Images;
+        tone = 'border-neutral-200 bg-neutral-50 text-neutral-600';
+    }
+
+    return (
+        <span
+            className={`text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border font-medium inline-flex items-center gap-1 ${tone}`}
+            title="Mockup image status across all screens"
+        >
+            <Icon size={10} />
+            {label}
+        </span>
+    );
+}

--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -18,6 +18,8 @@ import type { MockupImageQuality, MockupImageRecord, MockupPayload, MockupScreen
 import { useMockupImageStore } from '../../store/mockupImageStore';
 import { buildScreenScopeKey } from '../../lib/mockupImageStore';
 import { hasOpenAIKey } from '../../lib/openaiClient';
+import { getMockupImageMode, resolveMockupRender } from '../../lib/artifactModelSettings';
+import { MockupScreenUpload } from './MockupScreenUpload';
 
 interface Props {
     projectId: string;
@@ -87,6 +89,26 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
     }, [versionId, loadForVersion]);
 
     const keyPresent = hasOpenAIKey();
+
+    // Image source routing (Settings → Artifact Generation Models → Mockups):
+    //  - 'user_uploaded'             → always the manual upload sheet
+    //  - 'gpt_image' without a key   → fall back to the manual sheet (never
+    //                                  silently fail) and explain why
+    //  - 'gpt_image' with a key      → the OpenAI generator below
+    const { manual, forcedFallback } = resolveMockupRender(getMockupImageMode(), keyPresent);
+    if (manual) {
+        return (
+            <MockupScreenUpload
+                projectId={projectId}
+                artifactId={artifactId}
+                versionId={versionId}
+                screen={screen}
+                payload={payload}
+                settings={settings}
+                forcedFallback={forcedFallback}
+            />
+        );
+    }
 
     const hasHighQuality = records.some((r) => r.quality === 'high');
 

--- a/src/components/mockups/MockupScreenUpload.tsx
+++ b/src/components/mockups/MockupScreenUpload.tsx
@@ -1,0 +1,185 @@
+/**
+ * Manual mockup mode for a single MockupScreen. Shown instead of the OpenAI
+ * gpt-image-2 generator when the user has chosen "User Uploaded" in Settings,
+ * or when "GPT Image 2" is selected but no OpenAI key is configured (so we
+ * never silently fail). Renders a generated, copyable prompt describing the
+ * screen (goal, layout, visual style, expected upload format) and lets the user
+ * upload their own image against it.
+ *
+ * Storage reuses the proven per-screen upload store
+ * (`useScreenInventoryImageStore` + IndexedDB), keyed by the mockup version id,
+ * so uploads are versioned, preferred-tracked, and quota-safe (IDB, not
+ * localStorage).
+ */
+
+import { useEffect, useState } from 'react';
+import { Upload, Copy, Check, Loader2, AlertTriangle, ImageUp, Info } from 'lucide-react';
+import type { MockupPayload, MockupScreen, MockupSettings } from '../../types';
+import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
+import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
+import { buildScreenImagePrompt, pickImageSize } from '../../lib/services/mockupImageService';
+import { copyToClipboard } from '../../lib/utils/copyToClipboard';
+
+interface Props {
+    projectId: string;
+    artifactId: string;
+    versionId: string;
+    screen: MockupScreen;
+    payload: MockupPayload;
+    settings: MockupSettings;
+    /** True when this is a forced fallback (GPT Image 2 chosen but no key). */
+    forcedFallback?: boolean;
+}
+
+const formatHint = (settings: MockupSettings): string => {
+    const size = pickImageSize(settings.platform);
+    const orientation =
+        settings.platform === 'mobile' ? 'portrait' :
+        settings.platform === 'desktop' ? 'landscape' : 'square';
+    return `Upload PNG or JPG, ideally ~${size}px (${orientation}) to match this ${settings.platform} screen.`;
+};
+
+export function MockupScreenUpload({
+    projectId,
+    artifactId,
+    versionId,
+    screen,
+    payload,
+    settings,
+    forcedFallback,
+}: Props) {
+    const loadForArtifactVersion = useScreenInventoryImageStore((s) => s.loadForArtifactVersion);
+    const upload = useScreenInventoryImageStore((s) => s.upload);
+    const clearError = useScreenInventoryImageStore((s) => s.clearError);
+    const allImages = useScreenInventoryImageStore((s) => s.images);
+    const uploading = useScreenInventoryImageStore((s) => s.uploading);
+    const errors = useScreenInventoryImageStore((s) => s.errors);
+    const peekPreferred = useScreenInventoryImageStore((s) => s.peekPreferred);
+
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        void loadForArtifactVersion(versionId);
+    }, [versionId, loadForArtifactVersion]);
+
+    // `allImages` / `uploading` / `errors` are subscribed above so this
+    // re-derives reactively as uploads land.
+    void allImages;
+    const preferred = peekPreferred(versionId, screen.name);
+
+    const promptText = `${buildScreenImagePrompt(payload, screen, settings)}\n\n${formatHint(settings)}`;
+    // Bucket key matches the store's internal `${artifactVersionId}:${slug}`.
+    const bucket = `${versionId}:${slugifyScreenName(screen.name)}`;
+    const isUploading = !!uploading[bucket];
+    const error = errors[bucket];
+
+    const handleCopy = async () => {
+        const ok = await copyToClipboard(promptText);
+        if (ok) {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        }
+    };
+
+    const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = ''; // allow re-selecting the same file
+        if (!file) return;
+        clearError(versionId, screen.name);
+        void upload({
+            projectId,
+            artifactId,
+            artifactVersionId: versionId,
+            screenName: screen.name,
+            file,
+            prompt: promptText,
+        });
+    };
+
+    return (
+        <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
+            {preferred ? (
+                <>
+                    <div className="relative bg-neutral-50 flex items-center justify-center">
+                        <img
+                            src={preferred.dataUrl}
+                            alt={`Uploaded mockup of ${screen.name}`}
+                            className="max-w-full max-h-[680px] object-contain"
+                        />
+                    </div>
+                    <div className="px-4 py-3 border-t border-neutral-100 flex items-center gap-2 flex-wrap">
+                        <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-emerald-200 bg-emerald-50 text-emerald-700 font-medium inline-flex items-center gap-1">
+                            <ImageUp size={10} />
+                            Uploaded
+                        </span>
+                        <span className="text-[11px] text-neutral-400">
+                            {new Date(preferred.generatedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                        </span>
+                        <label className="ml-auto inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 cursor-pointer transition">
+                            <Upload size={12} />
+                            Replace
+                            <input type="file" accept="image/*" className="hidden" onChange={handleFile} />
+                        </label>
+                    </div>
+                </>
+            ) : (
+                <div className="p-5">
+                    {forcedFallback && (
+                        <div className="mb-4 flex items-start gap-2 text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+                            <Info size={13} className="mt-0.5 shrink-0" />
+                            <span>
+                                <strong>GPT Image 2</strong> is selected but no OpenAI key is configured, so
+                                automatic generation is unavailable. Use the prompt below to create the
+                                mockup yourself and upload it — or add an OpenAI key in Settings.
+                            </span>
+                        </div>
+                    )}
+
+                    <div className="flex items-center justify-between gap-2 mb-2">
+                        <p className="text-[11px] uppercase tracking-wider text-neutral-500 font-semibold">
+                            Mockup prompt — {screen.name}
+                        </p>
+                        <button
+                            type="button"
+                            onClick={handleCopy}
+                            className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-md text-indigo-600 hover:bg-indigo-50 transition"
+                        >
+                            {copied ? <Check size={12} /> : <Copy size={12} />}
+                            {copied ? 'Copied' : 'Copy prompt'}
+                        </button>
+                    </div>
+
+                    <pre className="text-[11px] leading-relaxed text-neutral-700 bg-neutral-50 border border-neutral-200 rounded-md p-3 whitespace-pre-wrap break-words max-h-56 overflow-auto">
+                        {promptText}
+                    </pre>
+
+                    {error && (
+                        <div className="mt-3 inline-flex items-start gap-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2 py-1.5">
+                            <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                            <span className="text-left break-words">{error}</span>
+                        </div>
+                    )}
+
+                    <div className="mt-4 flex items-center gap-3">
+                        <label className={`inline-flex items-center gap-2 text-sm px-4 py-2 rounded-md font-medium cursor-pointer transition ${
+                            isUploading
+                                ? 'bg-neutral-200 text-neutral-500 cursor-wait'
+                                : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                        }`}>
+                            {isUploading ? <Loader2 size={14} className="animate-spin" /> : <Upload size={14} />}
+                            {isUploading ? 'Uploading…' : 'Upload mockup image'}
+                            <input
+                                type="file"
+                                accept="image/*"
+                                className="hidden"
+                                disabled={isUploading}
+                                onChange={handleFile}
+                            />
+                        </label>
+                        <span className="text-[11px] text-neutral-400">Waiting for your upload</span>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/mockups/MockupViewer.tsx
+++ b/src/components/mockups/MockupViewer.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { MockupPayload, MockupSettings, StalenessState } from '../../types';
 import { StalenessBadge } from '../StalenessBadge';
 import { MockupScreenImage } from './MockupScreenImage';
+import { MockupImageStatusChip } from './MockupImageStatusChip';
 
 type Props = {
     payload: MockupPayload;
@@ -73,6 +74,7 @@ export function MockupViewer({
                     <span className={CHIP}>{FIDELITY_LABELS[settings.fidelity] ?? settings.fidelity}</span>
                     <span className={CHIP}>{SCOPE_LABELS[settings.scope] ?? settings.scope}</span>
                     <StalenessBadge staleness={staleness} />
+                    {versionId && <MockupImageStatusChip versionId={versionId} screens={payload.screens} />}
                     <span className="text-[10px] text-neutral-400 ml-auto tabular-nums">
                         v{versionNumber} · {formatDate(createdAt)}
                     </span>

--- a/src/components/settings/ArtifactModelsSection.tsx
+++ b/src/components/settings/ArtifactModelsSection.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import { Box, FileText, Image as ImageIcon, ChevronDown, Sparkles } from 'lucide-react';
+import { MODEL_CATALOG, modelDisplayName } from '../../lib/modelCatalog';
+import { CORE_ARTIFACT_DISPLAY_ORDER } from '../../lib/coreArtifactPipeline';
+import { CORE_ARTIFACT_COMPLEXITY } from '../../lib/artifactModelSettings';
+import type { MockupImageMode } from '../../lib/artifactModelSettings';
+import { DEFAULT_PRD_SECTIONS, selectModelTier } from '../../lib/services/progressivePrdGeneration';
+import type { CoreArtifactSubtype } from '../../types';
+
+interface ArtifactModelsSectionProps {
+    /** Live Fast/Expert model ids from the PRD Generation Models pickers (unsaved edits included). */
+    fastModel: string;
+    strongModel: string;
+    /** Per-artifact model overrides (controlled). */
+    overrides: Partial<Record<CoreArtifactSubtype, string>>;
+    onOverridesChange: (next: Partial<Record<CoreArtifactSubtype, string>>) => void;
+    /** Mockup image source mode (controlled). */
+    mockupMode: MockupImageMode;
+    onMockupModeChange: (mode: MockupImageMode) => void;
+}
+
+function ComplexityBadge({ complexity }: { complexity: 'low' | 'high' }) {
+    return complexity === 'high' ? (
+        <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-indigo-500/15 text-indigo-300 border border-indigo-500/30">
+            Complex
+        </span>
+    ) : (
+        <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
+            Simple
+        </span>
+    );
+}
+
+const selectClass =
+    'w-full bg-black/40 border border-white/10 rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 text-xs transition-all';
+
+function ArtifactRow({
+    icon,
+    title,
+    description,
+    children,
+    badge,
+}: {
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    children: React.ReactNode;
+    badge: React.ReactNode;
+}) {
+    return (
+        <div className="bg-white/5 border border-white/5 rounded-2xl p-4 space-y-3">
+            <div className="flex items-start gap-3">
+                <div className="text-neutral-400 mt-0.5 shrink-0">{icon}</div>
+                <div className="min-w-0">
+                    <h4 className="text-sm font-bold text-white">{title}</h4>
+                    <p className="text-[11px] text-neutral-400 leading-snug">{description}</p>
+                </div>
+            </div>
+            <div className="space-y-2">
+                {children}
+                <div>{badge}</div>
+            </div>
+        </div>
+    );
+}
+
+export function ArtifactModelsSection({
+    fastModel,
+    strongModel,
+    overrides,
+    onOverridesChange,
+    mockupMode,
+    onMockupModeChange,
+}: ArtifactModelsSectionProps) {
+    const [prdExpanded, setPrdExpanded] = useState(false);
+
+    const recommendedModel = (subtype: CoreArtifactSubtype): string =>
+        CORE_ARTIFACT_COMPLEXITY[subtype] === 'high' ? strongModel : fastModel;
+
+    const setOverride = (subtype: CoreArtifactSubtype, modelId: string) => {
+        onOverridesChange({ ...overrides, [subtype]: modelId });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="space-y-1">
+                <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
+                    <Box size={14} className="text-indigo-400" />
+                    Artifact Generation Models
+                    <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
+                        Recommended
+                    </span>
+                </label>
+                <p className="text-[11px] text-neutral-500 leading-relaxed">
+                    Choose the AI model for each type of artifact. By default we use Flash for
+                    simple tasks and Pro for complex reasoning — override any of them here.
+                </p>
+            </div>
+
+            <div className="space-y-3">
+                {/* PRD — multi-model, expandable (configured in PRD Generation Models). */}
+                <ArtifactRow
+                    icon={<FileText size={18} />}
+                    title="PRD"
+                    description="Final product requirements document"
+                    badge={
+                        <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-violet-500/15 text-violet-300 border border-violet-500/30">
+                            Multi
+                        </span>
+                    }
+                >
+                    <button
+                        type="button"
+                        onClick={() => setPrdExpanded((v) => !v)}
+                        className={`${selectClass} flex items-center justify-between text-left`}
+                        aria-expanded={prdExpanded}
+                    >
+                        <span className="text-neutral-300">Per-section routing (Flash / Pro)</span>
+                        <ChevronDown
+                            size={14}
+                            className={`transition-transform ${prdExpanded ? 'rotate-180' : ''}`}
+                        />
+                    </button>
+                    {prdExpanded && (
+                        <div className="rounded-xl border border-white/5 bg-black/20 divide-y divide-white/5">
+                            {DEFAULT_PRD_SECTIONS.map((section) => {
+                                const tier = selectModelTier(section.risk);
+                                const model = tier === 'fast' ? fastModel : strongModel;
+                                return (
+                                    <div
+                                        key={section.id}
+                                        className="flex items-center justify-between gap-2 px-3 py-2"
+                                    >
+                                        <span className="text-[11px] text-neutral-300 min-w-0 truncate">
+                                            {section.title}
+                                        </span>
+                                        <span className="flex items-center gap-2 shrink-0">
+                                            <ComplexityBadge complexity={section.risk} />
+                                            <span className="text-[11px] text-neutral-400">
+                                                {modelDisplayName(model)}
+                                            </span>
+                                        </span>
+                                    </div>
+                                );
+                            })}
+                            <p className="text-[10px] text-neutral-500 px-3 py-2">
+                                PRD sections route automatically by complexity. Change the underlying
+                                models in “PRD Generation Models” above.
+                            </p>
+                        </div>
+                    )}
+                </ArtifactRow>
+
+                {/* Text artifacts — one model selector each. */}
+                {CORE_ARTIFACT_DISPLAY_ORDER.map((meta) => {
+                    const complexity = CORE_ARTIFACT_COMPLEXITY[meta.subtype];
+                    const value = overrides[meta.subtype] ?? recommendedModel(meta.subtype);
+                    return (
+                        <ArtifactRow
+                            key={meta.subtype}
+                            icon={<Box size={18} />}
+                            title={meta.title}
+                            description={meta.description}
+                            badge={<ComplexityBadge complexity={complexity} />}
+                        >
+                            <select
+                                value={value}
+                                onChange={(e) => setOverride(meta.subtype, e.target.value)}
+                                className={selectClass}
+                                aria-label={`Model for ${meta.title}`}
+                            >
+                                {MODEL_CATALOG.map((m) => (
+                                    <option key={m.id} value={m.id}>
+                                        {m.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </ArtifactRow>
+                    );
+                })}
+
+                {/* Mockups — image source, not a text model. */}
+                <ArtifactRow
+                    icon={<ImageIcon size={18} />}
+                    title="Mockups"
+                    description="Interactive UI mockups and prototypes"
+                    badge={
+                        <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-amber-500/15 text-amber-300 border border-amber-500/30">
+                            Image Source
+                        </span>
+                    }
+                >
+                    <select
+                        value={mockupMode}
+                        onChange={(e) => onMockupModeChange(e.target.value as MockupImageMode)}
+                        className={selectClass}
+                        aria-label="Mockup image source"
+                    >
+                        <option value="gpt_image">GPT Image 2</option>
+                        <option value="user_uploaded">User Uploaded</option>
+                    </select>
+                    <p className="text-[10px] text-neutral-500 leading-relaxed">
+                        GPT Image 2 needs an OpenAI key (added above). “User Uploaded” gives you a
+                        per-screen prompt sheet to create and upload your own mockups. If no OpenAI
+                        key is configured, Synapse falls back to the upload sheet automatically.
+                    </p>
+                </ArtifactRow>
+            </div>
+
+            <div className="bg-indigo-500/10 border border-indigo-500/20 rounded-2xl p-4 flex items-start gap-3">
+                <Sparkles size={16} className="text-indigo-300 mt-0.5 shrink-0" />
+                <div>
+                    <p className="text-xs font-bold text-indigo-200 mb-0.5">Smart Model Routing</p>
+                    <p className="text-[11px] text-indigo-200/70 leading-relaxed">
+                        Defaults pick the best model for each artifact based on complexity, balancing
+                        accuracy against cost. Your overrides above always take precedence.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/settings/ArtifactModelsSection.tsx
+++ b/src/components/settings/ArtifactModelsSection.tsx
@@ -19,18 +19,6 @@ interface ArtifactModelsSectionProps {
     onMockupModeChange: (mode: MockupImageMode) => void;
 }
 
-function ComplexityBadge({ complexity }: { complexity: 'low' | 'high' }) {
-    return complexity === 'high' ? (
-        <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-indigo-500/15 text-indigo-300 border border-indigo-500/30">
-            Complex
-        </span>
-    ) : (
-        <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
-            Simple
-        </span>
-    );
-}
-
 const selectClass =
     'w-full bg-black/40 border border-white/10 rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 text-xs transition-all';
 
@@ -45,7 +33,7 @@ function ArtifactRow({
     title: string;
     description: string;
     children: React.ReactNode;
-    badge: React.ReactNode;
+    badge?: React.ReactNode;
 }) {
     return (
         <div className="bg-white/5 border border-white/5 rounded-2xl p-4 space-y-3">
@@ -58,7 +46,7 @@ function ArtifactRow({
             </div>
             <div className="space-y-2">
                 {children}
-                <div>{badge}</div>
+                {badge && <div>{badge}</div>}
             </div>
         </div>
     );
@@ -134,11 +122,8 @@ export function ArtifactModelsSection({
                                         <span className="text-[11px] text-neutral-300 min-w-0 truncate">
                                             {section.title}
                                         </span>
-                                        <span className="flex items-center gap-2 shrink-0">
-                                            <ComplexityBadge complexity={section.risk} />
-                                            <span className="text-[11px] text-neutral-400">
-                                                {modelDisplayName(model)}
-                                            </span>
+                                        <span className="text-[11px] text-neutral-400 shrink-0">
+                                            {modelDisplayName(model)}
                                         </span>
                                     </div>
                                 );
@@ -153,7 +138,6 @@ export function ArtifactModelsSection({
 
                 {/* Text artifacts — one model selector each. */}
                 {CORE_ARTIFACT_DISPLAY_ORDER.map((meta) => {
-                    const complexity = CORE_ARTIFACT_COMPLEXITY[meta.subtype];
                     const value = overrides[meta.subtype] ?? recommendedModel(meta.subtype);
                     return (
                         <ArtifactRow
@@ -161,7 +145,6 @@ export function ArtifactModelsSection({
                             icon={<Box size={18} />}
                             title={meta.title}
                             description={meta.description}
-                            badge={<ComplexityBadge complexity={complexity} />}
                         >
                             <select
                                 value={value}

--- a/src/lib/__tests__/artifactModelSettings.test.ts
+++ b/src/lib/__tests__/artifactModelSettings.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    CORE_ARTIFACT_COMPLEXITY,
+    getArtifactModel,
+    getArtifactModelOverrides,
+    setArtifactModelOverrides,
+    getRecommendedArtifactModel,
+    getMockupImageMode,
+    setMockupImageMode,
+    DEFAULT_MOCKUP_IMAGE_MODE,
+    resolveMockupRender,
+} from '../artifactModelSettings';
+import { DEFAULT_GEMINI_MODEL } from '../geminiClient';
+import type { CoreArtifactSubtype } from '../../types';
+
+describe('artifact model settings — persistence & defaults', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('defaults to the complexity recommendation when no override is set', () => {
+        localStorage.setItem('GEMINI_FAST_MODEL', 'flash-x');
+        localStorage.setItem('GEMINI_STRONG_MODEL', 'pro-x');
+
+        // high → strong, low → fast
+        expect(getRecommendedArtifactModel('data_model')).toBe('pro-x');
+        expect(getArtifactModel('data_model')).toBe('pro-x');
+        expect(getArtifactModel('design_system')).toBe('flash-x');
+    });
+
+    it('falls back through the tier resolvers to the single Default model', () => {
+        // Nothing set at all → DEFAULT_GEMINI_MODEL for every artifact.
+        for (const subtype of Object.keys(CORE_ARTIFACT_COMPLEXITY) as CoreArtifactSubtype[]) {
+            expect(getArtifactModel(subtype)).toBe(DEFAULT_GEMINI_MODEL);
+        }
+
+        localStorage.setItem('GEMINI_MODEL', 'single-x');
+        expect(getArtifactModel('data_model')).toBe('single-x');
+        expect(getArtifactModel('prompt_pack')).toBe('single-x');
+    });
+
+    it('persists and reads back an explicit per-artifact override', () => {
+        setArtifactModelOverrides({ design_system: 'pro-x', user_flows: 'flash-x' });
+
+        const stored = getArtifactModelOverrides();
+        expect(stored.design_system).toBe('pro-x');
+        expect(stored.user_flows).toBe('flash-x');
+
+        // Override wins over the complexity recommendation.
+        localStorage.setItem('GEMINI_FAST_MODEL', 'flash-default');
+        expect(getArtifactModel('design_system')).toBe('pro-x');
+    });
+
+    it('drops empty values and removes the key when the map is empty', () => {
+        setArtifactModelOverrides({ data_model: 'pro-x' });
+        expect(localStorage.getItem('GEMINI_ARTIFACT_MODELS')).not.toBeNull();
+
+        setArtifactModelOverrides({});
+        expect(localStorage.getItem('GEMINI_ARTIFACT_MODELS')).toBeNull();
+        expect(getArtifactModelOverrides()).toEqual({});
+    });
+
+    it('ignores unknown subtypes and malformed JSON defensively', () => {
+        localStorage.setItem('GEMINI_ARTIFACT_MODELS', '{ not json');
+        expect(getArtifactModelOverrides()).toEqual({});
+
+        localStorage.setItem(
+            'GEMINI_ARTIFACT_MODELS',
+            JSON.stringify({ bogus_subtype: 'x', data_model: 'pro-x' }),
+        );
+        const stored = getArtifactModelOverrides();
+        expect(stored).toEqual({ data_model: 'pro-x' });
+    });
+});
+
+describe('mockup image mode persistence', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('defaults to gpt_image', () => {
+        expect(getMockupImageMode()).toBe(DEFAULT_MOCKUP_IMAGE_MODE);
+        expect(getMockupImageMode()).toBe('gpt_image');
+    });
+
+    it('persists a user_uploaded selection', () => {
+        setMockupImageMode('user_uploaded');
+        expect(getMockupImageMode()).toBe('user_uploaded');
+    });
+
+    it('falls back to the default for an invalid stored value', () => {
+        localStorage.setItem('SYNAPSE_MOCKUP_IMAGE_MODE', 'garbage');
+        expect(getMockupImageMode()).toBe('gpt_image');
+    });
+});
+
+describe('resolveMockupRender — image source routing', () => {
+    it('uses the OpenAI generator when GPT Image 2 is selected and a key exists', () => {
+        expect(resolveMockupRender('gpt_image', true)).toEqual({
+            manual: false,
+            forcedFallback: false,
+        });
+    });
+
+    it('falls back to the manual sheet when GPT Image 2 is selected but no key (no silent fail)', () => {
+        expect(resolveMockupRender('gpt_image', false)).toEqual({
+            manual: true,
+            forcedFallback: true,
+        });
+    });
+
+    it('always shows the manual sheet for User Uploaded, regardless of key', () => {
+        expect(resolveMockupRender('user_uploaded', true)).toEqual({
+            manual: true,
+            forcedFallback: false,
+        });
+        expect(resolveMockupRender('user_uploaded', false)).toEqual({
+            manual: true,
+            forcedFallback: false,
+        });
+    });
+});

--- a/src/lib/artifactModelSettings.ts
+++ b/src/lib/artifactModelSettings.ts
@@ -1,0 +1,144 @@
+import type { CoreArtifactSubtype } from '../types';
+import { getFastModel, getStrongModel } from './geminiClient';
+
+/**
+ * Per-artifact model routing + persistence.
+ *
+ * Mirrors the PRD pipeline's Fast/Expert tiering but adds an explicit
+ * **per-artifact override** layer so users can pin a specific model for each
+ * artifact in Settings → "Artifact Generation Models".
+ *
+ * Resolution order for a given artifact subtype:
+ *   1. explicit user override (Settings)               — `getArtifactModelOverrides()`
+ *   2. complexity recommendation (Flash vs Pro)        — `CORE_ARTIFACT_COMPLEXITY`
+ *   3. tier-model fallback to the single Default model  — `getFastModel`/`getStrongModel`
+ *      → `getModel()` → `DEFAULT_GEMINI_MODEL`
+ *
+ * Existing projects have no override key, so behaviour is unchanged until the
+ * user picks a model — no migration is required.
+ *
+ * Keep `CORE_ARTIFACT_COMPLEXITY` in sync when adding a `CoreArtifactSubtype`.
+ */
+export type ArtifactComplexity = 'low' | 'high';
+
+export const CORE_ARTIFACT_COMPLEXITY: Record<CoreArtifactSubtype, ArtifactComplexity> = {
+    // High — deep reasoning / structural design over the full PRD.
+    screen_inventory: 'high',
+    user_flows: 'high',
+    data_model: 'high',
+    implementation_plan: 'high',
+    // Low — derivative of upstream artifacts or template-shaped.
+    component_inventory: 'low',
+    design_system: 'low',
+    prompt_pack: 'low',
+};
+
+const ARTIFACT_MODELS_KEY = 'GEMINI_ARTIFACT_MODELS';
+
+/** Read the persisted per-artifact model override map (defensive). */
+export const getArtifactModelOverrides = (): Partial<Record<CoreArtifactSubtype, string>> => {
+    try {
+        const raw = localStorage.getItem(ARTIFACT_MODELS_KEY);
+        if (!raw) return {};
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return {};
+        const out: Partial<Record<CoreArtifactSubtype, string>> = {};
+        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+            if (typeof v === 'string' && v && k in CORE_ARTIFACT_COMPLEXITY) {
+                out[k as CoreArtifactSubtype] = v;
+            }
+        }
+        return out;
+    } catch {
+        return {};
+    }
+};
+
+/**
+ * Persist per-artifact overrides. Empty values are dropped so a cleared
+ * selection cleanly falls back to the complexity recommendation; an empty map
+ * removes the key entirely.
+ */
+export const setArtifactModelOverrides = (
+    overrides: Partial<Record<CoreArtifactSubtype, string>>,
+): void => {
+    try {
+        const cleaned: Record<string, string> = {};
+        for (const [k, v] of Object.entries(overrides)) {
+            if (typeof v === 'string' && v && k in CORE_ARTIFACT_COMPLEXITY) {
+                cleaned[k] = v;
+            }
+        }
+        if (Object.keys(cleaned).length === 0) {
+            localStorage.removeItem(ARTIFACT_MODELS_KEY);
+        } else {
+            localStorage.setItem(ARTIFACT_MODELS_KEY, JSON.stringify(cleaned));
+        }
+    } catch {
+        /* ignore quota / serialization errors — selection is best-effort */
+    }
+};
+
+/** The recommended model for an artifact, derived purely from its complexity tier. */
+export const getRecommendedArtifactModel = (subtype: CoreArtifactSubtype): string =>
+    CORE_ARTIFACT_COMPLEXITY[subtype] === 'high' ? getStrongModel() : getFastModel();
+
+/**
+ * The effective model an artifact should generate with: an explicit user
+ * override when present, otherwise the complexity recommendation. This is the
+ * single resolution point consumed by generation, refinement, and metrics.
+ */
+export const getArtifactModel = (subtype: CoreArtifactSubtype): string => {
+    const override = getArtifactModelOverrides()[subtype];
+    return override || getRecommendedArtifactModel(subtype);
+};
+
+// ---------------------------------------------------------------------------
+// Mockup image source mode
+// ---------------------------------------------------------------------------
+//
+// Mockups are not a text artifact — their "model" is an image source. The user
+// chooses between auto-generating screen images via OpenAI GPT Image, or
+// supplying their own uploads against generated per-screen prompts.
+
+export type MockupImageMode = 'gpt_image' | 'user_uploaded';
+export const DEFAULT_MOCKUP_IMAGE_MODE: MockupImageMode = 'gpt_image';
+const MOCKUP_IMAGE_MODE_KEY = 'SYNAPSE_MOCKUP_IMAGE_MODE';
+
+export const getMockupImageMode = (): MockupImageMode => {
+    try {
+        const v = localStorage.getItem(MOCKUP_IMAGE_MODE_KEY);
+        return v === 'user_uploaded' || v === 'gpt_image' ? v : DEFAULT_MOCKUP_IMAGE_MODE;
+    } catch {
+        return DEFAULT_MOCKUP_IMAGE_MODE;
+    }
+};
+
+export const setMockupImageMode = (mode: MockupImageMode): void => {
+    try {
+        localStorage.setItem(MOCKUP_IMAGE_MODE_KEY, mode);
+    } catch {
+        /* ignore */
+    }
+};
+
+export interface MockupRenderDecision {
+    /** Render the manual prompt + upload sheet instead of the OpenAI generator. */
+    manual: boolean;
+    /** True when GPT Image 2 was chosen but no key is configured (forced fallback). */
+    forcedFallback: boolean;
+}
+
+/**
+ * Decide how a mockup screen should render given the selected mode and whether
+ * an OpenAI image key is available. 'user_uploaded' always shows the manual
+ * sheet; 'gpt_image' shows the generator only when a key exists, otherwise it
+ * falls back to the manual sheet (never a silent failure).
+ */
+export const resolveMockupRender = (
+    mode: MockupImageMode,
+    hasOpenAiKey: boolean,
+): MockupRenderDecision => ({
+    manual: mode === 'user_uploaded' || !hasOpenAiKey,
+    forcedFallback: mode === 'gpt_image' && !hasOpenAiKey,
+});

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -2,8 +2,14 @@ import { getCachedGeminiKey } from './geminiKeyVault';
 import { getLocalCredential, GEMINI_API_KEY } from './localCredentials';
 
 export interface JsonModeConfig {
-    responseMimeType: string;
-    responseSchema: object;
+    /**
+     * JSON-mode response controls. Optional so this config can also carry a
+     * plain-text per-call `model` override with no schema (the artifact tier
+     * routing passes `{ model }` alone). When omitted, no JSON `generationConfig`
+     * is sent and the call behaves as a normal text generation.
+     */
+    responseMimeType?: string;
+    responseSchema?: object;
     temperature?: number;
     topP?: number;
     topK?: number;
@@ -257,14 +263,18 @@ export const callGemini = async (systemInstruction: string, promptText: string, 
     };
 
     if (jsonMode) {
-        body.generationConfig = {
-            responseMimeType: jsonMode.responseMimeType,
-            responseSchema: jsonMode.responseSchema,
+        const generationConfig: Record<string, unknown> = {
+            ...(jsonMode.responseMimeType ? { responseMimeType: jsonMode.responseMimeType } : {}),
+            ...(jsonMode.responseSchema ? { responseSchema: jsonMode.responseSchema } : {}),
             ...(typeof jsonMode.temperature === 'number' ? { temperature: jsonMode.temperature } : {}),
             ...(typeof jsonMode.topP === 'number' ? { topP: jsonMode.topP } : {}),
             ...(typeof jsonMode.topK === 'number' ? { topK: jsonMode.topK } : {}),
             ...(typeof jsonMode.maxOutputTokens === 'number' ? { maxOutputTokens: jsonMode.maxOutputTokens } : {}),
         };
+        // A model-only override (no schema/params) carries no generationConfig.
+        if (Object.keys(generationConfig).length > 0) {
+            body.generationConfig = generationConfig;
+        }
     }
 
     const watchdog = createWatchdog(GEMINI_TIMEOUT_MS, signal);
@@ -339,14 +349,18 @@ export const callGeminiStream = async (
     };
 
     if (jsonMode) {
-        body.generationConfig = {
-            responseMimeType: jsonMode.responseMimeType,
-            responseSchema: jsonMode.responseSchema,
+        const generationConfig: Record<string, unknown> = {
+            ...(jsonMode.responseMimeType ? { responseMimeType: jsonMode.responseMimeType } : {}),
+            ...(jsonMode.responseSchema ? { responseSchema: jsonMode.responseSchema } : {}),
             ...(typeof jsonMode.temperature === 'number' ? { temperature: jsonMode.temperature } : {}),
             ...(typeof jsonMode.topP === 'number' ? { topP: jsonMode.topP } : {}),
             ...(typeof jsonMode.topK === 'number' ? { topK: jsonMode.topK } : {}),
             ...(typeof jsonMode.maxOutputTokens === 'number' ? { maxOutputTokens: jsonMode.maxOutputTokens } : {}),
         };
+        // A model-only override (no schema/params) carries no generationConfig.
+        if (Object.keys(generationConfig).length > 0) {
+            body.generationConfig = generationConfig;
+        }
     }
     const bodyJson = JSON.stringify(body);
 

--- a/src/lib/modelCatalog.ts
+++ b/src/lib/modelCatalog.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared Gemini model catalog. The single source of truth for the selectable
+ * model ids, their display names, and which tier (current vs legacy) they
+ * belong to. Used by the Settings model pickers (Default model, PRD Generation
+ * Models, and per-artifact Artifact Generation Models).
+ *
+ * The `id` is passed straight into the Gemini REST URL, so it must match what
+ * Google's API accepts (see https://ai.google.dev/gemini-api/docs/models).
+ */
+export type ModelCatalogTier = 'current' | 'legacy';
+
+export interface ModelOption {
+    id: string;
+    name: string;
+    description: string;
+    tier: ModelCatalogTier;
+}
+
+export const MODEL_CATALOG: ModelOption[] = [
+    {
+        id: 'gemini-3.5-flash',
+        name: 'Gemini 3.5 Flash',
+        description: 'Recommended default. Latest GA Flash — frontier-class quality with full quotas.',
+        tier: 'current',
+    },
+    {
+        id: 'gemini-3.1-pro-preview',
+        name: 'Gemini 3.1 Pro',
+        description: 'Maximum reasoning power for the most complex PRDs.',
+        tier: 'current',
+    },
+    {
+        id: 'gemini-3.1-flash-lite-preview',
+        name: 'Gemini 3.1 Flash-Lite',
+        description: 'Cheapest option. Good for quick drafts and iteration.',
+        tier: 'current',
+    },
+    {
+        id: 'gemini-3-flash-preview',
+        name: 'Gemini 3 Flash',
+        description: 'Previous-generation Flash preview — prefer 3.5 Flash, which is GA.',
+        tier: 'legacy',
+    },
+    {
+        id: 'gemini-2.5-pro',
+        name: 'Gemini 2.5 Pro',
+        description: 'Previous-generation high-reasoning model.',
+        tier: 'legacy',
+    },
+    {
+        id: 'gemini-2.5-flash',
+        name: 'Gemini 2.5 Flash',
+        description: 'Previous-generation fast model. Often hits capacity limits — prefer 3.5 Flash.',
+        tier: 'legacy',
+    },
+];
+
+export const CURRENT_MODELS = MODEL_CATALOG.filter((m) => m.tier === 'current');
+export const LEGACY_MODELS = MODEL_CATALOG.filter((m) => m.tier === 'legacy');
+
+/** Human-readable label for a model id, falling back to the raw id. */
+export const modelDisplayName = (id: string): string =>
+    MODEL_CATALOG.find((m) => m.id === id)?.name ?? id;

--- a/src/lib/services/__tests__/artifactModelRouting.test.ts
+++ b/src/lib/services/__tests__/artifactModelRouting.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    CORE_ARTIFACT_COMPLEXITY,
+    selectArtifactModel,
+} from '../coreArtifactService';
+import { DEFAULT_GEMINI_MODEL } from '../../geminiClient';
+import type { CoreArtifactSubtype } from '../../../types';
+
+const ALL_SUBTYPES: CoreArtifactSubtype[] = [
+    'screen_inventory',
+    'user_flows',
+    'data_model',
+    'component_inventory',
+    'implementation_plan',
+    'prompt_pack',
+    'design_system',
+];
+
+describe('core artifact complexity routing', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('tags every core artifact subtype with a complexity tier', () => {
+        for (const subtype of ALL_SUBTYPES) {
+            expect(CORE_ARTIFACT_COMPLEXITY[subtype]).toMatch(/^(low|high)$/);
+        }
+    });
+
+    it('routes high-complexity artifacts to the Expert (strong) model', () => {
+        localStorage.setItem('GEMINI_FAST_MODEL', 'gemini-flash-test');
+        localStorage.setItem('GEMINI_STRONG_MODEL', 'gemini-pro-test');
+
+        const high: CoreArtifactSubtype[] = [
+            'screen_inventory',
+            'user_flows',
+            'data_model',
+            'implementation_plan',
+        ];
+        for (const subtype of high) {
+            expect(CORE_ARTIFACT_COMPLEXITY[subtype]).toBe('high');
+            expect(selectArtifactModel(subtype)).toBe('gemini-pro-test');
+        }
+    });
+
+    it('routes low-complexity artifacts to the Fast (flash) model', () => {
+        localStorage.setItem('GEMINI_FAST_MODEL', 'gemini-flash-test');
+        localStorage.setItem('GEMINI_STRONG_MODEL', 'gemini-pro-test');
+
+        const low: CoreArtifactSubtype[] = [
+            'component_inventory',
+            'design_system',
+            'prompt_pack',
+        ];
+        for (const subtype of low) {
+            expect(CORE_ARTIFACT_COMPLEXITY[subtype]).toBe('low');
+            expect(selectArtifactModel(subtype)).toBe('gemini-flash-test');
+        }
+    });
+
+    it('falls back to the single Intelligence Level model when tier models are unset', () => {
+        // No GEMINI_FAST_MODEL / GEMINI_STRONG_MODEL and no GEMINI_MODEL → default.
+        expect(selectArtifactModel('design_system')).toBe(DEFAULT_GEMINI_MODEL);
+        expect(selectArtifactModel('implementation_plan')).toBe(DEFAULT_GEMINI_MODEL);
+
+        // With only the single model set, both tiers resolve to it.
+        localStorage.setItem('GEMINI_MODEL', 'gemini-single-test');
+        expect(selectArtifactModel('design_system')).toBe('gemini-single-test');
+        expect(selectArtifactModel('implementation_plan')).toBe('gemini-single-test');
+    });
+});

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 import { MOCKUP_SPEC_V1 } from '../../types';
 import { useProjectStore } from '../../store/projectStore';
-import { generateCoreArtifact } from './coreArtifactService';
+import { generateCoreArtifact, selectArtifactModel } from './coreArtifactService';
 import { generateMockup } from './mockupService';
 import { validateArtifactContent } from '../artifactValidation';
 import { validateCrossArtifactConsistency } from '../artifactOrchestration';
@@ -418,7 +418,7 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
                             nodeId: meta.subtype,
                             nodeName: meta.title,
                             agentName: 'Artifact Agent',
-                            model: getStrongModel(),
+                            model: selectArtifactModel(meta.subtype),
                             provider: 'gemini',
                             status: 'complete',
                             dependencyIds: meta.dependsOn,
@@ -431,7 +431,7 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
                             nodeId: meta.subtype,
                             nodeName: meta.title,
                             agentName: 'Artifact Agent',
-                            model: getStrongModel(),
+                            model: selectArtifactModel(meta.subtype),
                             provider: 'gemini',
                             status: 'error',
                             dependencyIds: meta.dependsOn,

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -1,6 +1,8 @@
 import type { StructuredPRD, CoreArtifactSubtype, DataModelContent, ComponentInventoryContent, DesignTokens, StructuredImplementationPlan } from '../../types';
-import { callGemini, callGeminiStream, getFastModel, getStrongModel } from '../geminiClient';
+import { callGemini, callGeminiStream } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
+import { getArtifactModel, CORE_ARTIFACT_COMPLEXITY } from '../artifactModelSettings';
+import type { ArtifactComplexity } from '../artifactModelSettings';
 import { screenInventorySchema, dataModelSchema, componentInventorySchema, designSystemTokensSchema, implementationPlanSchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
 import { normalizeScreenInventory, screenInventoryToMarkdown } from '../screenInventoryNormalize';
@@ -23,40 +25,21 @@ export interface CoreArtifactGenerationResult {
     metadata?: Record<string, unknown>;
 }
 
-/**
- * Complexity-based model routing for the core artifacts, mirroring the PRD
- * pipeline's Fast/Expert tiering (see `progressivePrdGeneration.ts`
- * `selectModelTier`). Low-complexity artifacts — largely derivative of upstream
- * artifacts or template-shaped — run on the **Fast (Flash)** model
- * (`GEMINI_FAST_MODEL`); high-complexity artifacts that require deeper reasoning
- * over the whole PRD run on the **Expert (Pro)** model (`GEMINI_STRONG_MODEL`).
- * Both are configured in Settings → "PRD Generation Models" and shared across
- * the PRD pipeline and artifacts. When the user hasn't picked tier models, both
- * resolvers fall back to the single "Intelligence Level" model (`getModel`).
- *
- * Keep this map in sync with any new `CoreArtifactSubtype`.
- */
-export type ArtifactComplexity = 'low' | 'high';
-
-export const CORE_ARTIFACT_COMPLEXITY: Record<CoreArtifactSubtype, ArtifactComplexity> = {
-    // High — deep reasoning / structural design over the full PRD.
-    screen_inventory: 'high',
-    user_flows: 'high',
-    data_model: 'high',
-    implementation_plan: 'high',
-    // Low — derivative of upstream artifacts or template-shaped.
-    component_inventory: 'low',
-    design_system: 'low',
-    prompt_pack: 'low',
-};
+// Per-artifact model routing now lives in `artifactModelSettings.ts` so the
+// Settings UI and the generation pipeline share one source of truth. Re-export
+// the complexity map and type for back-compat with existing importers.
+export { CORE_ARTIFACT_COMPLEXITY };
+export type { ArtifactComplexity };
 
 /**
- * Resolve the Gemini model id a given core artifact should generate with,
- * based on its complexity tier. Exported so the artifact orchestrator can
- * record the *actual* model in workflow metrics (rather than assuming Pro).
+ * Resolve the Gemini model id a given core artifact should generate with.
+ * Honors an explicit per-artifact override (Settings → "Artifact Generation
+ * Models") and otherwise falls back to the complexity recommendation. Exported
+ * so the artifact orchestrator can record the *actual* model in workflow
+ * metrics.
  */
 export const selectArtifactModel = (subtype: CoreArtifactSubtype): string =>
-    CORE_ARTIFACT_COMPLEXITY[subtype] === 'high' ? getStrongModel() : getFastModel();
+    getArtifactModel(subtype);
 
 const CORE_ARTIFACT_PROMPTS: Record<CoreArtifactSubtype, { system: string; userPrefix: string }> = {
     screen_inventory: {

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -1,5 +1,5 @@
 import type { StructuredPRD, CoreArtifactSubtype, DataModelContent, ComponentInventoryContent, DesignTokens, StructuredImplementationPlan } from '../../types';
-import { callGemini, callGeminiStream } from '../geminiClient';
+import { callGemini, callGeminiStream, getFastModel, getStrongModel } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
 import { screenInventorySchema, dataModelSchema, componentInventorySchema, designSystemTokensSchema, implementationPlanSchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
@@ -22,6 +22,41 @@ export interface CoreArtifactGenerationResult {
      */
     metadata?: Record<string, unknown>;
 }
+
+/**
+ * Complexity-based model routing for the core artifacts, mirroring the PRD
+ * pipeline's Fast/Expert tiering (see `progressivePrdGeneration.ts`
+ * `selectModelTier`). Low-complexity artifacts — largely derivative of upstream
+ * artifacts or template-shaped — run on the **Fast (Flash)** model
+ * (`GEMINI_FAST_MODEL`); high-complexity artifacts that require deeper reasoning
+ * over the whole PRD run on the **Expert (Pro)** model (`GEMINI_STRONG_MODEL`).
+ * Both are configured in Settings → "PRD Generation Models" and shared across
+ * the PRD pipeline and artifacts. When the user hasn't picked tier models, both
+ * resolvers fall back to the single "Intelligence Level" model (`getModel`).
+ *
+ * Keep this map in sync with any new `CoreArtifactSubtype`.
+ */
+export type ArtifactComplexity = 'low' | 'high';
+
+export const CORE_ARTIFACT_COMPLEXITY: Record<CoreArtifactSubtype, ArtifactComplexity> = {
+    // High — deep reasoning / structural design over the full PRD.
+    screen_inventory: 'high',
+    user_flows: 'high',
+    data_model: 'high',
+    implementation_plan: 'high',
+    // Low — derivative of upstream artifacts or template-shaped.
+    component_inventory: 'low',
+    design_system: 'low',
+    prompt_pack: 'low',
+};
+
+/**
+ * Resolve the Gemini model id a given core artifact should generate with,
+ * based on its complexity tier. Exported so the artifact orchestrator can
+ * record the *actual* model in workflow metrics (rather than assuming Pro).
+ */
+export const selectArtifactModel = (subtype: CoreArtifactSubtype): string =>
+    CORE_ARTIFACT_COMPLEXITY[subtype] === 'high' ? getStrongModel() : getFastModel();
 
 const CORE_ARTIFACT_PROMPTS: Record<CoreArtifactSubtype, { system: string; userPrefix: string }> = {
     screen_inventory: {
@@ -380,6 +415,9 @@ export const generateCoreArtifact = async (
 ): Promise<CoreArtifactGenerationResult> => {
     const config = CORE_ARTIFACT_PROMPTS[subtype];
     const onProgress = options?.onProgress;
+    // Route by complexity: high-reasoning artifacts → Expert (Pro), the rest →
+    // Fast (Flash). Mirrors the PRD pipeline's per-section tiering.
+    const model = selectArtifactModel(subtype);
 
     const featureList = structuredPRD.features.map(f => {
         let line = `- [${f.id}] ${f.name} (${f.complexity}${f.priority ? `, ${f.priority}` : ''}): ${f.description}`;
@@ -469,7 +507,7 @@ Architecture: ${structuredPRD.architecture}${
                 onError: () => {},
             },
             options?.signal,
-            { responseMimeType: 'application/json', responseSchema: schema },
+            { responseMimeType: 'application/json', responseSchema: schema, model },
         );
         onProgress?.('Validating output…');
 
@@ -515,6 +553,7 @@ Architecture: ${structuredPRD.architecture}${
             onError: () => {},
         },
         options?.signal,
+        { model },
     );
     onProgress?.('Validating output…');
     return { content: normalizeArtifactMarkdown(result) };
@@ -530,6 +569,8 @@ export const refineCoreArtifact = async (
 ): Promise<string> => {
     options?.onStatus?.(`Refining ${subtype.replace(/_/g, ' ')}...`);
 
+    // Refine on the same complexity tier the artifact was generated with.
+    const model = selectArtifactModel(subtype);
     const featureSummary = structuredPRD.features.map(f => `- ${f.name}: ${f.description}`).join('\n');
 
     if (subtype === 'screen_inventory') {
@@ -549,7 +590,7 @@ Rules:
         const result = await callGemini(
             system,
             `Here is the current screen inventory (may be JSON or markdown):\n\n${currentContent}\n\n---\n\nUser's refinement instruction: ${instruction}\n\n---\n\nPRD context for reference:\n${prdContent}\n\nFeatures:\n${featureSummary}`,
-            { responseMimeType: 'application/json', responseSchema: screenInventorySchema },
+            { responseMimeType: 'application/json', responseSchema: screenInventorySchema, model },
             options?.signal,
         );
 
@@ -574,7 +615,7 @@ Rules:
     return callGemini(
         system,
         `Here is the current ${subtype.replace(/_/g, ' ')}:\n\n${currentContent}\n\n---\n\nUser's refinement instruction: ${instruction}\n\n---\n\nPRD context for reference:\n${prdContent}\n\nFeatures:\n${featureSummary}`,
-        undefined,
+        { model },
         options?.signal,
     );
 };

--- a/src/store/__tests__/mockupUpload.test.ts
+++ b/src/store/__tests__/mockupUpload.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ScreenInventoryImageRecord } from '../../types';
+
+// In-memory fake of the IndexedDB persistence layer so we can exercise the
+// upload store (the same store the mockup manual-upload UI uses) without a real
+// IndexedDB. Keeps the real slug/key helpers for fidelity.
+vi.mock('../../lib/screenInventoryImageStore', () => {
+    const db = new Map<string, ScreenInventoryImageRecord>();
+    const slugifyScreenName = (name: string): string =>
+        name.toLowerCase().normalize('NFKD').replace(/[^\w\s-]/g, '').trim()
+            .replace(/\s+/g, '-').replace(/-+/g, '-') || 'screen';
+    const buildScreenImageKey = (v: string, slug: string, n: number) => `${v}:${slug}:${n}`;
+    return {
+        slugifyScreenName,
+        buildScreenImageKey,
+        listScreenImagesForArtifactVersion: async (artifactVersionId: string) =>
+            [...db.values()].filter((r) => r.artifactVersionId === artifactVersionId),
+        putScreenImage: async (record: ScreenInventoryImageRecord) => {
+            db.set(record.key, record);
+        },
+        setPreferredScreenImage: async (artifactVersionId: string, slug: string, versionNumber: number) => {
+            const updated: ScreenInventoryImageRecord[] = [];
+            for (const r of db.values()) {
+                if (r.artifactVersionId === artifactVersionId && r.screenSlug === slug) {
+                    const next = { ...r, isPreferred: r.versionNumber === versionNumber };
+                    db.set(r.key, next);
+                    updated.push(next);
+                }
+            }
+            return updated;
+        },
+    };
+});
+
+import { useScreenInventoryImageStore } from '../screenInventoryImageStore';
+
+const makeFile = (name = 'mock.png') =>
+    new File([new Uint8Array([1, 2, 3, 4])], name, { type: 'image/png' });
+
+describe('mockup manual upload — uploaded image accepted as the mockup source', () => {
+    beforeEach(() => {
+        useScreenInventoryImageStore.setState({ images: {}, hydrated: {}, uploading: {}, errors: {} });
+    });
+
+    it('stores an uploaded file as the preferred image for a mockup screen', async () => {
+        const versionId = 'mockup-version-1';
+        const screenName = 'Home Screen';
+
+        await useScreenInventoryImageStore.getState().upload({
+            projectId: 'p1',
+            artifactId: 'mockup-artifact-1',
+            artifactVersionId: versionId,
+            screenName,
+            file: makeFile(),
+            prompt: 'Upload a mockup of the Home Screen',
+        });
+
+        const preferred = useScreenInventoryImageStore.getState().peekPreferred(versionId, screenName);
+        expect(preferred).toBeDefined();
+        expect(preferred?.isPreferred).toBe(true);
+        expect(preferred?.dataUrl.startsWith('data:image/png')).toBe(true);
+        expect(preferred?.prompt).toContain('Home Screen');
+        expect(preferred?.versionNumber).toBe(1);
+    });
+
+    it('keeps the latest upload preferred and versions prior uploads', async () => {
+        const versionId = 'mockup-version-2';
+        const screenName = 'Settings';
+        const store = useScreenInventoryImageStore.getState();
+
+        await store.upload({
+            projectId: 'p1', artifactId: 'a1', artifactVersionId: versionId,
+            screenName, file: makeFile('v1.png'), prompt: 'first',
+        });
+        await store.upload({
+            projectId: 'p1', artifactId: 'a1', artifactVersionId: versionId,
+            screenName, file: makeFile('v2.png'), prompt: 'second',
+        });
+
+        const all = useScreenInventoryImageStore.getState().listForScreen(versionId, screenName);
+        expect(all).toHaveLength(2);
+        const preferred = useScreenInventoryImageStore.getState().peekPreferred(versionId, screenName);
+        expect(preferred?.versionNumber).toBe(2);
+        // Exactly one preferred at a time.
+        expect(all.filter((r) => r.isPreferred)).toHaveLength(1);
+    });
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+// Build-time constants injected via Vite `define` (see vite.config.ts).
+declare const __APP_VERSION__: string;
+declare const __BUILD_DATE__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'node:fs'
+
+// Build-time constants surfaced in the UI (Settings → System Status). The build
+// date is stamped when `vite build` (or the dev server) starts, so it reflects
+// the actual build instead of a hardcoded, perpetually-stale string.
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8')) as { version: string }
+const buildDate = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_DATE__: JSON.stringify(buildDate),
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,12 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
     plugins: [react()],
+    // Mirror vite.config's build-time constants so components that read them
+    // (e.g. SettingsModal's System Status) don't hit an undefined global.
+    define: {
+        __APP_VERSION__: JSON.stringify('test'),
+        __BUILD_DATE__: JSON.stringify('test'),
+    },
     test: {
         environment: 'jsdom',
         globals: true,


### PR DESCRIPTION
Artifacts previously all generated on the single "Intelligence Level"
model regardless of complexity. Mirror the PRD pipeline's per-section
tiering: tag each core artifact subtype low/high in
CORE_ARTIFACT_COMPLEXITY and resolve the model via selectArtifactModel —
high-reasoning artifacts (screen_inventory, user_flows, data_model,
implementation_plan) run on the Expert/Pro model, derivative ones
(component_inventory, design_system, prompt_pack) on the Fast/Flash
model. The resolved model is threaded into every generate and refine
call.

Also fix the metrics mislabel: artifactJobController recorded the strong
model for every artifact node; it now records the actual per-subtype
model. JsonModeConfig.responseMimeType/responseSchema are now optional so
a plain-text model-only override ({ model }) is valid, and the
generationConfig builder no longer emits undefined schema fields.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LNj9vtohLgBJzkonwpaavx