### PR TITLE
Add cross-device mockup image sync via Vercel Blob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,14 @@ restores it under the stable `DEMO_PROJECT_ID`.
   dropped mockup images from snapshots.
 - Note: user-uploaded Screen Inventory images
   (`src/lib/screenInventoryImageStore.ts`, a separate IndexedDB store) are **not
-  yet** captured in snapshots, and `/api/projects` cross-device sync is
-  text-only (no images) — both are documented gaps, not bugs to "fix" silently.
+  yet** captured in snapshots. `/api/projects` cross-device sync **does** now
+  carry **mockup** images (via a separate Blob ref layer — see "Cross-device
+  mockup image sync" below). The snapshot feature and the project-sync image
+  layer are **independent**: different Blob prefixes (`snapshots/<id>/…` vs
+  `users/<userId>/mockup-images/…`), different ref models, different auth gates
+  (owner token vs per-user session). Do not entangle them. Screen Inventory
+  images remain a documented gap on the project-sync path too — the ref layer is
+  built generic (`kind`/`meta`) so they can be wired in later.
 
 ### Server-side project storage (`api/projects.js`, `api/_lib/projectsStore.js`, `src/store/projectServerSync.ts`)
 
@@ -225,6 +231,83 @@ device-scoped and never syncs) and full design.
   import.** This is distinct from the anonymous→account *legacy* import
   (`userScope.ts`); after a legacy import, `HomePage` triggers a server
   reconcile so the newly-claimed projects upload to the account.
+
+### Cross-device mockup image sync (`api/_lib/imageRefsStore.js`, `src/store/projectImageSync.ts`)
+
+AI-generated **mockup** images follow a signed-in user's projects across devices.
+The `/api/projects` bundle stays **text-only**; image BYTES go to **Vercel Blob**
+and only small **reference** records live in Mongo. This is the per-user sync
+path and is **independent of the owner-only snapshot feature** (`api/snapshots.js`)
+— different Blob prefix, ref model, and auth gate; don't entangle them.
+
+- **Local-first, unchanged render path.** IndexedDB (`src/lib/mockupImageStore.ts`)
+  remains the source of truth / render cache; generation still writes there.
+  `MockupScreenImage` renders from the Zustand cache exactly as before.
+- **Content-addressing.** Images are addressed by `sha256(dataUrl)`
+  (`src/lib/imageBlobHash.ts`) and stored at the per-user, deterministic path
+  `users/<userId>/mockup-images/<hash>.<ext>` (`addRandomSuffix:false`,
+  `allowOverwrite:true`). Identical renders dedup to one blob; the hash → blob is
+  1:1, which makes refcount GC exact. **Blob access is `public`** (unguessable
+  uuid userId + sha256 path) — a deliberate decision: the architecture requires
+  the browser to download bytes **directly** from the Blob URL (no function
+  proxy), and a `private` blob would need a per-download function call to mint a
+  signed URL. Mockups are low-sensitivity, so public + unguessable is the
+  chosen trade-off. If image sensitivity ever rises, switch to signed URLs.
+- **Client-direct upload.** Bytes go browser → Blob via `@vercel/blob/client`
+  `upload()` (`src/lib/imageRefsClient.ts`), so they never traverse a serverless
+  body (dodging Vercel's ~4.5 MB cap). The function only mints a signed token.
+- **Ref store** (`api/_lib/imageRefsStore.js`, collection `project_images`). One
+  doc per `(userId, projectId, key)`. A ref carries `{ key, hash, blobUrl,
+  byteSize, kind, versionId?, screenId?, quality?, meta }` where `meta` is the
+  dataUrl-less image record (so the client can reconstruct it on pull) — generic
+  over `kind` (`mockup` | `screen_inventory`) so a second image type can reuse
+  it. **RLS-equivalent** exactly like `projectsStore.js`: every function pins
+  `{ userId }` (from `requireUser`, never the body). Indexes
+  (`ensureImageRefIndexes`): `{userId,projectId,key}` unique, `{userId,projectId}`,
+  `{userId,hash}`.
+- **Endpoints — folded into `api/projects.js` via `?action=` (NO new function;
+  the repo is at 11/12).** `image-upload-token` (POST, `handleUpload` token
+  issuer — `onBeforeGenerateToken` restricts the pathname to the caller's
+  `users/<userId>/…` prefix + allowed image types; `onUploadCompleted` persists a
+  backup ref). `image-refs` (GET, list a project's refs). `image-ref-put` (POST,
+  authoritative ref persist after upload — rejects a `blobUrl` outside the
+  caller's prefix). `image-ref-delete` (POST, refcount-GCs orphan blobs).
+  **`image-upload-token` runs BEFORE the global `requireUser`**: the
+  upload-completed callback is a signed server-to-server request with no session
+  cookie — `handleUpload` verifies its signature, and the userId comes from the
+  `tokenPayload` stamped (from the verified session) at token-gen time. Never
+  move it behind `requireUser`.
+- **Dual ref-persist (both idempotent).** The client's `image-ref-put` is the
+  **authoritative** path (works everywhere, incl. localhost where Vercel can't
+  reach `onUploadCompleted`). `onUploadCompleted` is a best-effort backup for the
+  tab-closed-early case and persists a minimal ref (routing parsed from the key).
+- **Push** (`pushProjectImages`, fired after each text save AND from
+  `mockupImageStore.generate` via `notifyMockupImageGenerated` — generation
+  writes IDB directly and would otherwise never trigger a push). Diffs local
+  image keys against a per-user uploaded-marker set
+  (`synapse-mockup-images-uploaded::u:<userId>`, `src/lib/imageUploadMarker.ts`,
+  mirrors `projectMigration.ts`) + the server refs, uploads the missing ones,
+  persists refs, marks them. **Image sync NEVER blocks text sync** and every
+  failure is non-fatal (the image is left unmarked and retried next push); a
+  failed image never reverts local data.
+- **Pull = refs only, hydrate lazily.** Reconcile pulls refs into an in-memory
+  registry (`src/lib/imageRefRegistry.ts`, keyed by versionId). `loadForVersion`
+  in the mockup image store, on an IndexedDB cache **miss** where a ref exists,
+  fetches the Blob URL directly (concurrency-limited, mirrors snapshot
+  `hydrateImages`), writes it into IndexedDB, then renders. **No bulk download on
+  sign-in.**
+- **GC.** Project **hard-delete** (`api/projects.js`) calls
+  `deleteRefsForProject` then `del()`s the returned **orphaned** blob URLs —
+  refcount-aware: a blob is deleted only once NO remaining ref for that user
+  points at its hash (`findOrphanedHashes`; pure mirror in
+  `src/lib/imageSyncDiff.ts`). Soft-delete keeps refs (recoverable). GC failures
+  are logged, never fatal. **Known gap (sweep TODO):** per-image overwrite /
+  version regen can orphan a blob until project hard-delete (a new render = new
+  hash = new blob; the old ref/blob isn't eagerly collected). `image-ref-delete`
+  exists for a future fine-grained sweep.
+- **CSP.** `vercel.json` `connect-src` must include `https://*.vercel-storage.com`
+  for the browser's upload/download fetches — without it the feature breaks in
+  prod.
 
 ### LLM layer (`src/lib/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,11 @@ restores it under the stable `DEMO_PROJECT_ID`.
   `users/<userId>/mockup-images/…`), different ref models, different auth gates
   (owner token vs per-user session). Do not entangle them. Screen Inventory
   images remain a documented gap on the project-sync path too — the ref layer is
-  built generic (`kind`/`meta`) so they can be wired in later.
+  built generic (`kind`/`meta`) so they can be wired in later. **Note:** the
+  `user_uploaded` **mockup image source mode** (the OpenAI-key-free path that
+  lets the user upload their own mockup) persists to `screenInventoryImageStore`,
+  **not** `mockupImageStore` — so those uploads ride on this same not-yet-synced
+  gap. Only the `gpt_image` (AI-generated) mockups sync across devices today.
 
 ### Server-side project storage (`api/projects.js`, `api/_lib/projectsStore.js`, `src/store/projectServerSync.ts`)
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,10 @@ live cache; **for signed-in users projects also sync to the server** (a MongoDB
 `projects` collection scoped to your account) so they follow you across web and
 mobile and survive a browser-data clear. AI-generated mockup PNGs persist to
 **IndexedDB** (typically gigabytes of headroom, so high-quality images don't
-blow the localStorage 5-10 MB cap) and are device-local for now.
+blow the localStorage 5-10 MB cap) as the local cache, and for signed-in users
+**now also sync across devices** via Vercel Blob (image bytes go to Blob, only
+small references travel with the project) so mockups appear on your other
+devices too — hydrated lazily on view.
 
 Prefer to look before you build? Visit `http://localhost:5173/tour` for the
 interactive product tour — it runs entirely on demo data with no API key.
@@ -313,7 +316,7 @@ variables:
 | Variable | Where it comes from |
 | --- | --- |
 | `SYNAPSE_OWNER_TOKEN` | Any random string &geq; 24 chars. The server compares with `crypto.timingSafeEqual`; the client stores it in `localStorage`. |
-| `BLOB_READ_WRITE_TOKEN` | Created automatically when you provision Vercel Blob for the project. No manual setup needed. |
+| `BLOB_READ_WRITE_TOKEN` | Created automatically when you provision Vercel Blob for the project. No manual setup needed. Also powers per-user **cross-device mockup image sync** (independent of snapshots). |
 
 The owner-token gate is single-tenant: there is no signup, no per-user
 isolation, no demo access. It exists so the project owner can persist real work
@@ -385,6 +388,8 @@ Portfolio project. Demo visitors (and the public `/tour`) run the workspace
 fully in-browser &mdash; spine + artifact state in `localStorage`, mockup PNGs in
 IndexedDB, no telemetry. **Signed-in users get cross-device project sync**:
 projects persist to a per-account server collection and reconcile onto any device
-on sign-in, with localStorage kept as the offline cache. (Mockup images remain
-device-local for now — see `tasks/TODO.md`.) The owner can additionally opt-in to
+on sign-in, with localStorage kept as the offline cache. **Mockup images sync
+across devices too** — bytes live in Vercel Blob, only small refs travel with the
+project, and they hydrate lazily on view (Screen Inventory upload images are not
+synced yet — see `tasks/TODO.md`). The owner can additionally opt-in to
 Vercel-Blob-backed Cloud Snapshots (gated by `SYNAPSE_OWNER_TOKEN`).

--- a/README.md
+++ b/README.md
@@ -398,8 +398,9 @@ Portfolio project. Demo visitors (and the public `/tour`) run the workspace
 fully in-browser &mdash; spine + artifact state in `localStorage`, mockup PNGs in
 IndexedDB, no telemetry. **Signed-in users get cross-device project sync**:
 projects persist to a per-account server collection and reconcile onto any device
-on sign-in, with localStorage kept as the offline cache. **Mockup images sync
-across devices too** — bytes live in Vercel Blob, only small refs travel with the
-project, and they hydrate lazily on view (Screen Inventory upload images are not
-synced yet — see `tasks/TODO.md`). The owner can additionally opt-in to
-Vercel-Blob-backed Cloud Snapshots (gated by `SYNAPSE_OWNER_TOKEN`).
+on sign-in, with localStorage kept as the offline cache. **AI-generated mockup
+images sync across devices too** — bytes live in Vercel Blob, only small refs
+travel with the project, and they hydrate lazily on view (user-uploaded mockup
+images and Screen Inventory uploads are not synced yet — see `tasks/TODO.md`).
+The owner can additionally opt-in to Vercel-Blob-backed Cloud Snapshots (gated by
+`SYNAPSE_OWNER_TOKEN`).

--- a/api/__tests__/projects.test.js
+++ b/api/__tests__/projects.test.js
@@ -17,9 +17,25 @@ const dataLayer = {
   importProjects: vi.fn(),
 };
 
+// Image-ref data layer + Blob SDK — mocked so the handler's image-sync routing
+// can be exercised without Mongo or Vercel Blob.
+const imageRefs = {
+  isValidImageKey: vi.fn((k) => typeof k === 'string' && k.length > 0 && k.length <= 512),
+  isValidRef: vi.fn((r) => Boolean(r && r.key && r.hash && r.blobUrl)),
+  listImageRefs: vi.fn(),
+  upsertImageRef: vi.fn(),
+  deleteImageRefs: vi.fn(),
+  deleteRefsForProject: vi.fn(),
+};
+const handleUpload = vi.fn();
+const del = vi.fn();
+
 vi.mock('../_lib/requireUser.js', () => ({ requireUser: (...a) => requireUser(...a) }));
 vi.mock('../_lib/rateLimit.js', () => ({ enforceRateLimit: (...a) => enforceRateLimit(...a) }));
 vi.mock('../_lib/projectsStore.js', () => dataLayer);
+vi.mock('../_lib/imageRefsStore.js', () => imageRefs);
+vi.mock('@vercel/blob/client', () => ({ handleUpload: (...a) => handleUpload(...a) }));
+vi.mock('@vercel/blob', () => ({ del: (...a) => del(...a) }));
 
 let handler;
 
@@ -41,9 +57,15 @@ beforeEach(async () => {
   requireUser.mockReset().mockResolvedValue({ userId: 'user-a' });
   enforceRateLimit.mockReset().mockReturnValue(false);
   Object.values(dataLayer).forEach((fn) => fn.mockReset());
+  Object.values(imageRefs).forEach((fn) => fn.mockReset());
+  handleUpload.mockReset();
+  del.mockReset();
+  imageRefs.isValidImageKey.mockImplementation((k) => typeof k === 'string' && k.length > 0 && k.length <= 512);
+  imageRefs.isValidRef.mockImplementation((r) => Boolean(r && r.key && r.hash && r.blobUrl));
   dataLayer.isValidProjectId.mockImplementation(
     (id) => typeof id === 'string' && /^[A-Za-z0-9_-]{1,64}$/.test(id),
   );
+  process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
   ({ default: handler } = await import('../projects.js'));
 });
 
@@ -156,5 +178,81 @@ describe('POST actions', () => {
     await handler({ method: 'POST', query: { action: 'restore', id: 'p1' }, headers: {} }, res);
     expect(res.statusCode).toBe(200);
     expect(parsed(res).restored).toBe(true);
+  });
+});
+
+describe('image sync actions', () => {
+  it('GET image-refs lists the session user\'s refs for the project', async () => {
+    imageRefs.listImageRefs.mockResolvedValue([{ key: 'k1' }]);
+    const res = mockRes();
+    await handler({ method: 'GET', query: { action: 'image-refs', id: 'p1' }, headers: {} }, res);
+    expect(res.statusCode).toBe(200);
+    expect(parsed(res)).toEqual({ refs: [{ key: 'k1' }] });
+    expect(imageRefs.listImageRefs).toHaveBeenCalledWith('user-a', 'p1');
+  });
+
+  it('image-ref-put upserts under the session user when the blob URL is in their prefix', async () => {
+    imageRefs.upsertImageRef.mockResolvedValue({ key: 'k1' });
+    const res = mockRes();
+    const ref = { key: 'k1', hash: 'h', blobUrl: 'https://blob/users/user-a/mockup-images/h.png' };
+    await handler({ method: 'POST', query: { action: 'image-ref-put', id: 'p1' }, headers: {}, body: { ref } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(imageRefs.upsertImageRef).toHaveBeenCalledWith('user-a', 'p1', ref);
+  });
+
+  it('image-ref-put rejects a blob URL outside the caller\'s prefix', async () => {
+    const res = mockRes();
+    const ref = { key: 'k1', hash: 'h', blobUrl: 'https://blob/users/SOMEONE_ELSE/mockup-images/h.png' };
+    await handler({ method: 'POST', query: { action: 'image-ref-put', id: 'p1' }, headers: {}, body: { ref } }, res);
+    expect(res.statusCode).toBe(403);
+    expect(parsed(res).error).toBe('forbidden_blob_url');
+    expect(imageRefs.upsertImageRef).not.toHaveBeenCalled();
+  });
+
+  it('image-ref-delete deletes refs and GCs the orphaned blobs', async () => {
+    imageRefs.deleteImageRefs.mockResolvedValue({ deletedCount: 2, orphanedBlobUrls: ['url1', 'url2'] });
+    const res = mockRes();
+    await handler({ method: 'POST', query: { action: 'image-ref-delete', id: 'p1' }, headers: {}, body: { keys: ['k1', 'k2'] } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(parsed(res)).toEqual({ deletedCount: 2, orphanedBlobs: 2 });
+    expect(imageRefs.deleteImageRefs).toHaveBeenCalledWith('user-a', 'p1', ['k1', 'k2']);
+    expect(del).toHaveBeenCalledWith(['url1', 'url2']);
+  });
+
+  it('hard-delete also GCs the project\'s image refs + orphan blobs', async () => {
+    dataLayer.hardDeleteProject.mockResolvedValue(true);
+    imageRefs.deleteRefsForProject.mockResolvedValue({ deletedCount: 1, orphanedBlobUrls: ['url1'] });
+    const res = mockRes();
+    await handler({ method: 'DELETE', query: { id: 'p1', hard: '1' }, headers: {} }, res);
+    expect(res.statusCode).toBe(200);
+    expect(imageRefs.deleteRefsForProject).toHaveBeenCalledWith('user-a', 'p1');
+    expect(del).toHaveBeenCalledWith(['url1']);
+  });
+
+  it('image-upload-token authenticates the browser token request and calls handleUpload', async () => {
+    handleUpload.mockResolvedValue({ type: 'blob.generate-client-token', clientToken: 'tok' });
+    const res = mockRes();
+    await handler(
+      { method: 'POST', query: { action: 'image-upload-token' }, headers: {}, body: { type: 'blob.generate-client-token' } },
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(parsed(res)).toEqual({ type: 'blob.generate-client-token', clientToken: 'tok' });
+    expect(requireUser).toHaveBeenCalled();
+    expect(handleUpload).toHaveBeenCalled();
+  });
+
+  it('image-upload-token does NOT require a session for the signed completion callback', async () => {
+    handleUpload.mockResolvedValue({ type: 'blob.upload-completed', response: 'ok' });
+    const res = mockRes();
+    await handler(
+      { method: 'POST', query: { action: 'image-upload-token' }, headers: {}, body: { type: 'blob.upload-completed', payload: {} } },
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    // The callback is a server-to-server request with no cookie — auth is the
+    // handleUpload signature check, not requireUser.
+    expect(requireUser).not.toHaveBeenCalled();
+    expect(handleUpload).toHaveBeenCalled();
   });
 });

--- a/api/_lib/__tests__/imageRefsStore.test.js
+++ b/api/_lib/__tests__/imageRefsStore.test.js
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the Mongo shim so we can assert every imageRefsStore function pins the
+// owner's userId into the filter (the RLS-equivalent guarantee) and that the
+// refcount-aware GC only orphans blobs with zero remaining refs.
+const runMongoAction = vi.fn();
+vi.mock('../db.js', () => ({ runMongoAction: (...a) => runMongoAction(...a) }));
+
+let store;
+
+const validRef = (overrides = {}) => ({
+  key: 'v1:s1:low',
+  hash: 'a'.repeat(64),
+  blobUrl: 'https://blob/users/user-a/mockup-images/x.png',
+  byteSize: 100,
+  kind: 'mockup',
+  versionId: 'v1',
+  screenId: 's1',
+  quality: 'low',
+  meta: { prompt: 'x' },
+  ...overrides,
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  runMongoAction.mockReset();
+  runMongoAction.mockResolvedValue({});
+  store = await import('../imageRefsStore.js');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('validators', () => {
+  it('isValidImageKey bounds the key', () => {
+    expect(store.isValidImageKey('v1:s1:low')).toBe(true);
+    expect(store.isValidImageKey('')).toBe(false);
+    expect(store.isValidImageKey('x'.repeat(513))).toBe(false);
+    expect(store.isValidImageKey(null)).toBe(false);
+  });
+
+  it('isValidHash requires a 64-char hex digest', () => {
+    expect(store.isValidHash('a'.repeat(64))).toBe(true);
+    expect(store.isValidHash('A'.repeat(64))).toBe(false); // lowercase only
+    expect(store.isValidHash('abc')).toBe(false);
+  });
+
+  it('isValidRef requires key, hash and a blobUrl', () => {
+    expect(store.isValidRef(validRef())).toBe(true);
+    expect(store.isValidRef(validRef({ hash: 'short' }))).toBe(false);
+    expect(store.isValidRef(validRef({ blobUrl: '' }))).toBe(false);
+    expect(store.isValidRef(null)).toBe(false);
+  });
+});
+
+describe('listImageRefs', () => {
+  it('scopes the query to the owner + project', async () => {
+    runMongoAction.mockImplementation(async (action) =>
+      action === 'find' ? { documents: [{ key: 'k1' }] } : {},
+    );
+    const out = await store.listImageRefs('user-a', 'p1');
+    expect(out).toEqual([{ key: 'k1' }]);
+    const find = runMongoAction.mock.calls.find(([a]) => a === 'find')[1];
+    expect(find.filter).toEqual({ userId: 'user-a', projectId: 'p1' });
+    // Never leak the owner id back to the client.
+    expect(find.projection.userId).toBe(0);
+  });
+});
+
+describe('upsertImageRef', () => {
+  it('pins userId+projectId+key and upserts the sanitized ref', async () => {
+    runMongoAction.mockImplementation(async (action) =>
+      action === 'updateOne' ? { upsertedId: { _id: 'x' } } : {},
+    );
+    const saved = await store.upsertImageRef('user-a', 'p1', validRef());
+    expect(saved).toMatchObject({ projectId: 'p1', key: 'v1:s1:low', kind: 'mockup' });
+    const update = runMongoAction.mock.calls.find(([a]) => a === 'updateOne')[1];
+    expect(update.upsert).toBe(true);
+    expect(update.filter).toEqual({ userId: 'user-a', projectId: 'p1', key: 'v1:s1:low' });
+    expect(update.update.$set.userId).toBe('user-a');
+    // dataUrl can never sneak in via meta-less top-level fields.
+    expect(update.update.$set.dataUrl).toBeUndefined();
+  });
+
+  it('rejects an invalid ref', async () => {
+    await expect(store.upsertImageRef('user-a', 'p1', { key: 'k' })).rejects.toThrow(/invalid ref/);
+  });
+});
+
+describe('findOrphanedHashes (refcount policy)', () => {
+  it('orphans only hashes whose remaining count is zero', async () => {
+    const hDead = 'd'.repeat(64);
+    const hLive = 'e'.repeat(64);
+    const lookup = async (hash) => (hash === hDead ? 0 : 2);
+    const out = await store.findOrphanedHashes('user-a', [hDead, hLive, hDead], lookup);
+    expect(out).toEqual([hDead]);
+  });
+
+  it('ignores malformed hashes (never queries / deletes for them)', async () => {
+    const lookup = vi.fn(async () => 0);
+    const out = await store.findOrphanedHashes('user-a', ['not-a-hash'], lookup);
+    expect(out).toEqual([]);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteImageRefs (refcount-aware GC)', () => {
+  it('deletes owner-scoped refs and orphans only blobs with no remaining refs', async () => {
+    const h1 = '1'.repeat(64);
+    const h2 = '2'.repeat(64);
+    runMongoAction.mockImplementation(async (action, payload) => {
+      if (action === 'find') {
+        if (payload.filter.key && payload.filter.key.$in) {
+          return {
+            documents: [
+              { key: 'k1', hash: h1, blobUrl: 'url1' },
+              { key: 'k2', hash: h2, blobUrl: 'url2' },
+            ],
+          };
+        }
+        // refcount lookups: h1 has none remaining, h2 still referenced.
+        if (payload.filter.hash === h1) return { documents: [] };
+        if (payload.filter.hash === h2) return { documents: [{ key: 'kx' }] };
+        return { documents: [] };
+      }
+      if (action === 'deleteMany') return { deletedCount: 2 };
+      return {};
+    });
+
+    const out = await store.deleteImageRefs('user-a', 'p1', ['k1', 'k2']);
+    expect(out.deletedCount).toBe(2);
+    expect(out.orphanedBlobUrls).toEqual(['url1']); // url2 retained (h2 still referenced)
+
+    const del = runMongoAction.mock.calls.find(([a]) => a === 'deleteMany')[1];
+    expect(del.filter.userId).toBe('user-a');
+    expect(del.filter.projectId).toBe('p1');
+  });
+
+  it('no-ops (no delete, no orphans) when no keys match', async () => {
+    runMongoAction.mockImplementation(async (action) =>
+      action === 'find' ? { documents: [] } : {},
+    );
+    const out = await store.deleteImageRefs('user-a', 'p1', ['nope']);
+    expect(out).toEqual({ deletedCount: 0, orphanedBlobUrls: [] });
+    expect(runMongoAction).not.toHaveBeenCalledWith('deleteMany', expect.anything());
+  });
+});
+
+describe('deleteRefsForProject', () => {
+  it('deletes every ref for the project, owner-scoped', async () => {
+    const h1 = '1'.repeat(64);
+    runMongoAction.mockImplementation(async (action, payload) => {
+      if (action === 'find') {
+        if (!payload.filter.hash) return { documents: [{ key: 'k1', hash: h1, blobUrl: 'url1' }] };
+        return { documents: [] }; // h1 has no remaining refs
+      }
+      if (action === 'deleteMany') return { deletedCount: 1 };
+      return {};
+    });
+    const out = await store.deleteRefsForProject('user-a', 'p1');
+    expect(out.deletedCount).toBe(1);
+    expect(out.orphanedBlobUrls).toEqual(['url1']);
+    const del = runMongoAction.mock.calls.find(([a]) => a === 'deleteMany')[1];
+    expect(del.filter).toEqual({ userId: 'user-a', projectId: 'p1' });
+  });
+});

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -50,6 +50,7 @@ async function getDb() {
  *   - insertOne → { insertedId }
  *   - updateOne → { matchedCount, modifiedCount, upsertedId }
  *   - deleteOne → { deletedCount }
+ *   - deleteMany → { deletedCount }
  *   - aggregate → { documents }
  *   - createIndexes → { ok: true } (idempotent; payload.indexes is a list of
  *                      driver index specs: { key, ...options })
@@ -96,6 +97,10 @@ export async function runMongoAction(action, payload = {}) {
     }
     case 'deleteOne': {
       const result = await collection.deleteOne(payload.filter || {});
+      return { deletedCount: result.deletedCount };
+    }
+    case 'deleteMany': {
+      const result = await collection.deleteMany(payload.filter || {});
       return { deletedCount: result.deletedCount };
     }
     case 'aggregate': {

--- a/api/_lib/imageRefsStore.js
+++ b/api/_lib/imageRefsStore.js
@@ -1,0 +1,237 @@
+// Server-side store for per-user image references. The image BYTES live in
+// Vercel Blob (content-addressed under `users/<userId>/mockup-images/<hash>`);
+// this collection only holds small *reference* records so the `projects`
+// documents (and the /api/projects bundle) stay text-only. One document per
+// (userId, projectId, key) where `key` is the IndexedDB composite key the
+// client uses to find the image locally.
+//
+// This is the durability layer for the per-user /api/projects sync path. It is
+// SEPARATE from the owner-only snapshot feature (api/snapshots.js) and does not
+// touch it.
+//
+// ACCESS CONTROL (RLS-equivalent), identical to projectsStore.js: MongoDB has
+// no row-level security, so every function takes `userId` as its first argument
+// and pins `{ userId }` into the filter. No code path reads or writes a ref
+// without the owner's id in the filter, so one user's query can never match
+// another user's row. `userId` always comes from the verified session at the
+// call site (requireUser) — never from a client-supplied value.
+//
+// CONTENT-ADDRESSING + GC: blobs are addressed by sha256(dataUrl), so identical
+// renders dedup to one blob and the hash → blob path is 1:1. Deleting refs is
+// therefore refcount-aware: a blob is only orphaned (safe to delete) once NO
+// remaining ref for that user points at its hash. The store computes the
+// orphaned blob URLs and returns them; the HTTP handler performs the actual
+// Blob `del()` so the data layer stays free of Blob-SDK concerns.
+
+import { runMongoAction } from './db.js';
+
+export const IMAGE_REFS_COLLECTION = 'project_images';
+
+// Image keys are client composite keys: `${versionId}:${screenId}:${quality}`
+// for mockups, or `${artifactVersionId}:${screenSlug}:${versionNumber}` for
+// screen-inventory uploads. Keep this permissive but bounded.
+const KEY_RE = /^[\x20-\x7E]{1,512}$/;
+const HASH_RE = /^[0-9a-f]{64}$/;
+const VALID_KINDS = new Set(['mockup', 'screen_inventory']);
+
+export function isValidImageKey(key) {
+  return typeof key === 'string' && KEY_RE.test(key);
+}
+
+export function isValidHash(hash) {
+  return typeof hash === 'string' && HASH_RE.test(hash);
+}
+
+let indexPromise = null;
+
+/**
+ * Create the image-ref indexes once per warm serverless instance. Idempotent —
+ * createIndex is a no-op when an identical index already exists. Never throws
+ * out to a request.
+ */
+export async function ensureImageRefIndexes() {
+  if (!indexPromise) {
+    indexPromise = runMongoAction('createIndexes', {
+      collection: IMAGE_REFS_COLLECTION,
+      indexes: [
+        { key: { userId: 1, projectId: 1, key: 1 }, unique: true, name: 'user_project_key_unique' },
+        { key: { userId: 1, projectId: 1 }, name: 'user_project' },
+        { key: { userId: 1, hash: 1 }, name: 'user_hash' },
+      ],
+    }).catch((error) => {
+      indexPromise = null;
+      console.error('[imageRefsStore] ensureImageRefIndexes failed', error?.name || 'error');
+    });
+  }
+  return indexPromise;
+}
+
+// Only ever persist the fields we control. `meta` is the opaque, dataUrl-less
+// image record the client reconstructs from (so this store stays generic across
+// mockup and screen-inventory images); everything else is indexed / validated.
+function sanitizeRef(ref) {
+  const kind = VALID_KINDS.has(ref?.kind) ? ref.kind : 'mockup';
+  const out = {
+    key: String(ref.key),
+    hash: String(ref.hash),
+    blobUrl: String(ref.blobUrl),
+    byteSize: Number.isFinite(ref?.byteSize) ? Math.max(0, Math.floor(ref.byteSize)) : 0,
+    kind,
+    meta: ref?.meta && typeof ref.meta === 'object' ? ref.meta : {},
+  };
+  // Surface the mockup routing fields at the top level for queryability when
+  // present (screen-inventory refs simply omit them).
+  if (typeof ref?.versionId === 'string') out.versionId = ref.versionId;
+  if (typeof ref?.screenId === 'string') out.screenId = ref.screenId;
+  if (typeof ref?.quality === 'string') out.quality = ref.quality;
+  return out;
+}
+
+/** True when `value` is a structurally valid ref the server will accept. */
+export function isValidRef(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && isValidImageKey(value.key)
+    && isValidHash(value.hash)
+    && typeof value.blobUrl === 'string'
+    && value.blobUrl.length > 0
+    && value.blobUrl.length <= 2048,
+  );
+}
+
+/** List a user's image refs for one project. */
+export async function listImageRefs(userId, projectId) {
+  if (!userId) throw new Error('listImageRefs: userId is required');
+  if (typeof projectId !== 'string' || !projectId) return [];
+  await ensureImageRefIndexes();
+  const result = await runMongoAction('find', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, projectId },
+    projection: { _id: 0, userId: 0 },
+  });
+  return Array.isArray(result?.documents) ? result.documents : [];
+}
+
+/**
+ * Create-or-update a single image ref, owner-scoped and idempotent on
+ * (userId, projectId, key). Re-uploading the same render just refreshes the
+ * blobUrl/updatedAt. Returns the saved ref.
+ */
+export async function upsertImageRef(userId, projectId, ref) {
+  if (!userId) throw new Error('upsertImageRef: userId is required');
+  if (typeof projectId !== 'string' || !projectId) throw new Error('upsertImageRef: projectId is required');
+  if (!isValidRef(ref)) throw new Error('upsertImageRef: invalid ref');
+  await ensureImageRefIndexes();
+
+  const now = new Date();
+  const clean = sanitizeRef(ref);
+  await runMongoAction('updateOne', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, projectId, key: clean.key },
+    update: {
+      $set: { userId, projectId, ...clean, updatedAt: now },
+      $setOnInsert: { createdAt: now },
+    },
+    upsert: true,
+  });
+  return { projectId, ...clean, updatedAt: now };
+}
+
+/**
+ * Decide which of `hashes` are now orphaned (no remaining ref for the user
+ * points at them) and therefore safe to delete from Blob. Pure given the
+ * remaining-refs lookup, which is injected for testability.
+ */
+export async function findOrphanedHashes(userId, hashes, lookupRemaining) {
+  const orphaned = [];
+  for (const hash of new Set(hashes)) {
+    if (!isValidHash(hash)) continue;
+    const remaining = await lookupRemaining(hash);
+    if (remaining === 0) orphaned.push(hash);
+  }
+  return orphaned;
+}
+
+async function countRefsForHash(userId, hash) {
+  const result = await runMongoAction('find', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, hash },
+    projection: { _id: 0, key: 1 },
+  });
+  return Array.isArray(result?.documents) ? result.documents.length : 0;
+}
+
+/**
+ * Delete a set of refs (by key) within one project, then refcount-GC: return
+ * the blob URLs whose hash no longer has ANY ref for this user. The handler
+ * deletes those blobs from Vercel Blob. Returns
+ * `{ deletedCount, orphanedBlobUrls }`.
+ */
+export async function deleteImageRefs(userId, projectId, keys) {
+  if (!userId) throw new Error('deleteImageRefs: userId is required');
+  if (typeof projectId !== 'string' || !projectId) return { deletedCount: 0, orphanedBlobUrls: [] };
+  const validKeys = (Array.isArray(keys) ? keys : []).filter(isValidImageKey);
+  if (validKeys.length === 0) return { deletedCount: 0, orphanedBlobUrls: [] };
+  await ensureImageRefIndexes();
+
+  // Snapshot the refs we're about to delete so we know their hashes/urls.
+  const existing = await runMongoAction('find', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, projectId, key: { $in: validKeys } },
+    projection: { _id: 0, key: 1, hash: 1, blobUrl: 1 },
+  });
+  const toDelete = Array.isArray(existing?.documents) ? existing.documents : [];
+  if (toDelete.length === 0) return { deletedCount: 0, orphanedBlobUrls: [] };
+
+  const del = await runMongoAction('deleteMany', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, projectId, key: { $in: validKeys } },
+  });
+
+  const orphanedBlobUrls = await collectOrphanedBlobUrls(userId, toDelete);
+  return { deletedCount: del?.deletedCount ?? 0, orphanedBlobUrls };
+}
+
+/**
+ * Delete every ref for one project (used on project hard-delete) and return the
+ * blob URLs orphaned by the deletion.
+ */
+export async function deleteRefsForProject(userId, projectId) {
+  if (!userId) throw new Error('deleteRefsForProject: userId is required');
+  if (typeof projectId !== 'string' || !projectId) return { deletedCount: 0, orphanedBlobUrls: [] };
+  await ensureImageRefIndexes();
+
+  const existing = await runMongoAction('find', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, projectId },
+    projection: { _id: 0, key: 1, hash: 1, blobUrl: 1 },
+  });
+  const toDelete = Array.isArray(existing?.documents) ? existing.documents : [];
+  if (toDelete.length === 0) return { deletedCount: 0, orphanedBlobUrls: [] };
+
+  const del = await runMongoAction('deleteMany', {
+    collection: IMAGE_REFS_COLLECTION,
+    filter: { userId, projectId },
+  });
+
+  const orphanedBlobUrls = await collectOrphanedBlobUrls(userId, toDelete);
+  return { deletedCount: del?.deletedCount ?? 0, orphanedBlobUrls };
+}
+
+// Shared refcount-GC core: given the refs that were just deleted, return the
+// blob URLs whose hash has zero remaining refs for this user. The remaining
+// count is queried AFTER deletion, so a hash still referenced by another
+// project/version is correctly retained.
+async function collectOrphanedBlobUrls(userId, deletedRefs) {
+  const hashToUrl = new Map();
+  for (const r of deletedRefs) {
+    if (isValidHash(r?.hash) && typeof r?.blobUrl === 'string') hashToUrl.set(r.hash, r.blobUrl);
+  }
+  const orphanedHashes = await findOrphanedHashes(
+    userId,
+    [...hashToUrl.keys()],
+    (hash) => countRefsForHash(userId, hash),
+  );
+  return orphanedHashes.map((h) => hashToUrl.get(h)).filter(Boolean);
+}

--- a/api/projects.js
+++ b/api/projects.js
@@ -1,3 +1,5 @@
+import { handleUpload } from '@vercel/blob/client';
+import { del } from '@vercel/blob';
 import { json, methodNotAllowed } from './_lib/response.js';
 import { requireUser } from './_lib/requireUser.js';
 import { enforceRateLimit } from './_lib/rateLimit.js';
@@ -12,6 +14,14 @@ import {
   hardDeleteProject,
   importProjects,
 } from './_lib/projectsStore.js';
+import {
+  isValidImageKey,
+  isValidRef,
+  listImageRefs,
+  upsertImageRef,
+  deleteImageRefs,
+  deleteRefsForProject,
+} from './_lib/imageRefsStore.js';
 
 // Server-side storage for a user's PRD projects. Every route is session-gated
 // via requireUser and operates only on the authenticated user's own projects —
@@ -25,8 +35,138 @@ import {
 //   POST   /api/projects?action=archive&id=  -> archive (status only)
 //   POST   /api/projects?action=unarchive&id=-> unarchive
 //   DELETE /api/projects?id=<id>             -> soft-delete (default) or &hard=1 to remove
+//
+// Cross-device mockup-image sync (image BYTES live in Vercel Blob, only small
+// refs live in Mongo — see api/_lib/imageRefsStore.js). Folded in here via
+// ?action= so we don't exceed Vercel Hobby's 12-serverless-function cap:
+//   POST   /api/projects?action=image-upload-token  -> mint a client-direct Blob upload token
+//   GET    /api/projects?action=image-refs&id=<id>  -> list a project's image refs
+//   POST   /api/projects?action=image-ref-put&id=<id>    -> persist one ref after upload
+//   POST   /api/projects?action=image-ref-delete&id=<id> -> delete refs (refcount-GCs orphan blobs)
 
 const MAX_BODY_BYTES = 8 * 1024 * 1024; // 8MB — bundles are text-only (no images)
+
+// Client-direct Blob uploads: the PNG bytes go browser -> Blob and never
+// traverse this function body, so the request/response stay text-sized. These
+// bound the signed token, not the function body.
+const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+
+function blobNotConfigured(res) {
+  console.error('[projects] BLOB_READ_WRITE_TOKEN is not set on this deployment.');
+  return json(res, 503, {
+    error: 'blob_not_configured',
+    message:
+      'Vercel Blob is not connected to this project. In the Vercel dashboard go to Storage, then connect the Blob store to this project (this adds BLOB_READ_WRITE_TOKEN to the environment), then redeploy.',
+  });
+}
+
+// Derive the mockup routing fields from a composite key so a ref persisted only
+// by the (server-to-server) onUploadCompleted callback — which carries no full
+// metadata — is still hydratable. Mockup keys are `versionId:screenId:quality`.
+function routingFromKey(key) {
+  const parts = String(key).split(':');
+  if (parts.length < 3) return {};
+  const quality = parts[parts.length - 1];
+  const screenId = parts[parts.length - 2];
+  const versionId = parts.slice(0, parts.length - 2).join(':');
+  return { versionId, screenId, quality };
+}
+
+// Mint a client-direct upload token (and handle the upload-completed callback).
+// This runs BEFORE the global requireUser gate because the completion callback
+// is a server-to-server request from Vercel Blob that carries no session
+// cookie — handleUpload verifies its signature instead, and the userId is taken
+// from the tokenPayload we stamped (from the verified session) at token-gen time.
+async function handleImageUploadToken(req, res) {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) return blobNotConfigured(res);
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    if (error?.code === 'payload_too_large') {
+      return json(res, 413, { error: 'payload_too_large', limitBytes: MAX_BODY_BYTES });
+    }
+    return json(res, 400, { error: 'invalid_json' });
+  }
+
+  // The token-generation request comes from the browser with the session
+  // cookie; authenticate it. The completion callback does not — skip auth there.
+  let tokenUserId = null;
+  if (body?.type === 'blob.generate-client-token') {
+    const user = await requireUser(req, res);
+    if (!user) return; // 401 already sent
+    tokenUserId = user.userId;
+  }
+
+  try {
+    const result = await handleUpload({
+      body,
+      request: req,
+      onBeforeGenerateToken: async (pathname, clientPayload) => {
+        // Pin uploads to the caller's own per-user prefix — a client can never
+        // mint a token for another user's path or an arbitrary content type.
+        const prefix = `users/${tokenUserId}/mockup-images/`;
+        if (!tokenUserId || !pathname.startsWith(prefix)) {
+          throw new Error('forbidden_pathname');
+        }
+        let meta = {};
+        try {
+          meta = clientPayload ? JSON.parse(clientPayload) : {};
+        } catch {
+          meta = {};
+        }
+        return {
+          addRandomSuffix: false,
+          allowOverwrite: true,
+          maximumSizeInBytes: MAX_IMAGE_BYTES,
+          allowedContentTypes: ALLOWED_IMAGE_TYPES,
+          // Stamp the server-derived identity so the (unauthenticated) callback
+          // can attribute the upload. Kept small — the client's image-ref-put
+          // persists the full ref; this is only a tab-closed-early backup.
+          tokenPayload: JSON.stringify({
+            userId: tokenUserId,
+            projectId: meta.projectId ?? null,
+            key: meta.key ?? null,
+            hash: meta.hash ?? null,
+            kind: meta.kind ?? 'mockup',
+            byteSize: meta.byteSize ?? 0,
+          }),
+        };
+      },
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
+        // Best-effort backup persistence. The client's image-ref-put is the
+        // authoritative path (and the only one that fires on localhost, where
+        // Vercel can't reach this callback). Idempotent upsert, so both is fine.
+        try {
+          const parsed = tokenPayload ? JSON.parse(tokenPayload) : {};
+          const { userId, projectId, key, hash, kind, byteSize } = parsed;
+          if (userId && projectId && isValidImageKey(key) && hash) {
+            await upsertImageRef(userId, projectId, {
+              key,
+              hash,
+              blobUrl: blob.url,
+              byteSize: byteSize || 0,
+              kind: kind || 'mockup',
+              meta: {},
+              ...(kind === 'mockup' || !kind ? routingFromKey(key) : {}),
+            });
+          }
+        } catch (error) {
+          console.error('[projects] onUploadCompleted failed', error?.name || 'error');
+        }
+      },
+    });
+    return json(res, 200, result);
+  } catch (error) {
+    if (error?.message === 'forbidden_pathname') {
+      return json(res, 403, { error: 'forbidden_pathname' });
+    }
+    console.error('[projects] image-upload-token failed', error?.name || 'error');
+    return json(res, 500, { error: 'image_token_failed' });
+  }
+}
 
 async function readJsonBody(req) {
   if (req.body && typeof req.body === 'object' && !Buffer.isBuffer(req.body)) {
@@ -58,6 +198,19 @@ function truthy(value) {
   return value === '1' || value === 'true';
 }
 
+// Best-effort Blob deletion for GC. Failures are logged, never fatal — an
+// orphaned blob is harmless (just storage), whereas throwing here would break
+// the user-facing delete. No-op when Blob isn't configured.
+async function deleteBlobs(urls) {
+  if (!Array.isArray(urls) || urls.length === 0) return;
+  if (!process.env.BLOB_READ_WRITE_TOKEN) return;
+  try {
+    await del(urls);
+  } catch (error) {
+    console.error('[projects] blob GC failed', error?.name || 'error');
+  }
+}
+
 export default async function handler(req, res) {
   if (!['GET', 'PUT', 'POST', 'DELETE'].includes(req.method)) {
     return methodNotAllowed(res, ['GET', 'PUT', 'POST', 'DELETE']);
@@ -67,15 +220,27 @@ export default async function handler(req, res) {
     return; // 429 already sent
   }
 
+  const id = req.query?.id ?? null;
+  const action = req.query?.action ?? null;
+
+  // image-upload-token must run before requireUser: its upload-completed
+  // callback is a signed server-to-server request with no session cookie.
+  if (req.method === 'POST' && action === 'image-upload-token') {
+    return handleImageUploadToken(req, res);
+  }
+
   const user = await requireUser(req, res);
   if (!user) return; // 401 already sent
 
   const userId = user.userId;
-  const id = req.query?.id ?? null;
-  const action = req.query?.action ?? null;
 
   try {
     if (req.method === 'GET') {
+      if (action === 'image-refs') {
+        if (!isValidProjectId(id)) return json(res, 400, { error: 'invalid_id' });
+        const refs = await listImageRefs(userId, id);
+        return json(res, 200, { refs });
+      }
       if (id) {
         if (!isValidProjectId(id)) return json(res, 400, { error: 'invalid_id' });
         const project = await getProject(userId, id);
@@ -109,6 +274,27 @@ export default async function handler(req, res) {
         const result = await importProjects(userId, bundles);
         return json(res, 200, result);
       }
+      if (action === 'image-ref-put') {
+        if (!isValidProjectId(id)) return json(res, 400, { error: 'invalid_id' });
+        const body = await readJsonBody(req);
+        const ref = body?.ref ?? body;
+        if (!isValidRef(ref)) return json(res, 400, { error: 'invalid_ref' });
+        // The blobUrl must point inside the caller's own per-user prefix — never
+        // trust an arbitrary client-supplied URL into the ref store.
+        if (!ref.blobUrl.includes(`/users/${userId}/mockup-images/`)) {
+          return json(res, 403, { error: 'forbidden_blob_url' });
+        }
+        const saved = await upsertImageRef(userId, id, ref);
+        return json(res, 200, { ref: saved });
+      }
+      if (action === 'image-ref-delete') {
+        if (!isValidProjectId(id)) return json(res, 400, { error: 'invalid_id' });
+        const body = await readJsonBody(req);
+        const keys = Array.isArray(body?.keys) ? body.keys : [];
+        const { deletedCount, orphanedBlobUrls } = await deleteImageRefs(userId, id, keys);
+        await deleteBlobs(orphanedBlobUrls);
+        return json(res, 200, { deletedCount, orphanedBlobs: orphanedBlobUrls.length });
+      }
       if (!isValidProjectId(id)) return json(res, 400, { error: 'invalid_id' });
       if (action === 'restore') {
         const ok = await restoreProject(userId, id);
@@ -129,6 +315,14 @@ export default async function handler(req, res) {
     if (!isValidProjectId(id)) return json(res, 400, { error: 'invalid_id' });
     if (truthy(req.query?.hard)) {
       const ok = await hardDeleteProject(userId, id);
+      // GC the project's image refs + any blobs they orphaned. Best-effort:
+      // a GC failure must not fail the project delete.
+      try {
+        const { orphanedBlobUrls } = await deleteRefsForProject(userId, id);
+        await deleteBlobs(orphanedBlobUrls);
+      } catch (error) {
+        console.error('[projects] image GC on hard-delete failed', error?.name || 'error');
+      }
       return ok ? json(res, 200, { id, deleted: true }) : json(res, 404, { error: 'not_found' });
     }
     const ok = await softDeleteProject(userId, id);

--- a/src/lib/__tests__/imageBlobHash.test.ts
+++ b/src/lib/__tests__/imageBlobHash.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sha256Hex,
+  contentTypeFromDataUrl,
+  extFromContentType,
+  buildImageBlobPath,
+  dataUrlToBlob,
+} from '../imageBlobHash';
+
+describe('sha256Hex', () => {
+  it('matches the known SHA-256 vector for the empty string', async () => {
+    expect(await sha256Hex('')).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+  });
+
+  it('is deterministic — identical input dedups to the same hash', async () => {
+    const a = await sha256Hex('data:image/png;base64,AAAA');
+    const b = await sha256Hex('data:image/png;base64,AAAA');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('different input → different hash', async () => {
+    expect(await sha256Hex('a')).not.toBe(await sha256Hex('b'));
+  });
+});
+
+describe('contentTypeFromDataUrl / extFromContentType', () => {
+  it('extracts the mime type, defaulting to png', () => {
+    expect(contentTypeFromDataUrl('data:image/png;base64,AAAA')).toBe('image/png');
+    expect(contentTypeFromDataUrl('data:image/jpeg;base64,AAAA')).toBe('image/jpeg');
+    expect(contentTypeFromDataUrl('not-a-data-url')).toBe('image/png');
+  });
+
+  it('maps mime to extension with a png fallback', () => {
+    expect(extFromContentType('image/png')).toBe('png');
+    expect(extFromContentType('image/jpeg')).toBe('jpg');
+    expect(extFromContentType('image/webp')).toBe('webp');
+    expect(extFromContentType('image/gif')).toBe('png');
+  });
+});
+
+describe('buildImageBlobPath', () => {
+  it('namespaces under the user and content-addresses by hash', () => {
+    expect(buildImageBlobPath('u1', 'abc123', 'image/png')).toBe('users/u1/mockup-images/abc123.png');
+    expect(buildImageBlobPath('u1', 'abc123', 'image/jpeg')).toBe('users/u1/mockup-images/abc123.jpg');
+  });
+});
+
+describe('dataUrlToBlob', () => {
+  it('decodes a base64 data URL into a typed Blob', () => {
+    const dataUrl = `data:image/png;base64,${btoa('hello')}`;
+    const blob = dataUrlToBlob(dataUrl);
+    expect(blob.type).toBe('image/png');
+    expect(blob.size).toBe(5);
+  });
+});

--- a/src/lib/__tests__/imageRef.test.ts
+++ b/src/lib/__tests__/imageRef.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { buildMockupImageRef, mockupRecordFromRef, refVersionId, type ImageRef } from '../imageRef';
+import type { MockupImageRecord } from '../../types';
+
+const record: MockupImageRecord = {
+  key: 'v1:s1:low',
+  projectId: 'p1',
+  artifactId: 'a1',
+  versionId: 'v1',
+  screenId: 's1',
+  dataUrl: 'data:image/png;base64,AAAA',
+  quality: 'low',
+  prompt: 'draw a login screen',
+  generatedAt: 123,
+};
+
+describe('buildMockupImageRef', () => {
+  it('strips the dataUrl into meta and carries hash/blobUrl/byteSize + routing', () => {
+    const ref = buildMockupImageRef(record, 'hash123', 'https://blob/u1/x.png', 42);
+    expect(ref).toMatchObject({
+      projectId: 'p1',
+      key: 'v1:s1:low',
+      hash: 'hash123',
+      blobUrl: 'https://blob/u1/x.png',
+      byteSize: 42,
+      kind: 'mockup',
+      versionId: 'v1',
+      screenId: 's1',
+      quality: 'low',
+    });
+    // The big payload never lands in the ref.
+    expect((ref.meta as Record<string, unknown>).dataUrl).toBeUndefined();
+    expect((ref.meta as Record<string, unknown>).prompt).toBe('draw a login screen');
+  });
+});
+
+describe('mockupRecordFromRef', () => {
+  it('reconstructs a full record from the rich meta + fetched dataUrl', () => {
+    const ref = buildMockupImageRef(record, 'h', 'https://blob/x.png', 10);
+    const out = mockupRecordFromRef(ref, 'data:image/png;base64,BBBB');
+    expect(out).toEqual({ ...record, dataUrl: 'data:image/png;base64,BBBB' });
+  });
+
+  it('degrades to top-level routing fields when only a backup ref exists (empty meta)', () => {
+    const ref: ImageRef = {
+      projectId: 'p1',
+      key: 'v9:s9:high',
+      hash: 'h',
+      blobUrl: 'https://blob/x.png',
+      byteSize: 0,
+      kind: 'mockup',
+      versionId: 'v9',
+      screenId: 's9',
+      quality: 'high',
+      meta: {},
+    };
+    const out = mockupRecordFromRef(ref, 'data:image/png;base64,CCCC');
+    expect(out).toMatchObject({
+      key: 'v9:s9:high',
+      projectId: 'p1',
+      versionId: 'v9',
+      screenId: 's9',
+      quality: 'high',
+      dataUrl: 'data:image/png;base64,CCCC',
+      artifactId: '',
+      prompt: '',
+    });
+  });
+});
+
+describe('refVersionId', () => {
+  it('prefers meta.versionId, falling back to the top-level field', () => {
+    expect(refVersionId(buildMockupImageRef(record, 'h', 'u', 1))).toBe('v1');
+    expect(
+      refVersionId({
+        projectId: 'p',
+        key: 'k',
+        hash: 'h',
+        blobUrl: 'u',
+        byteSize: 0,
+        kind: 'mockup',
+        versionId: 'vTop',
+        meta: {},
+      }),
+    ).toBe('vTop');
+  });
+});

--- a/src/lib/__tests__/imageRefsClient.test.ts
+++ b/src/lib/__tests__/imageRefsClient.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// upload() from the Blob client SDK does a real network handshake; mock it.
+const uploadMock = vi.fn((...args: unknown[]): Promise<{ url: string }> => {
+  void args;
+  return Promise.resolve({ url: 'https://blob/users/u1/mockup-images/h.png' });
+});
+vi.mock('@vercel/blob/client', () => ({ upload: (...a: unknown[]) => uploadMock(...a) }));
+
+import {
+  fetchImageRefs,
+  putImageRef,
+  deleteImageRefsRemote,
+  uploadImageToBlob,
+  fetchBlobAsDataUrl,
+} from '../imageRefsClient';
+import type { ImageRef } from '../imageRef';
+
+function okJson(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+function errJson(status: number, body: unknown) {
+  return { ok: false, status, json: async () => body } as unknown as Response;
+}
+
+const ref: ImageRef = {
+  projectId: 'p1',
+  key: 'v1:s1:low',
+  hash: 'h',
+  blobUrl: 'https://blob/users/u1/mockup-images/h.png',
+  byteSize: 10,
+  kind: 'mockup',
+  versionId: 'v1',
+  meta: {},
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  uploadMock.mockClear();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('imageRefsClient', () => {
+  it('fetchImageRefs GETs the project refs with the session cookie', async () => {
+    const fetchMock = vi.fn(async () => okJson({ refs: [ref] }));
+    vi.stubGlobal('fetch', fetchMock);
+    const out = await fetchImageRefs('p1');
+    expect(out).toEqual([ref]);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/projects?action=image-refs&id=p1');
+    expect(init.credentials).toBe('include');
+  });
+
+  it('putImageRef POSTs the ref to the image-ref-put action', async () => {
+    const fetchMock = vi.fn(async () => okJson({ ref }));
+    vi.stubGlobal('fetch', fetchMock);
+    await putImageRef('p1', ref);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/projects?action=image-ref-put&id=p1');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ ref });
+  });
+
+  it('putImageRef throws on a non-2xx so a failure never silently drops the ref', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errJson(403, { error: 'forbidden_blob_url' })));
+    await expect(putImageRef('p1', ref)).rejects.toThrow(/forbidden_blob_url/);
+  });
+
+  it('deleteImageRefsRemote no-ops on an empty key list', async () => {
+    const fetchMock = vi.fn(async () => okJson({}));
+    vi.stubGlobal('fetch', fetchMock);
+    await deleteImageRefsRemote('p1', []);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('deleteImageRefsRemote tolerates a 404 (already gone)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errJson(404, { error: 'not_found' })));
+    await expect(deleteImageRefsRemote('p1', ['k1'])).resolves.toBeUndefined();
+  });
+
+  it('uploadImageToBlob routes bytes through the SDK to the token endpoint', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    const out = await uploadImageToBlob('users/u1/mockup-images/h.png', blob, 'image/png', '{"k":1}');
+    expect(out).toEqual({ url: 'https://blob/users/u1/mockup-images/h.png' });
+    const [path, body, opts] = uploadMock.mock.calls[0] as unknown as [string, Blob, Record<string, unknown>];
+    expect(path).toBe('users/u1/mockup-images/h.png');
+    expect(body).toBe(blob);
+    expect(opts.access).toBe('public');
+    expect(opts.handleUploadUrl).toBe('/api/projects?action=image-upload-token');
+    expect(opts.clientPayload).toBe('{"k":1}');
+  });
+
+  it('fetchBlobAsDataUrl downloads the blob directly and decodes it', async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, blob: async () => blob }) as unknown as Response));
+    const dataUrl = await fetchBlobAsDataUrl('https://blob/x.png');
+    expect(dataUrl.startsWith('data:image/png;base64,')).toBe(true);
+  });
+});

--- a/src/lib/__tests__/imageSyncDiff.test.ts
+++ b/src/lib/__tests__/imageSyncDiff.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { computeImagesToUpload, computeOrphanedHashes } from '../imageSyncDiff';
+
+describe('computeImagesToUpload', () => {
+  it('uploads only keys absent from BOTH the server and the uploaded markers', () => {
+    const out = computeImagesToUpload(
+      ['a', 'b', 'c', 'd'],
+      new Set(['b']), // already on server
+      new Set(['c']), // already marked uploaded
+    );
+    expect(out.sort()).toEqual(['a', 'd']);
+  });
+
+  it('dedups repeated local keys', () => {
+    expect(computeImagesToUpload(['a', 'a', 'a'], new Set(), new Set())).toEqual(['a']);
+  });
+
+  it('returns nothing when everything is already synced', () => {
+    expect(computeImagesToUpload(['a', 'b'], new Set(['a', 'b']), new Set())).toEqual([]);
+  });
+});
+
+describe('computeOrphanedHashes', () => {
+  it('orphans a hash only when no remaining ref points at it (refcount)', () => {
+    const deleted = [{ hash: 'h1' }, { hash: 'h2' }];
+    const remaining = [{ hash: 'h2' }]; // h2 still referenced elsewhere
+    expect(computeOrphanedHashes(deleted, remaining)).toEqual(['h1']);
+  });
+
+  it('orphans every deleted hash when nothing remains', () => {
+    expect(computeOrphanedHashes([{ hash: 'h1' }, { hash: 'h2' }], [])).toEqual(['h1', 'h2']);
+  });
+
+  it('orphans nothing when all hashes are still referenced', () => {
+    expect(computeOrphanedHashes([{ hash: 'h1' }], [{ hash: 'h1' }])).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/imageUploadMarker.test.ts
+++ b/src/lib/__tests__/imageUploadMarker.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getUploadedImageKeys,
+  markImagesUploaded,
+  unmarkImagesUploaded,
+} from '../imageUploadMarker';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('imageUploadMarker', () => {
+  it('records uploaded image keys per user', () => {
+    markImagesUploaded('user-a', ['k1', 'k2']);
+    expect([...getUploadedImageKeys('user-a')].sort()).toEqual(['k1', 'k2']);
+  });
+
+  it('is namespaced per user', () => {
+    markImagesUploaded('user-a', ['k1']);
+    expect(getUploadedImageKeys('user-b').has('k1')).toBe(false);
+  });
+
+  it('does not duplicate keys on repeated marking', () => {
+    markImagesUploaded('user-a', ['k1']);
+    markImagesUploaded('user-a', ['k1', 'k1', 'k2']);
+    expect(getUploadedImageKeys('user-a').size).toBe(2);
+  });
+
+  it('unmark forgets keys so a re-add re-uploads', () => {
+    markImagesUploaded('user-a', ['k1', 'k2']);
+    unmarkImagesUploaded('user-a', ['k1']);
+    expect([...getUploadedImageKeys('user-a')]).toEqual(['k2']);
+  });
+});

--- a/src/lib/imageBlobHash.ts
+++ b/src/lib/imageBlobHash.ts
@@ -1,0 +1,51 @@
+// Pure helpers for content-addressing mockup images in Vercel Blob.
+//
+// Images are addressed by sha256(dataUrl) so identical renders dedup to a single
+// blob and the hash → blob path is 1:1 (which makes refcount GC clean). The blob
+// path is per-user (`users/<userId>/mockup-images/<hash>.<ext>`) so one user's
+// images live under their own prefix. No store / network access here — these are
+// unit-testable in isolation.
+
+const EXT_BY_TYPE: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+/** Hex sha256 of a string, via Web Crypto (available in browsers + Node 20+). */
+export async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Extract the MIME type from a data URL, defaulting to image/png. */
+export function contentTypeFromDataUrl(dataUrl: string): string {
+  const m = /^data:([^;,]+)[;,]/.exec(dataUrl);
+  return m?.[1] || 'image/png';
+}
+
+export function extFromContentType(contentType: string): string {
+  return EXT_BY_TYPE[contentType] ?? 'png';
+}
+
+/** Per-user, content-addressed blob path. The handler pins uploads to this prefix. */
+export function buildImageBlobPath(userId: string, hash: string, contentType: string): string {
+  return `users/${userId}/mockup-images/${hash}.${extFromContentType(contentType)}`;
+}
+
+/**
+ * Decode a base64 data URL into a Blob suitable for a client-direct upload. The
+ * bytes go browser → Blob and never traverse a serverless function body.
+ */
+export function dataUrlToBlob(dataUrl: string): Blob {
+  const contentType = contentTypeFromDataUrl(dataUrl);
+  const commaIdx = dataUrl.indexOf(',');
+  const b64 = commaIdx >= 0 ? dataUrl.slice(commaIdx + 1) : '';
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: contentType });
+}

--- a/src/lib/imageRef.ts
+++ b/src/lib/imageRef.ts
@@ -1,0 +1,81 @@
+// The transport unit for cross-device image sync: a small *reference* record
+// pointing at the Blob-stored bytes. Mirrors snapshotClient's `imageMetadata`
+// (the full image record minus its dataUrl, carried in `meta`) plus the
+// content-address (`hash`), the Blob URL (`blobUrl`) and `byteSize`.
+//
+// Deliberately generic over image kind so the same ref store / Blob path can
+// back both mockup images and (later) Screen Inventory upload images — only the
+// `meta` shape and the routing fields differ.
+
+import type { MockupImageQuality, MockupImageRecord } from '../types';
+
+export type ImageRefKind = 'mockup' | 'screen_inventory';
+
+export interface ImageRef {
+  projectId: string;
+  /** The IndexedDB composite key the client uses to find the image locally. */
+  key: string;
+  /** sha256(dataUrl) — content address; identical renders share one blob. */
+  hash: string;
+  blobUrl: string;
+  byteSize: number;
+  kind: ImageRefKind;
+  // Mockup routing fields, surfaced at top level for queryability when present.
+  versionId?: string;
+  screenId?: string;
+  quality?: MockupImageQuality;
+  /** The dataUrl-less image record, so the client can reconstruct it on pull. */
+  meta?: Record<string, unknown>;
+  updatedAt?: number | string;
+}
+
+/** Build a ref to persist from a mockup image record (dataUrl stripped into Blob). */
+export function buildMockupImageRef(
+  record: MockupImageRecord,
+  hash: string,
+  blobUrl: string,
+  byteSize: number,
+): ImageRef {
+  const { dataUrl: _dataUrl, ...meta } = record;
+  void _dataUrl;
+  return {
+    projectId: record.projectId,
+    key: record.key,
+    hash,
+    blobUrl,
+    byteSize,
+    kind: 'mockup',
+    versionId: record.versionId,
+    screenId: record.screenId,
+    quality: record.quality,
+    meta,
+  };
+}
+
+/**
+ * Reconstruct a full MockupImageRecord from a pulled ref + freshly fetched
+ * dataUrl. Prefers the rich `meta` (set by the authoritative client persist
+ * path) but degrades gracefully to the top-level routing fields if only the
+ * server-callback backup ref exists (meta empty).
+ */
+export function mockupRecordFromRef(ref: ImageRef, dataUrl: string): MockupImageRecord {
+  const meta = (ref.meta ?? {}) as Partial<MockupImageRecord>;
+  return {
+    key: meta.key ?? ref.key,
+    projectId: meta.projectId ?? ref.projectId,
+    artifactId: meta.artifactId ?? '',
+    versionId: meta.versionId ?? ref.versionId ?? '',
+    screenId: meta.screenId ?? ref.screenId ?? '',
+    dataUrl,
+    quality: (meta.quality ?? ref.quality ?? 'low') as MockupImageQuality,
+    prompt: meta.prompt ?? '',
+    generatedAt: meta.generatedAt ?? 0,
+  };
+}
+
+/** The versionId a ref is grouped under for lazy hydration (meta wins). */
+export function refVersionId(ref: ImageRef): string | undefined {
+  const metaVersion = (ref.meta as { versionId?: unknown } | undefined)?.versionId;
+  if (typeof metaVersion === 'string' && metaVersion) return metaVersion;
+  return ref.versionId;
+}

--- a/src/lib/imageRefRegistry.ts
+++ b/src/lib/imageRefRegistry.ts
@@ -1,0 +1,50 @@
+// In-memory registry of image refs pulled from the server, grouped by version
+// id so the mockup image store can hydrate a version's images lazily (on
+// mount / IndexedDB cache miss) without re-fetching refs each time.
+//
+// Refs are pulled on sign-in reconcile (and after each project save). This is a
+// pure cache of server state — NOT the local source of truth (IndexedDB is).
+
+import type { ImageRef } from './imageRef';
+import { refVersionId } from './imageRef';
+
+let allRefs: ImageRef[] = [];
+const byVersion = new Map<string, ImageRef[]>();
+const byKey = new Map<string, ImageRef>();
+
+function reindex(): void {
+  byVersion.clear();
+  byKey.clear();
+  for (const ref of allRefs) {
+    byKey.set(ref.key, ref);
+    const versionId = refVersionId(ref);
+    if (versionId) {
+      const list = byVersion.get(versionId);
+      if (list) list.push(ref);
+      else byVersion.set(versionId, [ref]);
+    }
+  }
+}
+
+/** Replace the registry's refs for one project with a freshly pulled set. */
+export function setProjectRefs(projectId: string, refs: ImageRef[]): void {
+  allRefs = allRefs.filter((r) => r.projectId !== projectId).concat(refs);
+  reindex();
+}
+
+/** Every pulled ref for one artifact version (for lazy hydration). */
+export function getRefsForVersion(versionId: string): ImageRef[] {
+  return byVersion.get(versionId) ?? [];
+}
+
+/** One pulled ref by its composite key, if any. */
+export function getImageRef(key: string): ImageRef | undefined {
+  return byKey.get(key);
+}
+
+/** Drop all registry state (sign-out / namespace switch). */
+export function clearImageRefRegistry(): void {
+  allRefs = [];
+  byVersion.clear();
+  byKey.clear();
+}

--- a/src/lib/imageRefsClient.ts
+++ b/src/lib/imageRefsClient.ts
@@ -1,0 +1,93 @@
+// Client transport for image refs + the client-direct Blob upload/download.
+//
+// Refs are small JSON records persisted via /api/projects?action=image-*; the
+// image BYTES go browser → Blob directly (upload) and Blob → browser directly
+// (download), never through a serverless function body, so neither crosses
+// Vercel's ~4.5 MB request/response cap.
+
+import { upload } from '@vercel/blob/client';
+import type { ImageRef } from './imageRef';
+
+const API_BASE = '/api/projects';
+
+async function parseError(resp: Response, fallback: string): Promise<Error> {
+  let body: { error?: string; message?: string } | null = null;
+  try {
+    body = (await resp.json()) as { error?: string; message?: string };
+  } catch {
+    body = null;
+  }
+  const code = body?.error || `${fallback}_${resp.status}`;
+  return new Error(body?.message ? `${code}: ${body.message}` : code);
+}
+
+/** List the signed-in user's image refs for one project. */
+export async function fetchImageRefs(projectId: string): Promise<ImageRef[]> {
+  const resp = await fetch(`${API_BASE}?action=image-refs&id=${encodeURIComponent(projectId)}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!resp.ok) throw await parseError(resp, 'image_refs_failed');
+  const data = (await resp.json()) as { refs?: ImageRef[] };
+  return Array.isArray(data.refs) ? data.refs : [];
+}
+
+/** Persist one image ref after its bytes have been uploaded to Blob. */
+export async function putImageRef(projectId: string, ref: ImageRef): Promise<void> {
+  const resp = await fetch(`${API_BASE}?action=image-ref-put&id=${encodeURIComponent(projectId)}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ref }),
+  });
+  if (!resp.ok) throw await parseError(resp, 'image_ref_put_failed');
+}
+
+/** Delete refs by key (the server refcount-GCs any orphaned blobs). */
+export async function deleteImageRefsRemote(projectId: string, keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  const resp = await fetch(`${API_BASE}?action=image-ref-delete&id=${encodeURIComponent(projectId)}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ keys }),
+  });
+  if (!resp.ok && resp.status !== 404) throw await parseError(resp, 'image_ref_delete_failed');
+}
+
+/**
+ * Upload image bytes directly to Blob. The serverless function only mints a
+ * signed, prefix-restricted token (handleUpload); the bytes never pass through
+ * it. `clientPayload` carries the routing metadata to the token issuer.
+ */
+export async function uploadImageToBlob(
+  path: string,
+  blob: Blob,
+  contentType: string,
+  clientPayload: string,
+): Promise<{ url: string }> {
+  const result = await upload(path, blob, {
+    access: 'public',
+    contentType,
+    handleUploadUrl: `${API_BASE}?action=image-upload-token`,
+    clientPayload,
+  });
+  return { url: result.url };
+}
+
+/** Download a blob URL directly and decode it back into a data URL for IndexedDB. */
+export async function fetchBlobAsDataUrl(blobUrl: string): Promise<string> {
+  const resp = await fetch(blobUrl);
+  if (!resp.ok) throw new Error(`blob_fetch_failed_${resp.status}`);
+  const blob = await resp.blob();
+  return await blobToDataUrl(blob);
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('blob_decode_failed'));
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/lib/imageSyncDiff.ts
+++ b/src/lib/imageSyncDiff.ts
@@ -1,0 +1,42 @@
+// Pure push/pull/GC decision logic for cross-device image sync. No store,
+// network, or Blob access — unit-testable in isolation.
+
+/**
+ * Which local image keys need uploading: those present locally but NOT already
+ * on the server AND NOT already recorded in the per-user "uploaded" markers.
+ * Mirrors projectMigration's marker pattern — the server upsert is idempotent
+ * on (userId, projectId, key), so a missed marker only costs a redundant
+ * (harmless) re-upload, never a duplicate.
+ */
+export function computeImagesToUpload(
+  localKeys: Iterable<string>,
+  serverKeys: ReadonlySet<string>,
+  uploadedMarkers: ReadonlySet<string>,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const key of localKeys) {
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (!serverKeys.has(key) && !uploadedMarkers.has(key)) out.push(key);
+  }
+  return out;
+}
+
+/**
+ * Refcount-GC decision (pure): given the refs being deleted and ALL refs that
+ * remain, return the content hashes that no longer have any reference and are
+ * therefore safe to delete from Blob. Because images are content-addressed, a
+ * hash still referenced by another version/project is correctly retained.
+ */
+export function computeOrphanedHashes(
+  deleted: ReadonlyArray<{ hash: string }>,
+  remaining: ReadonlyArray<{ hash: string }>,
+): string[] {
+  const remainingHashes = new Set(remaining.map((r) => r.hash));
+  const orphaned = new Set<string>();
+  for (const d of deleted) {
+    if (!remainingHashes.has(d.hash)) orphaned.add(d.hash);
+  }
+  return [...orphaned];
+}

--- a/src/lib/imageUploadMarker.ts
+++ b/src/lib/imageUploadMarker.ts
@@ -1,0 +1,67 @@
+// Per-user markers for which mockup-image keys have already been uploaded to
+// Blob, so the push path can skip them without a network round-trip. Mirrors
+// projectMigration.ts exactly (per-user localStorage namespacing, defensive
+// try/catch). The server upsert is idempotent on (userId, projectId, key), so
+// these markers are an optimization — never a correctness dependency.
+//
+// Leaf module (localStorage only).
+
+const UPLOADED_PREFIX = 'synapse-mockup-images-uploaded::u:';
+
+function keyFor(userId: string): string {
+  return `${UPLOADED_PREFIX}${userId}`;
+}
+
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable / full — non-fatal for upload tracking.
+  }
+}
+
+/** Set of image keys this user has already uploaded to Blob. */
+export function getUploadedImageKeys(userId: string): Set<string> {
+  if (!userId) return new Set();
+  const raw = safeGet(keyFor(userId));
+  if (!raw) return new Set();
+  try {
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+/** Record that `keys` have been uploaded for `userId`. */
+export function markImagesUploaded(userId: string, keys: string[]): void {
+  if (!userId || keys.length === 0) return;
+  const current = getUploadedImageKeys(userId);
+  let changed = false;
+  for (const key of keys) {
+    if (!current.has(key)) {
+      current.add(key);
+      changed = true;
+    }
+  }
+  if (changed) safeSet(keyFor(userId), JSON.stringify([...current]));
+}
+
+/** Forget `keys` for `userId` (e.g. after a remote delete, so a re-add re-uploads). */
+export function unmarkImagesUploaded(userId: string, keys: string[]): void {
+  if (!userId || keys.length === 0) return;
+  const current = getUploadedImageKeys(userId);
+  let changed = false;
+  for (const key of keys) {
+    if (current.delete(key)) changed = true;
+  }
+  if (changed) safeSet(keyFor(userId), JSON.stringify([...current]));
+}

--- a/src/store/mockupImageStore.ts
+++ b/src/store/mockupImageStore.ts
@@ -26,6 +26,35 @@ import {
     listImagesForVersion as idbListImages,
     putImage as idbPutImage,
 } from '../lib/mockupImageStore';
+import { getRefsForVersion } from '../lib/imageRefRegistry';
+import { fetchBlobAsDataUrl } from '../lib/imageRefsClient';
+import { mockupRecordFromRef, type ImageRef } from '../lib/imageRef';
+import { notifyMockupImageGenerated } from './projectImageSync';
+
+// Pull blob bytes for refs the local IndexedDB doesn't have yet (cross-device
+// case). Concurrency-limited so a version with many screens doesn't open a fetch
+// per screen at once. A failed fetch is skipped (render shows empty, retried on
+// next mount) — never throws out of the loader.
+const hydrateMissingRefs = async (refs: ImageRef[]): Promise<MockupImageRecord[]> => {
+    const CONCURRENCY = 4;
+    const out: MockupImageRecord[] = [];
+    let cursor = 0;
+    const workers = Array.from({ length: Math.min(CONCURRENCY, refs.length) }, async () => {
+        while (true) {
+            const idx = cursor++;
+            if (idx >= refs.length) return;
+            const ref = refs[idx];
+            try {
+                const dataUrl = await fetchBlobAsDataUrl(ref.blobUrl);
+                out.push(mockupRecordFromRef(ref, dataUrl));
+            } catch {
+                // skip — best-effort hydration
+            }
+        }
+    });
+    await Promise.all(workers);
+    return out;
+};
 
 interface InFlight {
     quality: MockupImageQuality;
@@ -82,10 +111,27 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
 
     loadForVersion: async (versionId) => {
         const records = await idbListImages(versionId);
-        if (records.length === 0) return;
+        const haveKeys = new Set(records.map((r) => r.key));
+        if (records.length > 0) {
+            set((state) => {
+                const next = { ...state.images };
+                for (const r of records) next[r.key] = r;
+                return { images: next };
+            });
+        }
+
+        // Cross-device hydration: for any server ref this device is missing,
+        // fetch the blob, write it into IndexedDB (the local source of truth),
+        // and surface it in the reactive cache. Lazy — only on view, never a
+        // bulk download on sign-in.
+        const missing = getRefsForVersion(versionId).filter((r) => !haveKeys.has(r.key));
+        if (missing.length === 0) return;
+        const hydrated = await hydrateMissingRefs(missing);
+        if (hydrated.length === 0) return;
+        for (const record of hydrated) await idbPutImage(record);
         set((state) => {
             const next = { ...state.images };
-            for (const r of records) next[r.key] = r;
+            for (const r of hydrated) next[r.key] = r;
             return { images: next };
         });
     },
@@ -148,6 +194,10 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
                     inFlight: nextInFlight,
                 };
             });
+            // Sync the freshly generated render to Blob (best-effort; no-op when
+            // signed out). Image generation writes IndexedDB directly and never
+            // touches the project store, so the bundle-push path wouldn't see it.
+            notifyMockupImageGenerated(projectId, versionId);
         } catch (err) {
             const aborted = (err as { name?: string })?.name === 'AbortError' || abort.signal.aborted;
             const message = aborted

--- a/src/store/projectImageSync.ts
+++ b/src/store/projectImageSync.ts
@@ -1,0 +1,151 @@
+// Cross-device mockup-image sync orchestrator. Sits alongside projectServerSync
+// (text/bundle sync) and is driven by it: text always syncs first and is NEVER
+// blocked by image sync — every function here is best-effort and swallows its
+// own failures so a Blob hiccup can't revert or stall a project save.
+//
+// Local-first: IndexedDB stays the source of truth / render cache. This layer
+// (1) pushes locally-generated image bytes to Blob + persists their refs, and
+// (2) pulls refs into the registry so the mockup image store can hydrate lazily
+// on another device. It imports only leaf libs (no Zustand store), so the
+// mockup image store can call back into it without a cycle.
+
+import type { MockupImageRecord } from '../types';
+import { listImagesForVersion } from '../lib/mockupImageStore';
+import { sha256Hex, dataUrlToBlob, buildImageBlobPath, contentTypeFromDataUrl } from '../lib/imageBlobHash';
+import { buildMockupImageRef, type ImageRef } from '../lib/imageRef';
+import { computeImagesToUpload } from '../lib/imageSyncDiff';
+import { getUploadedImageKeys, markImagesUploaded } from '../lib/imageUploadMarker';
+import {
+  fetchImageRefs,
+  putImageRef,
+  uploadImageToBlob,
+  deleteImageRefsRemote,
+} from '../lib/imageRefsClient';
+import { setProjectRefs } from '../lib/imageRefRegistry';
+import { projectsDebug } from '../lib/projectsDebug';
+import { DEMO_PROJECT_ID } from '../data/demoProject';
+
+const UPLOAD_CONCURRENCY = 3;
+
+// The active user, mirrored from projectServerSync so image-generation callbacks
+// (which don't go through the bundle push path) can resolve identity. null when
+// signed out → all image sync is a no-op.
+let activeUserId: string | null = null;
+
+export function setImageSyncUser(userId: string | null): void {
+  activeUserId = userId;
+}
+
+async function runWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      await worker(items[idx]);
+    }
+  });
+  await Promise.all(runners);
+}
+
+/**
+ * Push a project's not-yet-synced mockup images to Blob and persist their refs.
+ * `versionIds` are the project's artifact version ids (image keys are scoped by
+ * version). Best-effort and idempotent — a failed image is left unmarked and
+ * retried on the next push; it never blocks text sync.
+ */
+export async function pushProjectImages(userId: string, projectId: string, versionIds: string[]): Promise<void> {
+  if (!userId || projectId === DEMO_PROJECT_ID || versionIds.length === 0) return;
+  try {
+    const records: MockupImageRecord[] = [];
+    for (const versionId of versionIds) {
+      records.push(...(await listImagesForVersion(versionId)));
+    }
+    if (records.length === 0) return;
+    const byKey = new Map(records.map((r) => [r.key, r]));
+
+    // Diff against the server (best-effort) + the per-user uploaded markers.
+    let serverKeys = new Set<string>();
+    try {
+      serverKeys = new Set((await fetchImageRefs(projectId)).map((r) => r.key));
+    } catch {
+      // Offline / transient: fall back to markers only. Re-upload is idempotent.
+    }
+    const uploaded = getUploadedImageKeys(userId);
+    const toUpload = computeImagesToUpload(byKey.keys(), serverKeys, uploaded);
+    if (toUpload.length === 0) return;
+
+    await runWithConcurrency(toUpload, UPLOAD_CONCURRENCY, async (key) => {
+      const record = byKey.get(key);
+      if (!record) return;
+      try {
+        const hash = await sha256Hex(record.dataUrl);
+        const contentType = contentTypeFromDataUrl(record.dataUrl);
+        const path = buildImageBlobPath(userId, hash, contentType);
+        const blob = dataUrlToBlob(record.dataUrl);
+        const clientPayload = JSON.stringify({
+          projectId,
+          key: record.key,
+          hash,
+          kind: 'mockup',
+          byteSize: blob.size,
+        });
+        const { url } = await uploadImageToBlob(path, blob, contentType, clientPayload);
+        const ref: ImageRef = buildMockupImageRef(record, hash, url, blob.size);
+        ref.projectId = projectId;
+        await putImageRef(projectId, ref);
+        markImagesUploaded(userId, [record.key]);
+        projectsDebug('image pushed to blob', { projectId, key: record.key });
+      } catch (error) {
+        projectsDebug('image push failed', {
+          projectId,
+          key,
+          message: error instanceof Error ? error.message : 'error',
+        });
+      }
+    });
+  } catch (error) {
+    projectsDebug('pushProjectImages failed', {
+      projectId,
+      message: error instanceof Error ? error.message : 'error',
+    });
+  }
+}
+
+/** Pull a project's image refs into the registry for lazy hydration. Best-effort. */
+export async function pullProjectImageRefs(projectId: string): Promise<void> {
+  if (projectId === DEMO_PROJECT_ID) return;
+  try {
+    const refs = await fetchImageRefs(projectId);
+    setProjectRefs(projectId, refs);
+    projectsDebug('image refs pulled', { projectId, count: refs.length });
+  } catch (error) {
+    projectsDebug('pullProjectImageRefs failed', {
+      projectId,
+      message: error instanceof Error ? error.message : 'error',
+    });
+  }
+}
+
+/**
+ * Called by the mockup image store right after a new image is written to
+ * IndexedDB, so a freshly generated render syncs without waiting for an
+ * unrelated bundle change to trigger a push. No-op when signed out.
+ */
+export function notifyMockupImageGenerated(projectId: string, versionId: string): void {
+  if (!activeUserId || projectId === DEMO_PROJECT_ID) return;
+  void pushProjectImages(activeUserId, projectId, [versionId]);
+}
+
+/** Delete specific image refs remotely (refcount-GCs orphan blobs server-side). */
+export async function deleteProjectImageRefs(projectId: string, keys: string[]): Promise<void> {
+  if (projectId === DEMO_PROJECT_ID || keys.length === 0) return;
+  try {
+    await deleteImageRefsRemote(projectId, keys);
+  } catch (error) {
+    projectsDebug('deleteProjectImageRefs failed', {
+      projectId,
+      message: error instanceof Error ? error.message : 'error',
+    });
+  }
+}

--- a/src/store/projectServerSync.ts
+++ b/src/store/projectServerSync.ts
@@ -25,6 +25,12 @@ import {
 } from '../lib/projectsClient';
 import { markProjectsMigrated, getMigratedProjectIds } from '../lib/projectMigration';
 import { projectsDebug } from '../lib/projectsDebug';
+import { clearImageRefRegistry } from '../lib/imageRefRegistry';
+import {
+  setImageSyncUser,
+  pushProjectImages,
+  pullProjectImageRefs,
+} from './projectImageSync';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
 
 const PUSH_DEBOUNCE_MS = 1500;
@@ -69,6 +75,11 @@ async function pushProjectNow(projectId: string): Promise<void> {
     if (activeUserId) markProjectsMigrated(activeUserId, [projectId]);
     useProjectSyncStore.getState().setProjectSync(projectId, { state: 'saved', updatedAt: Date.now() });
     projectsDebug('project pushed to server', { projectId });
+    // Image sync runs AFTER (and never blocks) the text save. Fire-and-forget:
+    // a Blob failure is non-fatal and retried on the next push.
+    if (activeUserId) {
+      void pushProjectImages(activeUserId, projectId, bundle.artifactVersions.map((v) => v.id));
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'sync_failed';
     // A failed save NEVER drops local data — it stays in localStorage. Surface
@@ -166,6 +177,14 @@ async function reconcile(userId: string): Promise<void> {
 
     knownProjectIds = new Set(syncableIds(useProjectStore.getState()));
     useProjectSyncStore.getState().markPulled(migratedCount);
+
+    // Pull image refs for every syncable project into the registry so the mockup
+    // image store can hydrate bytes lazily on view. Refs only (no bytes), and
+    // best-effort — never blocks the reconcile.
+    for (const id of knownProjectIds) {
+      void pullProjectImageRefs(id);
+    }
+
     projectsDebug('project sync reconciled', {
       userId,
       pulled: addedIds.length,
@@ -220,6 +239,7 @@ export function startProjectSync(userId: string | null): void {
   if (activeUserId === userId && unsubscribe) return; // already syncing this user
   stopProjectSync();
   activeUserId = userId;
+  setImageSyncUser(userId);
   knownProjectIds = new Set(syncableIds(useProjectStore.getState()));
 
   void reconcile(userId).then(() => {
@@ -239,6 +259,8 @@ export function stopProjectSync(): void {
   for (const timer of pushTimers.values()) clearTimeout(timer);
   pushTimers.clear();
   activeUserId = null;
+  setImageSyncUser(null);
+  clearImageRefRegistry();
   knownProjectIds = new Set();
   useProjectSyncStore.getState().reset();
 }

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -124,7 +124,10 @@ see CLAUDE.md "Cross-device mockup image sync"). Follow-ups:
       'screen_inventory'`, opaque `meta`); needs a push/pull path analogous to
       `projectImageSync.ts` and a hydration hook in the screen-inventory image
       consumer. Blob path prefix can stay `users/<userId>/mockup-images/` or be
-      generalized to `users/<userId>/images/`.
+      generalized to `users/<userId>/images/`. **This also covers the
+      `user_uploaded` mockup image source mode** (PR #168): user-uploaded mockups
+      persist to `screenInventoryImageStore`, so they only become cross-device
+      once this store is wired. Today only `gpt_image` (AI-generated) mockups sync.
 - [ ] **Eager GC for per-image overwrite / version regen.** Today a new render
       (new hash → new blob) leaves the prior blob/ref until project hard-delete.
       Add a sweep (or wire `deleteProjectImageRefs` into `deleteImagesForVersion`

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -112,3 +112,27 @@ below are the durable follow-ups that need backend work.
       workspace is client-only today, so metrics are per-browser).
 - [ ] Record interrupted/aborted runs as a distinct status instead of dropping
       them.
+
+## Cross-device image sync TODOs
+
+Image durability for the per-user `/api/projects` path is implemented for
+**mockup** images (bytes → Vercel Blob, refs → `project_images`, lazy hydration;
+see CLAUDE.md "Cross-device mockup image sync"). Follow-ups:
+
+- [ ] Wire **Screen Inventory** upload images (`screenInventoryImageStore.ts`)
+      onto the same ref layer. The ref store is already generic (`kind:
+      'screen_inventory'`, opaque `meta`); needs a push/pull path analogous to
+      `projectImageSync.ts` and a hydration hook in the screen-inventory image
+      consumer. Blob path prefix can stay `users/<userId>/mockup-images/` or be
+      generalized to `users/<userId>/images/`.
+- [ ] **Eager GC for per-image overwrite / version regen.** Today a new render
+      (new hash → new blob) leaves the prior blob/ref until project hard-delete.
+      Add a sweep (or wire `deleteProjectImageRefs` into `deleteImagesForVersion`
+      / regen paths) that refcount-GCs blobs no longer referenced by any live
+      key. `image-ref-delete` already exists for this.
+- [ ] Reconcile server-newer images per-key (today push is local-keys-out,
+      pull is refs-in for hydration; there's no per-image conflict resolution,
+      matching the text-bundle "local wins" stance).
+- [ ] Consider switching to signed/expiring read URLs if mockups ever carry
+      sensitive content (current decision: public + unguessable content-addressed
+      path, for direct browser downloads).

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://vitals.vercel-insights.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://vitals.vercel-insights.com https://*.vercel-storage.com; font-src 'self' data:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
         }
       ]
     },


### PR DESCRIPTION
AI-generated mockup images now follow a signed-in user's projects across
devices. The /api/projects bundle stays text-only: image bytes go to Vercel
Blob (client-direct upload, content-addressed by sha256), and only small
reference records live in Mongo. Independent of the owner-only snapshot feature.

Server (no new serverless function — folded into api/projects.js via ?action=,
repo stays at 11/12):
- api/_lib/imageRefsStore.js: RLS-equivalent `project_images` ref store
  (one doc per userId+projectId+key), refcount-aware orphan-blob GC.
- api/projects.js actions: image-upload-token (handleUpload token issuer,
  prefix-restricted; runs before requireUser so the signed upload-completed
  callback works), image-refs (GET), image-ref-put, image-ref-delete.
  Hard-delete refcount-GCs the project's refs + orphan blobs.
- api/_lib/db.js: add deleteMany action to the Mongo shim.

Client:
- imageBlobHash / imageRef / imageSyncDiff / imageUploadMarker: pure helpers
  (hashing, ref build/reconstruct, push/pull diff, refcount-GC decision, markers).
- imageRefsClient: refs transport + client-direct Blob upload/download.
- imageRefRegistry: in-memory pulled-ref cache for lazy hydration.
- store/projectImageSync: push (after text save + on generation), pull refs,
  best-effort — never blocks or reverts text sync.
- projectServerSync: wire push/pull/registry lifecycle.
- mockupImageStore: hydrate IndexedDB misses from server refs lazily on view.

Access decision: blobs are public + unguessable (content-addressed under a
per-user uuid prefix) so the browser downloads bytes directly; documented.

vercel.json: allow https://*.vercel-storage.com in CSP connect-src.
Docs: CLAUDE.md, README.md, tasks/TODO.md updated.
Tests: pure helpers, server ref store (RLS + refcount GC), handler actions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MeHE6AMTXnKLdQXBmGgT1y