### PR TITLE
Refine Mockups page: Pages navigator + document layout

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -118,6 +118,12 @@ export function ArtifactWorkspace({
     const [tasksModalSource, setTasksModalSource] = useState<
         { artifactId: string; content: string } | null
     >(null);
+    // Mockup regenerate confirm — surfaces "Creates Version N. Current
+    // version remains available." before kicking off a new run so the user
+    // doesn't fear losing their existing render.
+    const [mockupRegenConfirm, setMockupRegenConfirm] = useState<
+        { nextVersion: number } | null
+    >(null);
 
     const job = getJob(projectId);
 
@@ -330,7 +336,7 @@ export function ArtifactWorkspace({
                         {renderVersionControls(mockup.id, preferred)}
                         <button
                             type="button"
-                            onClick={() => handleRetrySlot('mockup')}
+                            onClick={() => setMockupRegenConfirm({ nextVersion: preferred.versionNumber + 1 })}
                             className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
                         >
                             <RefreshCcw size={12} /> Regenerate Mockup
@@ -570,6 +576,53 @@ export function ArtifactWorkspace({
                     projectName={getProject(projectId)?.name}
                     onClose={() => setTasksModalSource(null)}
                 />
+            )}
+
+            {mockupRegenConfirm && (
+                <div
+                    className="fixed inset-0 z-50 bg-black/40 flex items-end md:items-center justify-center p-4"
+                    onClick={() => setMockupRegenConfirm(null)}
+                    role="presentation"
+                >
+                    <div
+                        className="bg-white rounded-xl shadow-xl border border-neutral-200 w-full max-w-sm overflow-hidden"
+                        onClick={(e) => e.stopPropagation()}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="mockup-regen-title"
+                    >
+                        <div className="px-5 pt-5 pb-3">
+                            <h3 id="mockup-regen-title" className="text-base font-bold text-neutral-900">
+                                Regenerate Mockup
+                            </h3>
+                            <p className="text-sm text-neutral-700 mt-1">
+                                Creates Version {mockupRegenConfirm.nextVersion}.
+                            </p>
+                            <p className="text-xs text-neutral-500 mt-1">
+                                Current version remains available in version history.
+                            </p>
+                        </div>
+                        <div className="px-5 pb-4 flex items-center justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setMockupRegenConfirm(null)}
+                                className="px-3 py-1.5 text-sm text-neutral-700 hover:bg-neutral-100 rounded-md transition"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setMockupRegenConfirm(null);
+                                    handleRetrySlot('mockup');
+                                }}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white hover:bg-indigo-700 rounded-md transition"
+                            >
+                                <RefreshCcw size={13} /> Regenerate
+                            </button>
+                        </div>
+                    </div>
+                </div>
             )}
 
             {versionHistoryArtifactId && (() => {

--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -110,8 +110,6 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
         );
     }
 
-    const hasHighQuality = records.some((r) => r.quality === 'high');
-
     const handleGenerate = (quality: MockupImageQuality) => {
         // High quality is the expensive variant — confirm before spending. Paid
         // OpenAI usage is billed to the user's own account via their key.
@@ -149,8 +147,13 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
     }
 
     if (activeRecord) {
+        // Quality is now chosen in Settings, not per-card — the old "Generate
+        // high quality" inline upgrade button was removed to keep the artifact
+        // surface focused on a single primary action. Multiple quality
+        // variants can still exist (e.g. from older sessions), and we keep the
+        // small toggle so the user can flip between them.
         return (
-            <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
+            <div className="overflow-hidden">
                 <div className="relative bg-neutral-50 flex items-center justify-center">
                     <img
                         src={activeRecord.dataUrl}
@@ -158,15 +161,8 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
                         className="max-w-full max-h-[680px] object-contain"
                     />
                 </div>
-                <div className="px-4 py-3 border-t border-neutral-100 flex items-center gap-2 flex-wrap">
-                    <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 font-medium inline-flex items-center gap-1">
-                        <Sparkles size={10} />
-                        gpt-image-2 · {activeRecord.quality}
-                    </span>
-                    <span className="text-[11px] text-neutral-400">
-                        {new Date(activeRecord.generatedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
-                    </span>
-                    {records.length > 1 && (
+                {records.length > 1 && (
+                    <div className="px-4 py-2 border-t border-neutral-100 flex items-center justify-end">
                         <div className="inline-flex items-center bg-neutral-100 rounded-md p-0.5 text-[11px] font-medium" role="group" aria-label="Switch quality">
                             {records.map((r) => {
                                 const selected = r.quality === effectiveQuality;
@@ -187,31 +183,19 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
                                 );
                             })}
                         </div>
-                    )}
-                    <div className="ml-auto flex items-center gap-1.5">
-                        {!hasHighQuality && (
-                            <button
-                                type="button"
-                                disabled={!keyPresent}
-                                onClick={() => handleGenerate('high')}
-                                className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
-                                title={keyPresent ? 'Generate at high quality (slower, ~30-60s) — your low-quality render is preserved' : 'Add an OpenAI API key in Settings to enable'}
-                            >
-                                <Sparkles size={12} />
-                                Generate high quality
-                            </button>
-                        )}
-                        <button
-                            type="button"
-                            disabled={!keyPresent}
-                            onClick={() => handleGenerate(activeRecord.quality)}
-                            className="inline-flex items-center gap-1.5 text-xs px-2 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 disabled:cursor-not-allowed transition"
-                            title={`Re-run gpt-image-2 at ${activeRecord.quality} quality (replaces this render)`}
-                        >
-                            <RefreshCw size={12} />
-                            Redo {activeRecord.quality}
-                        </button>
                     </div>
+                )}
+                <div className="px-4 py-2 border-t border-neutral-100 flex items-center justify-end">
+                    <button
+                        type="button"
+                        disabled={!keyPresent}
+                        onClick={() => handleGenerate(activeRecord.quality)}
+                        className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        title={keyPresent ? 'Re-run this screen at the same quality (replaces this render)' : 'Add an OpenAI API key in Settings to enable'}
+                    >
+                        <RefreshCw size={12} />
+                        Regenerate
+                    </button>
                 </div>
             </div>
         );

--- a/src/components/mockups/MockupViewer.tsx
+++ b/src/components/mockups/MockupViewer.tsx
@@ -1,8 +1,13 @@
-import { useState } from 'react';
-import type { MockupPayload, MockupSettings, StalenessState } from '../../types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, ChevronRight, FileText, Sparkles, Check, ArrowUp } from 'lucide-react';
+import type { MockupImageRecord, MockupPayload, MockupScreen, MockupSettings, StalenessState } from '../../types';
+import { useMockupImageStore } from '../../store/mockupImageStore';
+import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
+import { buildScreenScopeKey } from '../../lib/mockupImageStore';
+import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
 import { StalenessBadge } from '../StalenessBadge';
 import { MockupScreenImage } from './MockupScreenImage';
-import { MockupImageStatusChip } from './MockupImageStatusChip';
+import { useIsMobile } from '../../lib/useIsMobile';
 
 type Props = {
     payload: MockupPayload;
@@ -17,19 +22,119 @@ type Props = {
     artifactId?: string;
 };
 
-const CHIP = 'text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-neutral-200 bg-neutral-50 text-neutral-500 font-medium';
-
-const FIDELITY_LABELS: Record<string, string> = {
-    low: 'Wireframe', mid: 'Structured', high: 'Polished',
-};
-const SCOPE_LABELS: Record<string, string> = {
-    single_screen: 'Single Screen', multi_screen: 'Multi-Screen', key_workflow: 'Key Workflow',
-};
+const QUALITY_RANK: Record<string, number> = { low: 0, medium: 1, high: 2 };
 
 function formatDate(ts: number): string {
     return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+function formatDateTime(ts: number): string {
+    return new Date(ts).toLocaleString(undefined, {
+        month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+    });
+}
+
+function pickPreviewRecord(records: MockupImageRecord[]): MockupImageRecord | undefined {
+    if (records.length === 0) return undefined;
+    return records.reduce<MockupImageRecord>(
+        (best, r) => (QUALITY_RANK[r.quality] > QUALITY_RANK[best.quality] ? r : best),
+        records[0],
+    );
+}
+
+function pageAnchorId(versionId: string | undefined, screen: MockupScreen, idx: number): string {
+    const base = versionId ?? 'mockup';
+    return `mockup-page-${base}-${screen.id ?? idx}`;
+}
+
+/**
+ * Tiny thumbnail rendered inside the Pages navigator. Reads from the
+ * mockup-image-store (AI) and screen-inventory-image-store (uploaded) so the
+ * navigator mirrors whatever the user is actually viewing below. If no image
+ * exists yet, falls back to a neutral placeholder so the row still aligns.
+ */
+function PageThumb({ versionId, screen }: { versionId?: string; screen: MockupScreen }) {
+    const aiImages = useMockupImageStore((s) => s.images);
+    const uploads = useScreenInventoryImageStore((s) => s.images);
+
+    const src = useMemo(() => {
+        if (!versionId) return null;
+        const slug = slugifyScreenName(screen.name);
+        const upload = Object.values(uploads).find(
+            (u) => u.artifactVersionId === versionId && u.screenSlug === slug && u.isPreferred,
+        );
+        if (upload) return upload.dataUrl;
+        const aiScope = buildScreenScopeKey(versionId, screen.id);
+        const matching: MockupImageRecord[] = [];
+        for (const k of Object.keys(aiImages)) {
+            if (k.startsWith(aiScope)) matching.push(aiImages[k]);
+        }
+        const best = pickPreviewRecord(matching);
+        return best?.dataUrl ?? null;
+    }, [versionId, aiImages, uploads, screen.id, screen.name]);
+
+    if (!src) {
+        return (
+            <div className="w-16 h-12 sm:w-20 sm:h-14 rounded-md bg-neutral-100 border border-neutral-200 shrink-0" />
+        );
+    }
+    return (
+        <div className="w-16 h-12 sm:w-20 sm:h-14 rounded-md overflow-hidden border border-neutral-200 bg-neutral-900 shrink-0">
+            <img src={src} alt="" className="w-full h-full object-cover" />
+        </div>
+    );
+}
+
+/**
+ * Per-page footer: simple "AI Generated · date · Regenerate". Only shown when
+ * an image actually exists for this screen — empty/loading states are rendered
+ * by MockupScreenImage itself. The "Regenerate" here re-runs the same quality
+ * on the current screen; it does not bump the artifact version.
+ */
+function PageImageFooter({ versionId, screen }: { versionId?: string; screen: MockupScreen }) {
+    const aiImages = useMockupImageStore((s) => s.images);
+    const uploads = useScreenInventoryImageStore((s) => s.images);
+
+    const info = useMemo(() => {
+        if (!versionId) return null;
+        const slug = slugifyScreenName(screen.name);
+        const upload = Object.values(uploads).find(
+            (u) => u.artifactVersionId === versionId && u.screenSlug === slug && u.isPreferred,
+        );
+        if (upload) {
+            return { label: 'Uploaded', generatedAt: upload.generatedAt };
+        }
+        const aiScope = buildScreenScopeKey(versionId, screen.id);
+        const matching: MockupImageRecord[] = [];
+        for (const k of Object.keys(aiImages)) {
+            if (k.startsWith(aiScope)) matching.push(aiImages[k]);
+        }
+        const best = pickPreviewRecord(matching);
+        if (!best) return null;
+        return { label: 'AI Generated', generatedAt: best.generatedAt };
+    }, [versionId, aiImages, uploads, screen.id, screen.name]);
+
+    if (!info) return null;
+    return (
+        <div className="px-5 py-2.5 border-t border-neutral-100 bg-neutral-50/60 flex items-center gap-2 flex-wrap text-[11px]">
+            <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 font-medium">
+                <Sparkles size={10} />
+                {info.label}
+            </span>
+            <span className="text-neutral-500">{formatDateTime(info.generatedAt)}</span>
+        </div>
+    );
+}
+
+/**
+ * The mockups page. Treats the artifact as a document whose chapters are the
+ * screens: a collapsible "Pages" table-of-contents at the top, then every
+ * screen rendered in order. An IntersectionObserver tracks which screen is in
+ * view so the navigator stays in sync as the user scrolls.
+ *
+ * On mobile, once the navigator scrolls out of view a floating "Pages" button
+ * reopens it (uncollapsing if needed) so the user never loses navigation.
+ */
 export function MockupViewer({
     payload,
     settings,
@@ -43,13 +148,87 @@ export function MockupViewer({
     artifactId,
 }: Props) {
     const aiImageEnabled = !!(projectId && artifactId && versionId);
+    const isMobile = useIsMobile();
+
+    const screens = payload.screens;
+
+    // Pages navigator: collapsed on mobile once the user picks a row so the
+    // long page list doesn't trap them at the top.
+    const [navOpen, setNavOpen] = useState(true);
     const [activeIdx, setActiveIdx] = useState(0);
 
-    const safeIdx = Math.min(activeIdx, Math.max(0, payload.screens.length - 1));
-    const activeScreen = payload.screens[safeIdx];
-    const hasMultiple = payload.screens.length > 1;
+    const navRef = useRef<HTMLDivElement | null>(null);
+    const sectionRefs = useRef<Array<HTMLElement | null>>([]);
+    const [showFloatingNav, setShowFloatingNav] = useState(false);
+    const [descExpanded, setDescExpanded] = useState(false);
 
-    if (!activeScreen) {
+    // Track which page is most visible. We score each section by the
+    // intersection ratio of its top quarter so a tall page that's just leaving
+    // the viewport doesn't keep "winning" over the next one.
+    useEffect(() => {
+        if (typeof IntersectionObserver === 'undefined') return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                let best: { idx: number; ratio: number } | null = null;
+                for (const entry of entries) {
+                    const idxAttr = entry.target.getAttribute('data-page-idx');
+                    if (idxAttr === null) continue;
+                    const idx = Number(idxAttr);
+                    if (Number.isNaN(idx)) continue;
+                    if (entry.isIntersecting) {
+                        if (!best || entry.intersectionRatio > best.ratio) {
+                            best = { idx, ratio: entry.intersectionRatio };
+                        }
+                    }
+                }
+                if (best) setActiveIdx(best.idx);
+            },
+            // Top quarter of the viewport: a section is "active" once its
+            // header has reached the top fifth of the page.
+            { rootMargin: '-15% 0px -60% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] },
+        );
+        for (const el of sectionRefs.current) {
+            if (el) observer.observe(el);
+        }
+        return () => observer.disconnect();
+    }, [screens.length]);
+
+    // Show the floating "Pages" button (mobile only) once the navigator card
+    // has scrolled out of view.
+    useEffect(() => {
+        if (typeof IntersectionObserver === 'undefined') return;
+        const el = navRef.current;
+        if (!el) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const entry = entries[0];
+                setShowFloatingNav(!entry.isIntersecting);
+            },
+            { threshold: 0 },
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    const handleSelectPage = (idx: number) => {
+        setActiveIdx(idx);
+        const section = sectionRefs.current[idx];
+        if (section) {
+            section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        // On mobile, collapse the navigator after a tap so the page itself is
+        // the next thing on screen — the floating button handles re-opening.
+        if (isMobile) setNavOpen(false);
+    };
+
+    const handleOpenFloatingNav = () => {
+        setNavOpen(true);
+        if (navRef.current) {
+            navRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    };
+
+    if (screens.length === 0) {
         return (
             <div className="bg-white rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500">
                 This mockup version has no screens.
@@ -57,133 +236,235 @@ export function MockupViewer({
         );
     }
 
+    const pageCountLabel = `${screens.length} ${screens.length === 1 ? 'Page' : 'Pages'}`;
+
     return (
-        <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden">
-            <div className="px-5 pt-5 pb-4 border-b border-neutral-100">
-                <div className="min-w-0">
-                    <h3 className="text-base font-bold text-neutral-900 tracking-tight truncate">
+        <>
+            <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden">
+                {/* --- Artifact header ------------------------------------ */}
+                <div className="px-5 pt-5 pb-4 border-b border-neutral-100">
+                    <h3 className="text-base font-bold text-neutral-900 tracking-tight">
                         {payload.title}
                     </h3>
                     {payload.summary && (
-                        <p className="text-sm text-neutral-500 mt-0.5 line-clamp-2">{payload.summary}</p>
-                    )}
-                </div>
-
-                <div className="flex flex-wrap items-center gap-1.5 mt-3">
-                    <span className={CHIP}>{settings.platform}</span>
-                    <span className={CHIP}>{FIDELITY_LABELS[settings.fidelity] ?? settings.fidelity}</span>
-                    <span className={CHIP}>{SCOPE_LABELS[settings.scope] ?? settings.scope}</span>
-                    <StalenessBadge staleness={staleness} />
-                    {versionId && <MockupImageStatusChip versionId={versionId} screens={payload.screens} />}
-                    <span className="text-[10px] text-neutral-400 ml-auto tabular-nums">
-                        v{versionNumber} · {formatDate(createdAt)}
-                    </span>
-                </div>
-            </div>
-
-            <div className="px-5 pt-3 pb-2 flex items-center gap-2 flex-wrap">
-                {hasMultiple ? (
-                    <div className="flex items-center gap-1 flex-wrap">
-                        {payload.screens.map((screen, idx) => {
-                            const selected = idx === safeIdx;
-                            return (
+                        <div className="mt-1">
+                            <p className={`text-sm text-neutral-500 ${descExpanded ? '' : 'line-clamp-2'}`}>
+                                {payload.summary}
+                            </p>
+                            {payload.summary.length > 140 && (
                                 <button
-                                    key={screen.id}
                                     type="button"
-                                    onClick={() => setActiveIdx(idx)}
-                                    className={`text-xs px-3 py-1.5 rounded-full border transition ${
-                                        selected
-                                            ? 'bg-indigo-50 text-indigo-700 border-indigo-200 font-medium'
-                                            : 'bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-50'
-                                    }`}
+                                    onClick={() => setDescExpanded(!descExpanded)}
+                                    className="mt-1 text-xs text-indigo-600 hover:text-indigo-700 font-medium"
                                 >
-                                    {screen.name}
+                                    {descExpanded ? 'Show less' : 'Show more'}
                                 </button>
-                            );
-                        })}
-                    </div>
-                ) : (
-                    <div className="text-xs text-neutral-500 font-medium">{activeScreen.name}</div>
-                )}
-            </div>
-
-            <div className="px-5 pb-4">
-                {aiImageEnabled && projectId && artifactId && versionId ? (
-                    <MockupScreenImage
-                        key={`${activeScreen.id}:img`}
-                        projectId={projectId}
-                        artifactId={artifactId}
-                        versionId={versionId}
-                        screen={activeScreen}
-                        payload={payload}
-                        settings={settings}
-                    />
-                ) : (
-                    <div className="bg-white rounded-lg border border-dashed border-neutral-300 p-6 text-sm text-neutral-500 text-center">
-                        AI image preview is unavailable in this context.
-                    </div>
-                )}
-            </div>
-
-            {(activeScreen.purpose || activeScreen.userIntent || activeScreen.notes) && (
-                <div className="px-5 pb-4 space-y-1">
-                    {activeScreen.purpose && (
-                        <p className="text-sm text-neutral-600">{activeScreen.purpose}</p>
-                    )}
-                    {activeScreen.userIntent && (
-                        <p className="text-xs text-neutral-500 italic">User intent: {activeScreen.userIntent}</p>
-                    )}
-                    {activeScreen.notes && (
-                        <p className="text-xs text-neutral-400 italic">{activeScreen.notes}</p>
-                    )}
-                </div>
-            )}
-
-            {(activeScreen.coreUIElements?.length || activeScreen.componentRefs?.length) && (
-                <div className="px-5 pb-4 grid gap-3 md:grid-cols-2">
-                    {activeScreen.coreUIElements && activeScreen.coreUIElements.length > 0 && (
-                        <div className="rounded-md border border-neutral-200 bg-neutral-50/60 px-3 py-2">
-                            <p className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium mb-1">
-                                Core UI elements
-                            </p>
-                            <ul className="text-xs text-neutral-700 space-y-0.5">
-                                {activeScreen.coreUIElements.map((el, i) => (
-                                    <li key={i}>· {el}</li>
-                                ))}
-                            </ul>
+                            )}
                         </div>
                     )}
-                    {activeScreen.componentRefs && activeScreen.componentRefs.length > 0 && (
-                        <div className="rounded-md border border-neutral-200 bg-neutral-50/60 px-3 py-2">
-                            <p className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium mb-1">
-                                Components used
-                            </p>
-                            <ul className="text-xs text-neutral-700 space-y-0.5">
-                                {activeScreen.componentRefs.map((c, i) => (
-                                    <li key={i} className="font-mono">· {c}</li>
-                                ))}
-                            </ul>
+
+                    <div className="flex items-center justify-between gap-2 flex-wrap mt-3">
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 font-medium">
+                                <Sparkles size={10} />
+                                AI Generated
+                            </span>
+                            <span className="text-[11px] text-neutral-500">{pageCountLabel}</span>
+                            <StalenessBadge staleness={staleness} />
                         </div>
+                        <span className="text-[11px] text-neutral-400 tabular-nums">
+                            v{versionNumber} · {formatDate(createdAt)}
+                        </span>
+                    </div>
+                </div>
+
+                {/* --- Pages navigator ----------------------------------- */}
+                <div ref={navRef} className="border-b border-neutral-100">
+                    <button
+                        type="button"
+                        onClick={() => setNavOpen(!navOpen)}
+                        className="w-full px-5 py-3 flex items-center justify-between gap-3 text-left hover:bg-neutral-50/60 transition"
+                        aria-expanded={navOpen}
+                        aria-controls="mockup-pages-list"
+                    >
+                        <span className="inline-flex items-center gap-2 text-sm font-semibold text-neutral-900">
+                            <FileText size={15} className="text-neutral-500" />
+                            Pages
+                        </span>
+                        <span className="inline-flex items-center gap-1.5 text-xs text-neutral-500">
+                            {screens.length} {screens.length === 1 ? 'page' : 'pages'}
+                            {navOpen
+                                ? <ChevronDown size={14} className="text-neutral-400" />
+                                : <ChevronRight size={14} className="text-neutral-400" />}
+                        </span>
+                    </button>
+                    {navOpen && (
+                        <ul id="mockup-pages-list" className="pb-2">
+                            {screens.map((screen, idx) => {
+                                const selected = idx === activeIdx;
+                                return (
+                                    <li key={screen.id ?? idx}>
+                                        <button
+                                            type="button"
+                                            onClick={() => handleSelectPage(idx)}
+                                            className={`w-full px-5 py-2.5 flex items-center gap-3 text-left border-l-2 transition ${
+                                                selected
+                                                    ? 'border-indigo-500 bg-indigo-50/40'
+                                                    : 'border-transparent hover:bg-neutral-50'
+                                            }`}
+                                            aria-current={selected ? 'true' : undefined}
+                                        >
+                                            <PageThumb versionId={versionId} screen={screen} />
+                                            <span
+                                                className={`shrink-0 w-7 h-7 rounded-md flex items-center justify-center text-xs font-semibold tabular-nums ${
+                                                    selected
+                                                        ? 'bg-indigo-100 text-indigo-700'
+                                                        : 'bg-neutral-100 text-neutral-500'
+                                                }`}
+                                            >
+                                                {idx + 1}
+                                            </span>
+                                            <span className="flex-1 min-w-0">
+                                                <span className="block text-sm font-semibold text-neutral-900 truncate">
+                                                    {screen.name}
+                                                </span>
+                                                {screen.purpose && (
+                                                    <span className="block text-xs text-neutral-500 truncate">
+                                                        {screen.purpose}
+                                                    </span>
+                                                )}
+                                            </span>
+                                            <ChevronRight size={16} className="text-neutral-300 shrink-0" />
+                                        </button>
+                                    </li>
+                                );
+                            })}
+                        </ul>
                     )}
                 </div>
-            )}
 
-            {actions && (
-                <div className="px-5 py-3 border-t border-neutral-100 bg-neutral-50/40 flex items-center gap-2 flex-wrap">
-                    {actions}
+                {/* --- Document layout: every page rendered in order ---- */}
+                <div className="divide-y divide-neutral-100">
+                    {screens.map((screen, idx) => (
+                        <section
+                            key={screen.id ?? idx}
+                            id={pageAnchorId(versionId, screen, idx)}
+                            data-page-idx={idx}
+                            ref={(el) => {
+                                sectionRefs.current[idx] = el;
+                            }}
+                            className="scroll-mt-20"
+                        >
+                            <div className="px-5 pt-5 pb-3 flex items-center gap-2">
+                                <span className="inline-flex items-center justify-center text-[11px] font-semibold tabular-nums px-2 py-0.5 rounded-md bg-neutral-100 text-neutral-500">
+                                    {idx + 1} / {screens.length}
+                                </span>
+                                <h4 className="text-sm font-bold text-neutral-900 truncate">
+                                    {screen.name}
+                                </h4>
+                            </div>
+
+                            <div className="px-5 pb-4">
+                                {aiImageEnabled && projectId && artifactId && versionId ? (
+                                    <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
+                                        <MockupScreenImage
+                                            key={`${screen.id}:img`}
+                                            projectId={projectId}
+                                            artifactId={artifactId}
+                                            versionId={versionId}
+                                            screen={screen}
+                                            payload={payload}
+                                            settings={settings}
+                                        />
+                                        <PageImageFooter versionId={versionId} screen={screen} />
+                                    </div>
+                                ) : (
+                                    <div className="bg-white rounded-lg border border-dashed border-neutral-300 p-6 text-sm text-neutral-500 text-center">
+                                        AI image preview is unavailable in this context.
+                                    </div>
+                                )}
+                            </div>
+
+                            {(screen.purpose || screen.userIntent) && (
+                                <div className="px-5 pb-3 space-y-1">
+                                    {screen.purpose && (
+                                        <p className="text-sm text-neutral-700">{screen.purpose}</p>
+                                    )}
+                                    {screen.userIntent && (
+                                        <p className="text-xs text-neutral-500 italic">
+                                            User intent: {screen.userIntent}
+                                        </p>
+                                    )}
+                                </div>
+                            )}
+
+                            {screen.coreUIElements && screen.coreUIElements.length > 0 && (
+                                <div className="px-5 pb-4">
+                                    <p className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium mb-1.5">
+                                        Key Elements
+                                    </p>
+                                    <ul className="space-y-1">
+                                        {screen.coreUIElements.map((el, i) => (
+                                            <li
+                                                key={i}
+                                                className="flex items-start gap-2 text-xs text-neutral-700"
+                                            >
+                                                <Check
+                                                    size={13}
+                                                    className="text-emerald-500 mt-0.5 shrink-0"
+                                                />
+                                                <span>{el}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+
+                            {screen.notes && (
+                                <p className="px-5 pb-4 text-xs text-neutral-400 italic">
+                                    {screen.notes}
+                                </p>
+                            )}
+                        </section>
+                    ))}
                 </div>
-            )}
-            <div className="px-5 py-2 text-[11px] text-neutral-400 border-t border-neutral-100 flex items-center gap-1.5">
-                <span>v{versionNumber}</span>
-                <span className="text-neutral-300">·</span>
-                <span>{formatDate(createdAt)}</span>
-                {sourceSpineVersionId && (
-                    <>
-                        <span className="text-neutral-300">·</span>
-                        <span>PRD {sourceSpineVersionId.slice(0, 8)}</span>
-                    </>
+
+                {actions && (
+                    <div className="px-5 py-3 border-t border-neutral-100 bg-neutral-50/40 flex items-center gap-2 flex-wrap">
+                        {actions}
+                    </div>
                 )}
+                <div className="px-5 py-2 text-[11px] text-neutral-400 border-t border-neutral-100 flex items-center gap-1.5">
+                    <span>v{versionNumber}</span>
+                    <span className="text-neutral-300">·</span>
+                    <span>{formatDate(createdAt)}</span>
+                    {sourceSpineVersionId && (
+                        <>
+                            <span className="text-neutral-300">·</span>
+                            <span>PRD {sourceSpineVersionId.slice(0, 8)}</span>
+                        </>
+                    )}
+                </div>
             </div>
-        </div>
+
+            {/* Floating Pages button (mobile only) — surfaces once the user
+                has scrolled past the navigator card. */}
+            {isMobile && showFloatingNav && (
+                <button
+                    type="button"
+                    onClick={handleOpenFloatingNav}
+                    className="md:hidden fixed bottom-5 right-5 z-30 inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-full bg-neutral-900 text-white text-xs font-semibold shadow-lg hover:bg-neutral-800 active:scale-[0.98] transition"
+                    style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.25rem)' }}
+                    aria-label="Open Pages navigator"
+                >
+                    <FileText size={14} />
+                    Pages
+                    <span className="text-[10px] opacity-70 tabular-nums">
+                        {activeIdx + 1}/{screens.length}
+                    </span>
+                    <ArrowUp size={12} className="opacity-70" />
+                </button>
+            )}
+        </>
     );
 }


### PR DESCRIPTION
Reshapes the mockups artifact view to read as a multi-page document
rather than a pill switcher over a single active screen.

Changes (preserving the existing visual language, no new design system):
- MockupViewer now renders every screen stacked in order, each as a
  numbered section with its own anchor so the page list can scroll-to.
- New collapsible "Pages" navigator with thumbnails (pulled from the
  mockup-image-store / screen-inventory-image-store) + title + purpose
  subtitle. IntersectionObserver tracks the visible page and highlights
  the row.
- Drop the platform / fidelity / scope chips ("Desktop / Polished /
  Key Workflow"); header now shows AI Generated · N Pages · staleness ·
  version · date.
- Summary clamps to two lines with a Show more / Show less toggle.
- Per-page footer simplified to "AI Generated · timestamp"; the per-
  screen "Generate high quality" button is removed (quality is chosen
  in Settings) and "Redo low" is renamed to "Regenerate". The quality
  switcher still appears when more than one variant exists.
- Per-page content order: image -> purpose -> user intent -> Key
  Elements rendered as a checked list (one item per coreUIElement).
- ArtifactWorkspace's "Regenerate Mockup" now shows a small confirm
  modal: "Creates Version N. Current version remains available."
- Mobile-only floating "Pages" button surfaces once the navigator
  scrolls out of view; tapping it re-opens the navigator and scrolls
  back to it. Honours env(safe-area-inset-bottom).

Build (tsc -b + vite), lint, and full vitest suite all pass locally.