### PR TITLE
Show image prompt per mockup via icon button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synapse-prd",
-  "version": "0.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synapse-prd",
-      "version": "0.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
         "@tailwindcss/typography": "^0.5.19",

--- a/src/components/mockups/MockupPromptDialog.tsx
+++ b/src/components/mockups/MockupPromptDialog.tsx
@@ -1,0 +1,111 @@
+/**
+ * Modal that reveals the prompt used to generate (or accompany the upload of)
+ * a single mockup image. Lets the user inspect and copy the exact text the
+ * image was created from — useful for auditing, refining the project's spec,
+ * or re-running the same prompt elsewhere.
+ *
+ * Stateless on its own — the host (PageImageFooter) controls open state and
+ * supplies the prompt and a short label (screen name).
+ */
+
+import { useEffect, useState } from 'react';
+import { X, Copy, Check } from 'lucide-react';
+import { copyToClipboard } from '../../lib/utils/copyToClipboard';
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+    screenName: string;
+    prompt: string;
+}
+
+export function MockupPromptDialog({ open, onClose, screenName, prompt }: Props) {
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [open, onClose]);
+
+    if (!open) return null;
+
+    const handleCopy = async () => {
+        const ok = await copyToClipboard(prompt);
+        if (ok) {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex justify-center items-center overflow-y-auto p-4 md:p-8"
+            onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mockup-prompt-dialog-title"
+        >
+            <div
+                className="bg-white rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="px-5 py-4 border-b border-neutral-200 flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                        <h2
+                            id="mockup-prompt-dialog-title"
+                            className="text-base font-semibold text-neutral-900 truncate"
+                        >
+                            Image prompt — {screenName}
+                        </h2>
+                        <p className="text-xs text-neutral-500 mt-0.5">
+                            The exact text used to create this mockup image.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="p-2 -m-1 text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 rounded-full transition shrink-0"
+                        aria-label="Close"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                <div className="px-5 py-4 overflow-y-auto">
+                    {prompt ? (
+                        <pre className="text-[12px] leading-relaxed text-neutral-800 bg-neutral-50 border border-neutral-200 rounded-md p-3 whitespace-pre-wrap break-words">
+                            {prompt}
+                        </pre>
+                    ) : (
+                        <div className="text-sm text-neutral-500 italic">
+                            No prompt was recorded for this image.
+                        </div>
+                    )}
+                </div>
+
+                <div className="px-5 py-3 border-t border-neutral-100 bg-neutral-50/60 flex items-center justify-end gap-2">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-xs px-3 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 transition"
+                    >
+                        Close
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        disabled={!prompt}
+                        className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
+                    >
+                        {copied ? <Check size={12} /> : <Copy size={12} />}
+                        {copied ? 'Copied' : 'Copy prompt'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/mockups/MockupViewer.tsx
+++ b/src/components/mockups/MockupViewer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronDown, ChevronRight, FileText, Sparkles, Check, ArrowUp } from 'lucide-react';
+import { ChevronDown, ChevronRight, FileText, Sparkles, Check, ArrowUp, MessageSquareText } from 'lucide-react';
 import type { MockupImageRecord, MockupPayload, MockupScreen, MockupSettings, StalenessState } from '../../types';
 import { useMockupImageStore } from '../../store/mockupImageStore';
 import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
@@ -7,6 +7,7 @@ import { buildScreenScopeKey } from '../../lib/mockupImageStore';
 import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
 import { StalenessBadge } from '../StalenessBadge';
 import { MockupScreenImage } from './MockupScreenImage';
+import { MockupPromptDialog } from './MockupPromptDialog';
 import { useIsMobile } from '../../lib/useIsMobile';
 
 type Props = {
@@ -86,14 +87,15 @@ function PageThumb({ versionId, screen }: { versionId?: string; screen: MockupSc
 }
 
 /**
- * Per-page footer: simple "AI Generated · date · Regenerate". Only shown when
- * an image actually exists for this screen — empty/loading states are rendered
- * by MockupScreenImage itself. The "Regenerate" here re-runs the same quality
- * on the current screen; it does not bump the artifact version.
+ * Per-page footer: simple "AI Generated · date" plus a "view prompt" icon
+ * button that opens the prompt used to create the image. Only shown when an
+ * image actually exists for this screen — empty/loading states are rendered
+ * by MockupScreenImage itself.
  */
 function PageImageFooter({ versionId, screen }: { versionId?: string; screen: MockupScreen }) {
     const aiImages = useMockupImageStore((s) => s.images);
     const uploads = useScreenInventoryImageStore((s) => s.images);
+    const [promptOpen, setPromptOpen] = useState(false);
 
     const info = useMemo(() => {
         if (!versionId) return null;
@@ -102,7 +104,7 @@ function PageImageFooter({ versionId, screen }: { versionId?: string; screen: Mo
             (u) => u.artifactVersionId === versionId && u.screenSlug === slug && u.isPreferred,
         );
         if (upload) {
-            return { label: 'Uploaded', generatedAt: upload.generatedAt };
+            return { label: 'Uploaded', generatedAt: upload.generatedAt, prompt: upload.prompt ?? '' };
         }
         const aiScope = buildScreenScopeKey(versionId, screen.id);
         const matching: MockupImageRecord[] = [];
@@ -111,18 +113,38 @@ function PageImageFooter({ versionId, screen }: { versionId?: string; screen: Mo
         }
         const best = pickPreviewRecord(matching);
         if (!best) return null;
-        return { label: 'AI Generated', generatedAt: best.generatedAt };
+        return { label: 'AI Generated', generatedAt: best.generatedAt, prompt: best.prompt ?? '' };
     }, [versionId, aiImages, uploads, screen.id, screen.name]);
 
     if (!info) return null;
+    const hasPrompt = info.prompt.length > 0;
     return (
-        <div className="px-5 py-2.5 border-t border-neutral-100 bg-neutral-50/60 flex items-center gap-2 flex-wrap text-[11px]">
-            <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 font-medium">
-                <Sparkles size={10} />
-                {info.label}
-            </span>
-            <span className="text-neutral-500">{formatDateTime(info.generatedAt)}</span>
-        </div>
+        <>
+            <div className="px-5 py-2.5 border-t border-neutral-100 bg-neutral-50/60 flex items-center gap-2 flex-wrap text-[11px]">
+                <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 font-medium">
+                    <Sparkles size={10} />
+                    {info.label}
+                </span>
+                <span className="text-neutral-500">{formatDateTime(info.generatedAt)}</span>
+                <button
+                    type="button"
+                    onClick={() => setPromptOpen(true)}
+                    disabled={!hasPrompt}
+                    className="ml-auto inline-flex items-center gap-1 px-1.5 py-1 rounded-md text-neutral-500 hover:text-indigo-700 hover:bg-indigo-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                    aria-label={`View prompt for ${screen.name}`}
+                    title={hasPrompt ? 'View image prompt' : 'No prompt recorded for this image'}
+                >
+                    <MessageSquareText size={13} />
+                    <span className="text-[11px] font-medium hidden sm:inline">Prompt</span>
+                </button>
+            </div>
+            <MockupPromptDialog
+                open={promptOpen}
+                onClose={() => setPromptOpen(false)}
+                screenName={screen.name}
+                prompt={info.prompt}
+            />
+        </>
     );
 }
 


### PR DESCRIPTION
Each mockup page footer now has a "Prompt" icon that opens a modal with
the exact text used to create the image (AI-generated or user-uploaded),
plus a copy action. The prompt was already persisted on
MockupImageRecord/ScreenInventoryImageRecord — this surfaces it.