### PR TITLE
Group artifact sidebar into workflow sections + rename labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -737,6 +737,18 @@ User prompt → HomePage.handleCreateProject() → PreflightModeChoice
 
 ### Post-finalization transition (Mark Final → Assets)
 
+The artifact sidebar is organized into four workflow-named sections —
+**Project Foundation** (PRD), **UX & Design** (User Flows, Screen Inventory,
+Mockups, UI Components, Design System), **Architecture** (Data Model), and
+**Development** (Developer Prompts, Build Plan) — driven by `ARTIFACT_GROUPS` in
+`ArtifactWorkspace.tsx`. Grouping is purely visual; `CoreArtifactSubtype` ids
+(`'data_model'`, `'component_inventory'`, `'design_system'`, `'prompt_pack'`,
+`'implementation_plan'`) are unchanged so persisted artifacts, generation, and
+per-artifact model overrides keep working. `title`/`description` in
+`CORE_ARTIFACT_PIPELINE` are display-only labels that may be renamed freely; the
+sidebar's iteration order (and the right-rail / mobile-header / auto-open order)
+all derive from `ARTIFACT_GROUPS`, not `displayOrder`.
+
 Marking a spine final must not dump the user back on something that looks like
 the PRD again. `ProjectWorkspace.handleToggleFinal` (on the finalize edge)
 starts artifact generation and shows `FinalizationSuccessModal` ("PRD
@@ -747,9 +759,9 @@ check of the 7 core artifacts + mockups) **without** switching stage. Its
 `ArtifactWorkspace` as `autoOpenIntent`. `ArtifactWorkspace` consumes it once
 (via `onAutoOpenConsumed`): it auto-selects the first **non-PRD** artifact —
 preferring `done`, then `generating`, then `queued`, else the first slot in
-`CORE_ARTIFACT_DISPLAY_ORDER` (data_model → … → prompt_pack, then mockups) — and
-opens the mobile drawer (`useIsMobile`-gated, so it never reopens after the user
-closes it; desktop keeps the persistent side rail). While the overall run is in
+`ARTIFACT_GROUPS` order (user_flows → screen_inventory → mockup → … →
+implementation_plan) — and opens the mobile drawer (`useIsMobile`-gated, so it
+never reopens after the user closes it; desktop keeps the persistent side rail). While the overall run is in
 flight, an idle slot renders a centered `BuildAssetsLoading` ("Creating your
 build assets…") instead of an empty state.
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Mark your PRD as final and Synapse generates all the assets you need to build �
 in parallel, from that single source of truth:
 
 - **Screen Inventory** and **User Flows**
-- **Component Inventory** (a searchable, filterable component library with live
+- **UI Components** (a searchable, filterable component library with live
   previews and per-component accessibility contracts) and **Design System**
 - **Data Model** schemas with entities, fields, and relationships
-- **Implementation Plan** and **Prompt Pack**
+- **Build Plan** and **Developer Prompts**
 
 Three of them (`screen_inventory`, `data_model`, `component_inventory`) use
 Gemini JSON mode with explicit schemas and render as card grids, entity tables,
@@ -187,10 +187,10 @@ address the critique without regenerating the whole document.
 
 #### Track implementation progress
 
-The Implementation Plan converts into a tracked task checklist — no LLM call,
+The Build Plan converts into a tracked task checklist — no LLM call,
 derived deterministically from the plan. Review and edit the extracted tasks,
 **save them to the project**, and a progress checklist appears on the
-Implementation Plan: a `done / total` progress bar, a per-task status toggle
+Build Plan: a `done / total` progress bar, a per-task status toggle
 (to do → in progress → done), and expandable acceptance criteria. Export the
 tasks to **Markdown** or **GitHub issues**; created GitHub issues are linked
 back to each task so you can jump straight to them. Progress persists across
@@ -274,8 +274,8 @@ graph TD
 
     H --> J(Screen Inventory)
     H --> K(Data Model)
-    H --> L(Component Library)
-    H --> M(Implementation Plan)
+    H --> L(UI Components)
+    H --> M(Build Plan)
 ```
 
 ## Tech stack

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
     RefreshCcw, StopCircle, Menu, X, ChevronLeft, ChevronRight, ListChecks, History,
+    Layers, Database, Code2,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -54,17 +55,45 @@ interface SlotMeta {
     icon: typeof FileText;
 }
 
+interface ArtifactGroup {
+    id: string;
+    title: string;
+    icon: typeof FileText;
+    items: WorkspaceSelection[];
+}
+
+// Sidebar grouping is purely visual — subtype IDs are unchanged. Order within
+// a group is the order rows render in. The "Project Foundation → UX & Design
+// → Architecture → Development" sequence tells the product-build story; keep
+// it in sync with the README/tour if either changes.
+const ARTIFACT_GROUPS: ArtifactGroup[] = [
+    { id: 'foundation', title: 'Project Foundation', icon: FileText, items: ['prd'] },
+    {
+        id: 'design',
+        title: 'UX & Design',
+        icon: Layers,
+        items: ['user_flows', 'screen_inventory', 'mockup', 'component_inventory', 'design_system'],
+    },
+    { id: 'architecture', title: 'Architecture', icon: Database, items: ['data_model'] },
+    { id: 'development', title: 'Development', icon: Code2, items: ['prompt_pack', 'implementation_plan'] },
+];
+
 function buildSlotMetas(): SlotMeta[] {
-    return [
-        { key: 'prd', title: 'PRD', description: 'Final product requirements document', icon: FileText },
-        ...CORE_ARTIFACT_DISPLAY_ORDER.map(meta => ({
+    const base: Record<WorkspaceSelection, SlotMeta> = {
+        prd: { key: 'prd', title: 'PRD', description: 'Final product requirements document', icon: FileText },
+        mockup: { key: 'mockup', title: 'Mockups', description: 'Interactive UI mockups', icon: Image },
+    } as Record<WorkspaceSelection, SlotMeta>;
+    for (const meta of CORE_ARTIFACT_DISPLAY_ORDER) {
+        base[meta.subtype as WorkspaceSelection] = {
             key: meta.subtype as WorkspaceSelection,
             title: meta.title,
             description: meta.description,
             icon: Package,
-        })),
-        { key: 'mockup' as WorkspaceSelection, title: 'Mockups', description: 'Interactive UI mockups', icon: Image },
-    ];
+        };
+    }
+    // Materialize in the group order so the right rail / counts / mobile
+    // header iterate in the same order the sidebar shows.
+    return ARTIFACT_GROUPS.flatMap(group => group.items.map(key => base[key]));
 }
 
 function StatusDot({ status }: { status: GenerationStatus }) {
@@ -487,39 +516,65 @@ export function ArtifactWorkspace({
                         <X size={18} />
                     </button>
                 </div>
-                <ul className="py-2">
-                    {slotMetas.map(slot => {
-                        const status = slotStatusFor(slot.key);
-                        const isSel = selected === slot.key;
-                        const Icon = slot.icon;
+                <nav aria-label="Artifacts" className="py-2">
+                    {ARTIFACT_GROUPS.map((group, groupIdx) => {
+                        const SectionIcon = group.icon;
+                        const groupSlots = group.items
+                            .map(key => slotMetas.find(s => s.key === key))
+                            .filter((s): s is SlotMeta => Boolean(s));
+                        if (groupSlots.length === 0) return null;
                         return (
-                            <li key={slot.key}>
-                                <button
-                                    type="button"
-                                    onClick={() => handleSelect(slot.key)}
-                                    className={`w-full flex items-start gap-3 px-4 py-2.5 text-left transition border-l-2 ${
-                                        isSel
-                                            ? 'bg-indigo-50 border-indigo-500'
-                                            : 'border-transparent hover:bg-neutral-50'
-                                    }`}
-                                >
-                                    <Icon size={16} className={`shrink-0 mt-0.5 ${isSel ? 'text-indigo-600' : 'text-neutral-400'}`} />
-                                    <div className="flex-1 min-w-0">
-                                        <div className="flex items-center gap-2">
-                                            <span className={`text-sm font-medium truncate ${isSel ? 'text-indigo-900' : 'text-neutral-800'}`}>
-                                                {slot.title}
-                                            </span>
-                                            <StatusDot status={status} />
-                                        </div>
-                                        <div className="text-[11px] text-neutral-500 leading-tight truncate">
-                                            {slot.description}
-                                        </div>
-                                    </div>
-                                </button>
-                            </li>
+                            <div
+                                key={group.id}
+                                className={
+                                    groupIdx > 0
+                                        ? 'mt-3 pt-3 border-t border-neutral-200/70'
+                                        : undefined
+                                }
+                            >
+                                <div className="px-4 pb-1.5 flex items-center gap-2">
+                                    <SectionIcon size={14} className="shrink-0 text-indigo-500" aria-hidden="true" />
+                                    <span className="text-[11px] font-semibold text-indigo-600 uppercase tracking-wider">
+                                        {group.title}
+                                    </span>
+                                </div>
+                                <ul>
+                                    {groupSlots.map(slot => {
+                                        const status = slotStatusFor(slot.key);
+                                        const isSel = selected === slot.key;
+                                        const Icon = slot.icon;
+                                        return (
+                                            <li key={slot.key}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleSelect(slot.key)}
+                                                    className={`w-full flex items-start gap-3 px-4 py-2.5 text-left transition border-l-2 ${
+                                                        isSel
+                                                            ? 'bg-indigo-50 border-indigo-500'
+                                                            : 'border-transparent hover:bg-neutral-50'
+                                                    }`}
+                                                >
+                                                    <Icon size={16} className={`shrink-0 mt-0.5 ${isSel ? 'text-indigo-600' : 'text-neutral-400'}`} />
+                                                    <div className="flex-1 min-w-0">
+                                                        <div className="flex items-center gap-2">
+                                                            <span className={`text-sm font-medium truncate ${isSel ? 'text-indigo-900' : 'text-neutral-800'}`}>
+                                                                {slot.title}
+                                                            </span>
+                                                            <StatusDot status={status} />
+                                                        </div>
+                                                        <div className="text-[11px] text-neutral-500 leading-tight truncate">
+                                                            {slot.description}
+                                                        </div>
+                                                    </div>
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            </div>
                         );
                     })}
-                </ul>
+                </nav>
             </aside>
 
             {/* Main pane */}

--- a/src/lib/coreArtifactPipeline.ts
+++ b/src/lib/coreArtifactPipeline.ts
@@ -18,54 +18,60 @@ export interface CoreArtifactMeta {
 // prompt, so most artifacts can be generated independently from it. Spurious
 // deps serialize the pipeline — buildDependencyLayers turns them into wait
 // gates — which kneecaps parallelism with little quality benefit.
+// `subtype` is the stable internal id and must not change — generation,
+// routing, persisted artifacts, and per-artifact model overrides all key off
+// it. `title`/`description` are display-only labels (shown in the artifact
+// sidebar, settings model picker, and progress messages) and may be renamed
+// freely. The grouping that drives the sidebar's visual sections lives in
+// ArtifactWorkspace's ARTIFACT_GROUPS, which keys off subtype.
 export const CORE_ARTIFACT_PIPELINE: CoreArtifactMeta[] = [
-    {
-        subtype: 'screen_inventory',
-        title: 'Screen Inventory',
-        description: 'Structured list of screens and views implied by the PRD',
-        dependsOn: [],
-        displayOrder: 3,
-    },
     {
         subtype: 'user_flows',
         title: 'User Flows',
-        description: 'Primary user journeys and key flow sequences',
+        description: 'Primary user journeys and key flows',
         dependsOn: ['screen_inventory'],
+        displayOrder: 1,
+    },
+    {
+        subtype: 'screen_inventory',
+        title: 'Screen Inventory',
+        description: 'Structured list of screens and views',
+        dependsOn: [],
         displayOrder: 2,
     },
     {
         subtype: 'component_inventory',
-        title: 'Component Inventory',
-        description: 'Reusable components implied by the product design',
+        title: 'UI Components',
+        description: 'Reusable components and patterns',
         dependsOn: ['screen_inventory'],
+        displayOrder: 3,
+    },
+    {
+        subtype: 'design_system',
+        title: 'Design System',
+        description: 'Foundational UI system and styles',
+        dependsOn: [],
         displayOrder: 4,
     },
     {
         subtype: 'data_model',
-        title: 'Data Model Draft',
-        description: 'Primary entities, relationships, and data needs',
-        dependsOn: [],
-        displayOrder: 1,
-    },
-    {
-        subtype: 'implementation_plan',
-        title: 'Implementation Plan',
-        description: 'High-level build sequence and milestone-oriented dev plan',
-        dependsOn: [],
-        displayOrder: 6,
-    },
-    {
-        subtype: 'design_system',
-        title: 'Design System Starter',
-        description: 'Foundational UI system draft with patterns and components',
+        title: 'Data Model',
+        description: 'Entities, relationships, and data schema',
         dependsOn: [],
         displayOrder: 5,
     },
     {
         subtype: 'prompt_pack',
-        title: 'Prompt Pack',
-        description: 'Downstream prompts for design, coding, critique, and testing',
+        title: 'Developer Prompts',
+        description: 'AI prompts for downstream tasks',
         dependsOn: ['implementation_plan', 'design_system', 'data_model'],
+        displayOrder: 6,
+    },
+    {
+        subtype: 'implementation_plan',
+        title: 'Build Plan',
+        description: 'High-level build sequence and milestones',
+        dependsOn: [],
         displayOrder: 7,
     },
 ];


### PR DESCRIPTION
Reorganize the Artifacts navigation into four workflow-named sections
(Project Foundation, UX & Design, Architecture, Development) driven by a
new ARTIFACT_GROUPS map in ArtifactWorkspace, with small monochrome
section icons, thin separators, and the existing row styling preserved.
Update CORE_ARTIFACT_PIPELINE titles/descriptions to the new labels
(Data Model, UI Components, Design System, Developer Prompts, Build
Plan). Subtype ids are unchanged so generation, persisted artifacts, and
per-artifact model overrides keep working.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015mxku8LdfN9TsjfvaU6tcE