### PR TITLE
Fix demo mockup images vanishing without an OpenAI key

### DIFF
--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -83,19 +83,49 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
 
     // Hydrate this version's records from IDB on mount so reload / tab
     // switches surface every cached quality variant. We seed once per
-    // versionId; loadForVersion is itself idempotent.
+    // versionId; loadForVersion is itself idempotent. `hydrated` gates the
+    // forced-fallback routing below so we don't briefly flash the manual
+    // upload sheet before existing AI images load (e.g. the public demo).
+    const [hydratedVersion, setHydratedVersion] = useState<string | null>(null);
     useEffect(() => {
-        void loadForVersion(versionId);
+        let cancelled = false;
+        void loadForVersion(versionId).finally(() => {
+            if (!cancelled) setHydratedVersion(versionId);
+        });
+        return () => { cancelled = true; };
     }, [versionId, loadForVersion]);
+    // Until this version's load settles, hydratedVersion still points at the
+    // prior version, so a version switch correctly reads as not-yet-hydrated.
+    const hydrated = hydratedVersion === versionId;
 
     const keyPresent = hasOpenAIKey();
 
     // Image source routing (Settings → Artifact Generation Models → Mockups):
     //  - 'user_uploaded'             → always the manual upload sheet
     //  - 'gpt_image' without a key   → fall back to the manual sheet (never
-    //                                  silently fail) and explain why
+    //                                  silently fail) and explain why — BUT only
+    //                                  when there are no AI images to show.
+    //                                  Already-generated renders (e.g. the public
+    //                                  demo project, cross-device sync, or images
+    //                                  made in an earlier keyed session) must
+    //                                  still render even without a key, otherwise
+    //                                  the manual sheet — which reads a different
+    //                                  store (screenInventoryImageStore) — hides
+    //                                  them and the mockups appear to vanish.
     //  - 'gpt_image' with a key      → the OpenAI generator below
-    const { manual, forcedFallback } = resolveMockupRender(getMockupImageMode(), keyPresent);
+    const mode = getMockupImageMode();
+    const { forcedFallback } = resolveMockupRender(mode, keyPresent);
+    const hasAiImages = records.length > 0;
+    // While a forced-fallback version is still hydrating we don't yet know if AI
+    // images exist; render the loading state until we do rather than guessing.
+    if (forcedFallback && !hydrated && !hasAiImages) {
+        return (
+            <div className="bg-white rounded-lg border border-neutral-200 p-8 flex items-center justify-center min-h-[420px]">
+                <Loader2 size={24} className="text-neutral-300 animate-spin" />
+            </div>
+        );
+    }
+    const manual = mode === 'user_uploaded' || (forcedFallback && !hasAiImages);
     if (manual) {
         return (
             <MockupScreenUpload


### PR DESCRIPTION
The mockup image source routing (PR #168) sent every keyless viewer to the
manual upload sheet (MockupScreenUpload), which reads a different store
(screenInventoryImageStore). The demo project's AI-generated mockups live in
mockupImageStore, so they were never displayed to anonymous demo viewers — who
by definition have no OpenAI key.

resolveMockupRender's forced fallback (gpt_image chosen but no key) now only
takes over when there are no AI images to show. Already-generated renders — the
public demo, cross-device synced images, or renders made in an earlier keyed
session — render read-only even without a key. A hydration gate avoids briefly
flashing the upload sheet before the cached images load.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019jMMUyt3EeR43ZodN6oFHu