### PR TITLE
Refetch demo project when owner pins a newer snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,18 @@ upload nor download crosses Vercel's ~4.5 MB cap. One snapshot can be pinned as
 **the demo** (`_demo.json` pointer + public `?demo=1` read); `loadDemoProject`
 restores it under the stable `DEMO_PROJECT_ID`.
 
+- **Demo cache freshness — never short-circuit on a `DEMO_PROJECT_ID` cache hit
+  alone.** Each restored demo project stores its source snapshot id in the
+  optional `Project.demoSourceSnapshotId` (so it travels with the per-user
+  project namespace). On every `loadDemoProject` call, the client first probes
+  the lightweight public `GET /api/snapshots?demo=1&pointer=1`
+  (`loadDemoSnapshotPointer`) and only reuses the cached demo when the stamped
+  id matches the live pointer. When the owner pins a newer snapshot the
+  pointer differs → the full bundle is re-fetched and `restoreSnapshotAs`
+  overwrites the cache. If the pointer probe itself fails (offline / proxy
+  error) the cache is preferred over an empty state. **Do not** re-add an
+  early `if (existing) return` — that's exactly what made the desktop serve a
+  stale demo while mobile (with no cache) silently saw the latest.
 - **Restoring under a *different* project id MUST namespace the artifact version
   ids** (`namespaceSnapshotForRestore` → `rewriteIds`), not just the project id.
   Mockup images are keyed in IndexedDB by `versionId` with **no projectId in the

--- a/api/snapshots.js
+++ b/api/snapshots.js
@@ -15,6 +15,7 @@ import { requireOwner } from './_lib/ownerAuth.js';
 //   GET    /api/snapshots?id=...&image=<key>  -> load one image (owner)
 //   DELETE /api/snapshots?id=...              -> remove one snapshot (owner)
 //   GET    /api/snapshots?demo=1              -> load the demo snapshot (PUBLIC)
+//   GET    /api/snapshots?demo=1&pointer=1    -> read the demo pointer (PUBLIC)
 //   GET    /api/snapshots?demo=1&image=<key>  -> load one demo image (PUBLIC)
 //   PUT    /api/snapshots?demo=1&id=          -> mark a snapshot as the demo (owner)
 //   PUT    /api/snapshots?demo=1              -> clear the demo pointer (owner)
@@ -328,6 +329,19 @@ async function handleGetDemoImage(key, res) {
   return await handleGetImage(pointer.snapshotId, key, res);
 }
 
+// Public, lightweight: return JUST the current demo pointer so clients can
+// invalidate a cached demo project without paying the cost of downloading the
+// full bundle + per-image blobs. Returns 200 with `{ snapshotId: null }` when
+// no demo has been pinned so callers can distinguish "no demo" from a network
+// failure without parsing 404s.
+async function handleGetDemoPointer(res) {
+  const pointer = await readDemoPointer();
+  return json(res, 200, {
+    snapshotId: pointer?.snapshotId ?? null,
+    updatedAt: pointer?.updatedAt ?? null,
+  });
+}
+
 async function handlePutDemo(id, res) {
   // PUT /api/snapshots?demo=1&id=<id>  -> set pointer
   // PUT /api/snapshots?demo=1          -> clear pointer
@@ -431,9 +445,14 @@ export default async function handler(req, res) {
     ? imageQuery
     : null;
 
+  // `pointer=1` is the lightweight demo-pointer probe — see
+  // `handleGetDemoPointer`. Only meaningful on the demo channel.
+  const isPointerProbe = req.query?.pointer === '1' || req.query?.pointer === 'true';
+
   try {
     if (isDemoChannel) {
       if (req.method === 'GET') {
+        if (isPointerProbe) return await handleGetDemoPointer(res);
         if (imageReadKey !== null) return await handleGetDemoImage(imageReadKey, res);
         return await handleGetDemo(res);
       }

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -264,6 +264,27 @@ const hydrateImages = async (
     return out;
 };
 
+// Public, lightweight: read just the demo pointer so callers can decide
+// whether their cached demo project is still current without paying the
+// full bundle+image download. Returns null when no demo has been pinned
+// or the probe fails — the caller is expected to fall back to its cache.
+export type DemoPointer = { snapshotId: string; updatedAt: string | null };
+
+export const loadDemoSnapshotPointer = async (): Promise<DemoPointer | null> => {
+    const resp = await fetch(`${API_BASE}?demo=1&pointer=1`);
+    if (!resp.ok) return null;
+    const body = await resp.json().catch(() => null) as
+        | { snapshotId?: unknown; updatedAt?: unknown }
+        | null;
+    if (!body || typeof body.snapshotId !== 'string' || body.snapshotId.length === 0) {
+        return null;
+    }
+    return {
+        snapshotId: body.snapshotId,
+        updatedAt: typeof body.updatedAt === 'string' ? body.updatedAt : null,
+    };
+};
+
 // Public: fetch the snapshot the owner has marked as the demo. No auth.
 // Returns null when no demo has been set (server returns 404 in that case).
 export const loadDemoSnapshotPublic = async (): Promise<SnapshotPayload | null> => {

--- a/src/store/__tests__/loadDemoProject.test.ts
+++ b/src/store/__tests__/loadDemoProject.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import { DEMO_PROJECT_ID } from '../../data/demoProject';
+import type { SnapshotPayload } from '../../lib/snapshotClient';
+import type { Project } from '../../types';
+
+// We don't care about the bundle/image plumbing here — `restoreSnapshotAs`
+// already has its own coverage. We just need to verify `loadDemoProject`
+// short-circuits when the cached demo matches the live pointer, and
+// re-fetches when it doesn't.
+vi.mock('../../lib/snapshotClient', () => ({
+    loadDemoSnapshotPointer: vi.fn(),
+    loadDemoSnapshotPublic: vi.fn(),
+    restoreSnapshotAs: vi.fn(),
+}));
+
+import {
+    loadDemoSnapshotPointer,
+    loadDemoSnapshotPublic,
+    restoreSnapshotAs,
+} from '../../lib/snapshotClient';
+
+const mockedPointer = vi.mocked(loadDemoSnapshotPointer);
+const mockedPublic = vi.mocked(loadDemoSnapshotPublic);
+const mockedRestore = vi.mocked(restoreSnapshotAs);
+
+function seedDemo(sourceId: string | undefined): void {
+    const project: Project = {
+        id: DEMO_PROJECT_ID,
+        name: 'Demo',
+        createdAt: 0,
+        ...(sourceId ? { demoSourceSnapshotId: sourceId } : {}),
+    };
+    useProjectStore.setState((state) => ({
+        projects: { ...state.projects, [DEMO_PROJECT_ID]: project },
+    }));
+}
+
+function fakePayload(snapshotId: string): SnapshotPayload {
+    return {
+        schemaVersion: 2,
+        manifest: {
+            id: snapshotId,
+            title: 't',
+            projectName: 'Demo',
+            createdAt: '2026-01-01',
+            schemaVersion: 2,
+            imageCount: 0,
+        },
+        project: {
+            project: { id: DEMO_PROJECT_ID, name: 'Demo', createdAt: 0 },
+            spineVersions: [],
+            historyEvents: [],
+            branches: [],
+            artifacts: [],
+            artifactVersions: [],
+            feedbackItems: [],
+        },
+        images: [],
+    };
+}
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+    localStorage.clear();
+    mockedPointer.mockReset();
+    mockedPublic.mockReset();
+    mockedRestore.mockReset();
+    // The mock `restoreSnapshotAs` should still write the project into the
+    // store so the post-restore source-id stamp has something to update.
+    mockedRestore.mockImplementation(async (payload, targetId) => {
+        useProjectStore.setState((state) => ({
+            projects: {
+                ...state.projects,
+                [targetId]: {
+                    ...payload.project.project,
+                    id: targetId,
+                },
+            },
+        }));
+        return targetId;
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('loadDemoProject — freshness check', () => {
+    it('serves the cached demo when its source snapshot id matches the live pointer', async () => {
+        seedDemo('snap-A');
+        mockedPointer.mockResolvedValue({ snapshotId: 'snap-A', updatedAt: null });
+
+        const result = await useProjectStore.getState().loadDemoProject();
+
+        expect(result).toEqual({ projectId: DEMO_PROJECT_ID, available: true });
+        expect(mockedPublic).not.toHaveBeenCalled();
+        expect(mockedRestore).not.toHaveBeenCalled();
+    });
+
+    it('re-fetches and restores when the owner has pinned a newer snapshot', async () => {
+        seedDemo('snap-A');
+        mockedPointer.mockResolvedValue({ snapshotId: 'snap-B', updatedAt: null });
+        mockedPublic.mockResolvedValue(fakePayload('snap-B'));
+
+        const result = await useProjectStore.getState().loadDemoProject();
+
+        expect(result).toEqual({ projectId: DEMO_PROJECT_ID, available: true });
+        expect(mockedPublic).toHaveBeenCalledTimes(1);
+        expect(mockedRestore).toHaveBeenCalledTimes(1);
+        // The new source id is stamped so the NEXT click can short-circuit.
+        const project = useProjectStore.getState().projects[DEMO_PROJECT_ID];
+        expect(project?.demoSourceSnapshotId).toBe('snap-B');
+    });
+
+    it('re-fetches when the cache exists but carries no source id (legacy cache)', async () => {
+        seedDemo(undefined);
+        mockedPointer.mockResolvedValue({ snapshotId: 'snap-A', updatedAt: null });
+        mockedPublic.mockResolvedValue(fakePayload('snap-A'));
+
+        await useProjectStore.getState().loadDemoProject();
+
+        expect(mockedPublic).toHaveBeenCalledTimes(1);
+        const project = useProjectStore.getState().projects[DEMO_PROJECT_ID];
+        expect(project?.demoSourceSnapshotId).toBe('snap-A');
+    });
+
+    it('keeps serving the cached demo when the pointer probe itself fails', async () => {
+        seedDemo('snap-A');
+        mockedPointer.mockResolvedValue(null);
+
+        const result = await useProjectStore.getState().loadDemoProject();
+
+        expect(result).toEqual({ projectId: DEMO_PROJECT_ID, available: true });
+        expect(mockedPublic).not.toHaveBeenCalled();
+    });
+
+    it('reports unavailable when no cache exists and the demo fetch fails', async () => {
+        mockedPointer.mockResolvedValue({ snapshotId: 'snap-X', updatedAt: null });
+        mockedPublic.mockResolvedValue(null);
+
+        const result = await useProjectStore.getState().loadDemoProject();
+
+        expect(result).toEqual({ projectId: DEMO_PROJECT_ID, available: false });
+    });
+
+    it('fetches and stamps the source id on first load (no cache)', async () => {
+        mockedPointer.mockResolvedValue({ snapshotId: 'snap-A', updatedAt: null });
+        mockedPublic.mockResolvedValue(fakePayload('snap-A'));
+
+        await useProjectStore.getState().loadDemoProject();
+
+        const project = useProjectStore.getState().projects[DEMO_PROJECT_ID];
+        expect(project?.demoSourceSnapshotId).toBe('snap-A');
+    });
+});

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -4,7 +4,11 @@ import type { Project, HistoryEvent, PipelineStage, ProjectPlatform } from '../.
 import type { ProjectState } from '../types';
 import { trackActivity } from '../../lib/recruiterApi';
 import { DEMO_PROJECT_ID } from '../../data/demoProject';
-import { loadDemoSnapshotPublic, restoreSnapshotAs } from '../../lib/snapshotClient';
+import {
+    loadDemoSnapshotPointer,
+    loadDemoSnapshotPublic,
+    restoreSnapshotAs,
+} from '../../lib/snapshotClient';
 import { projectsDebug } from '../../lib/projectsDebug';
 import { resolveProjectStorageName } from '../userScope';
 
@@ -120,15 +124,33 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
         void trackActivity(stage === 'mockups' ? 'viewed_mockups' : 'clicked_section', { section: stage, projectId });
     },
 
-    // Hydrates the store with the demo project. The demo is now a normal
-    // cloud snapshot that the owner has pinned via SnapshotsPanel — we fetch
-    // it from the public `/api/snapshots?demo=1` endpoint and splice it in
-    // at the stable DEMO_PROJECT_ID. Idempotent: if the demo is already
-    // present, returns without a network call so a user's in-progress
-    // changes to the demo copy aren't clobbered on re-click.
+    // Hydrates the store with the demo project. The demo is a cloud snapshot
+    // the owner has pinned via SnapshotsPanel — we fetch it from the public
+    // `/api/snapshots?demo=1` endpoint and splice it in at the stable
+    // DEMO_PROJECT_ID.
+    //
+    // Freshness: a previously cached demo is reused ONLY when its source
+    // snapshot id still matches the live pointer. Otherwise (owner pinned a
+    // newer snapshot) we re-fetch and overwrite the cache. This is why the
+    // desktop used to show a stale demo while mobile — with no cache — showed
+    // the latest one. The pointer probe is a tiny, public JSON fetch and runs
+    // before any heavy bundle/image download. If the pointer fetch itself
+    // fails (offline / proxy error), we fall back to the cached copy so the
+    // demo still opens.
     loadDemoProject: async () => {
         const existing = get().projects[DEMO_PROJECT_ID];
-        if (existing) {
+
+        const pointer = await loadDemoSnapshotPointer().catch((err) => {
+            console.error('[loadDemoProject] failed to read demo pointer', err);
+            return null;
+        });
+
+        if (existing && pointer && existing.demoSourceSnapshotId === pointer.snapshotId) {
+            return { projectId: DEMO_PROJECT_ID, available: true };
+        }
+        if (existing && !pointer) {
+            // Pointer probe failed — keep the cached demo rather than wiping
+            // it. Better stale than empty.
             return { projectId: DEMO_PROJECT_ID, available: true };
         }
 
@@ -137,10 +159,31 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             return null;
         });
         if (!payload) {
-            return { projectId: DEMO_PROJECT_ID, available: false };
+            // Fetch failed and nothing is cached — surface unavailable. If a
+            // cache exists, keep serving it.
+            return { projectId: DEMO_PROJECT_ID, available: !!existing };
         }
 
         await restoreSnapshotAs(payload, DEMO_PROJECT_ID);
+
+        // Stamp the source snapshot id so the next click can short-circuit
+        // when the pointer is unchanged. Pull from the freshly-restored
+        // payload's manifest, falling back to the pointer if the manifest
+        // didn't carry an id (defensive — older bundles always did).
+        const sourceId = payload.manifest?.id ?? pointer?.snapshotId ?? null;
+        if (sourceId) {
+            set((state) => {
+                const restored = state.projects[DEMO_PROJECT_ID];
+                if (!restored) return {};
+                return {
+                    projects: {
+                        ...state.projects,
+                        [DEMO_PROJECT_ID]: { ...restored, demoSourceSnapshotId: sourceId },
+                    },
+                };
+            });
+        }
+
         return { projectId: DEMO_PROJECT_ID, available: true };
     },
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,11 @@ export type Project = {
     // the user-chosen `name`.
     productName?: string;
     productCategory?: string;
+    // Only set on the cached demo project: the snapshot id this device's demo
+    // was hydrated from. Used by `loadDemoProject` to detect when the owner
+    // has pinned a newer demo snapshot and re-fetch instead of serving stale
+    // local cache. Optional so legacy persisted projects keep working.
+    demoSourceSnapshotId?: string;
 };
 
 export type BranchMessage = {


### PR DESCRIPTION
The desktop's loadDemoProject early-returned on any cached DEMO_PROJECT_ID,
so once a device had loaded the demo it never picked up newer pinned
snapshots. Mobile had no cache and silently fetched fresh each time, hiding
the staleness.

Add a public, lightweight GET /api/snapshots?demo=1&pointer=1 probe,
stamp the source snapshot id on the cached demo
(Project.demoSourceSnapshotId), and reuse the cache only when the
stamped id matches the live pointer. If the pointer probe itself fails
we still serve the cache so the demo stays openable offline.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JfP6LRZpyP5ye2YmNYLMyW