### PR TITLE
Replace pill nav with shared Artifact Outline on Design System & Data Model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,19 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     every card still shows a preview and a dedicated a11y block.
     `componentInventoryParse.ts` round-trips all these fields through
     markdown.
+    **Artifact in-page navigation** is a shared, collapsible **Artifact
+    Outline** — `src/components/ArtifactOutlineNav.tsx` (presentational/
+    controlled) + `src/lib/useArtifactOutline.ts` (scroll-spy via
+    IntersectionObserver, smooth-scroll, and hash `history.pushState` so
+    back/forward steps through sections). It mirrors the Mockups "Pages"
+    navigator: a numbered list/card, subtle purple active highlight + a
+    "Current section/entity" badge, `collapseOnSelect` on mobile (passed
+    `isMobile`) with a floating re-open button. Used by the **Design System**
+    (sections) and **Data Model** (entities) renderers, which anchor each
+    section with a `scroll-mt-*` id matching an outline item. This **replaced
+    the old wrapping "pill" nav** (`SectionTabs`) on those two pages — do not
+    reintroduce pills there; `SectionTabs` survives only for the Implementation
+    Plan renderer.
   - `branchService.ts` — branch consolidation back into the spine.
   - `preflightService.ts` — optional pre-PRD clarification (see "Preflight
     clarification" below). `generatePreflightQuestions()` (safety-gated) and

--- a/src/components/ArtifactOutlineNav.tsx
+++ b/src/components/ArtifactOutlineNav.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, ChevronRight, List, ArrowUp } from 'lucide-react';
+import { useIsMobile } from '../lib/useIsMobile';
+
+/**
+ * A single row in the artifact outline.
+ */
+export type ArtifactOutlineItem = {
+    id: string;
+    label: string;
+    description?: string;
+    /** Compact metadata shown on the right of the row, e.g. "11 tokens". */
+    countLabel?: string;
+};
+
+export type ArtifactOutlineNavProps = {
+    /** Group label, e.g. "Sections" or "Entities". */
+    title: string;
+    items: ArtifactOutlineItem[];
+    activeId: string;
+    /** Badge text for the active row, e.g. "Current section" or "Current entity". */
+    activeLabel: string;
+    defaultExpanded?: boolean;
+    /** Collapse after a row is selected (used on mobile to reduce scrolling). */
+    collapseOnSelect?: boolean;
+    onSelect: (id: string) => void;
+};
+
+/**
+ * Shared, collapsible outline navigation for long structured artifacts.
+ *
+ * Replaces the wrapping "pill" nav (`SectionTabs`) on the Design System and
+ * Data Model pages with a single scannable list/card that mirrors the refined
+ * Mockups "Pages" navigator: a collapsible header, compact numbered rows, a
+ * subtle purple highlight + badge on the current row, and (on mobile) a
+ * floating button to re-open the outline once it scrolls out of view.
+ *
+ * The component is presentational/controlled — it surfaces selection via
+ * `onSelect`; the owning renderer pairs it with `useArtifactOutline` for the
+ * scroll-spy (`activeId`) and smooth-scroll/hash behaviour.
+ */
+export function ArtifactOutlineNav({
+    title,
+    items,
+    activeId,
+    activeLabel,
+    defaultExpanded = true,
+    collapseOnSelect = false,
+    onSelect,
+}: ArtifactOutlineNavProps) {
+    const isMobile = useIsMobile();
+    const [expanded, setExpanded] = useState(defaultExpanded);
+
+    const navRef = useRef<HTMLDivElement | null>(null);
+    const [showFloating, setShowFloating] = useState(false);
+
+    // Show the floating re-open control (mobile only) once the outline card has
+    // scrolled out of view — mirrors the Mockups navigator.
+    useEffect(() => {
+        if (typeof IntersectionObserver === 'undefined') return;
+        const el = navRef.current;
+        if (!el) return;
+        const observer = new IntersectionObserver(
+            (entries) => setShowFloating(!entries[0].isIntersecting),
+            { threshold: 0 },
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    if (items.length === 0) return null;
+
+    const activeItem = items.find(i => i.id === activeId) ?? items[0];
+
+    const handleSelect = (id: string) => {
+        onSelect(id);
+        if (collapseOnSelect) setExpanded(false);
+    };
+
+    const handleOpenFloating = () => {
+        setExpanded(true);
+        navRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    const listId = `artifact-outline-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+
+    return (
+        <>
+            <div
+                ref={navRef}
+                className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-hidden"
+            >
+                {/* Collapsible header */}
+                <button
+                    type="button"
+                    onClick={() => setExpanded(prev => !prev)}
+                    className="w-full px-4 py-3 flex items-center justify-between gap-3 text-left hover:bg-neutral-50/60 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset"
+                    aria-expanded={expanded}
+                    aria-controls={listId}
+                >
+                    <span className="inline-flex items-center gap-2 min-w-0 text-sm font-semibold text-neutral-900">
+                        <List size={15} className="text-neutral-500 shrink-0" />
+                        <span className="shrink-0">{title}</span>
+                        <span className="text-neutral-400 font-normal shrink-0">({items.length})</span>
+                        {!expanded && (
+                            <span className="text-neutral-400 font-normal truncate">
+                                · Current: <span className="text-neutral-600">{activeItem.label}</span>
+                            </span>
+                        )}
+                    </span>
+                    {expanded
+                        ? <ChevronDown size={16} className="text-neutral-400 shrink-0" />
+                        : <ChevronRight size={16} className="text-neutral-400 shrink-0" />}
+                </button>
+
+                {expanded && (
+                    <ul
+                        id={listId}
+                        className="border-t border-neutral-100 max-h-[60vh] overflow-y-auto"
+                    >
+                        {items.map((item, idx) => {
+                            const active = item.id === activeId;
+                            return (
+                                <li key={item.id}>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSelect(item.id)}
+                                        aria-current={active ? 'true' : undefined}
+                                        className={`w-full px-4 min-h-[44px] py-2.5 md:min-h-0 md:py-2 flex items-center gap-3 text-left border-l-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset ${
+                                            active
+                                                ? 'border-indigo-500 bg-indigo-50/50'
+                                                : 'border-transparent hover:bg-neutral-50'
+                                        }`}
+                                    >
+                                        <span
+                                            className={`shrink-0 w-6 h-6 rounded-md flex items-center justify-center text-[11px] font-semibold tabular-nums ${
+                                                active
+                                                    ? 'bg-indigo-100 text-indigo-700'
+                                                    : 'bg-neutral-100 text-neutral-500'
+                                            }`}
+                                        >
+                                            {idx + 1}
+                                        </span>
+                                        <span className="flex-1 min-w-0">
+                                            <span className="flex items-center gap-2 min-w-0">
+                                                <span
+                                                    className={`block text-sm font-medium truncate ${
+                                                        active ? 'text-indigo-900' : 'text-neutral-900'
+                                                    }`}
+                                                >
+                                                    {item.label}
+                                                </span>
+                                                {active && (
+                                                    <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-indigo-100 text-indigo-700">
+                                                        {activeLabel}
+                                                    </span>
+                                                )}
+                                            </span>
+                                            {item.description && (
+                                                <span className="block text-xs text-neutral-500 truncate">
+                                                    {item.description}
+                                                </span>
+                                            )}
+                                        </span>
+                                        {item.countLabel && (
+                                            <span className="shrink-0 text-[11px] text-neutral-400 tabular-nums">
+                                                {item.countLabel}
+                                            </span>
+                                        )}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
+
+            {/* Floating re-open control (mobile only). */}
+            {isMobile && showFloating && (
+                <button
+                    type="button"
+                    onClick={handleOpenFloating}
+                    className="md:hidden fixed bottom-5 right-5 z-30 inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-full bg-neutral-900 text-white text-xs font-semibold shadow-lg hover:bg-neutral-800 active:scale-[0.98] transition"
+                    style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.25rem)' }}
+                    aria-label={`Open ${title} outline`}
+                >
+                    <List size={14} />
+                    {title}
+                    <span className="text-[10px] opacity-70 truncate max-w-[7rem]">{activeItem.label}</span>
+                    <ArrowUp size={12} className="opacity-70" />
+                </button>
+            )}
+        </>
+    );
+}

--- a/src/components/__tests__/ArtifactOutlineNav.test.tsx
+++ b/src/components/__tests__/ArtifactOutlineNav.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ArtifactOutlineNav, type ArtifactOutlineItem } from '../ArtifactOutlineNav';
+
+const ITEMS: ArtifactOutlineItem[] = [
+    { id: 'a', label: 'Summary', description: 'Overview' },
+    { id: 'b', label: 'Colors', countLabel: '11 tokens' },
+    { id: 'c', label: 'Typography', countLabel: '5 roles' },
+];
+
+function renderNav(
+    overrides: Partial<React.ComponentProps<typeof ArtifactOutlineNav>> = {},
+) {
+    const props = {
+        title: 'Sections',
+        items: ITEMS,
+        activeId: 'b',
+        activeLabel: 'Current section',
+        onSelect: vi.fn(),
+        ...overrides,
+    };
+    return { props, ...render(<ArtifactOutlineNav {...props} />) };
+}
+
+describe('ArtifactOutlineNav', () => {
+    it('renders rows as accessible buttons with count labels', () => {
+        renderNav();
+        // Each row is a button (not a clickable div).
+        expect(screen.getByRole('button', { name: /Summary/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Colors/ })).toBeInTheDocument();
+        expect(screen.getByText('11 tokens')).toBeInTheDocument();
+    });
+
+    it('marks the active row with aria-current and the active badge', () => {
+        renderNav({ activeId: 'b', activeLabel: 'Current section' });
+        const active = screen.getByRole('button', { name: /Colors/ });
+        expect(active).toHaveAttribute('aria-current', 'true');
+        expect(screen.getByText('Current section')).toBeInTheDocument();
+    });
+
+    it('exposes aria-expanded on the collapsible header and toggles it', () => {
+        renderNav();
+        const header = screen.getByRole('button', { name: /Sections/ });
+        expect(header).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.click(header);
+        expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('calls onSelect with the row id when a row is clicked', () => {
+        const { props } = renderNav();
+        fireEvent.click(screen.getByRole('button', { name: /Typography/ }));
+        expect(props.onSelect).toHaveBeenCalledWith('c');
+    });
+
+    it('collapses after selection when collapseOnSelect is set', () => {
+        renderNav({ collapseOnSelect: true });
+        const header = screen.getByRole('button', { name: /Sections/ });
+        expect(header).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.click(screen.getByRole('button', { name: /Typography/ }));
+        expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('shows the current item in the collapsed header', () => {
+        renderNav({ defaultExpanded: false, activeId: 'a' });
+        // Collapsed header echoes the current selection.
+        expect(screen.getByText('Summary')).toBeInTheDocument();
+        expect(screen.getByText(/Current:/)).toBeInTheDocument();
+    });
+});

--- a/src/components/renderers/DataModelRenderer.tsx
+++ b/src/components/renderers/DataModelRenderer.tsx
@@ -11,7 +11,9 @@ import {
     type ParsedDataModel,
     type ParsedEntity,
 } from '../../lib/services/dataModelMarkdown';
-import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+import { ArtifactOutlineNav, type ArtifactOutlineItem } from '../ArtifactOutlineNav';
+import { useArtifactOutline } from '../../lib/useArtifactOutline';
+import { useIsMobile } from '../../lib/useIsMobile';
 
 interface Props {
     content: string;
@@ -235,7 +237,13 @@ function markEntityGroupsAuto(parsed: ParsedDataModel, sourceMarkdown: string): 
     }
 }
 
+function entityFieldCount(entity: ParsedEntity): number {
+    return entity.fieldGroups.reduce((sum, g) => sum + g.fields.length, 0);
+}
+
 export function DataModelRenderer({ content }: Props) {
+    const isMobile = useIsMobile();
+
     const { parsed, sourceMarkdown } = useMemo(() => {
         const json = tryParseAsJson(content);
         if (json) {
@@ -247,6 +255,20 @@ export function DataModelRenderer({ content }: Props) {
         return { parsed: result, sourceMarkdown: content };
     }, [content]);
 
+    const outlineItems: ArtifactOutlineItem[] = useMemo(() => {
+        if (!parsed) return [];
+        return parsed.entities.map(e => {
+            const count = entityFieldCount(e);
+            return {
+                id: entityAnchorId(e.name),
+                label: e.name,
+                countLabel: `${count} ${count === 1 ? 'field' : 'fields'}`,
+            };
+        });
+    }, [parsed]);
+    const outlineIds = useMemo(() => outlineItems.map(i => i.id), [outlineItems]);
+    const { activeId, scrollTo } = useArtifactOutline(outlineIds);
+
     if (!parsed) {
         return (
             <div className="prose prose-sm prose-neutral max-w-none">
@@ -257,14 +279,18 @@ export function DataModelRenderer({ content }: Props) {
 
     markEntityGroupsAuto(parsed, sourceMarkdown);
 
-    const tabItems: SectionTabItem[] = parsed.entities.map(e => ({
-        id: entityAnchorId(e.name),
-        label: e.name,
-    }));
-
     return (
         <div className="space-y-6">
-            {parsed.entities.length > 3 && <SectionTabs items={tabItems} />}
+            {parsed.entities.length > 1 && (
+                <ArtifactOutlineNav
+                    title="Entities"
+                    items={outlineItems}
+                    activeId={activeId}
+                    activeLabel="Current entity"
+                    collapseOnSelect={isMobile}
+                    onSelect={scrollTo}
+                />
+            )}
 
             {parsed.overview && (
                 <section className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-5">

--- a/src/components/renderers/DesignSystemRenderer.tsx
+++ b/src/components/renderers/DesignSystemRenderer.tsx
@@ -7,7 +7,9 @@ import { AlertTriangle, CheckCircle2 } from 'lucide-react';
 import type { DesignTokens, DesignTypographyToken, DesignComponentToken } from '../../types';
 import { useProjectStore } from '../../store/projectStore';
 import { hashDesignTokens } from '../../lib/designTokens';
-import { SectionTabs, type SectionTabItem } from '../SectionTabs';
+import { ArtifactOutlineNav, type ArtifactOutlineItem } from '../ArtifactOutlineNav';
+import { useArtifactOutline } from '../../lib/useArtifactOutline';
+import { useIsMobile } from '../../lib/useIsMobile';
 
 // Render a `design_system` artifact. The renderer prefers a structured
 // token contract on `metadata.tokens` (new generations) and falls back
@@ -55,20 +57,39 @@ function useTokensFromMetadata(metadata: Record<string, unknown> | undefined): D
 
 // ─── Tokenized renderer ───────────────────────────────────────────────────
 
+function plural(n: number, singular: string, pluralForm = `${singular}s`): string {
+    return `${n} ${n === 1 ? singular : pluralForm}`;
+}
+
 function TokenizedDesignSystem({ tokens, projectId }: { tokens: DesignTokens; projectId?: string }) {
-    const tabs: SectionTabItem[] = [
-        { id: 'ds-summary', label: 'Summary' },
-        { id: 'ds-colors', label: 'Colors' },
-        { id: 'ds-typography', label: 'Typography' },
-        { id: 'ds-spacing', label: 'Spacing & Radius' },
-        { id: 'ds-components', label: 'Components' },
-        { id: 'ds-rules', label: 'Rules' },
-        { id: 'ds-downstream', label: 'Downstream' },
-    ];
+    const isMobile = useIsMobile();
+
+    const items: ArtifactOutlineItem[] = useMemo(() => {
+        const spacingCount = Object.keys(tokens.spacing).length + Object.keys(tokens.radius).length;
+        return [
+            { id: 'ds-summary', label: 'Summary', description: 'Token overview & hash' },
+            { id: 'ds-colors', label: 'Colors', countLabel: plural(Object.keys(tokens.colors).length, 'token') },
+            { id: 'ds-typography', label: 'Typography', countLabel: plural(Object.keys(tokens.typography).length, 'role') },
+            { id: 'ds-spacing', label: 'Spacing & Radius', countLabel: plural(spacingCount, 'token') },
+            { id: 'ds-components', label: 'Components', countLabel: plural(Object.keys(tokens.components).length, 'component') },
+            { id: 'ds-rules', label: 'Rules', countLabel: plural(tokens.rules.length, 'rule') },
+            { id: 'ds-downstream', label: 'Downstream Effects' },
+        ];
+    }, [tokens]);
+
+    const ids = useMemo(() => items.map(i => i.id), [items]);
+    const { activeId, scrollTo } = useArtifactOutline(ids);
 
     return (
         <div className="space-y-6">
-            <SectionTabs items={tabs} />
+            <ArtifactOutlineNav
+                title="Sections"
+                items={items}
+                activeId={activeId}
+                activeLabel="Current section"
+                collapseOnSelect={isMobile}
+                onSelect={scrollTo}
+            />
 
             <Section id="ds-summary" title="Token Summary">
                 <TokenSummary tokens={tokens} />
@@ -810,14 +831,27 @@ function FallbackMarkdown({ body }: { body: string }) {
 }
 
 function LegacyMarkdownDesignSystem({ content }: { content: string }) {
+    const isMobile = useIsMobile();
     const sections = useMemo(() => splitByH3(content), [content]);
-    const tabs: SectionTabItem[] = sections
-        .filter(s => s.title)
-        .map(s => ({ id: `ds-${slug(s.title)}`, label: s.title }));
+    const items: ArtifactOutlineItem[] = useMemo(
+        () => sections.filter(s => s.title).map(s => ({ id: `ds-${slug(s.title)}`, label: s.title })),
+        [sections],
+    );
+    const ids = useMemo(() => items.map(i => i.id), [items]);
+    const { activeId, scrollTo } = useArtifactOutline(ids);
 
     return (
         <div className="space-y-6">
-            <SectionTabs items={tabs} />
+            {items.length > 1 && (
+                <ArtifactOutlineNav
+                    title="Sections"
+                    items={items}
+                    activeId={activeId}
+                    activeLabel="Current section"
+                    collapseOnSelect={isMobile}
+                    onSelect={scrollTo}
+                />
+            )}
             {sections.map((section, i) => {
                 const title = section.title.toLowerCase();
                 let body: React.ReactNode;

--- a/src/lib/useArtifactOutline.ts
+++ b/src/lib/useArtifactOutline.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Shared scroll-spy + smooth-scroll controller for the Artifact Outline
+ * navigation (see `ArtifactOutlineNav`). Both the Design System (sections) and
+ * Data Model (entities) renderers drive their outline through this hook so the
+ * highlight/scroll behaviour stays identical across artifacts.
+ *
+ * - `activeId` tracks the section/entity currently in view via an
+ *   IntersectionObserver (mirrors the Mockups "Pages" navigator), so the
+ *   outline highlight follows the user as they scroll.
+ * - `scrollTo(id)` smooth-scrolls to the matching anchor element (which must
+ *   carry a `scroll-mt-*` class so a non-sticky/collapsed header doesn't cover
+ *   the jump target) and records the id in the URL hash via `history.pushState`
+ *   so browser back/forward steps through visited sections.
+ * - A `popstate` listener re-syncs the active id + scroll position when the
+ *   user navigates back/forward.
+ *
+ * `ids` must be a stable (memoised) array — it keys the observer effect.
+ */
+export function useArtifactOutline(ids: string[], initialId?: string) {
+    const [activeId, setActiveId] = useState<string>(initialId ?? ids[0] ?? '');
+
+    // Scroll-spy: choose the topmost intersecting section as active.
+    useEffect(() => {
+        if (typeof IntersectionObserver === 'undefined') return;
+        const elements = ids
+            .map(id => document.getElementById(id))
+            .filter((el): el is HTMLElement => el != null);
+        if (elements.length === 0) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const visible = entries
+                    .filter(e => e.isIntersecting)
+                    .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+                if (visible.length > 0) setActiveId(visible[0].target.id);
+            },
+            { rootMargin: '-100px 0px -60% 0px', threshold: 0 },
+        );
+        elements.forEach(el => observer.observe(el));
+        return () => observer.disconnect();
+    }, [ids]);
+
+    const scrollTo = useCallback((id: string) => {
+        setActiveId(id);
+        const el = document.getElementById(id);
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            // Preserve browser back/forward across visited sections.
+            if (typeof history !== 'undefined' && typeof history.pushState === 'function') {
+                try {
+                    history.pushState(null, '', `#${id}`);
+                } catch {
+                    // pushState can throw in sandboxed contexts; navigation still works.
+                }
+            }
+        }
+    }, []);
+
+    // Re-sync on back/forward.
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const onPop = () => {
+            const hash = window.location.hash.slice(1);
+            if (!hash || !ids.includes(hash)) return;
+            setActiveId(hash);
+            const el = document.getElementById(hash);
+            if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        };
+        window.addEventListener('popstate', onPop);
+        return () => window.removeEventListener('popstate', onPop);
+    }, [ids]);
+
+    return { activeId, setActiveId, scrollTo };
+}


### PR DESCRIPTION
Replace the wrapping SectionTabs "pill" navigation on the Design System
(sections) and Data Model (entities) artifact pages with a shared,
collapsible Artifact Outline that mirrors the refined Mockups "Pages"
navigator.

- Add `ArtifactOutlineNav` (presentational/controlled): numbered list/card,
  subtle purple active highlight + "Current section/entity" badge, count
  labels, collapsible header with aria-expanded, aria-current on the active
  row, >=44px touch targets on mobile, collapse-on-select + floating re-open
  button on mobile.
- Add `useArtifactOutline` hook: IntersectionObserver scroll-spy, smooth
  scroll, and hash history.pushState so browser back/forward steps through
  sections.
- Wire both renderers (tokenized + legacy Design System, JSON + markdown
  Data Model) to the shared outline; anchors keep their scroll-mt ids and no
  artifact content is removed.
- Add ArtifactOutlineNav tests; update CLAUDE.md.

SectionTabs is retained only for the Implementation Plan renderer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PC69VugcfixzERVkALz9B