### PR TITLE
Unify mockup/screen prompts on a shared design-system brief + add presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,6 +383,38 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       retry, run summary, model, est-vs-actual, and `surface` (mobile/web).
   - `mockupService.ts` + `mockupImageService.ts` — mockup HTML and image
     generation.
+  - **Shared design-system brief (single source of visual truth for image
+    prompts).** `buildDesignSystemBrief(tokens)` (`designTokens/promptSnippet.ts`,
+    replaced the old `tokensToImagePromptBrief`) is the ONE concise-but-complete
+    Design System Brief embedded into every prompt that drives a mockup/screen
+    image. Both the internal gpt-image-2 path (`mockupImageService.buildScreenImagePrompt`)
+    and the user-copied external prompt on the Screen Inventory page
+    (`screenInventoryImageService.buildExternalMockupPrompt`, formerly
+    `buildScreenInventoryImagePrompt`) call it, so an externally generated mockup
+    follows the same visual language as the internal one instead of drifting to a
+    generic "neutral palette" look. The brief covers palette, typography,
+    spacing/density, radius, elevation, button/card/form/modal conventions,
+    navigation, responsive behavior, and accessibility — token data verbatim,
+    the rest as derived conventions. `buildExternalMockupPrompt` takes optional
+    `designTokens` (threaded from `ArtifactWorkspace` via `selectPreferredDesignTokens`
+    into `ScreenImageGalleryContext`); with no design system it falls back to the
+    neutral style hint so legacy projects still get a working prompt. Do **not**
+    re-duplicate design-system prose into a prompt builder — reuse the brief.
+  - **Design System Presets (`src/lib/designSystemPresets.ts`).** A one-time
+    visual-direction choice (`SaaS Minimal`, `AI Workspace`, `Editorial /
+    Learning`, `Developer Tool`, `Consumer Mobile`, `Custom / Generate for me`)
+    surfaced by `DesignSystemPresetChoice` on the Mark-as-Final edge in
+    `ProjectWorkspace` (only when a real project hasn't picked one yet). The
+    chosen id is stored on `Project.designSystemPreset`
+    (`setProjectDesignSystemPreset`) and read at generation time by
+    `artifactJobController.runCoreArtifactSlot` off the project (NOT threaded
+    through every call site) and passed to `generateCoreArtifact`, which injects
+    `getDesignSystemPresetDirective(id)` into the **design_system** prompt only.
+    `custom`/unknown/missing → empty directive → original PRD-only behavior. The
+    preset steers design_system generation and therefore both internal mockups
+    and the external copy-prompt, keeping the project visually consistent. The
+    `DesignSystemRenderer` shows a banner explaining this coupling and that
+    regenerating may shift downstream mockups/screen prompts.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
     implementation_plan, prompt_pack, design_system). **Per-artifact model

--- a/README.md
+++ b/README.md
@@ -143,7 +143,14 @@ feedback event — with diffs where it matters.
 <img width="100%" alt="Mark the PRD as final to generate every downstream asset in parallel" src="public/screenshots/tour-assets.png" />
 
 Mark your PRD as final and Synapse generates all the assets you need to build —
-in parallel, from that single source of truth:
+in parallel, from that single source of truth. Just before generation, you pick
+a **Design System Preset** (SaaS Minimal, AI Workspace, Editorial / Learning,
+Developer Tool, Consumer Mobile, or *Custom / Generate for me*) that sets the
+project's visual direction. The choice is stored on the project and steers the
+**Design System** artifact — and through it, both the internal mockups and the
+prompts you copy for external image tools, so everything stays visually
+consistent. You can regenerate the design system later, but doing so may shift
+your mockups and screen-level prompts.
 
 - **Screen Inventory** and **User Flows**
 - **UI Components** (a searchable, filterable component library with live
@@ -176,6 +183,13 @@ sources (chosen in Settings → **Artifact Generation Models → Mockups**): Ope
 each screen (goal, layout, visual style, expected format) to guide what you
 create and upload. If GPT Image is selected without an OpenAI key, Synapse falls
 back to the upload sheet rather than failing silently.
+
+The Screen Inventory page also offers a **Copy image prompt** action per screen
+for generating a mockup in any external tool. That copied prompt embeds the
+**same** Design System Brief the internal mockups use (palette, typography,
+spacing, radius, component conventions, accessibility) alongside the screen's
+specifics, so externally generated mockups match your project's visual
+language instead of drifting.
 
 #### Integrated feedback loop
 

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -21,6 +21,7 @@ import { TaskChecklist } from './tasks/TaskChecklist';
 import { StalenessBadge } from './StalenessBadge';
 import { VersionHistoryPanel, type VersionEntry } from './versions';
 import { tryParsePayload, extractMockupSettings } from '../lib/mockupParsing';
+import { selectPreferredDesignTokens } from '../lib/designTokens';
 import type {
     ArtifactSlotKey, CoreArtifactSubtype, ProjectPlatform, StructuredPRD, GenerationStatus,
     ProjectTask,
@@ -121,6 +122,10 @@ export function ArtifactWorkspace({
     // Subscribe to tasks so the Implementation Plan button label tracks saved
     // count reactively (the checklist itself reads the store directly).
     const projectTasks = useProjectStore(s => s.tasks[projectId] ?? EMPTY_TASKS);
+    // Active design tokens, so the Screen Inventory copy-prompt embeds the same
+    // Design System Brief the internal mockups use. selectPreferredDesignTokens
+    // is reference-stable per ArtifactVersion, so it's safe inside a selector.
+    const designTokens = useProjectStore(s => selectPreferredDesignTokens(s, projectId));
 
     const slotMetas = useMemo(() => buildSlotMetas(), []);
     const [selected, setSelected] = useState<WorkspaceSelection>('prd');
@@ -379,6 +384,12 @@ export function ArtifactWorkspace({
                 artifactVersionId: preferred.id,
                 productTitle: structuredPRD.productName ?? getProject(projectId)?.name ?? 'this product',
                 productSummary: structuredPRD.executiveSummary ?? structuredPRD.vision,
+                designTokens,
+                platformHint: (projectPlatform === 'app'
+                    ? 'mobile'
+                    : projectPlatform === 'web'
+                        ? 'desktop'
+                        : 'responsive') as 'mobile' | 'desktop' | 'responsive',
             }
             : undefined;
         const promptEdits = subtype === 'prompt_pack'

--- a/src/components/DesignSystemPresetChoice.tsx
+++ b/src/components/DesignSystemPresetChoice.tsx
@@ -1,0 +1,72 @@
+import { X } from 'lucide-react';
+import { DESIGN_SYSTEM_PRESETS } from '../lib/designSystemPresets';
+
+interface DesignSystemPresetChoiceProps {
+    onChoose: (presetId: string) => void;
+    onClose: () => void;
+}
+
+/**
+ * One-time "visual direction" choice shown right before assets are generated
+ * (on Mark as Final). The selected preset is stored on the project and steers
+ * design-system generation — and through it, both the internal mockups and the
+ * prompts users copy for external image tools, so the two stay consistent.
+ *
+ * Responsive: centered dialog on desktop, full-width bottom sheet on mobile —
+ * mirrors PreflightModeChoice.
+ */
+export function DesignSystemPresetChoice({ onChoose, onClose }: DesignSystemPresetChoiceProps) {
+    return (
+        <div
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-end sm:items-center justify-center z-50"
+            onClick={onClose}
+        >
+            <div
+                className="bg-neutral-900 border border-white/10 rounded-t-3xl sm:rounded-3xl w-full sm:max-w-lg max-h-[90vh] overflow-y-auto"
+                style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between px-6 pt-6 pb-2">
+                    <h2 className="text-lg font-semibold text-white">Choose your visual direction</h2>
+                    <button
+                        onClick={onClose}
+                        className="p-2 -mr-2 text-neutral-400 hover:text-white rounded-lg transition"
+                        aria-label="Cancel"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+                <p className="px-6 text-sm text-neutral-400 mb-1">
+                    This sets your project's design system. Internal mockups and the prompts you copy
+                    for external image tools will both follow it, so everything stays visually consistent.
+                </p>
+                <p className="px-6 text-xs text-neutral-500 mb-4">
+                    You can regenerate the design system later, but that may change your mockups and
+                    screen-level prompts.
+                </p>
+                <div className="px-4 pb-5 space-y-2">
+                    {DESIGN_SYSTEM_PRESETS.map(({ id, icon: Icon, label, subtitle, detail }) => (
+                        <button
+                            key={id}
+                            onClick={() => onChoose(id)}
+                            className="w-full text-left flex items-start gap-4 p-4 min-h-[64px] rounded-2xl border border-white/10 bg-white/[0.03] hover:bg-white/[0.07] hover:border-indigo-500/50 transition group"
+                        >
+                            <div className="shrink-0 w-10 h-10 rounded-xl bg-indigo-500/15 text-indigo-300 flex items-center justify-center group-hover:bg-indigo-500/25 transition">
+                                <Icon size={18} />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <span className="font-medium text-white">{label}</span>
+                                    <span className="text-xs text-indigo-300/80 bg-indigo-500/10 px-2 py-0.5 rounded-full">
+                                        {subtitle}
+                                    </span>
+                                </div>
+                                <p className="text-sm text-neutral-400 mt-0.5">{detail}</p>
+                            </div>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -27,6 +27,7 @@ import { SafetyBoundariesCard } from './SafetyBoundariesCard';
 import { PreflightView } from './preflight/PreflightView';
 import { ArtifactWorkspace } from './ArtifactWorkspace';
 import { FinalizationSuccessModal } from './FinalizationSuccessModal';
+import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
 import { CORE_ARTIFACT_DISPLAY_ORDER } from '../lib/coreArtifactPipeline';
 import { HistoryView } from './HistoryView';
 import { VersionHistoryPanel, VersionCompareView, RevertConfirmModal, type VersionEntry } from './versions';
@@ -45,7 +46,7 @@ export function ProjectWorkspace() {
     const navigate = useNavigate();
     const authUser = useAuthStore((s) => s.user);
     const logout = useAuthStore((s) => s.logout);
-    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, editSpineStructuredPRD, revertSpineToVersion, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, getArtifactStaleness, markSpineFinal, setProjectStage, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, getArtifacts, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus } = useProjectStore();
+    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, editSpineStructuredPRD, revertSpineToVersion, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, getArtifactStaleness, markSpineFinal, setProjectStage, setProjectDesignSystemPreset, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, getArtifacts, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus } = useProjectStore();
     const prdProgress = useProjectStore((s) => (projectId ? s.prdProgress[projectId] : undefined));
     const prdSectionStatus = useProjectStore((s) => (projectId ? s.prdSectionStatus[projectId] : undefined));
     // Live asset-generation job for the post-finalize status pill.
@@ -74,6 +75,9 @@ export function ProjectWorkspace() {
     // and selects the first non-PRD artifact on arrival from finalize.
     const [showFinalizeSuccess, setShowFinalizeSuccess] = useState(false);
     const [finalizeAutoOpen, setFinalizeAutoOpen] = useState(false);
+    // Gate shown on the finalize edge when the project hasn't picked a
+    // design-system direction yet. Choosing one stores it, then finalizes.
+    const [showPresetChoice, setShowPresetChoice] = useState(false);
     const overflowRef = useRef<HTMLDivElement>(null);
     const overflowButtonRef = useRef<HTMLButtonElement>(null);
     const overflowMenuRef = useRef<HTMLDivElement>(null);
@@ -460,8 +464,28 @@ export function ProjectWorkspace() {
         // Blocked spines can never advance to the workspace / artifact stage.
         if (activeSpine.safetyReview?.status === 'blocked') return;
         const next = !activeSpine.isFinal;
-        markSpineFinal(projectId, activeSpine.id, next);
-        if (!next) return;
+        if (!next) {
+            // Un-finalizing — just flip the flag, no generation involved.
+            markSpineFinal(projectId, activeSpine.id, false);
+            return;
+        }
+
+        // Finalizing. If this real project will generate assets but hasn't
+        // picked a design-system direction yet, ask first — the choice steers
+        // the design system (and therefore mockups + copied prompts). The demo
+        // never generates and skips straight through.
+        if (activeSpine.structuredPRD && projectId !== DEMO_PROJECT_ID && !project?.designSystemPreset) {
+            setShowPresetChoice(true);
+            return;
+        }
+        finalizeAndGenerate();
+    };
+
+    // Performs the actual finalize + asset kickoff. Split out so it can run
+    // either directly (preset already chosen / demo) or after the preset gate.
+    const finalizeAndGenerate = () => {
+        if (!projectId || !activeSpine) return;
+        markSpineFinal(projectId, activeSpine.id, true);
 
         // Kick off artifact generation immediately so assets are underway
         // while the success modal is visible. We deliberately do NOT switch
@@ -477,6 +501,15 @@ export function ProjectWorkspace() {
             });
         }
         setShowFinalizeSuccess(true);
+    };
+
+    const handleChooseDesignSystemPreset = (presetId: string) => {
+        if (!projectId) return;
+        // Persist the choice synchronously so the generation pipeline reads it
+        // off the project when design_system runs.
+        setProjectDesignSystemPreset(projectId, presetId);
+        setShowPresetChoice(false);
+        finalizeAndGenerate();
     };
 
     // "Open Assets" from the success modal: navigate to the Assets stage and
@@ -653,6 +686,12 @@ export function ProjectWorkspace() {
                 </div>
             </div>
 
+            {showPresetChoice && (
+                <DesignSystemPresetChoice
+                    onChoose={handleChooseDesignSystemPreset}
+                    onClose={() => setShowPresetChoice(false)}
+                />
+            )}
             {showFinalizeSuccess && (
                 <FinalizationSuccessModal
                     assetsReady={assetsReady}

--- a/src/components/renderers/DesignSystemRenderer.tsx
+++ b/src/components/renderers/DesignSystemRenderer.tsx
@@ -6,6 +6,7 @@ import rehypeRaw from 'rehype-raw';
 import { AlertTriangle, CheckCircle2 } from 'lucide-react';
 import type { DesignTokens, DesignTypographyToken, DesignComponentToken } from '../../types';
 import { useProjectStore } from '../../store/projectStore';
+import { getDesignSystemPresetLabel } from '../../lib/designSystemPresets';
 import { ArtifactOutlineNav, type ArtifactOutlineItem } from '../ArtifactOutlineNav';
 import { useArtifactOutline } from '../../lib/useArtifactOutline';
 import { useIsMobile } from '../../lib/useIsMobile';
@@ -88,6 +89,8 @@ function TokenizedDesignSystem({ tokens, projectId }: { tokens: DesignTokens; pr
                 onSelect={scrollTo}
             />
 
+            <DesignDirectionNote projectId={projectId} />
+
             <Section id="ds-colors" title="Color Tokens">
                 <ColorTokens tokens={tokens} />
             </Section>
@@ -111,6 +114,28 @@ function TokenizedDesignSystem({ tokens, projectId }: { tokens: DesignTokens; pr
             <Section id="ds-downstream" title="Downstream Usage">
                 <DownstreamUsage projectId={projectId} />
             </Section>
+        </div>
+    );
+}
+
+// Explains the design system's role as the project's single visual source of
+// truth: internal mockups and the prompts users copy for external image tools
+// both follow it, and regenerating it can shift those downstream assets. Shows
+// the chosen preset direction when one was set.
+function DesignDirectionNote({ projectId }: { projectId?: string }) {
+    const presetId = useProjectStore(s => (projectId ? s.projects[projectId]?.designSystemPreset : undefined));
+    const presetLabel = getDesignSystemPresetLabel(presetId);
+    return (
+        <div className="rounded-lg border border-indigo-200 bg-indigo-50/60 px-4 py-3 text-xs text-indigo-900">
+            <p>
+                <span className="font-semibold">This design system is your project's visual source of truth.</span>{' '}
+                Internal mockups and the prompts you copy for external image tools both follow it, so they
+                stay consistent.
+                {presetLabel ? <> Direction: <span className="font-medium">{presetLabel}</span>.</> : null}
+            </p>
+            <p className="mt-1 text-indigo-700/90">
+                Regenerating the design system may change your mockups and screen-level prompts.
+            </p>
         </div>
     );
 }

--- a/src/components/renderers/ScreenImageGallery.tsx
+++ b/src/components/renderers/ScreenImageGallery.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Copy, Check, Upload, Image as ImageIcon, X, AlertTriangle, Loader2 } from 'lucide-react';
-import type { ScreenItem } from '../../types';
+import type { DesignTokens, ScreenItem } from '../../types';
 import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
-import { buildScreenInventoryImagePrompt } from '../../lib/services/screenInventoryImageService';
+import { buildExternalMockupPrompt } from '../../lib/services/screenInventoryImageService';
 import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
 
 export interface ScreenImageGalleryContext {
@@ -11,6 +11,14 @@ export interface ScreenImageGalleryContext {
     artifactVersionId: string;
     productTitle: string;
     productSummary: string;
+    /**
+     * Active project design system tokens, when present. Threaded into the
+     * copied external prompt so it matches the internal mockup's visual
+     * language. Optional — legacy projects / pre-design-system states omit it.
+     */
+    designTokens?: DesignTokens;
+    /** Platform hint for the rendered mockup (app → mobile, web → desktop). */
+    platformHint?: 'mobile' | 'desktop' | 'responsive';
 }
 
 interface Props {
@@ -19,7 +27,7 @@ interface Props {
 }
 
 export function ScreenImageGallery({ screen, context }: Props) {
-    const { projectId, artifactId, artifactVersionId, productTitle, productSummary } = context;
+    const { projectId, artifactId, artifactVersionId, productTitle, productSummary, designTokens, platformHint } = context;
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [copied, setCopied] = useState(false);
     const [lightboxKey, setLightboxKey] = useState<string | null>(null);
@@ -43,7 +51,7 @@ export function ScreenImageGallery({ screen, context }: Props) {
     const setPreferred = useScreenInventoryImageStore(s => s.setPreferred);
     const clearError = useScreenInventoryImageStore(s => s.clearError);
 
-    const prompt = buildScreenInventoryImagePrompt(screen, { productTitle, productSummary });
+    const prompt = buildExternalMockupPrompt(screen, { productTitle, productSummary, designTokens, platformHint });
     const preferred = versions.find(v => v.isPreferred);
     const lightboxRecord = lightboxKey ? versions.find(v => v.key === lightboxKey) : null;
 

--- a/src/lib/__tests__/designSystemPresets.test.ts
+++ b/src/lib/__tests__/designSystemPresets.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DESIGN_SYSTEM_PRESETS,
+    getDesignSystemPreset,
+    getDesignSystemPresetDirective,
+    getDesignSystemPresetLabel,
+} from '../designSystemPresets';
+
+describe('design system presets', () => {
+    it('exposes the six expected presets including a custom option', () => {
+        const ids = DESIGN_SYSTEM_PRESETS.map(p => p.id);
+        expect(ids).toEqual([
+            'saas_minimal',
+            'ai_workspace',
+            'editorial_learning',
+            'developer_tool',
+            'consumer_mobile',
+            'custom',
+        ]);
+    });
+
+    it('returns a non-empty steering directive for concrete presets', () => {
+        const directive = getDesignSystemPresetDirective('saas_minimal');
+        expect(directive.length).toBeGreaterThan(20);
+        expect(directive).toMatch(/SaaS/i);
+    });
+
+    it('returns an empty directive for custom / unknown / missing ids (no steering)', () => {
+        expect(getDesignSystemPresetDirective('custom')).toBe('');
+        expect(getDesignSystemPresetDirective('does-not-exist')).toBe('');
+        expect(getDesignSystemPresetDirective(undefined)).toBe('');
+    });
+
+    it('resolves preset metadata and labels', () => {
+        expect(getDesignSystemPreset('ai_workspace')?.label).toBe('AI Workspace');
+        expect(getDesignSystemPresetLabel('developer_tool')).toBe('Developer Tool');
+        // Unknown id falls back to the raw id rather than throwing.
+        expect(getDesignSystemPresetLabel('mystery')).toBe('mystery');
+        expect(getDesignSystemPresetLabel(undefined)).toBeUndefined();
+    });
+});

--- a/src/lib/__tests__/designTokens.test.ts
+++ b/src/lib/__tests__/designTokens.test.ts
@@ -5,7 +5,7 @@ import {
     tokensToCssVariables,
     tokensToCssStyleBlock,
     tokensToPromptSnippet,
-    tokensToImagePromptBrief,
+    buildDesignSystemBrief,
     designSystemTokensToMarkdown,
 } from '../designTokens';
 
@@ -177,13 +177,32 @@ describe('tokensToPromptSnippet', () => {
     });
 });
 
-describe('tokensToImagePromptBrief', () => {
+describe('buildDesignSystemBrief', () => {
     it('includes palette and typography descriptions', () => {
         const tokens = normalizeDesignTokens({});
-        const brief = tokensToImagePromptBrief(tokens);
+        const brief = buildDesignSystemBrief(tokens);
         expect(brief).toMatch(/brand\.primary/);
-        expect(brief).toMatch(/Heading typography/);
-        expect(brief).toMatch(/brand\.primary/);
+        expect(brief).toMatch(/[Tt]ypography/);
+    });
+
+    it('covers the core design-system aspects without ballooning in length', () => {
+        const tokens = normalizeDesignTokens({});
+        const brief = buildDesignSystemBrief(tokens);
+        // Completeness: each listed aspect is represented.
+        expect(brief).toMatch(/Color palette/i);
+        expect(brief).toMatch(/typography/i);
+        expect(brief).toMatch(/density/i);
+        expect(brief).toMatch(/radius/i);
+        expect(brief).toMatch(/[Ee]levation|shadow/);
+        expect(brief).toMatch(/button/i);
+        expect(brief).toMatch(/[Cc]ards?/);
+        expect(brief).toMatch(/[Ff]orms?/);
+        expect(brief).toMatch(/[Mm]odals?/);
+        expect(brief).toMatch(/[Nn]avigation/);
+        expect(brief).toMatch(/[Rr]esponsive/);
+        expect(brief).toMatch(/[Aa]ccessibility|WCAG/);
+        // Conciseness: a brief, not a spec dump.
+        expect(brief.length).toBeLessThan(1600);
     });
 });
 

--- a/src/lib/__tests__/externalMockupPrompt.test.ts
+++ b/src/lib/__tests__/externalMockupPrompt.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import type { MockupPayload, MockupScreen, MockupSettings, ScreenItem } from '../../types';
+import { buildExternalMockupPrompt } from '../services/screenInventoryImageService';
+import { buildScreenImagePrompt } from '../services/mockupImageService';
+import { buildDesignSystemBrief } from '../designTokens';
+import { normalizeDesignTokens } from '../designTokens/normalize';
+
+const screen: ScreenItem = {
+    name: 'Triage Queue',
+    priority: 'P0',
+    purpose: 'Review urgent patient cases and assign a triage owner.',
+    userIntent: 'Find the most urgent case quickly.',
+    coreUIElements: ['Case list table', 'Urgency filter', 'Assign owner CTA'],
+    entryPoints: ['Dashboard'],
+    exitPaths: [{ label: 'Open case', target: 'Case Detail' }],
+    states: [
+        { name: 'Empty', description: 'No cases in queue' },
+        { name: 'Loading', description: 'Fetching cases' },
+    ],
+};
+
+const context = {
+    productTitle: 'ClinicFlow',
+    productSummary: 'Coordinate clinic intake and triage decisions in one place.',
+    platformHint: 'desktop' as const,
+};
+
+// A design system distinctive enough that its values appear verbatim.
+const tokens = normalizeDesignTokens({
+    colors: { 'brand.primary': '#FF5722', 'surface.app': '#101418' },
+    typography: { 'heading.lg': { font: 'Outfit', size: 30, weight: 800, lineHeight: 1.2 } },
+});
+
+describe('buildExternalMockupPrompt (Screen Inventory copy prompt)', () => {
+    it('includes the Design System Brief when design tokens are available', () => {
+        const prompt = buildExternalMockupPrompt(screen, { ...context, designTokens: tokens });
+        // The shared brief content is embedded verbatim.
+        expect(prompt).toContain(buildDesignSystemBrief(tokens));
+        // And concrete design-system values flow through.
+        expect(prompt).toContain('#FF5722');
+        expect(prompt).toContain('Outfit');
+        // It should NOT keep the generic "neutral palette" claim that would
+        // contradict the design system.
+        expect(prompt).not.toContain('neutral palette with one accent color');
+    });
+
+    it('still produces a usable prompt when no design system exists', () => {
+        const prompt = buildExternalMockupPrompt(screen, context);
+        // Falls back to the generic neutral style hint.
+        expect(prompt).toContain('neutral palette with one accent color');
+        // No design-system brief leakage.
+        expect(prompt).not.toContain('Follow this design system exactly');
+        // Still a complete, grounded prompt.
+        expect(prompt).toContain('UI mockup of "Triage Queue"');
+        expect(prompt).toContain('ClinicFlow');
+    });
+
+    it('preserves all the screen-specific context', () => {
+        const prompt = buildExternalMockupPrompt(screen, { ...context, designTokens: tokens });
+        expect(prompt).toContain('Triage Queue');                       // screen name
+        expect(prompt).toContain('Review urgent patient cases');        // purpose
+        expect(prompt).toContain('Find the most urgent case quickly');  // user intent
+        expect(prompt).toContain('Coordinate clinic intake');           // product context
+        expect(prompt).toContain('Case list table');                    // key UI elements
+        expect(prompt).toContain('reachable from Dashboard');           // navigation (entry)
+        expect(prompt).toContain('navigates to Case Detail');           // navigation (exit)
+        expect(prompt).toContain('desktop web app screen');             // responsive target
+        expect(prompt).toContain('Empty');                              // alternate states
+        expect(prompt).toContain('Loading');
+    });
+
+    it('stays concise — not an enormous prompt', () => {
+        const prompt = buildExternalMockupPrompt(screen, { ...context, designTokens: tokens });
+        // A complete spec, but nowhere near the wall-of-text the full
+        // `tokensToPromptSnippet` catalog would produce for an image tool.
+        expect(prompt.length).toBeLessThan(2400);
+    });
+});
+
+describe('shared design-system source across mockup paths', () => {
+    it('internal mockup and external screen prompts embed the same brief', () => {
+        const mockupScreen: MockupScreen = {
+            id: 's1',
+            name: 'Triage Queue',
+            purpose: 'Review urgent patient cases and assign a triage owner.',
+            priority: 'P0',
+            coreUIElements: ['Case list table'],
+        };
+        const payload: MockupPayload = {
+            version: 'mockup_spec_v1',
+            title: 'ClinicFlow',
+            summary: 'Coordinate clinic intake and triage decisions in one place.',
+            screens: [mockupScreen],
+        };
+        const settings: MockupSettings = { platform: 'desktop', fidelity: 'mid', scope: 'multi_screen' };
+
+        const internalPrompt = buildScreenImagePrompt(payload, mockupScreen, settings, tokens);
+        const externalPrompt = buildExternalMockupPrompt(screen, { ...context, designTokens: tokens });
+
+        const brief = buildDesignSystemBrief(tokens);
+        expect(internalPrompt).toContain(brief);
+        expect(externalPrompt).toContain(brief);
+    });
+});

--- a/src/lib/designSystemPresets.ts
+++ b/src/lib/designSystemPresets.ts
@@ -1,0 +1,109 @@
+// Design System Presets — a one-time visual-direction choice made before
+// artifact generation. The selected preset id is stored on the Project
+// (`Project.designSystemPreset`) and read at design-system generation time
+// (`coreArtifactService` via `artifactJobController`) so that every downstream
+// consumer — internal mockups, the Screen Inventory copy-prompt, uploaded
+// external mockups — stays anchored to the same visual language.
+//
+// Presets only *steer* generation; the Gemini design-system pass still adapts
+// the chosen direction to the product's domain and audience. "Custom /
+// Generate for me" carries an empty directive, preserving the original
+// PRD-only behavior for users who'd rather let the model decide.
+
+import type { LucideIcon } from 'lucide-react';
+import { LayoutGrid, Sparkles, BookOpen, Terminal, Smartphone, Wand2 } from 'lucide-react';
+
+export interface DesignSystemPreset {
+    /** Stable id persisted on the project. Never rename — older projects store it. */
+    id: string;
+    /** Short label shown in the picker. */
+    label: string;
+    /** Tiny tag shown beside the label. */
+    subtitle: string;
+    /** One-line description for the picker card. */
+    detail: string;
+    /** Picker icon. */
+    icon: LucideIcon;
+    /**
+     * Direction injected into the design-system generation prompt. Empty for
+     * "Custom / Generate for me" (no steering → original behavior).
+     */
+    directive: string;
+}
+
+export const DESIGN_SYSTEM_PRESETS: DesignSystemPreset[] = [
+    {
+        id: 'saas_minimal',
+        label: 'SaaS Minimal',
+        subtitle: 'Clean B2B',
+        detail: 'Restrained, professional, whitespace-forward. Great for dashboards and admin tools.',
+        icon: LayoutGrid,
+        directive:
+            'Adopt a restrained, professional B2B SaaS aesthetic: a neutral grayscale surface system with a single confident brand accent, generous whitespace, crisp ~1px borders, small-to-medium radii (6–10px), and a clean sans-serif UI face (Inter or system-ui). Subtle, low shadows. Prioritize clarity, legibility, and density over decoration.',
+    },
+    {
+        id: 'ai_workspace',
+        label: 'AI Workspace',
+        subtitle: 'Modern, focused',
+        detail: 'Calm dark-or-light surfaces, a vivid accent, soft depth. Suits assistants and agent tools.',
+        icon: Sparkles,
+        directive:
+            'Adopt a modern AI-workspace aesthetic: calm, slightly cool neutral surfaces with one vivid, saturated brand accent (e.g. indigo/violet/teal) reserved for primary actions and active states. Soft, layered elevation, medium radii (10–16px), a contemporary geometric sans (Inter, Outfit, or Manrope). Focused and uncluttered, with clear hierarchy for conversational/canvas layouts.',
+    },
+    {
+        id: 'editorial_learning',
+        label: 'Editorial / Learning',
+        subtitle: 'Readable, warm',
+        detail: 'Reading-first typography, warm neutrals, comfortable rhythm. For content and courses.',
+        icon: BookOpen,
+        directive:
+            'Adopt an editorial, reading-first aesthetic: warm off-white/paper neutrals, a comfortable serif or humanist-sans for body text with strong typographic hierarchy, generous line-height and spacing, and a single muted accent for links and actions. Soft or minimal shadows, gentle radii (4–8px). Optimize for sustained reading and content density without crowding.',
+    },
+    {
+        id: 'developer_tool',
+        label: 'Developer Tool',
+        subtitle: 'Dense, technical',
+        detail: 'Dark-leaning, monospace accents, compact spacing. For IDEs, CLIs, and infra UIs.',
+        icon: Terminal,
+        directive:
+            'Adopt a developer-tool aesthetic: dark-leaning, high-contrast neutral surfaces with a precise functional accent (often green/blue/amber), compact spacing for information density, small radii (2–6px), and a monospace face for code, identifiers, and data. Minimal, sharp shadows. Favor legibility of dense technical content and status/state colors over visual flourish.',
+    },
+    {
+        id: 'consumer_mobile',
+        label: 'Consumer Mobile',
+        subtitle: 'Bold, friendly',
+        detail: 'Vivid color, rounded shapes, big tap targets. For lifestyle and social apps.',
+        icon: Smartphone,
+        directive:
+            'Adopt a consumer-mobile aesthetic: vivid, friendly color with a high-energy brand accent, large rounded shapes (16–24px radii), bold rounded sans typography, generous tap targets, and playful but tasteful elevation. Mobile-first layouts with prominent primary actions. Energetic and approachable while staying accessible.',
+    },
+    {
+        id: 'custom',
+        label: 'Custom / Generate for me',
+        subtitle: 'AI decides',
+        detail: "Let Synapse design the system from your PRD's domain and audience.",
+        icon: Wand2,
+        directive: '',
+    },
+];
+
+const PRESETS_BY_ID = new Map(DESIGN_SYSTEM_PRESETS.map(p => [p.id, p]));
+
+export function getDesignSystemPreset(id?: string): DesignSystemPreset | undefined {
+    if (!id) return undefined;
+    return PRESETS_BY_ID.get(id);
+}
+
+/**
+ * Resolve the prompt directive for a preset id. Returns '' for unknown ids,
+ * a missing id, or the explicit "custom" preset — in all of which cases the
+ * design-system prompt is left unchanged.
+ */
+export function getDesignSystemPresetDirective(id?: string): string {
+    return getDesignSystemPreset(id)?.directive ?? '';
+}
+
+/** Human label for a stored preset id (falls back to the raw id). */
+export function getDesignSystemPresetLabel(id?: string): string | undefined {
+    return id ? (getDesignSystemPreset(id)?.label ?? id) : undefined;
+}

--- a/src/lib/designTokens/index.ts
+++ b/src/lib/designTokens/index.ts
@@ -1,7 +1,7 @@
 export { normalizeDesignTokens } from './normalize';
 export { hashDesignTokens } from './hash';
 export { tokensToCssVariables, tokensToCssStyleBlock } from './cssVariables';
-export { tokensToPromptSnippet, tokensToImagePromptBrief } from './promptSnippet';
+export { tokensToPromptSnippet, buildDesignSystemBrief } from './promptSnippet';
 export { designSystemTokensToMarkdown } from './markdownRenderer';
 export {
     selectPreferredDesignSystem,

--- a/src/lib/designTokens/promptSnippet.ts
+++ b/src/lib/designTokens/promptSnippet.ts
@@ -75,23 +75,63 @@ export function tokensToPromptSnippet(tokens: DesignTokens): string {
 }
 
 /**
- * Shorter image-prompt-friendly token brief for AI image mockups
- * (gpt-image-2). Image generation prompts tolerate far less structured
- * markdown — keep this terse.
+ * Concise-but-complete "Design System Brief" — the SINGLE source of design
+ * direction for every prompt that drives a mockup/screen image, whether it
+ * is the internal gpt-image-2 path (`buildScreenImagePrompt`) or the
+ * user-copied external prompt on the Screen Inventory page
+ * (`buildExternalMockupPrompt`). Both call this so an externally generated
+ * mockup follows the same visual language as the internal one.
+ *
+ * Token data (colors, typography, spacing, radius, component recipes, rules)
+ * comes straight from the design system. Aspects the token contract does not
+ * encode — elevation, navigation styling, responsive behavior, accessibility
+ * — are expressed as sensible, derived conventions so the brief reads as a
+ * complete spec without bloating into a wall of text. Kept terse on purpose:
+ * image models tolerate far less structured prose than text models.
  */
-export function tokensToImagePromptBrief(tokens: DesignTokens): string {
+export function buildDesignSystemBrief(tokens: DesignTokens): string {
     const palette = Object.entries(tokens.colors)
-        .filter(([key]) => /^(brand|surface|text|state)\./.test(key))
+        .filter(([key]) => /^(brand|surface|text|state|border)\./.test(key))
         .sort((a, b) => a[0].localeCompare(b[0]))
         .map(([key, hex]) => `${key} ${hex}`)
         .join(', ');
+
     const headingFont = tokens.typography['heading.lg']?.font ?? tokens.typography['heading.md']?.font ?? 'sans-serif';
+    const headingWeight = tokens.typography['heading.lg']?.weight ?? tokens.typography['heading.md']?.weight ?? 700;
     const bodyFont = tokens.typography['body.md']?.font ?? 'sans-serif';
+    const bodySize = tokens.typography['body.md']?.size ?? 16;
+
     const radiusMd = tokens.radius.md ?? 8;
+    const spacingMd = tokens.spacing.md ?? 16;
+    const density = spacingMd <= 8
+        ? 'compact, information-dense'
+        : spacingMd >= 20
+            ? 'spacious and airy'
+            : 'comfortable and balanced';
+
+    const button = tokens.components['button.primary'];
+    const card = tokens.components['card.default'];
+    const buttonLine = button
+        ? `Primary buttons: background ${button.background ?? 'brand.primary'}, text ${button.text ?? 'on the brand color'}, radius ${button.radius ?? 'md'}.`
+        : `Primary buttons filled with brand.primary, ~${radiusMd}px corners.`;
+    const cardLine = card
+        ? `Cards: background ${card.background ?? 'surface.card'}, border ${card.border ?? 'border.subtle'}, radius ${card.radius ?? 'md'}.`
+        : `Cards: surface.card background with a subtle border.`;
+
+    const rules = tokens.rules.slice(0, 4).join(' ');
+
     return [
-        `You MUST follow this design system exactly: palette ${palette}.`,
-        `Heading typography: ${headingFont}. Body typography: ${bodyFont}.`,
-        `Corner radius around ${radiusMd}px on cards and buttons.`,
-        `Primary actions in brand.primary; do not introduce additional accent colors.`,
-    ].join(' ');
+        'Follow this design system exactly — do not invent unrelated colors, fonts, or styling.',
+        `Color palette: ${palette}.`,
+        `Typography: headings in ${headingFont} (weight ${headingWeight}), body in ${bodyFont} (~${bodySize}px).`,
+        `Density: ${density}, ${spacingMd}px base spacing; ~${radiusMd}px radius on buttons, inputs, cards, and modals.`,
+        'Elevation: soft, subtle shadows lift cards and modals off the surface — no heavy drop shadows.',
+        buttonLine,
+        'Secondary buttons are outlined/low-emphasis — never a second brand color.',
+        cardLine,
+        'Forms: labelled inputs, subtle borders, comfortable hit areas, visible focus. Modals: surface.card panels over a dimmed backdrop matching card radius/elevation.',
+        'Navigation: consistent bars/menus using the text colors, brand.primary for the active item.',
+        'Responsive: reflow cleanly between mobile and desktop, no horizontal scroll. Accessibility: WCAG AA contrast, visible focus ring, tap targets ≥44px.',
+        rules ? `Rules: ${rules}` : '',
+    ].filter(Boolean).join(' ');
 }

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -162,9 +162,14 @@ async function runCoreArtifactSlot(
             attempt: (store.getSlot(projectId, subtype)?.attempt ?? 0) + 1,
             progressLog: [],
         });
+        // Read the chosen design-system preset off the project here (rather than
+        // threading it through every startAll/regenerate/resume call site) so
+        // ALL generation paths consistently honor it. Only design_system uses it.
+        const designSystemPreset = store.getProject(projectId)?.designSystemPreset;
         const result = await generateCoreArtifact(subtype, prdContent, structuredPRD, {
             generatedArtifacts,
             signal,
+            designSystemPreset,
             onProgress: (msg) => useProjectStore.getState().appendSlotProgress(projectId, subtype, msg),
         });
         content = result.content;

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -12,6 +12,7 @@ import {
     hashDesignTokens,
     designSystemTokensToMarkdown,
 } from '../designTokens';
+import { getDesignSystemPresetDirective } from '../designSystemPresets';
 
 export interface CoreArtifactGenerationResult {
     /** Canonical markdown body, stored in `ArtifactVersion.content`. */
@@ -394,6 +395,12 @@ export const generateCoreArtifact = async (
         generatedArtifacts?: Partial<Record<CoreArtifactSubtype, string>>;
         signal?: AbortSignal;
         onProgress?: (message: string) => void;
+        /**
+         * The project's chosen design-system preset id (see
+         * DESIGN_SYSTEM_PRESETS). Consumed only by the `design_system` subtype;
+         * other subtypes ignore it. Absent/unknown/'custom' → no steering.
+         */
+        designSystemPreset?: string;
     },
 ): Promise<CoreArtifactGenerationResult> => {
     const config = CORE_ARTIFACT_PROMPTS[subtype];
@@ -437,6 +444,16 @@ Architecture: ${structuredPRD.architecture}${
         ? `\n\n---\n\nMockup Context (reference for screens, components, and layout):\n${options.mockupContext.slice(0, 3000)}`
         : '';
 
+    // Design-system preset steering. Only the design_system subtype consumes
+    // it; an absent/unknown/'custom' preset yields '' (no steering → original
+    // PRD-only behavior). The model still adapts the direction to the domain.
+    const presetDirective = subtype === 'design_system'
+        ? getDesignSystemPresetDirective(options?.designSystemPreset)
+        : '';
+    const presetSection = presetDirective
+        ? `\n\n---\n\nSELECTED DESIGN DIRECTION (the user explicitly chose this preset — honor it while still fitting the product's domain and audience):\n${presetDirective}\n\nEnsure your token choices (palette, typography, radius, spacing, component recipes) clearly reflect this direction, and include one \`rules\` entry that names the resulting design direction and briefly explains why it fits this product.`
+        : '';
+
     // Use JSON mode for supported artifact types
     const jsonSchemas: Partial<Record<CoreArtifactSubtype, object>> = {
         screen_inventory: screenInventorySchema,
@@ -446,7 +463,7 @@ Architecture: ${structuredPRD.architecture}${
         implementation_plan: implementationPlanSchema,
     };
 
-    const userPrompt = `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`;
+    const userPrompt = `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}${presetSection}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`;
 
     // Cap progress messages at ~3/s; emit every 250 chars OR 350ms to keep the
     // UI feeling alive without thrashing the store.

--- a/src/lib/services/mockupImageService.ts
+++ b/src/lib/services/mockupImageService.ts
@@ -3,7 +3,7 @@
 // store can stay thin.
 
 import type { DesignTokens, MockupPayload, MockupScreen, MockupSettings, MockupPlatform } from '../../types';
-import { tokensToImagePromptBrief } from '../designTokens';
+import { buildDesignSystemBrief } from '../designTokens';
 
 const FIDELITY_STYLE_HINTS: Record<string, string> = {
     low: 'low-fidelity wireframe, neutral grey palette, simple rectangular placeholders and labels, sketch-style linework, no imagery',
@@ -53,7 +53,7 @@ export const buildScreenImagePrompt = (
     const userStyle = settings.style?.trim();
     const styleSuffix = userStyle ? ` Visual direction: ${userStyle}.` : '';
     const tokenBrief = designTokens
-        ? ` ${tokensToImagePromptBrief(designTokens)}`
+        ? ` ${buildDesignSystemBrief(designTokens)}`
         : '';
 
     const intentLine = screen.userIntent

--- a/src/lib/services/screenInventoryImageService.ts
+++ b/src/lib/services/screenInventoryImageService.ts
@@ -4,7 +4,8 @@
 // onto the screen card. No API calls happen in here — this module is
 // strictly prompt assembly so the renderer / store stay thin.
 
-import type { ScreenItem } from '../../types';
+import type { DesignTokens, ScreenItem } from '../../types';
+import { buildDesignSystemBrief } from '../designTokens';
 
 interface ScreenImagePromptContext {
     /** Product title for grounding the mockup. */
@@ -13,6 +14,15 @@ interface ScreenImagePromptContext {
     productSummary: string;
     /** Optional platform hint — defaults to "responsive web app screen". */
     platformHint?: 'mobile' | 'desktop' | 'responsive';
+    /**
+     * The project's active Design System tokens, when available. When present
+     * the prompt embeds a concise Design System Brief (the SAME brief the
+     * internal gpt-image-2 mockup path uses) so externally generated mockups
+     * follow the project's intended visual language instead of drifting to a
+     * generic "neutral palette" look. Legacy projects without a design system
+     * still get a complete, working prompt.
+     */
+    designTokens?: DesignTokens;
 }
 
 const PLATFORM_HINTS: Record<NonNullable<ScreenImagePromptContext['platformHint']>, string> = {
@@ -26,11 +36,16 @@ const PLATFORM_HINTS: Record<NonNullable<ScreenImagePromptContext['platformHint'
  * row. Tool-agnostic — the same string works in any modern image model
  * (Nano Banana / Gemini Imagen, GPT image, Midjourney, etc.).
  *
- * The structure mirrors `buildScreenImagePrompt` in `mockupImageService.ts`
- * but works from the screen-inventory data shape (which has no
- * `MockupSettings`), so we use sensible defaults for fidelity and platform.
+ * Two halves, neither duplicated elsewhere:
+ *   - Screen context (name, purpose, intent, product framing, key UI
+ *     elements, navigation, state, responsive target, alternate states)
+ *     drawn from the screen-inventory data shape.
+ *   - A Design System Brief from `buildDesignSystemBrief` — the SAME shared
+ *     source the internal mockup image path uses — so the two stay visually
+ *     consistent. Omitted only when the project has no design system yet, in
+ *     which case a neutral fallback style hint keeps the prompt usable.
  */
-export const buildScreenInventoryImagePrompt = (
+export const buildExternalMockupPrompt = (
     screen: ScreenItem,
     context: ScreenImagePromptContext,
 ): string => {
@@ -59,6 +74,16 @@ export const buildScreenInventoryImagePrompt = (
         ? `Render the default / primary state. Other states modeled: ${screen.states.map(s => s.name).join(', ')}.`
         : '';
 
+    // When the project has a design system, the brief dictates the palette,
+    // typography, radius, etc. — so we drop the generic "neutral palette with
+    // one accent color" claim that would otherwise contradict it. Without a
+    // design system we keep that neutral fallback so the prompt still works.
+    const tokens = context.designTokens;
+    const styleLine = tokens
+        ? `Style: mid-fidelity flat UI mockup, structured layout with clear visual hierarchy, no decorative imagery.`
+        : `Style: mid-fidelity flat UI mockup, structured layout with clear visual hierarchy, neutral palette with one accent color, no decorative imagery.`;
+    const designBriefLine = tokens ? buildDesignSystemBrief(tokens) : '';
+
     return [
         `UI mockup of "${screen.name}" for the product "${context.productTitle}".`,
         `Screen purpose: ${screen.purpose}`,
@@ -68,7 +93,8 @@ export const buildScreenInventoryImagePrompt = (
         navLine,
         stateLine,
         `Render as a ${platform}.`,
-        `Style: mid-fidelity flat UI mockup, structured layout with clear visual hierarchy, neutral palette with one accent color, no decorative imagery.`,
+        styleLine,
+        designBriefLine,
         `Avoid lorem ipsum — use realistic placeholder copy that fits the screen purpose.`,
         `No watermarks, no logos of real companies, no photographic people.`,
     ].filter(Boolean).join(' ');

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -20,6 +20,7 @@ export type ProjectSlice = {
     getProject: ProjectState['getProject'];
     getHistoryEvents: ProjectState['getHistoryEvents'];
     setProjectStage: ProjectState['setProjectStage'];
+    setProjectDesignSystemPreset: ProjectState['setProjectDesignSystemPreset'];
     loadDemoProject: ProjectState['loadDemoProject'];
 };
 
@@ -122,6 +123,19 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             }
         }));
         void trackActivity(stage === 'mockups' ? 'viewed_mockups' : 'clicked_section', { section: stage, projectId });
+    },
+
+    setProjectDesignSystemPreset: (projectId: string, presetId: string) => {
+        set((state) => {
+            const project = state.projects[projectId];
+            if (!project) return state;
+            return {
+                projects: {
+                    ...state.projects,
+                    [projectId]: { ...project, designSystemPreset: presetId },
+                },
+            };
+        });
     },
 
     // Hydrates the store with the demo project. The demo is a cloud snapshot

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -54,6 +54,9 @@ export interface ProjectState {
     // Pipeline stage
     setProjectStage: (projectId: string, stage: PipelineStage) => void;
 
+    // Stores the chosen design-system preset id (see DESIGN_SYSTEM_PRESETS).
+    setProjectDesignSystemPreset: (projectId: string, presetId: string) => void;
+
     // Demo project hydration. Returns the stable DEMO_PROJECT_ID and whether
     // a demo snapshot was available. When `available` is false, the home
     // page surfaces a friendly "no demo set" message.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,12 @@ export type Project = {
     // has pinned a newer demo snapshot and re-fetch instead of serving stale
     // local cache. Optional so legacy persisted projects keep working.
     demoSourceSnapshotId?: string;
+    // The user-chosen design-system direction (a `DESIGN_SYSTEM_PRESETS` id,
+    // e.g. 'saas_minimal' or 'custom'), picked once before artifact generation.
+    // Steers design_system generation and, through it, the visual language of
+    // mockups and the Screen Inventory copy-prompt. Optional — legacy projects
+    // and the demo have none and behave exactly as before.
+    designSystemPreset?: string;
 };
 
 export type BranchMessage = {


### PR DESCRIPTION
Screen Inventory's "Copy image prompt" produced a generic style hint that
ignored the project's Design System, so externally generated mockups drifted
from the internal ones. Fix the disconnect and add a visual-direction preset.

Prompt unification:
- Add buildDesignSystemBrief(tokens) as the single concise-but-complete
  Design System Brief (replaces tokensToImagePromptBrief). It covers palette,
  typography, spacing/density, radius, elevation, button/card/form/modal
  conventions, navigation, responsive behavior, and accessibility.
- Internal mockup image prompt (buildScreenImagePrompt) and the Screen
  Inventory copy-prompt (renamed buildScreenInventoryImagePrompt ->
  buildExternalMockupPrompt) both embed the same brief, so external mockups
  match the project's visual language. Falls back to the neutral hint when no
  design system exists; keeps the upload-external-image workflow intact.
- Thread design tokens + platform hint into ScreenImageGalleryContext from
  ArtifactWorkspace via the reference-stable selectPreferredDesignTokens.

Design System Preset:
- New designSystemPresets.ts catalog (SaaS Minimal, AI Workspace, Editorial /
  Learning, Developer Tool, Consumer Mobile, Custom / Generate for me).
- DesignSystemPresetChoice modal shown on the Mark-as-Final edge when a real
  project hasn't chosen one; choice persists to Project.designSystemPreset.
- coreArtifactService injects the preset directive into the design_system
  prompt only; artifactJobController reads the preset off the project so all
  generation paths honor it. Custom/unknown -> no steering (unchanged behavior).
- DesignSystemRenderer banner + modal copy explain the coupling and that
  regenerating may shift mockups/screen prompts.

Tests: external prompt includes DS content when available and works without it;
internal + external prompts share the same DS source; brief is complete yet
concise; preset directive injection.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MAUTCF7sQ3c3hVeDvNWDVP