### PR TITLE
Capture screen-inventory images, tasks, and metrics in snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,24 @@ otherwise have nothing in common — keep that distinction in mind:
 Owner-only project snapshots bundle a project's Zustand slice **plus its
 IndexedDB-backed mockup images** (base64 PNGs from `src/lib/mockupImageStore.ts`,
 keyed `versionId:screenId:quality` where `versionId` is the **artifact version
-id**) and push them to Vercel Blob behind a `SYNAPSE_OWNER_TOKEN` gate. Images
-are split out of the JSON envelope and shipped one request each so neither
-upload nor download crosses Vercel's ~4.5 MB cap. One snapshot can be pinned as
-**the demo** (`_demo.json` pointer + public `?demo=1` read); `loadDemoProject`
-restores it under the stable `DEMO_PROJECT_ID`.
+id**) **and its user-uploaded Screen Inventory images** (from
+`src/lib/screenInventoryImageStore.ts`, a separate IDB store, keyed
+`artifactVersionId:screenSlug:versionNumber`) and push them to Vercel Blob
+behind a `SYNAPSE_OWNER_TOKEN` gate. The bundle also carries the project's
+**implementation tasks** (`tasks` slice) and **orchestration metrics**
+(`workflowRuns` slice) — every *persisted* store slice for the project, so a
+restored snapshot is a faithful copy. Both image kinds split out of the JSON
+envelope and ship one request each (reusing the **same** per-image blob channel
+— each blob is keyed by a hash of the image key, and the two key shapes never
+collide) so neither upload nor download crosses Vercel's ~4.5 MB cap. The wire
+format carries mockup images in `payload.images` and screen-inventory images in
+`payload.screenImages`. One snapshot can be pinned as **the demo** (`_demo.json`
+pointer + public `?demo=1` read); `loadDemoProject` restores it under the stable
+`DEMO_PROJECT_ID`. Snapshot fields (`tasks`/`workflowRuns`/`screenImages`) are
+all **optional on the wire** — pre-existing snapshots lack them and restore
+defaults each to `[]`. When adding a new persisted slice or IDB image store,
+add it to `collectProjectBundle`/`collectScreenImages`, the restore writers, and
+`namespaceSnapshotForRestore`, or it silently won't travel in snapshots.
 
 - **Demo cache freshness — never short-circuit on a `DEMO_PROJECT_ID` cache hit
   alone.** Each restored demo project stores its source snapshot id in the
@@ -168,31 +181,39 @@ restores it under the stable `DEMO_PROJECT_ID`.
   stale demo while mobile (with no cache) silently saw the latest.
 - **Restoring under a *different* project id MUST namespace the artifact version
   ids** (`namespaceSnapshotForRestore` → `rewriteIds`), not just the project id.
-  Mockup images are keyed in IndexedDB by `versionId` with **no projectId in the
-  key**, so a demo restored from a real project's snapshot would otherwise share
-  version ids — and `restoreSnapshotAs`'s `deleteImagesForVersion()` would wipe
-  and re-tag the **source project's** images. Version ids are namespaced as
-  `${targetProjectId}:${versionId}` (deterministic → idempotent re-restores) and
-  each image's composite `key` is rebuilt from the remapped fields. Never restore
-  a snapshot under a foreign project id without this remap.
+  Both mockup images AND screen-inventory images are keyed in IndexedDB by the
+  artifact version id with **no projectId in the key**, so a demo restored from a
+  real project's snapshot would otherwise share version ids — and
+  `restoreSnapshotAs`'s `deleteImagesForVersion()` /
+  `deleteScreenImagesForArtifactVersion()` would wipe and re-tag the **source
+  project's** images. Version ids are namespaced as `${targetProjectId}:${versionId}`
+  (deterministic → idempotent re-restores) and each image's composite `key` is
+  rebuilt from the remapped fields (`buildImageKey` for mockups,
+  `buildScreenImageKey` for screen-inventory). `rewriteIds` runs over the whole
+  bundle, so `tasks`/`workflowRuns` (which carry `projectId`) are remapped too.
+  Never restore a snapshot under a foreign project id without this remap.
 - **`collectProjectImages` must not filter images by the stored `record.projectId`.**
   A version id uniquely identifies its owning project, so collect by version id
   only; filtering on a (possibly drifted) `projectId` tag is what silently
   dropped mockup images from snapshots.
+- **`collectScreenImages` (like `collectProjectImages`) must not filter by the
+  stored `record.projectId`** — collect by artifact version id only, for the same
+  drift reason.
 - Note: user-uploaded Screen Inventory images
-  (`src/lib/screenInventoryImageStore.ts`, a separate IndexedDB store) are **not
-  yet** captured in snapshots. `/api/projects` cross-device sync **does** now
-  carry **mockup** images (via a separate Blob ref layer — see "Cross-device
-  mockup image sync" below). The snapshot feature and the project-sync image
-  layer are **independent**: different Blob prefixes (`snapshots/<id>/…` vs
-  `users/<userId>/mockup-images/…`), different ref models, different auth gates
-  (owner token vs per-user session). Do not entangle them. Screen Inventory
-  images remain a documented gap on the project-sync path too — the ref layer is
-  built generic (`kind`/`meta`) so they can be wired in later. **Note:** the
-  `user_uploaded` **mockup image source mode** (the OpenAI-key-free path that
-  lets the user upload their own mockup) persists to `screenInventoryImageStore`,
-  **not** `mockupImageStore` — so those uploads ride on this same not-yet-synced
-  gap. Only the `gpt_image` (AI-generated) mockups sync across devices today.
+  (`src/lib/screenInventoryImageStore.ts`, a separate IndexedDB store) **are now
+  captured in snapshots** (and therefore the demo) via `payload.screenImages`.
+  They are **still a gap on the `/api/projects` cross-device sync path**, which
+  only carries **mockup** images (via a separate Blob ref layer — see
+  "Cross-device mockup image sync" below). The snapshot feature and the
+  project-sync image layer are **independent**: different Blob prefixes
+  (`snapshots/<id>/…` vs `users/<userId>/mockup-images/…`), different ref models,
+  different auth gates (owner token vs per-user session). Do not entangle them.
+  The project-sync ref layer is built generic (`kind`/`meta`) so screen-inventory
+  images can be wired into it later. **Note:** the `user_uploaded` **mockup image
+  source mode** (the OpenAI-key-free path that lets the user upload their own
+  mockup) persists to `screenInventoryImageStore`, **not** `mockupImageStore` — so
+  those uploads now travel in snapshots but still ride the cross-device-sync gap.
+  Only the `gpt_image` (AI-generated) mockups sync across devices today.
 
 ### Server-side project storage (`api/projects.js`, `api/_lib/projectsStore.js`, `src/store/projectServerSync.ts`)
 

--- a/api/snapshots.js
+++ b/api/snapshots.js
@@ -156,6 +156,7 @@ async function handlePost(req, res) {
 
   const project = body?.project;
   const rawImages = Array.isArray(body?.images) ? body.images : [];
+  const rawScreenImages = Array.isArray(body?.screenImages) ? body.screenImages : [];
   if (!project || typeof project !== 'object') {
     return json(res, 400, { error: 'missing_project' });
   }
@@ -163,9 +164,15 @@ async function handlePost(req, res) {
   // Drop any dataUrl that snuck through — image blobs are uploaded
   // individually via `?id=...&image=1`. Storing dataUrl inline would just
   // bring back the size problem this split was meant to solve.
-  const imageRefs = rawImages
-    .map(imageMetadata)
-    .filter((m) => m && typeof m.key === 'string' && m.key.length > 0 && m.key.length <= IMAGE_KEY_MAX);
+  const toRefs = (arr) =>
+    arr
+      .map(imageMetadata)
+      .filter((m) => m && typeof m.key === 'string' && m.key.length > 0 && m.key.length <= IMAGE_KEY_MAX);
+  const imageRefs = toRefs(rawImages);
+  // Screen Inventory images live in a separate client IDB store and travel as
+  // their own array, but they reuse the exact same per-image blob channel
+  // (keyed by a hash of the image key, which never collides with a mockup key).
+  const screenImageRefs = toRefs(rawScreenImages);
 
   const id = crypto.randomUUID();
   const manifest = {
@@ -175,6 +182,7 @@ async function handlePost(req, res) {
     createdAt: nowIso(),
     schemaVersion: CURRENT_SCHEMA_VERSION,
     imageCount: imageRefs.length,
+    screenImageCount: screenImageRefs.length,
   };
 
   const data = {
@@ -185,6 +193,7 @@ async function handlePost(req, res) {
     // separate blob under snapshots/<id>/images/<hash>.json so that no
     // single request crosses the 4.5 MB serverless body cap.
     images: imageRefs,
+    screenImages: screenImageRefs,
   };
   const dataJson = JSON.stringify(data);
   const manifestJson = JSON.stringify({ ...manifest, sizeBytes: dataJson.length });

--- a/src/components/SnapshotsPanel.tsx
+++ b/src/components/SnapshotsPanel.tsx
@@ -210,7 +210,7 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
                                     </button>
                                 </div>
                                 <p className="text-xs text-neutral-400 mb-3">
-                                    Bundles this project&rsquo;s spine versions, branches, artifacts, and any AI-generated mockup images, then stores it in Vercel Blob.
+                                    Bundles this project&rsquo;s spine versions, branches, artifacts, implementation tasks, orchestration metrics, and both AI-generated mockup images and uploaded screen-inventory images, then stores it in Vercel Blob.
                                 </p>
                                 <div className="flex gap-2">
                                     <input
@@ -276,7 +276,10 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
                                                             )}
                                                         </div>
                                                         <div className="text-[11px] text-neutral-500 mt-0.5">
-                                                            {s.projectName} &middot; {formatDate(s.createdAt)} &middot; {s.imageCount} image{s.imageCount === 1 ? '' : 's'} &middot; {formatBytes(s.sizeBytes)}
+                                                            {(() => {
+                                                                const total = s.imageCount + (s.screenImageCount ?? 0);
+                                                                return `${s.projectName} · ${formatDate(s.createdAt)} · ${total} image${total === 1 ? '' : 's'} · ${formatBytes(s.sizeBytes)}`;
+                                                            })()}
                                                         </div>
                                                     </div>
                                                     <div className="flex items-center gap-1 shrink-0">

--- a/src/lib/__tests__/snapshotClient.test.ts
+++ b/src/lib/__tests__/snapshotClient.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { namespaceSnapshotForRestore } from '../snapshotClient';
 import type { SnapshotPayload } from '../snapshotClient';
-import type { MockupImageRecord } from '../../types';
+import type { MockupImageRecord, ScreenInventoryImageRecord } from '../../types';
 import { buildImageKey } from '../mockupImageStore';
+import { buildScreenImageKey } from '../screenInventoryImageStore';
 
 // Builds a minimal-but-realistic snapshot for a source project that has one
 // mockup artifact version with two AI image records. Only the fields the
@@ -82,5 +83,60 @@ describe('namespaceSnapshotForRestore', () => {
         expect(bundle).toBe(snapshot.project);
         expect(images).toBe(snapshot.images);
         expect(images[0].versionId).toBe(VERSION_ID);
+    });
+
+    it('defaults screenImages to [] for snapshots saved before screen-image capture', () => {
+        const { screenImages } = namespaceSnapshotForRestore(makeSnapshot(), DEMO_PROJECT_ID);
+        expect(screenImages).toEqual([]);
+    });
+});
+
+const makeScreenImage = (versionNumber: number): ScreenInventoryImageRecord => ({
+    key: buildScreenImageKey(VERSION_ID, 'login', versionNumber),
+    projectId: SOURCE_PROJECT_ID,
+    artifactId: 'artifact-1',
+    artifactVersionId: VERSION_ID,
+    screenSlug: 'login',
+    screenName: 'Login',
+    versionNumber,
+    isPreferred: versionNumber === 1,
+    dataUrl: `data:image/png;base64,si${versionNumber}`,
+    mimeType: 'image/png',
+    prompt: 'p',
+    generatedAt: 1,
+});
+
+describe('namespaceSnapshotForRestore — screen images, tasks, metrics', () => {
+    const withExtras = (): SnapshotPayload => {
+        const snap = makeSnapshot();
+        return {
+            ...snap,
+            project: {
+                ...snap.project,
+                tasks: [{ id: 'task-1', projectId: SOURCE_PROJECT_ID }],
+                workflowRuns: [{ id: 'run-1', projectId: SOURCE_PROJECT_ID }],
+            } as unknown as SnapshotPayload['project'],
+            screenImages: [makeScreenImage(1), makeScreenImage(2)],
+        };
+    };
+
+    it('namespaces screen-inventory images by artifactVersionId and rebuilds the key', () => {
+        const { screenImages } = namespaceSnapshotForRestore(withExtras(), DEMO_PROJECT_ID);
+        const namespacedVersionId = `${DEMO_PROJECT_ID}:${VERSION_ID}`;
+        expect(screenImages).toHaveLength(2);
+        for (const img of screenImages) {
+            expect(img.artifactVersionId).toBe(namespacedVersionId);
+            expect(img.projectId).toBe(DEMO_PROJECT_ID);
+            expect(img.key).toBe(buildScreenImageKey(namespacedVersionId, img.screenSlug, img.versionNumber));
+            // Never reuse the source version id, so restore can't wipe the
+            // source project's screen images.
+            expect(img.artifactVersionId).not.toBe(VERSION_ID);
+        }
+    });
+
+    it('rewrites the projectId on bundled tasks and workflow runs', () => {
+        const { bundle } = namespaceSnapshotForRestore(withExtras(), DEMO_PROJECT_ID);
+        expect(bundle.tasks?.[0].projectId).toBe(DEMO_PROJECT_ID);
+        expect(bundle.workflowRuns?.[0].projectId).toBe(DEMO_PROJECT_ID);
     });
 });

--- a/src/lib/screenInventoryImageStore.ts
+++ b/src/lib/screenInventoryImageStore.ts
@@ -101,6 +101,36 @@ export const listScreenImagesForArtifactVersion = async (
     }
 };
 
+// Delete every record for one artifact version. Mirrors
+// `mockupImageStore.deleteImagesForVersion`; used by the snapshot restore path
+// to clear a version's stale screen-inventory images before repopulating them.
+export const deleteScreenImagesForArtifactVersion = async (
+    artifactVersionId: string,
+): Promise<void> => {
+    try {
+        const db = await openDb();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const idx = tx.objectStore(STORE_NAME).index(VERSION_INDEX);
+            const req = idx.openCursor(IDBKeyRange.only(artifactVersionId));
+            req.onsuccess = () => {
+                const cursor = req.result;
+                if (cursor) {
+                    cursor.delete();
+                    cursor.continue();
+                }
+            };
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error ?? new Error('IDB delete failed'));
+            tx.onabort = () => reject(tx.error ?? new Error('IDB delete aborted'));
+        });
+    } catch {
+        for (const [k, r] of memoryFallback.entries()) {
+            if (r.artifactVersionId === artifactVersionId) memoryFallback.delete(k);
+        }
+    }
+};
+
 // Transactional preferred-flip: clears `isPreferred` on every record in the
 // `(artifactVersionId, screenSlug)` bucket, then sets it on the target.
 // Returns the updated set so callers can reflect it in their reactive cache

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -22,9 +22,16 @@
 import type {
     Project, SpineVersion, HistoryEvent, Branch,
     Artifact, ArtifactVersion, FeedbackItem, MockupImageRecord,
+    ScreenInventoryImageRecord, ProjectTask, WorkflowRun,
 } from '../types';
 import { useProjectStore } from '../store/projectStore';
 import { buildImageKey, listImagesForVersion, putImage, deleteImagesForVersion } from './mockupImageStore';
+import {
+    buildScreenImageKey,
+    listScreenImagesForArtifactVersion,
+    putScreenImage,
+    deleteScreenImagesForArtifactVersion,
+} from './screenInventoryImageStore';
 
 export const OWNER_TOKEN_KEY = 'synapse-owner-token';
 
@@ -36,6 +43,12 @@ export type SnapshotProjectBundle = {
     artifacts: Artifact[];
     artifactVersions: ArtifactVersion[];
     feedbackItems: FeedbackItem[];
+    // Persisted store slices that were previously omitted from snapshots, so a
+    // restored project carries its implementation tasks and orchestration
+    // metrics too. Optional on the wire — snapshots saved before this layer
+    // existed won't have them, and restore defaults to [].
+    tasks?: ProjectTask[];
+    workflowRuns?: WorkflowRun[];
 };
 
 export type SnapshotManifest = {
@@ -45,6 +58,9 @@ export type SnapshotManifest = {
     createdAt: string;
     schemaVersion: number;
     imageCount: number;
+    // Count of user-uploaded Screen Inventory images bundled alongside the
+    // mockup images. Optional for back-compat with pre-existing manifests.
+    screenImageCount?: number;
     sizeBytes?: number;
 };
 
@@ -53,6 +69,10 @@ export type SnapshotPayload = {
     manifest: SnapshotManifest;
     project: SnapshotProjectBundle;
     images: MockupImageRecord[];
+    // User-uploaded Screen Inventory images. Lives in a separate IndexedDB
+    // store from mockup images (`screenInventoryImageStore`), so it travels as
+    // its own array. Optional on the wire — older snapshots won't have it.
+    screenImages?: ScreenInventoryImageRecord[];
 };
 
 export type SnapshotListItem = SnapshotManifest & { isDemo?: boolean };
@@ -124,6 +144,8 @@ export const collectProjectBundle = (projectId: string): SnapshotProjectBundle =
         artifacts: state.artifacts[projectId] ?? [],
         artifactVersions: state.artifactVersions[projectId] ?? [],
         feedbackItems: state.feedbackItems[projectId] ?? [],
+        tasks: state.tasks[projectId] ?? [],
+        workflowRuns: state.workflowRuns[projectId] ?? [],
     };
 };
 
@@ -148,12 +170,30 @@ const collectProjectImages = async (bundle: SnapshotProjectBundle): Promise<Mock
     return out;
 };
 
+// Gather every user-uploaded Screen Inventory image tied to one of this
+// project's artifact versions. Same rationale as `collectProjectImages`: the
+// IDB store is indexed by `artifactVersionId`, and a version id unambiguously
+// identifies its owning project, so we walk by version id and never filter on
+// the (drift-prone) stored `projectId`.
+const collectScreenImages = async (
+    bundle: SnapshotProjectBundle,
+): Promise<ScreenInventoryImageRecord[]> => {
+    const out: ScreenInventoryImageRecord[] = [];
+    for (const v of bundle.artifactVersions) {
+        const records = await listScreenImagesForArtifactVersion(v.id);
+        out.push(...records);
+    }
+    return out;
+};
+
 // Strip the (large) base64 payload off an image record so the bundle POST
 // only carries the routing metadata. The dataUrl is uploaded in its own
 // request immediately after.
-const imageMetadata = (img: MockupImageRecord): Omit<MockupImageRecord, 'dataUrl'> => {
+const imageMetadata = <T extends { dataUrl: string }>(img: T): Omit<T, 'dataUrl'> => {
     // We intentionally destructure-then-discard so a future field added to
-    // MockupImageRecord automatically makes it into the metadata blob.
+    // an image record automatically makes it into the metadata blob. Generic
+    // over the record shape so it serves both mockup and screen-inventory
+    // images.
     const { dataUrl: _dataUrl, ...meta } = img;
     void _dataUrl;
     return meta;
@@ -166,12 +206,13 @@ export const saveSnapshot = async (
 ): Promise<SnapshotManifest> => {
     const bundle = collectProjectBundle(projectId);
     const images = await collectProjectImages(bundle);
+    const screenImages = await collectScreenImages(bundle);
 
     onProgress?.({ phase: 'bundle', completed: 0, total: 0 });
 
     // Step 1 — POST the project bundle plus image metadata only. This is
     // bounded (typically a few hundred KB) regardless of how many or how
-    // large the mockup images are.
+    // large the mockup / screen images are.
     const bundleResp = await fetch(API_BASE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -179,6 +220,7 @@ export const saveSnapshot = async (
             title,
             project: bundle,
             images: images.map(imageMetadata),
+            screenImages: screenImages.map(imageMetadata),
         }),
     });
     if (!bundleResp.ok) throw await errorFromResponse(bundleResp, 'save_failed');
@@ -186,17 +228,21 @@ export const saveSnapshot = async (
 
     // Step 2 — upload each image as a separate request. We go sequentially
     // so a slow/flaky uplink doesn't try to push all images at once and so
-    // browsers don't hold every base64 payload in flight concurrently.
-    onProgress?.({ phase: 'images', completed: 0, total: images.length });
-    for (let i = 0; i < images.length; i++) {
-        const img = images[i];
+    // browsers don't hold every base64 payload in flight concurrently. Mockup
+    // and screen-inventory images share the same per-image endpoint (the
+    // server keys each blob by a hash of the image key, and the two key shapes
+    // never collide), so we upload them in one combined pass.
+    const allImages: Array<{ key: string; dataUrl: string }> = [...images, ...screenImages];
+    onProgress?.({ phase: 'images', completed: 0, total: allImages.length });
+    for (let i = 0; i < allImages.length; i++) {
+        const img = allImages[i];
         const resp = await fetch(`${API_BASE}?id=${encodeURIComponent(id)}&image=1`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', ...authHeaders() },
             body: JSON.stringify({ image: img }),
         });
         if (!resp.ok) throw await errorFromResponse(resp, 'save_image_failed');
-        onProgress?.({ phase: 'images', completed: i + 1, total: images.length });
+        onProgress?.({ phase: 'images', completed: i + 1, total: allImages.length });
     }
 
     return manifest;
@@ -226,7 +272,7 @@ export const setDemoSnapshot = async (snapshotId: string | null): Promise<string
 // True if the bundle still has every image dataUrl inline — i.e. a legacy
 // v1 snapshot. v2 bundles return image metadata only and need a follow-up
 // fetch per image to hydrate the dataUrls.
-const isFullyInlined = (images: unknown[]): images is MockupImageRecord[] => {
+const isFullyInlined = (images: unknown[]): boolean => {
     if (!Array.isArray(images)) return false;
     if (images.length === 0) return true;
     return images.every((img) =>
@@ -239,12 +285,12 @@ const isFullyInlined = (images: unknown[]): images is MockupImageRecord[] => {
 // Pull each image blob into a full MockupImageRecord. Runs the fetches
 // with a small concurrency limit so a project with dozens of screens
 // doesn't try to open a fetch for every one simultaneously.
-const hydrateImages = async (
+const hydrateImages = async <T extends { key: string; dataUrl: string }>(
     fetchOne: (key: string) => Promise<Response>,
-    refs: Array<Omit<MockupImageRecord, 'dataUrl'>>,
-): Promise<MockupImageRecord[]> => {
+    refs: Array<Omit<T, 'dataUrl'>>,
+): Promise<T[]> => {
     const CONCURRENCY = 4;
-    const out: MockupImageRecord[] = new Array(refs.length);
+    const out: T[] = new Array(refs.length);
     let cursor = 0;
     const workers = Array.from({ length: Math.min(CONCURRENCY, refs.length) }, async () => {
         while (true) {
@@ -253,7 +299,7 @@ const hydrateImages = async (
             const ref = refs[idx];
             const resp = await fetchOne(ref.key);
             if (!resp.ok) throw await errorFromResponse(resp, 'load_image_failed');
-            const body = await resp.json() as { image?: MockupImageRecord };
+            const body = await resp.json() as { image?: T };
             if (!body?.image || typeof body.image.dataUrl !== 'string') {
                 throw new Error(`load_image_failed: malformed image record for ${ref.key}`);
             }
@@ -262,6 +308,22 @@ const hydrateImages = async (
     });
     await Promise.all(workers);
     return out;
+};
+
+// Hydrate the optional `screenImages` array of a payload using the same
+// per-image fetch the mockup images use. Returns the payload unchanged when it
+// carries no screen images (legacy snapshots) or they are already inlined.
+const hydrateScreenImages = async (
+    payload: SnapshotPayload,
+    fetchOne: (key: string) => Promise<Response>,
+): Promise<ScreenInventoryImageRecord[] | undefined> => {
+    const screenImages = payload.screenImages;
+    if (!Array.isArray(screenImages) || screenImages.length === 0) return screenImages;
+    if (isFullyInlined(screenImages)) return screenImages;
+    return await hydrateImages<ScreenInventoryImageRecord>(
+        fetchOne,
+        screenImages as unknown as Array<Omit<ScreenInventoryImageRecord, 'dataUrl'>>,
+    );
 };
 
 // Public, lightweight: read just the demo pointer so callers can decide
@@ -292,27 +354,33 @@ export const loadDemoSnapshotPublic = async (): Promise<SnapshotPayload | null> 
     if (resp.status === 404) return null;
     if (!resp.ok) throw await errorFromResponse(resp, 'load_demo_failed');
     const payload = await resp.json() as SnapshotPayload;
-    if (isFullyInlined(payload.images)) return payload;
-    const hydrated = await hydrateImages(
-        (key) => fetch(`${API_BASE}?demo=1&image=${encodeURIComponent(key)}`),
-        payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
-    );
-    return { ...payload, images: hydrated };
+    const fetchOne = (key: string) => fetch(`${API_BASE}?demo=1&image=${encodeURIComponent(key)}`);
+    const images = isFullyInlined(payload.images)
+        ? payload.images
+        : await hydrateImages<MockupImageRecord>(
+            fetchOne,
+            payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
+        );
+    const screenImages = await hydrateScreenImages(payload, fetchOne);
+    return { ...payload, images, screenImages };
 };
 
 export const loadSnapshot = async (id: string): Promise<SnapshotPayload> => {
     const resp = await fetch(`${API_BASE}?id=${encodeURIComponent(id)}`, { headers: authHeaders() });
     if (!resp.ok) throw await errorFromResponse(resp, 'load_failed');
     const payload = await resp.json() as SnapshotPayload;
-    if (isFullyInlined(payload.images)) return payload;
-    const hydrated = await hydrateImages(
-        (key) => fetch(
-            `${API_BASE}?id=${encodeURIComponent(id)}&image=${encodeURIComponent(key)}`,
-            { headers: authHeaders() },
-        ),
-        payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
+    const fetchOne = (key: string) => fetch(
+        `${API_BASE}?id=${encodeURIComponent(id)}&image=${encodeURIComponent(key)}`,
+        { headers: authHeaders() },
     );
-    return { ...payload, images: hydrated };
+    const images = isFullyInlined(payload.images)
+        ? payload.images
+        : await hydrateImages<MockupImageRecord>(
+            fetchOne,
+            payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
+        );
+    const screenImages = await hydrateScreenImages(payload, fetchOne);
+    return { ...payload, images, screenImages };
 };
 
 export const deleteSnapshot = async (id: string): Promise<void> => {
@@ -323,16 +391,9 @@ export const deleteSnapshot = async (id: string): Promise<void> => {
     if (!resp.ok) throw await errorFromResponse(resp, 'delete_failed');
 };
 
-// Restore a snapshot into the live store. Replaces any existing project with
-// the same id (we use the snapshot's project id directly so external
-// references — e.g. screen URLs — keep working). Images are repopulated in
-// IndexedDB for the project's mockup versions.
-export const restoreSnapshot = async (snapshot: SnapshotPayload): Promise<string> => {
-    const { project: bundle, images } = snapshot;
-    const projectId = bundle.project.id;
-
-    // Repopulate IDB images first, before we expose the project in the store,
-    // so renderers don't briefly see "missing image" placeholders.
+// Repopulate the IndexedDB mockup-image store for a set of records, clearing
+// each touched version first so a restore is a clean replace, not a merge.
+const restoreMockupImagesToIdb = async (images: MockupImageRecord[]): Promise<void> => {
     const versionIds = new Set(images.map((r) => r.versionId));
     for (const vid of versionIds) {
         await deleteImagesForVersion(vid);
@@ -340,6 +401,35 @@ export const restoreSnapshot = async (snapshot: SnapshotPayload): Promise<string
     for (const record of images) {
         await putImage(record);
     }
+};
+
+// Same as above for the separate Screen Inventory image store, keyed by
+// `artifactVersionId`. No-op when the snapshot predates screen-image capture.
+const restoreScreenImagesToIdb = async (
+    screenImages: ScreenInventoryImageRecord[] | undefined,
+): Promise<void> => {
+    if (!screenImages || screenImages.length === 0) return;
+    const versionIds = new Set(screenImages.map((r) => r.artifactVersionId));
+    for (const vid of versionIds) {
+        await deleteScreenImagesForArtifactVersion(vid);
+    }
+    for (const record of screenImages) {
+        await putScreenImage(record);
+    }
+};
+
+// Restore a snapshot into the live store. Replaces any existing project with
+// the same id (we use the snapshot's project id directly so external
+// references — e.g. screen URLs — keep working). Images are repopulated in
+// IndexedDB for the project's mockup and screen-inventory versions.
+export const restoreSnapshot = async (snapshot: SnapshotPayload): Promise<string> => {
+    const { project: bundle, images } = snapshot;
+    const projectId = bundle.project.id;
+
+    // Repopulate IDB images first, before we expose the project in the store,
+    // so renderers don't briefly see "missing image" placeholders.
+    await restoreMockupImagesToIdb(images);
+    await restoreScreenImagesToIdb(snapshot.screenImages);
 
     // Splice the bundle back into the Zustand store. We mutate the store
     // imperatively because there's no public action for "replace one project
@@ -352,6 +442,8 @@ export const restoreSnapshot = async (snapshot: SnapshotPayload): Promise<string
         artifacts: { ...state.artifacts, [projectId]: bundle.artifacts },
         artifactVersions: { ...state.artifactVersions, [projectId]: bundle.artifactVersions },
         feedbackItems: { ...state.feedbackItems, [projectId]: bundle.feedbackItems },
+        tasks: { ...state.tasks, [projectId]: bundle.tasks ?? [] },
+        workflowRuns: { ...state.workflowRuns, [projectId]: bundle.workflowRuns ?? [] },
     }));
 
     return projectId;
@@ -394,8 +486,13 @@ const rewriteIds = <T,>(value: T, idMap: Map<string, string>): T => {
 export const namespaceSnapshotForRestore = (
     snapshot: SnapshotPayload,
     targetProjectId: string,
-): { bundle: SnapshotProjectBundle; images: MockupImageRecord[] } => {
+): {
+    bundle: SnapshotProjectBundle;
+    images: MockupImageRecord[];
+    screenImages: ScreenInventoryImageRecord[];
+} => {
     const sourceId = snapshot.project.project.id;
+    const screenImagesIn = snapshot.screenImages ?? [];
 
     const idMap = new Map<string, string>();
     if (sourceId !== targetProjectId) {
@@ -409,7 +506,7 @@ export const namespaceSnapshotForRestore = (
     }
 
     if (idMap.size === 0) {
-        return { bundle: snapshot.project, images: snapshot.images };
+        return { bundle: snapshot.project, images: snapshot.images, screenImages: screenImagesIn };
     }
 
     const bundle = rewriteIds(snapshot.project, idMap);
@@ -419,8 +516,19 @@ export const namespaceSnapshotForRestore = (
         // remapped fields rather than relying on exact-string replacement.
         return { ...next, key: buildImageKey(next.versionId, next.screenId, next.quality) };
     });
+    // Screen Inventory images are keyed in IDB by `artifactVersionId`, so they
+    // need the same remap as mockup images — otherwise a demo restored from a
+    // real project would share version ids and `restoreSnapshotAs`'s
+    // delete-then-put would wipe the source project's screen images.
+    const screenImages = screenImagesIn.map((record) => {
+        const next = rewriteIds(record, idMap);
+        return {
+            ...next,
+            key: buildScreenImageKey(next.artifactVersionId, next.screenSlug, next.versionNumber),
+        };
+    });
 
-    return { bundle, images };
+    return { bundle, images, screenImages };
 };
 
 // Restore a snapshot into the store under a fixed `targetProjectId` instead
@@ -431,15 +539,10 @@ export const restoreSnapshotAs = async (
     snapshot: SnapshotPayload,
     targetProjectId: string,
 ): Promise<string> => {
-    const { bundle: remapped, images } = namespaceSnapshotForRestore(snapshot, targetProjectId);
+    const { bundle: remapped, images, screenImages } = namespaceSnapshotForRestore(snapshot, targetProjectId);
 
-    const versionIds = new Set(images.map((r) => r.versionId));
-    for (const vid of versionIds) {
-        await deleteImagesForVersion(vid);
-    }
-    for (const record of images) {
-        await putImage(record);
-    }
+    await restoreMockupImagesToIdb(images);
+    await restoreScreenImagesToIdb(screenImages);
 
     useProjectStore.setState((state) => ({
         projects: { ...state.projects, [targetProjectId]: remapped.project },
@@ -449,6 +552,8 @@ export const restoreSnapshotAs = async (
         artifacts: { ...state.artifacts, [targetProjectId]: remapped.artifacts },
         artifactVersions: { ...state.artifactVersions, [targetProjectId]: remapped.artifactVersions },
         feedbackItems: { ...state.feedbackItems, [targetProjectId]: remapped.feedbackItems ?? [] },
+        tasks: { ...state.tasks, [targetProjectId]: remapped.tasks ?? [] },
+        workflowRuns: { ...state.workflowRuns, [targetProjectId]: remapped.workflowRuns ?? [] },
     }));
 
     return targetProjectId;


### PR DESCRIPTION
Snapshots (and therefore the pinned demo project) only bundled the
project's Zustand slices plus mockup images. Three categories of
persisted project data were silently omitted, so they never showed up
when loading the demo:

- User-uploaded Screen Inventory images (separate IndexedDB store,
  `screenInventoryImageStore`)
- Implementation tasks (`tasks` slice)
- Orchestration metrics (`workflowRuns` slice)

Changes:
- Add `screenImages` to the snapshot wire format. Collect screen images
  by artifact version id, ship them via the existing per-image blob
  channel (keyed by hash of the image key, which never collides with a
  mockup key), and hydrate them on load.
- Restore screen images into their IDB store on restore, namespacing
  their `artifactVersionId`-based keys exactly like mockup images so a
  demo restore can't wipe the source project's images. Add
  `deleteScreenImagesForArtifactVersion`.
- Bundle `tasks` and `workflowRuns` and restore them into the store;
  `rewriteIds` remaps their `projectId` automatically.
- Server stores `screenImages` metadata + a `screenImageCount`; the
  Snapshots panel shows the combined image count.
- All new fields are optional on the wire — older snapshots default to
  empty on restore.

Note: screen-inventory images remain a gap on the /api/projects
cross-device sync path (only mockups sync there); this change is the
owner snapshot/demo path only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017JgCRiNAACPmpmVjkPkhhN