### PR TITLE
Allow changing design direction after finalization + prompt mockup regen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,7 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     into `ScreenImageGalleryContext`); with no design system it falls back to the
     neutral style hint so legacy projects still get a working prompt. Do **not**
     re-duplicate design-system prose into a prompt builder — reuse the brief.
-  - **Design System Presets (`src/lib/designSystemPresets.ts`).** A one-time
+  - **Design System Presets (`src/lib/designSystemPresets.ts`).** A
     visual-direction choice (`SaaS Minimal`, `AI Workspace`, `Editorial /
     Learning`, `Developer Tool`, `Consumer Mobile`, `Custom / Generate for me`)
     surfaced by `DesignSystemPresetChoice` on the Mark-as-Final edge in
@@ -436,6 +436,27 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     and the external copy-prompt, keeping the project visually consistent. The
     `DesignSystemRenderer` shows a banner explaining this coupling and that
     regenerating may shift downstream mockups/screen prompts.
+    - **Post-finalization re-selection.** The preset is **no longer one-time**.
+      Because the Mark-as-Final gate only fires once (and never for projects
+      finalized before presets existed), the **Design System artifact** carries a
+      `DesignDirectionControl` (`src/components/DesignDirectionControl.tsx`,
+      presentational) above its content in `ArtifactWorkspace`: it shows the
+      current direction (or an "AI decides" fallback) and offers **Change
+      direction** (re-opens `DesignSystemPresetChoice`, now accepting
+      `currentPresetId`/`title`/`description` props so it doubles as a change
+      dialog) and **Regenerate**. Choosing a new direction persists it via
+      `setProjectDesignSystemPreset` then opens a regenerate-confirm that calls
+      `artifactJobController.retrySlot('design_system')` — which re-reads the
+      preset off the project, so the new direction actually reaches generation.
+    - **Mockup-drift prompt.** Regenerating the design system produces a new
+      `tokensHash`, which `stalenessSlice` already uses to flip dependent mockups
+      to `possibly_outdated` (the auto-flag). On top of that, the Mockups view in
+      `ArtifactWorkspace` renders an amber **"Design system changed … Regenerate
+      the mockups"** banner when the mockup's recorded design_system
+      `anchorInfo` (tokensHash) differs from the project's current preferred
+      design system (`selectPreferredDesignSystem`), wired to the existing mockup
+      regenerate-confirm. Mockup *images* are keyed by the new mockup version id,
+      so the user must regenerate to pull the new visual direction through.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
     implementation_plan, prompt_pack, design_system). **Per-artifact model

--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ Developer Tool, Consumer Mobile, or *Custom / Generate for me*) that sets the
 project's visual direction. The choice is stored on the project and steers the
 **Design System** artifact — and through it, both the internal mockups and the
 prompts you copy for external image tools, so everything stays visually
-consistent. You can regenerate the design system later, but doing so may shift
-your mockups and screen-level prompts.
+consistent. You can change the visual direction later from the **Design System**
+artifact and regenerate it; when its tokens change, Synapse flags the affected
+mockups and offers to regenerate them so they pick up the new direction.
 
 - **Screen Inventory** and **User Flows**
 - **UI Components** (a searchable, filterable component library with live

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -20,8 +20,10 @@ import { ConvertToTasksModal } from './ConvertToTasksModal';
 import { TaskChecklist } from './tasks/TaskChecklist';
 import { StalenessBadge } from './StalenessBadge';
 import { VersionHistoryPanel, type VersionEntry } from './versions';
+import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
+import { DesignDirectionControl } from './DesignDirectionControl';
 import { tryParsePayload, extractMockupSettings } from '../lib/mockupParsing';
-import { selectPreferredDesignTokens } from '../lib/designTokens';
+import { selectPreferredDesignTokens, selectPreferredDesignSystem } from '../lib/designTokens';
 import type {
     ArtifactSlotKey, CoreArtifactSubtype, ProjectPlatform, StructuredPRD, GenerationStatus,
     ProjectTask,
@@ -115,8 +117,11 @@ export function ArtifactWorkspace({
     const {
         getArtifacts, getPreferredVersion, getArtifactStaleness, getJob, getProject,
         updateArtifactVersionMetadata, getArtifactVersions, getSpineVersions,
-        revertArtifactToVersion,
+        revertArtifactToVersion, setProjectDesignSystemPreset,
     } = useProjectStore();
+    // Reactive read of the project's chosen visual direction, so the Design
+    // System "Design direction" control re-renders when it changes.
+    const designSystemPreset = useProjectStore(s => s.projects[projectId]?.designSystemPreset);
     // Which artifact's version-history panel is open (null = none).
     const [versionHistoryArtifactId, setVersionHistoryArtifactId] = useState<string | null>(null);
     // Subscribe to tasks so the Implementation Plan button label tracks saved
@@ -145,6 +150,12 @@ export function ArtifactWorkspace({
     // version remains available." before kicking off a new run so the user
     // doesn't fear losing their existing render.
     const [mockupRegenConfirm, setMockupRegenConfirm] = useState<
+        { nextVersion: number } | null
+    >(null);
+    // Post-finalization "design direction" flow on the Design System artifact:
+    // the preset picker, and the confirm before regenerating the design system.
+    const [showDirectionPicker, setShowDirectionPicker] = useState(false);
+    const [designRegenConfirm, setDesignRegenConfirm] = useState<
         { nextVersion: number } | null
     >(null);
 
@@ -214,6 +225,17 @@ export function ArtifactWorkspace({
         artifactJobController.retrySlot(slot, {
             projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
         });
+    };
+
+    // Persist a newly-chosen visual direction, then surface the regenerate
+    // confirm — the preset only takes effect when the design system is
+    // regenerated, so we lead the user straight into that step.
+    const handleChooseDirection = (presetId: string) => {
+        setProjectDesignSystemPreset(projectId, presetId);
+        setShowDirectionPicker(false);
+        const ds = getArtifacts(projectId, 'core_artifact').find(a => a.subtype === 'design_system');
+        const preferred = ds ? getPreferredVersion(projectId, ds.id) : undefined;
+        setDesignRegenConfirm({ nextVersion: (preferred?.versionNumber ?? 0) + 1 });
     };
 
     // Resolve a spine source-ref id to its positional "Version N" label, matching
@@ -341,6 +363,19 @@ export function ArtifactWorkspace({
             }
             const settings = extractMockupSettings(preferred);
             const staleness = getArtifactStaleness(projectId, mockup.id);
+            // Did the design system's tokens change since these mockups were
+            // generated? Mirrors stalenessSlice's mockup check: compare the
+            // tokensHash recorded on the mockup's design_system source ref
+            // against the project's current preferred design system. When they
+            // differ, prompt the user to regenerate so the new visual direction
+            // actually reaches the images.
+            const designRef = preferred.sourceRefs.find(
+                r => r.sourceType === 'core_artifact' && typeof r.anchorInfo === 'string',
+            );
+            const currentDesign = selectPreferredDesignSystem(useProjectStore.getState(), projectId);
+            const designSystemDrift = !!designRef
+                && !!currentDesign?.tokensHash
+                && currentDesign.tokensHash !== designRef.anchorInfo;
             return (
                 <div className="space-y-4">
                     <div className="flex items-center justify-between gap-2 flex-wrap">
@@ -353,6 +388,28 @@ export function ArtifactWorkspace({
                             <RefreshCcw size={12} /> Regenerate Mockup
                         </button>
                     </div>
+                    {designSystemDrift && (
+                        <div className="flex items-start justify-between gap-3 flex-wrap rounded-lg border border-amber-200 bg-amber-50 p-3">
+                            <div className="flex items-start gap-2 min-w-0">
+                                <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-600" />
+                                <div className="min-w-0">
+                                    <p className="text-sm font-medium text-amber-900">
+                                        Design system changed since these mockups were generated
+                                    </p>
+                                    <p className="text-xs text-amber-700 mt-0.5">
+                                        Regenerate the mockups to apply the new visual direction.
+                                    </p>
+                                </div>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => setMockupRegenConfirm({ nextVersion: preferred.versionNumber + 1 })}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-amber-600 hover:bg-amber-700 text-white rounded-md transition shrink-0"
+                            >
+                                <RefreshCcw size={12} /> Regenerate Mockup
+                            </button>
+                        </div>
+                    )}
                     <MockupErrorBoundary resetKey={preferred.id}>
                         <MockupViewer
                             payload={payload}
@@ -405,6 +462,15 @@ export function ArtifactWorkspace({
                 <div className="flex items-center justify-start">
                     {renderVersionControls(artifact.id, preferred)}
                 </div>
+                {subtype === 'design_system' && (
+                    <DesignDirectionControl
+                        presetId={designSystemPreset}
+                        onChangeDirection={() => setShowDirectionPicker(true)}
+                        onRegenerate={() =>
+                            setDesignRegenConfirm({ nextVersion: preferred.versionNumber + 1 })
+                        }
+                    />
+                )}
                 {subtype === 'implementation_plan' && (() => {
                     const savedCount = projectTasks.filter(t => t.sourceArtifactId === artifact.id).length;
                     return (
@@ -641,6 +707,64 @@ export function ArtifactWorkspace({
                                 onClick={() => {
                                     setMockupRegenConfirm(null);
                                     handleRetrySlot('mockup');
+                                }}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white hover:bg-indigo-700 rounded-md transition"
+                            >
+                                <RefreshCcw size={13} /> Regenerate
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {showDirectionPicker && (
+                <DesignSystemPresetChoice
+                    currentPresetId={designSystemPreset}
+                    title="Change your visual direction"
+                    description="Pick a new direction for this project's design system. Internal mockups and the prompts you copy for external image tools both follow it, so everything stays consistent."
+                    onChoose={handleChooseDirection}
+                    onClose={() => setShowDirectionPicker(false)}
+                />
+            )}
+
+            {designRegenConfirm && (
+                <div
+                    className="fixed inset-0 z-50 bg-black/40 flex items-end md:items-center justify-center p-4"
+                    onClick={() => setDesignRegenConfirm(null)}
+                    role="presentation"
+                >
+                    <div
+                        className="bg-white rounded-xl shadow-xl border border-neutral-200 w-full max-w-sm overflow-hidden"
+                        onClick={(e) => e.stopPropagation()}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="design-regen-title"
+                    >
+                        <div className="px-5 pt-5 pb-3">
+                            <h3 id="design-regen-title" className="text-base font-bold text-neutral-900">
+                                Regenerate design system
+                            </h3>
+                            <p className="text-sm text-neutral-700 mt-1">
+                                Creates Version {designRegenConfirm.nextVersion} using your chosen direction.
+                            </p>
+                            <p className="text-xs text-neutral-500 mt-1">
+                                This may make your existing mockups out of date — you can regenerate them
+                                afterward. The current version remains in version history.
+                            </p>
+                        </div>
+                        <div className="px-5 pb-4 flex items-center justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setDesignRegenConfirm(null)}
+                                className="px-3 py-1.5 text-sm text-neutral-700 hover:bg-neutral-100 rounded-md transition"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setDesignRegenConfirm(null);
+                                    handleRetrySlot('design_system');
                                 }}
                                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white hover:bg-indigo-700 rounded-md transition"
                             >

--- a/src/components/DesignDirectionControl.tsx
+++ b/src/components/DesignDirectionControl.tsx
@@ -1,0 +1,73 @@
+import { Palette, Wand2, RefreshCcw } from 'lucide-react';
+import { getDesignSystemPresetLabel } from '../lib/designSystemPresets';
+
+interface DesignDirectionControlProps {
+    /** Preset id stored on the project, if any. */
+    presetId?: string;
+    /** Open the preset picker to change the visual direction. */
+    onChangeDirection: () => void;
+    /** Regenerate the design system (applies the current direction). */
+    onRegenerate: () => void;
+}
+
+/**
+ * Post-finalization control on the Design System artifact. The visual direction
+ * is otherwise only chosen once, on Mark as Final — projects finalized before
+ * the preset feature existed have no way to pick or change it. This card lets
+ * the user (re)select a direction and regenerate the design system so the new
+ * tokens flow through to mockups and the copied screen prompts.
+ *
+ * Presentational only: all state + the actual regeneration live in
+ * ArtifactWorkspace, which owns the generation context.
+ */
+export function DesignDirectionControl({
+    presetId,
+    onChangeDirection,
+    onRegenerate,
+}: DesignDirectionControlProps) {
+    const label = getDesignSystemPresetLabel(presetId);
+    return (
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 not-prose">
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div className="flex items-start gap-3 min-w-0">
+                    <div className="shrink-0 w-9 h-9 rounded-lg bg-indigo-50 text-indigo-600 flex items-center justify-center">
+                        <Palette size={16} />
+                    </div>
+                    <div className="min-w-0">
+                        <p className="text-sm font-semibold text-neutral-900">Design direction</p>
+                        {label ? (
+                            <p className="text-xs text-neutral-600 mt-0.5">
+                                Current: <span className="font-medium text-neutral-800">{label}</span>
+                            </p>
+                        ) : (
+                            <p className="text-xs text-neutral-600 mt-0.5">
+                                No direction chosen — the design system was generated from your PRD alone
+                                (<span className="font-medium text-neutral-800">AI decides</span>).
+                            </p>
+                        )}
+                        <p className="text-xs text-neutral-500 mt-1">
+                            Changing the direction takes effect when you regenerate the design system. That
+                            produces new tokens and may make your existing mockups out of date.
+                        </p>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                    <button
+                        type="button"
+                        onClick={onChangeDirection}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
+                    >
+                        <Wand2 size={12} /> Change direction
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onRegenerate}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition"
+                    >
+                        <RefreshCcw size={12} /> Regenerate
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/DesignSystemPresetChoice.tsx
+++ b/src/components/DesignSystemPresetChoice.tsx
@@ -1,21 +1,41 @@
-import { X } from 'lucide-react';
+import { X, Check } from 'lucide-react';
 import { DESIGN_SYSTEM_PRESETS } from '../lib/designSystemPresets';
 
 interface DesignSystemPresetChoiceProps {
     onChoose: (presetId: string) => void;
     onClose: () => void;
+    /**
+     * The preset already stored on the project, if any. When set, the matching
+     * card is marked as the current choice — used by the post-finalization
+     * "change direction" flow so the user can see what's active.
+     */
+    currentPresetId?: string;
+    /** Heading override. Defaults to the first-time "Choose…" copy. */
+    title?: string;
+    /** Lead paragraph override (the explanatory line under the heading). */
+    description?: string;
 }
 
 /**
- * One-time "visual direction" choice shown right before assets are generated
- * (on Mark as Final). The selected preset is stored on the project and steers
- * design-system generation — and through it, both the internal mockups and the
- * prompts users copy for external image tools, so the two stay consistent.
+ * "Visual direction" picker. Shown in two places:
+ *  - One-time, right before assets are generated (on Mark as Final).
+ *  - Again later from the Design System artifact, to change direction after
+ *    finalization (pass `currentPresetId` so the active choice is marked).
+ *
+ * The selected preset is stored on the project and steers design-system
+ * generation — and through it, both the internal mockups and the prompts users
+ * copy for external image tools, so the two stay consistent.
  *
  * Responsive: centered dialog on desktop, full-width bottom sheet on mobile —
  * mirrors PreflightModeChoice.
  */
-export function DesignSystemPresetChoice({ onChoose, onClose }: DesignSystemPresetChoiceProps) {
+export function DesignSystemPresetChoice({
+    onChoose,
+    onClose,
+    currentPresetId,
+    title = 'Choose your visual direction',
+    description = "This sets your project's design system. Internal mockups and the prompts you copy for external image tools will both follow it, so everything stays visually consistent.",
+}: DesignSystemPresetChoiceProps) {
     return (
         <div
             className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-end sm:items-center justify-center z-50"
@@ -27,7 +47,7 @@ export function DesignSystemPresetChoice({ onChoose, onClose }: DesignSystemPres
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex items-center justify-between px-6 pt-6 pb-2">
-                    <h2 className="text-lg font-semibold text-white">Choose your visual direction</h2>
+                    <h2 className="text-lg font-semibold text-white">{title}</h2>
                     <button
                         onClick={onClose}
                         className="p-2 -mr-2 text-neutral-400 hover:text-white rounded-lg transition"
@@ -36,35 +56,45 @@ export function DesignSystemPresetChoice({ onChoose, onClose }: DesignSystemPres
                         <X size={18} />
                     </button>
                 </div>
-                <p className="px-6 text-sm text-neutral-400 mb-1">
-                    This sets your project's design system. Internal mockups and the prompts you copy
-                    for external image tools will both follow it, so everything stays visually consistent.
-                </p>
+                <p className="px-6 text-sm text-neutral-400 mb-1">{description}</p>
                 <p className="px-6 text-xs text-neutral-500 mb-4">
                     You can regenerate the design system later, but that may change your mockups and
                     screen-level prompts.
                 </p>
                 <div className="px-4 pb-5 space-y-2">
-                    {DESIGN_SYSTEM_PRESETS.map(({ id, icon: Icon, label, subtitle, detail }) => (
-                        <button
-                            key={id}
-                            onClick={() => onChoose(id)}
-                            className="w-full text-left flex items-start gap-4 p-4 min-h-[64px] rounded-2xl border border-white/10 bg-white/[0.03] hover:bg-white/[0.07] hover:border-indigo-500/50 transition group"
-                        >
-                            <div className="shrink-0 w-10 h-10 rounded-xl bg-indigo-500/15 text-indigo-300 flex items-center justify-center group-hover:bg-indigo-500/25 transition">
-                                <Icon size={18} />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2 flex-wrap">
-                                    <span className="font-medium text-white">{label}</span>
-                                    <span className="text-xs text-indigo-300/80 bg-indigo-500/10 px-2 py-0.5 rounded-full">
-                                        {subtitle}
-                                    </span>
+                    {DESIGN_SYSTEM_PRESETS.map(({ id, icon: Icon, label, subtitle, detail }) => {
+                        const isCurrent = id === currentPresetId;
+                        return (
+                            <button
+                                key={id}
+                                onClick={() => onChoose(id)}
+                                aria-current={isCurrent || undefined}
+                                className={`w-full text-left flex items-start gap-4 p-4 min-h-[64px] rounded-2xl border bg-white/[0.03] hover:bg-white/[0.07] transition group ${
+                                    isCurrent
+                                        ? 'border-indigo-500/70 ring-1 ring-indigo-500/40'
+                                        : 'border-white/10 hover:border-indigo-500/50'
+                                }`}
+                            >
+                                <div className="shrink-0 w-10 h-10 rounded-xl bg-indigo-500/15 text-indigo-300 flex items-center justify-center group-hover:bg-indigo-500/25 transition">
+                                    <Icon size={18} />
                                 </div>
-                                <p className="text-sm text-neutral-400 mt-0.5">{detail}</p>
-                            </div>
-                        </button>
-                    ))}
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <span className="font-medium text-white">{label}</span>
+                                        <span className="text-xs text-indigo-300/80 bg-indigo-500/10 px-2 py-0.5 rounded-full">
+                                            {subtitle}
+                                        </span>
+                                        {isCurrent && (
+                                            <span className="inline-flex items-center gap-1 text-xs text-emerald-300/90 bg-emerald-500/10 px-2 py-0.5 rounded-full">
+                                                <Check size={11} /> Current
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-sm text-neutral-400 mt-0.5">{detail}</p>
+                                </div>
+                            </button>
+                        );
+                    })}
                 </div>
             </div>
         </div>

--- a/src/components/__tests__/DesignDirectionControl.test.tsx
+++ b/src/components/__tests__/DesignDirectionControl.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DesignDirectionControl } from '../DesignDirectionControl';
+
+// The post-finalization "Design direction" card on the Design System artifact.
+// Verifies it surfaces the current direction (or the "AI decides" fallback for
+// projects finalized before the preset feature) and wires both actions.
+
+describe('DesignDirectionControl', () => {
+    it('shows the human label for a stored preset', () => {
+        render(
+            <DesignDirectionControl
+                presetId="saas_minimal"
+                onChangeDirection={() => {}}
+                onRegenerate={() => {}}
+            />,
+        );
+        expect(screen.getByText('SaaS Minimal')).toBeTruthy();
+    });
+
+    it('falls back to an "AI decides" note when no preset is set', () => {
+        render(
+            <DesignDirectionControl
+                onChangeDirection={() => {}}
+                onRegenerate={() => {}}
+            />,
+        );
+        expect(screen.getByText(/AI decides/i)).toBeTruthy();
+    });
+
+    it('fires the change and regenerate callbacks', () => {
+        const onChangeDirection = vi.fn();
+        const onRegenerate = vi.fn();
+        render(
+            <DesignDirectionControl
+                presetId="ai_workspace"
+                onChangeDirection={onChangeDirection}
+                onRegenerate={onRegenerate}
+            />,
+        );
+        fireEvent.click(screen.getByText('Change direction'));
+        fireEvent.click(screen.getByText('Regenerate'));
+        expect(onChangeDirection).toHaveBeenCalledTimes(1);
+        expect(onRegenerate).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
The Design System Preset (visual direction) was a one-time choice made
only at Mark-as-Final, and only when no preset was set. Projects
finalized before the preset feature existed had no way to pick or change
a direction, so regenerating the design system always used the PRD-only
"AI decides" path — and regenerating mockups alone never refreshed the
style.

Two changes:

1. Post-finalization design-direction control. The Design System
   artifact now shows a DesignDirectionControl card with the current
   direction (or an "AI decides" fallback) plus "Change direction" and
   "Regenerate" actions. Changing direction reuses DesignSystemPresetChoice
   (now accepting currentPresetId/title/description), persists the choice
   via setProjectDesignSystemPreset, and opens a confirm that regenerates
   the design system through retrySlot('design_system') — which re-reads
   the preset, so the new direction actually reaches generation and
   produces new tokens.

2. Mockup-drift prompt. Regenerating the design system changes its
   tokensHash, which stalenessSlice already uses to flag dependent mockups
   stale. The Mockups view now also renders an amber "Design system
   changed — regenerate the mockups" banner when the mockup's recorded
   design_system tokensHash differs from the project's current preferred
   design system, wired to the existing mockup regenerate flow.

Adds a DesignDirectionControl render/callback test. Docs (CLAUDE.md,
README) updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017JgCRiNAACPmpmVjkPkhhN