### PR TITLE
Make demo image hydration resilient so mobile stops serving a stale demo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,23 @@ add it to `collectProjectBundle`/`collectScreenImages`, the restore writers, and
   error) the cache is preferred over an empty state. **Do not** re-add an
   early `if (existing) return` — that's exactly what made the desktop serve a
   stale demo while mobile (with no cache) silently saw the latest.
+- **Demo image hydration is retried and failure-tolerant — never all-or-nothing.**
+  A cache-less demo load is a burst of `2 + imageCount + screenImageCount`
+  requests (pointer + bundle + one fetch per mockup/screen image). Per-image
+  fetches in `snapshotClient` retry transient failures with backoff
+  (`fetchImageWithRetry`); on the public demo path (`loadDemoSnapshotPublic`)
+  an image that still fails is **dropped** (`imagesComplete: false` on the
+  returned payload, a client-only field) instead of rejecting the whole
+  snapshot. `loadDemoProject` restores an incomplete payload (fresh-partial
+  beats stale cache) but skips stamping `demoSourceSnapshotId`, so the next
+  open re-fetches and self-heals. This is the fix for "mobile shows the demo
+  without its screen-inventory images": one failed image fetch used to reject
+  the entire fresh snapshot and silently fall back to the stale cached demo.
+  Owner-token `loadSnapshot` keeps strict all-or-nothing semantics (a restore
+  over real data must not be partial). Server side, the public demo GET
+  channel has its own rate-limit scope (`snapshots-demo`, 300/min in
+  `api/snapshots.js`) so an image-rich demo can't 429 its own hydration burst;
+  owner routes stay at 60/min.
 - **Restoring under a *different* project id MUST namespace the artifact version
   ids** (`namespaceSnapshotForRestore` → `rewriteIds`), not just the project id.
   Both mockup images AND screen-inventory images are keyed in IndexedDB by the

--- a/api/snapshots.js
+++ b/api/snapshots.js
@@ -410,22 +410,24 @@ export default async function handler(req, res) {
   if (!['GET', 'POST', 'PUT', 'DELETE'].includes(req.method)) {
     return methodNotAllowed(res, ['GET', 'POST', 'PUT', 'DELETE']);
   }
-  if (
-    enforceRateLimit(req, res, {
-      scope: 'snapshots',
-      limit: 60,
-      windowMs: 60_000,
-      errorBody: { error: 'rate_limited' },
-    })
-  ) {
-    return;
-  }
 
   // `?demo=1` is the public-demo channel. GET is anonymous (so any visitor
   // can load the demo), but PUT (set/clear pointer) is owner-only. Every
   // other route stays owner-gated as before.
   const isDemoChannel = req.query?.demo === '1' || req.query?.demo === 'true';
   const isPublicDemoRead = isDemoChannel && req.method === 'GET';
+
+  // The public demo read gets its own, larger budget: one cache-less demo
+  // load is a legitimate burst of `2 + imageCount + screenImageCount`
+  // requests (pointer + bundle + one fetch per image), so an image-rich demo
+  // would trip a 60/min cap on exactly the devices with no cache (mobile) and
+  // silently fall back to a stale copy. Owner-token routes keep the tight cap.
+  const rateOptions = isPublicDemoRead
+    ? { scope: 'snapshots-demo', limit: 300, windowMs: 60_000 }
+    : { scope: 'snapshots', limit: 60, windowMs: 60_000 };
+  if (enforceRateLimit(req, res, { ...rateOptions, errorBody: { error: 'rate_limited' } })) {
+    return;
+  }
   if (!isPublicDemoRead && requireOwner(req, res)) return;
 
   // @vercel/blob reads BLOB_READ_WRITE_TOKEN from the env. Just creating a

--- a/src/lib/__tests__/snapshotClient.test.ts
+++ b/src/lib/__tests__/snapshotClient.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { namespaceSnapshotForRestore } from '../snapshotClient';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { loadDemoSnapshotPublic, namespaceSnapshotForRestore } from '../snapshotClient';
 import type { SnapshotPayload } from '../snapshotClient';
 import type { MockupImageRecord, ScreenInventoryImageRecord } from '../../types';
 import { buildImageKey } from '../mockupImageStore';
@@ -138,5 +138,109 @@ describe('namespaceSnapshotForRestore — screen images, tasks, metrics', () => 
         const { bundle } = namespaceSnapshotForRestore(withExtras(), DEMO_PROJECT_ID);
         expect(bundle.tasks?.[0].projectId).toBe(DEMO_PROJECT_ID);
         expect(bundle.workflowRuns?.[0].projectId).toBe(DEMO_PROJECT_ID);
+    });
+});
+
+// --- loadDemoSnapshotPublic image hydration -------------------------------
+//
+// The public demo load is a burst of `2 + imageCount + screenImageCount`
+// fetches, so per-image failures (rate limit 429s, flaky mobile networks)
+// are a normal event, not an exception. These tests pin the resilience
+// contract: transient failures are retried, permanent failures drop only the
+// affected image and flag the payload incomplete — they must never reject
+// the whole snapshot (which used to silently serve a stale cached demo).
+
+// Strip the dataUrl so a record doubles as its v2 wire-format metadata ref.
+const imageMetadataOf = <T extends { dataUrl: string }>(img: T): Omit<T, 'dataUrl'> => {
+    const { dataUrl: _omit, ...meta } = img;
+    void _omit;
+    return meta;
+};
+
+type FetchResponder = (url: string, callCount: number) => { status: number; body: unknown };
+
+const okJson = (body: unknown) => ({ status: 200, body });
+
+const installFetchMock = (respond: FetchResponder) => {
+    const counts = new Map<string, number>();
+    const mock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        const n = (counts.get(url) ?? 0) + 1;
+        counts.set(url, n);
+        const { status, body } = respond(url, n);
+        return {
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => body,
+        } as Response;
+    });
+    vi.stubGlobal('fetch', mock);
+    return mock;
+};
+
+describe('loadDemoSnapshotPublic — hydration resilience', () => {
+    const mockupMeta = imageMetadataOf(makeImage('high'));
+    const screenMeta = imageMetadataOf(makeScreenImage(1));
+    const demoBundle: SnapshotPayload = {
+        ...makeSnapshot(),
+        images: [mockupMeta] as unknown as SnapshotPayload['images'],
+        screenImages: [screenMeta] as unknown as SnapshotPayload['screenImages'],
+    };
+    const imageUrl = (key: string) => `/api/snapshots?demo=1&image=${encodeURIComponent(key)}`;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    const runLoad = async (): Promise<SnapshotPayload | null> => {
+        const promise = loadDemoSnapshotPublic();
+        // Flush the retry backoff timers (500ms + 1500ms per image, at most).
+        await vi.advanceTimersByTimeAsync(10_000);
+        return await promise;
+    };
+
+    it('retries a transiently failing image fetch and reports a complete payload', async () => {
+        const fetchMock = installFetchMock((url, callCount) => {
+            if (url === '/api/snapshots?demo=1') return okJson(demoBundle);
+            if (url === imageUrl(screenMeta.key)) {
+                // First attempt is rate-limited; the retry succeeds.
+                if (callCount === 1) return { status: 429, body: { error: 'rate_limited' } };
+                return okJson({ image: makeScreenImage(1) });
+            }
+            if (url === imageUrl(mockupMeta.key)) return okJson({ image: makeImage('high') });
+            throw new Error(`unexpected fetch: ${url}`);
+        });
+
+        const payload = await runLoad();
+
+        expect(payload?.imagesComplete).toBe(true);
+        expect(payload?.images).toHaveLength(1);
+        expect(payload?.screenImages).toHaveLength(1);
+        expect(payload?.screenImages?.[0].dataUrl).toBe(makeScreenImage(1).dataUrl);
+        // 1 bundle + 1 mockup + 2 screen-image attempts.
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('drops a permanently failing image instead of rejecting the whole demo', async () => {
+        installFetchMock((url) => {
+            if (url === '/api/snapshots?demo=1') return okJson(demoBundle);
+            if (url === imageUrl(screenMeta.key)) return { status: 429, body: { error: 'rate_limited' } };
+            if (url === imageUrl(mockupMeta.key)) return okJson({ image: makeImage('high') });
+            throw new Error(`unexpected fetch: ${url}`);
+        });
+
+        const payload = await runLoad();
+
+        // The healthy mockup image survives; the failing screen image is
+        // dropped and the payload is flagged incomplete so loadDemoProject
+        // skips stamping the cache and self-heals on the next open.
+        expect(payload?.images).toHaveLength(1);
+        expect(payload?.screenImages).toHaveLength(0);
+        expect(payload?.imagesComplete).toBe(false);
     });
 });

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -73,6 +73,11 @@ export type SnapshotPayload = {
     // store from mockup images (`screenInventoryImageStore`), so it travels as
     // its own array. Optional on the wire — older snapshots won't have it.
     screenImages?: ScreenInventoryImageRecord[];
+    // Client-side only (never on the wire): false when the demo load had to
+    // drop one or more images whose per-image fetch kept failing (flaky mobile
+    // network / rate limit). `loadDemoProject` uses it to skip stamping
+    // `demoSourceSnapshotId`, so the next demo open re-fetches and self-heals.
+    imagesComplete?: boolean;
 };
 
 export type SnapshotListItem = SnapshotManifest & { isDemo?: boolean };
@@ -282,47 +287,97 @@ const isFullyInlined = (images: unknown[]): boolean => {
     );
 };
 
-// Pull each image blob into a full MockupImageRecord. Runs the fetches
-// with a small concurrency limit so a project with dozens of screens
-// doesn't try to open a fetch for every one simultaneously.
+// Backoff between per-image fetch attempts. A transient 429 (the demo load is
+// a burst of N+2 requests against one rate-limit scope) or a mobile-network
+// blip on one image must not cost the whole snapshot.
+const IMAGE_RETRY_DELAYS_MS = [500, 1500];
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Fetch one image record, retrying transient failures (non-2xx responses and
+// thrown network errors). A malformed body is permanent — retrying won't fix
+// it — so it fails immediately.
+const fetchImageWithRetry = async <T extends { key: string; dataUrl: string }>(
+    fetchOne: (key: string) => Promise<Response>,
+    key: string,
+): Promise<T> => {
+    let lastError: Error = new Error(`load_image_failed: ${key}`);
+    for (let attempt = 0; attempt <= IMAGE_RETRY_DELAYS_MS.length; attempt++) {
+        if (attempt > 0) await sleep(IMAGE_RETRY_DELAYS_MS[attempt - 1]);
+        try {
+            const resp = await fetchOne(key);
+            if (!resp.ok) {
+                lastError = await errorFromResponse(resp, 'load_image_failed');
+                continue;
+            }
+            const body = await resp.json() as { image?: T };
+            if (!body?.image || typeof body.image.dataUrl !== 'string') {
+                throw new Error(`load_image_failed: malformed image record for ${key}`);
+            }
+            return body.image;
+        } catch (err) {
+            if (err instanceof Error && err.message.startsWith('load_image_failed: malformed')) {
+                throw err;
+            }
+            lastError = err instanceof Error ? err : new Error(String(err));
+        }
+    }
+    throw lastError;
+};
+
+type HydrateResult<T> = { images: T[]; failedKeys: string[] };
+
+// Pull each image blob into a full record. Runs the fetches with a small
+// concurrency limit so a project with dozens of screens doesn't try to open a
+// fetch for every one simultaneously. With `tolerateFailures`, an image whose
+// fetch permanently fails is dropped (reported in `failedKeys`) instead of
+// rejecting the whole hydration — the public demo path uses this so one bad
+// image on a flaky mobile connection can't discard the entire fresh snapshot.
 const hydrateImages = async <T extends { key: string; dataUrl: string }>(
     fetchOne: (key: string) => Promise<Response>,
     refs: Array<Omit<T, 'dataUrl'>>,
-): Promise<T[]> => {
+    options?: { tolerateFailures?: boolean },
+): Promise<HydrateResult<T>> => {
     const CONCURRENCY = 4;
-    const out: T[] = new Array(refs.length);
+    const out: Array<T | undefined> = new Array(refs.length);
+    const failedKeys: string[] = [];
     let cursor = 0;
     const workers = Array.from({ length: Math.min(CONCURRENCY, refs.length) }, async () => {
         while (true) {
             const idx = cursor++;
             if (idx >= refs.length) return;
             const ref = refs[idx];
-            const resp = await fetchOne(ref.key);
-            if (!resp.ok) throw await errorFromResponse(resp, 'load_image_failed');
-            const body = await resp.json() as { image?: T };
-            if (!body?.image || typeof body.image.dataUrl !== 'string') {
-                throw new Error(`load_image_failed: malformed image record for ${ref.key}`);
+            try {
+                out[idx] = await fetchImageWithRetry<T>(fetchOne, ref.key);
+            } catch (err) {
+                if (!options?.tolerateFailures) throw err;
+                console.warn(`[snapshots] dropping image ${ref.key} after retries`, err);
+                failedKeys.push(ref.key);
             }
-            out[idx] = body.image;
         }
     });
     await Promise.all(workers);
-    return out;
+    return { images: out.filter((img): img is T => img !== undefined), failedKeys };
 };
 
 // Hydrate the optional `screenImages` array of a payload using the same
-// per-image fetch the mockup images use. Returns the payload unchanged when it
-// carries no screen images (legacy snapshots) or they are already inlined.
+// per-image fetch the mockup images use. Returns the payload's array unchanged
+// when it carries no screen images (legacy snapshots) or they are already
+// inlined.
 const hydrateScreenImages = async (
     payload: SnapshotPayload,
     fetchOne: (key: string) => Promise<Response>,
-): Promise<ScreenInventoryImageRecord[] | undefined> => {
+    options?: { tolerateFailures?: boolean },
+): Promise<{ images: ScreenInventoryImageRecord[] | undefined; failedKeys: string[] }> => {
     const screenImages = payload.screenImages;
-    if (!Array.isArray(screenImages) || screenImages.length === 0) return screenImages;
-    if (isFullyInlined(screenImages)) return screenImages;
+    if (!Array.isArray(screenImages) || screenImages.length === 0) {
+        return { images: screenImages, failedKeys: [] };
+    }
+    if (isFullyInlined(screenImages)) return { images: screenImages, failedKeys: [] };
     return await hydrateImages<ScreenInventoryImageRecord>(
         fetchOne,
         screenImages as unknown as Array<Omit<ScreenInventoryImageRecord, 'dataUrl'>>,
+        options,
     );
 };
 
@@ -349,22 +404,37 @@ export const loadDemoSnapshotPointer = async (): Promise<DemoPointer | null> => 
 
 // Public: fetch the snapshot the owner has marked as the demo. No auth.
 // Returns null when no demo has been set (server returns 404 in that case).
+//
+// Image hydration is failure-tolerant here: an image that keeps failing after
+// retries is dropped and `imagesComplete` is set false, so a single flaky
+// fetch on a mobile connection serves a fresh (mostly complete) demo instead
+// of silently falling back to a stale cached one.
 export const loadDemoSnapshotPublic = async (): Promise<SnapshotPayload | null> => {
     const resp = await fetch(`${API_BASE}?demo=1`);
     if (resp.status === 404) return null;
     if (!resp.ok) throw await errorFromResponse(resp, 'load_demo_failed');
     const payload = await resp.json() as SnapshotPayload;
     const fetchOne = (key: string) => fetch(`${API_BASE}?demo=1&image=${encodeURIComponent(key)}`);
-    const images = isFullyInlined(payload.images)
-        ? payload.images
+    const tolerate = { tolerateFailures: true };
+    const mockups = isFullyInlined(payload.images)
+        ? { images: payload.images, failedKeys: [] as string[] }
         : await hydrateImages<MockupImageRecord>(
             fetchOne,
             payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
+            tolerate,
         );
-    const screenImages = await hydrateScreenImages(payload, fetchOne);
-    return { ...payload, images, screenImages };
+    const screens = await hydrateScreenImages(payload, fetchOne, tolerate);
+    return {
+        ...payload,
+        images: mockups.images,
+        screenImages: screens.images,
+        imagesComplete: mockups.failedKeys.length === 0 && screens.failedKeys.length === 0,
+    };
 };
 
+// Owner-only load. Hydration retries transient failures but stays strict —
+// an owner restore should fail loudly rather than restore an incomplete
+// snapshot over real data.
 export const loadSnapshot = async (id: string): Promise<SnapshotPayload> => {
     const resp = await fetch(`${API_BASE}?id=${encodeURIComponent(id)}`, { headers: authHeaders() });
     if (!resp.ok) throw await errorFromResponse(resp, 'load_failed');
@@ -373,14 +443,14 @@ export const loadSnapshot = async (id: string): Promise<SnapshotPayload> => {
         `${API_BASE}?id=${encodeURIComponent(id)}&image=${encodeURIComponent(key)}`,
         { headers: authHeaders() },
     );
-    const images = isFullyInlined(payload.images)
-        ? payload.images
+    const mockups = isFullyInlined(payload.images)
+        ? { images: payload.images }
         : await hydrateImages<MockupImageRecord>(
             fetchOne,
             payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
         );
-    const screenImages = await hydrateScreenImages(payload, fetchOne);
-    return { ...payload, images, screenImages };
+    const screens = await hydrateScreenImages(payload, fetchOne);
+    return { ...payload, images: mockups.images, screenImages: screens.images };
 };
 
 export const deleteSnapshot = async (id: string): Promise<void> => {

--- a/src/store/__tests__/loadDemoProject.test.ts
+++ b/src/store/__tests__/loadDemoProject.test.ts
@@ -161,4 +161,21 @@ describe('loadDemoProject — freshness check', () => {
         const project = useProjectStore.getState().projects[DEMO_PROJECT_ID];
         expect(project?.demoSourceSnapshotId).toBe('snap-A');
     });
+
+    it('restores but does NOT stamp the source id when the load dropped images', async () => {
+        mockedPointer.mockResolvedValue({ snapshotId: 'snap-A', updatedAt: null });
+        // Some per-image fetches failed permanently (flaky network / rate
+        // limit) — the payload arrives fresh but incomplete.
+        mockedPublic.mockResolvedValue({ ...fakePayload('snap-A'), imagesComplete: false });
+
+        const result = await useProjectStore.getState().loadDemoProject();
+
+        // Fresh-partial still beats stale cache — the demo restores and opens…
+        expect(result).toEqual({ projectId: DEMO_PROJECT_ID, available: true });
+        expect(mockedRestore).toHaveBeenCalledTimes(1);
+        // …but no stamp, so the NEXT open re-fetches and self-heals instead of
+        // pinning the partial copy as "current".
+        const project = useProjectStore.getState().projects[DEMO_PROJECT_ID];
+        expect(project?.demoSourceSnapshotId).toBeUndefined();
+    });
 });

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -184,7 +184,15 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
         // when the pointer is unchanged. Pull from the freshly-restored
         // payload's manifest, falling back to the pointer if the manifest
         // didn't carry an id (defensive — older bundles always did).
-        const sourceId = payload.manifest?.id ?? pointer?.snapshotId ?? null;
+        //
+        // EXCEPT when the load dropped images (`imagesComplete === false`:
+        // some per-image fetches kept failing — flaky network / rate limit).
+        // We still restore what we have (fresh-partial beats stale cache) but
+        // leave the stamp off so the next demo open re-fetches and self-heals
+        // to the full image set instead of pinning the partial copy forever.
+        const sourceId = payload.imagesComplete === false
+            ? null
+            : payload.manifest?.id ?? pointer?.snapshotId ?? null;
         if (sourceId) {
             set((state) => {
                 const restored = state.projects[DEMO_PROJECT_ID];


### PR DESCRIPTION
A cache-less demo load (the mobile case) is a burst of
2 + imageCount + screenImageCount requests to /api/snapshots. Image
hydration had no retry and was all-or-nothing, so a single failed
per-image fetch (flaky mobile network, or a 429 from the shared
60/min rate-limit scope that the screen-inventory images now push
harder) rejected the entire fresh snapshot — and loadDemoProject then
silently fell back to the cached demo saved before the screen-inventory
images existed. Desktop short-circuited on its up-to-date cache, so
only mobile showed the old, image-less demo.

- snapshotClient: retry per-image fetches with backoff; on the public
  demo path, drop an image that still fails (imagesComplete: false)
  instead of rejecting the whole payload. Owner loadSnapshot stays
  strict (never restore a partial snapshot over real data).
- loadDemoProject: restore an incomplete payload (fresh-partial beats
  stale cache) but skip stamping demoSourceSnapshotId so the next open
  re-fetches and self-heals to the full image set.
- api/snapshots: give the public demo GET channel its own rate-limit
  scope (snapshots-demo, 300/min) so an image-rich demo can't 429 its
  own hydration burst; owner routes stay at 60/min.
- Tests for retry/partial-drop hydration and the no-stamp-on-incomplete
  behavior; CLAUDE.md snapshot section updated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018FRxtkRY6aBVkSPei1SDoV