### PR TITLE
Make Developer Prompts agent-agnostic and trim supporting cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,12 +547,14 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     header (Prompt N · Title · Category · "Generated <date>"), only **Edit** +
     **Copy Prompt** actions (Reset surfaces inside edit mode when modified),
     the prompt body rendered exactly as before (mono `whitespace-pre-wrap`,
-    unchanged), and reorganized supporting cards below it — **User Intent**
-    (`**Reason:**`), **Expected Output** (trailing `**Expected Output:**`),
-    **Dependencies** (feature names parsed from the body's `## Features In
-    Scope`), **Key Implementation Areas** (Category + Target Tool) — each
-    rendered only when its data exists, plus a subtle "Safe to regenerate /
-    Creates Version X" callout. `generatedAt` (version `createdAt`) and
+    unchanged), and a single supporting card below it — **Expected Output**
+    (trailing `**Expected Output:**`), rendered only when present — plus a
+    subtle "Safe to regenerate / Creates Version X" callout. **The generated
+    prompts are agent-agnostic** — the `prompt_pack` generation prompt
+    (`coreArtifactService.ts`) must never name or recommend a specific coding
+    agent (Cursor, Claude Code, ChatGPT, Copilot), and the renderer no longer
+    parses/shows a Target Tool, Reason/User Intent, Dependencies, or Key
+    Implementation Areas block. `generatedAt` (version `createdAt`) and
     `versionNumber` thread through `ArtifactContentRenderer`.
   - `branchService.ts` — branch consolidation back into the spine.
   - `preflightService.ts` — optional pre-PRD clarification (see "Preflight

--- a/src/components/renderers/PromptPackRenderer.tsx
+++ b/src/components/renderers/PromptPackRenderer.tsx
@@ -11,11 +11,10 @@ import type { Feature } from '../../types';
 // `### N. Title` heading — with the shared collapsible `ArtifactOutlineNav`
 // on top (same navigator used by Data Model and Design System) so the prompt
 // content gets the full page width instead of competing with a permanent left
-// rail. Each card extracts
-// `**Target Tool:**` / `**Reason:**` / `**Category:**` chips and the fenced
-// code block that holds the actual prompt body, then surfaces supporting
-// context (User Intent / Expected Output / Dependencies / Key Implementation
-// Areas) below the body. User edits are stored as a per-prompt overlay on the
+// rail. Each card extracts a `**Category:**` label and the fenced code block
+// that holds the actual prompt body, then surfaces the Expected Output summary
+// below the body. Prompts are agent-agnostic — no target-tool / recommendation
+// context is shown. User edits are stored as a per-prompt overlay on the
 // version's metadata; copy uses the edited body.
 
 interface Props {
@@ -35,13 +34,9 @@ interface Props {
 type PromptCard = {
     index: number;
     title: string;
-    targetTool?: string;
-    targetReason?: string;
     category?: string;
     promptBody: string;
     expected?: string;
-    /** Feature names this prompt declares under "## Features In Scope". */
-    dependencies: string[];
 };
 
 const PROMPT_HEADING = /^###\s+(\d+)\.?\s+(.+?)\s*$/;
@@ -76,7 +71,6 @@ function buildCard(active: { rawLines: string[]; index: number; title: string })
         index: active.index,
         title: active.title,
         promptBody: '',
-        dependencies: [],
     };
     let inFence = false;
     const promptLines: string[] = [];
@@ -90,16 +84,6 @@ function buildCard(active: { rawLines: string[]; index: number; title: string })
         }
         if (inFence) {
             promptLines.push(line);
-            continue;
-        }
-        const tool = line.match(/^\*\*Target Tool:\*\*\s*(.+)$/i);
-        if (tool) {
-            card.targetTool = tool[1].trim();
-            continue;
-        }
-        const reason = line.match(/^\*\*Reason:\*\*\s*(.+)$/i);
-        if (reason) {
-            card.targetReason = reason[1].trim();
             continue;
         }
         const cat = line.match(/^\*\*Category:\*\*\s*(.+)$/i);
@@ -121,36 +105,7 @@ function buildCard(active: { rawLines: string[]; index: number; title: string })
     if (expectedLines.length > 0) {
         card.expected = expectedLines.join('\n').trim();
     }
-    card.dependencies = parseFeaturesInScope(card.promptBody);
     return card;
-}
-
-// Pull the feature names a prompt declares under its "## Features In Scope"
-// section. Lines look like `- f1 — Feature Name` (id prefix + em dash) with
-// indented detail bullets beneath; we keep the top-level names only.
-function parseFeaturesInScope(body: string): string[] {
-    if (!body) return [];
-    const lines = body.split('\n');
-    let inScope = false;
-    const names: string[] = [];
-    for (const raw of lines) {
-        const heading = raw.match(/^##\s+(.+?)\s*$/);
-        if (heading) {
-            const name = heading[1].toLowerCase();
-            inScope = name.includes('features in scope') || name.includes('feature in scope');
-            continue;
-        }
-        if (!inScope) continue;
-        // Top-level bullet only (indented detail bullets start with spaces).
-        const bullet = raw.match(/^[-*]\s+(.+)$/);
-        if (!bullet) continue;
-        const text = bullet[1].trim();
-        // Strip a leading `f1 —` / `F-014 -` id prefix when present.
-        const withId = text.match(/^[fF]-?\d+\s*[—–-]\s*(.+)$/);
-        const cleaned = (withId ? withId[1] : text).replace(/[*_`]/g, '').trim();
-        if (cleaned) names.push(cleaned);
-    }
-    return Array.from(new Set(names));
 }
 
 // Find feature IDs (e.g. f1, F-014) that appear OUTSIDE a "## Features In
@@ -272,21 +227,6 @@ function SupportingCard({
     );
 }
 
-function ChipRow({ items }: { items: string[] }) {
-    return (
-        <div className="flex flex-wrap gap-1.5">
-            {items.map((item, i) => (
-                <span
-                    key={`${item}-${i}`}
-                    className="text-[11px] font-medium px-2 py-0.5 rounded-md bg-neutral-100 text-neutral-700 border border-neutral-200"
-                >
-                    {item}
-                </span>
-            ))}
-        </div>
-    );
-}
-
 interface PromptCardViewProps {
     card: PromptCard;
     effectiveBody: string;
@@ -311,10 +251,6 @@ function PromptCardView({
     const [editing, setEditing] = useState(false);
     const hasWarning = unresolvedIds.length > 0;
     const copyDisabled = hasWarning;
-    const implementationAreas = [
-        ...(card.category ? [card.category] : []),
-        ...(card.targetTool ? [card.targetTool] : []),
-    ];
     return (
         <article className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
 
@@ -408,27 +344,12 @@ function PromptCardView({
                 )
             )}
 
-            {/* --- Supporting context (reorganized below the body) --------- */}
-            {card.targetReason && (
-                <SupportingCard label="User Intent" accent="text-indigo-600">
-                    <p className="text-sm text-neutral-700 leading-relaxed">{card.targetReason}</p>
-                </SupportingCard>
-            )}
+            {/* --- Supporting context: Expected Output only ---------------- */}
             {card.expected && (
                 <SupportingCard label="Expected Output" accent="text-emerald-700">
                     <div className="prose prose-sm prose-neutral max-w-none">
                         <ReactMarkdown remarkPlugins={[remarkGfm]}>{card.expected}</ReactMarkdown>
                     </div>
-                </SupportingCard>
-            )}
-            {card.dependencies.length > 0 && (
-                <SupportingCard label="Dependencies" accent="text-neutral-500">
-                    <ChipRow items={card.dependencies} />
-                </SupportingCard>
-            )}
-            {implementationAreas.length > 0 && (
-                <SupportingCard label="Key Implementation Areas" accent="text-neutral-500">
-                    <ChipRow items={implementationAreas} />
                 </SupportingCard>
             )}
         </article>

--- a/src/components/renderers/__tests__/PromptPackRenderer.test.tsx
+++ b/src/components/renderers/__tests__/PromptPackRenderer.test.tsx
@@ -2,14 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { PromptPackRenderer } from '../PromptPackRenderer';
 
-// Two-prompt pack exercising the parser: title, target tool/reason, category,
-// a fenced prompt body, Features In Scope (→ Dependencies), and the trailing
-// Expected Output summary.
+// Two-prompt pack exercising the parser: title, category, a fenced prompt
+// body, and the trailing Expected Output summary. Prompts are agent-agnostic —
+// no target-tool / recommendation context is parsed or shown.
 const CONTENT = `Intro preamble line.
 
 ### 1. Geofence Configuration View
-**Target Tool:** Cursor
-**Reason:** Cursor applies multi-file code changes directly.
 **Category:** UI Implementation
 \`\`\`
 # Task
@@ -22,7 +20,6 @@ Implement the Geofence Configuration screen.
 **Expected Output:** A working geofence configuration screen.
 
 ### 2. Playback State Dashboard
-**Target Tool:** ChatGPT
 **Category:** State Management
 \`\`\`
 # Task
@@ -45,19 +42,16 @@ describe('PromptPackRenderer', () => {
         expect(within(nav).getByText('(2)')).toBeInTheDocument();
     });
 
-    it('surfaces supporting context: user intent, expected output, dependencies', () => {
+    it('surfaces only the Expected Output supporting context', () => {
         render(<PromptPackRenderer content={CONTENT} />);
-
-        expect(screen.getByText('User Intent')).toBeInTheDocument();
-        expect(screen.getByText(/Cursor applies multi-file code changes directly/)).toBeInTheDocument();
 
         expect(screen.getByText('Expected Output')).toBeInTheDocument();
         expect(screen.getByText(/A working geofence configuration screen/)).toBeInTheDocument();
 
-        // Dependencies come from "Features In Scope" feature names (id prefix stripped).
-        expect(screen.getByText('Dependencies')).toBeInTheDocument();
-        expect(screen.getByText('Geofence editor')).toBeInTheDocument();
-        expect(screen.getByText('Radius slider')).toBeInTheDocument();
+        // Agent-agnostic: no target-tool / intent / dependency context is shown.
+        expect(screen.queryByText('User Intent')).not.toBeInTheDocument();
+        expect(screen.queryByText('Dependencies')).not.toBeInTheDocument();
+        expect(screen.queryByText('Key Implementation Areas')).not.toBeInTheDocument();
     });
 
     it('only exposes Copy Prompt by default and Edit when editing is enabled', () => {

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -192,13 +192,11 @@ Use stable names for entities and fields: reuse the PRD's exact entity and field
         userPrefix: 'Create a Data Model from this PRD:',
     },
     prompt_pack: {
-        system: `You are a senior prompt engineer producing production-grade artifacts for engineering teams. Create a Prompt Pack — a bundle of ready-to-use downstream prompts that a developer can copy directly into Cursor, Claude Code, ChatGPT, or Copilot WITHOUT also pasting the PRD. Each prompt must be deterministic and directly tool-usable: precise, specific, and free of stylistic or "creative" language.
+        system: `You are a senior prompt engineer producing production-grade artifacts for engineering teams. Create a Prompt Pack — a bundle of ready-to-use downstream prompts that a developer can copy directly into any coding agent or AI assistant WITHOUT also pasting the PRD. Each prompt must be deterministic and directly tool-usable: precise, specific, and free of stylistic or "creative" language. The prompts MUST be agent-agnostic — never name, recommend, or assume a specific tool (e.g. Cursor, Claude Code, ChatGPT, Copilot). Do not tailor a prompt to any one agent's features.
 
 For each prompt, use this exact format:
 
 ### [N]. [Prompt Title]
-**Target Tool:** Cursor | Claude Code | ChatGPT | Copilot | Generic
-**Reason:** One short user-facing sentence (≤25 words) explaining why this target tool fits THIS prompt — e.g. "Cursor — best fit for applying multi-file code changes directly in the repo with diff preview." Keep it concrete; do not say "best AI tool". Select the tool by fit: Cursor for multi-file repo edits; Claude Code for repo-aware agentic tasks; ChatGPT or Generic for standalone reasoning, content, and critique; Copilot for inline code completion.
 **Category:** UI Implementation | UX Critique | Testing | API Design | Content | Accessibility
 **Prompt:**
 \`\`\`


### PR DESCRIPTION
## Summary

The generated **Developer Prompts** (`prompt_pack`) were baking in references to specific coding agents — the UI surfaced "Cursor — best fit for applying multi-file code changes…" and other prompts named Copilot / ChatGPT. Generated prompts should work with whatever agent the user chooses. This PR makes the prompts agent-agnostic and removes the supporting context blocks the user asked to drop.

## Changes

**Generation (`src/lib/services/coreArtifactService.ts`)**
- Removed the `**Target Tool:**` and `**Reason:**` lines from the `prompt_pack` output format.
- Reworded the intro so prompts are for "any coding agent or AI assistant" and added an explicit instruction that prompts MUST be agent-agnostic — never naming, recommending, or tailoring to Cursor / Claude Code / ChatGPT / Copilot.

**Renderer (`src/components/renderers/PromptPackRenderer.tsx`)**
- Removed the **User Intent**, **Dependencies**, and **Key Implementation Areas** supporting cards.
- Kept the **Expected Output** card, the prompt body, header, and the safe-to-regenerate callout unchanged.
- Deleted the now-unused parsing (`Target Tool` / `Reason`, `parseFeaturesInScope`, dependency chips) and the `ChipRow` component.

**Tests & docs**
- Updated `PromptPackRenderer.test.tsx` to assert only Expected Output renders and that User Intent / Dependencies / Key Implementation Areas are absent.
- Updated `CLAUDE.md` to reflect the agent-agnostic requirement and the single remaining supporting card.

## Testing
- `npm run build` — passes
- `npm run lint` — passes
- `npx vitest run src/components/renderers/__tests__/PromptPackRenderer.test.tsx` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2LBBLg4mnUznKqZcFgj6n

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2LBBLg4mnUznKqZcFgj6n)_