### PR TITLE
Reorganize generated PRD into a clearer logical section order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,16 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     merged deterministically (`prdSectionMerge.ts`, disjoint top-level fields)
     and markdown is rendered via `prdMarkdownRenderer.ts`. Do **not** re-add
     edges to sequence sections by document position — only by real data flow.
+    **PRD reading order ≠ generation (DAG) order.** The human/agent-facing
+    section order is a fixed logical flow (Product Overview → Target Users →
+    MVP Scope → Core Features → UX → Success Metrics → Risks → Technical
+    Architecture → Data Model → State Machines → NFRs → reference appendix)
+    defined in **two mirrored renderers that must stay in sync**:
+    `prdMarkdownRenderer.renderPremiumMarkdown` (export/`responseText`) and
+    `StructuredPRDView`/`PremiumSections` (in-app). Reordering is
+    presentation-only and safe — downstream artifacts/mockups consume the
+    `StructuredPRD` **object by field**, never this render order — but if you
+    change one renderer's section order, change the other to match.
     The legacy multi-pass scoring + revision passes were removed — old projects
     in localStorage retain their saved `qualityScores`, but no new generation
     writes them.

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -556,31 +556,35 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     the entire document. Hidden if the PRD has no actionable signal. */}
                 <ImplementationSummarySection prd={structuredPRD} />
 
+                {/* Section order is a logical reading flow (mirrors
+                    prdMarkdownRenderer): Product Overview → Target Users → MVP
+                    Scope → Features → UX → Metrics → Risks → Technical
+                    Architecture → Data Model → State Machines → reference. */}
+
+                {/* Product Overview: Vision → Problem → Thesis → Principles */}
                 {renderTextSection('Vision', 'vision', structuredPRD.vision)}
+
+                {renderTextSection('Core Problem', 'coreProblem', structuredPRD.coreProblem)}
 
                 {structuredPRD.productThesis && (
                     <ProductThesisSection thesis={structuredPRD.productThesis} />
                 )}
 
-                {/* JTBD if available, else legacy targetUsers list */}
-                {structuredPRD.jtbd && structuredPRD.jtbd.length > 0
-                    ? <JtbdSection jtbd={structuredPRD.jtbd} />
-                    : renderListSection('Target Users', 'targetUsers', structuredPRD.targetUsers)}
-
-                {renderTextSection('Core Problem', 'coreProblem', structuredPRD.coreProblem)}
-
                 {structuredPRD.principles && structuredPRD.principles.length > 0 && (
                     <PrinciplesSection principles={structuredPRD.principles} />
                 )}
 
-                {structuredPRD.userLoops && structuredPRD.userLoops.length > 0 && (
-                    <UserLoopsSection loops={structuredPRD.userLoops} />
-                )}
+                {/* Target Users — JTBD if available, else legacy targetUsers list */}
+                {structuredPRD.jtbd && structuredPRD.jtbd.length > 0
+                    ? <JtbdSection jtbd={structuredPRD.jtbd} />
+                    : renderListSection('Target Users', 'targetUsers', structuredPRD.targetUsers)}
 
-                {structuredPRD.uxPages && structuredPRD.uxPages.length > 0 && (
-                    <UxArchitectureSection pages={structuredPRD.uxPages} />
-                )}
+                {/* MVP Scope — what ships first, before the full feature detail */}
+                {structuredPRD.mvpScope && (structuredPRD.mvpScope.mvp.length || structuredPRD.mvpScope.v1.length || structuredPRD.mvpScope.later.length) ? (
+                    <MvpScopeSection scope={structuredPRD.mvpScope} />
+                ) : null}
 
+                {/* Core Features */}
                 {structuredPRD.featureSystems && structuredPRD.featureSystems.length > 0 && (
                     <FeatureSystemsSection systems={structuredPRD.featureSystems} />
                 )}
@@ -626,6 +630,36 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     </div>
                 </div>
 
+                {/* User Experience: UX Architecture → Core User Loops */}
+                {structuredPRD.uxPages && structuredPRD.uxPages.length > 0 && (
+                    <UxArchitectureSection pages={structuredPRD.uxPages} />
+                )}
+
+                {structuredPRD.userLoops && structuredPRD.userLoops.length > 0 && (
+                    <UserLoopsSection loops={structuredPRD.userLoops} />
+                )}
+
+                {/* Success Metrics */}
+                {structuredPRD.successMetrics && structuredPRD.successMetrics.length > 0 && (
+                    <MetricsSection metrics={structuredPRD.successMetrics} />
+                )}
+
+                {/* Risks: prefer detailed, fall back to legacy bullet list */}
+                {structuredPRD.risksDetailed && structuredPRD.risksDetailed.length > 0
+                    ? <RisksDetailedSection risks={structuredPRD.risksDetailed} />
+                    : renderListSection('Risks', 'risks', structuredPRD.risks)}
+
+                {/* Technical Architecture → Roles → Data Model → State Machines */}
+                {renderTextSection('Architecture', 'architecture', structuredPRD.architecture)}
+
+                {structuredPRD.architectureFlows && structuredPRD.architectureFlows.length > 0 && (
+                    <ArchFlowsSection flows={structuredPRD.architectureFlows} />
+                )}
+
+                {structuredPRD.roles && structuredPRD.roles.length > 0 && (
+                    <RolesSection roles={structuredPRD.roles} />
+                )}
+
                 {structuredPRD.richDataModel && structuredPRD.richDataModel.entities.length > 0 && (
                     <DataModelSection model={structuredPRD.richDataModel} />
                 )}
@@ -634,29 +668,7 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     <StateMachinesSection machines={structuredPRD.stateMachines} />
                 )}
 
-                {structuredPRD.roles && structuredPRD.roles.length > 0 && (
-                    <RolesSection roles={structuredPRD.roles} />
-                )}
-
-                {renderTextSection('Architecture', 'architecture', structuredPRD.architecture)}
-
-                {structuredPRD.architectureFlows && structuredPRD.architectureFlows.length > 0 && (
-                    <ArchFlowsSection flows={structuredPRD.architectureFlows} />
-                )}
-
-                {/* Risks: prefer detailed, fall back to legacy bullet list */}
-                {structuredPRD.risksDetailed && structuredPRD.risksDetailed.length > 0
-                    ? <RisksDetailedSection risks={structuredPRD.risksDetailed} />
-                    : renderListSection('Risks', 'risks', structuredPRD.risks)}
-
-                {structuredPRD.mvpScope && (structuredPRD.mvpScope.mvp.length || structuredPRD.mvpScope.v1.length || structuredPRD.mvpScope.later.length) ? (
-                    <MvpScopeSection scope={structuredPRD.mvpScope} />
-                ) : null}
-
-                {structuredPRD.successMetrics && structuredPRD.successMetrics.length > 0 && (
-                    <MetricsSection metrics={structuredPRD.successMetrics} />
-                )}
-
+                {/* Appendix / Reference Material */}
                 {renderDomainEntities()}
                 {renderPrimaryActions()}
 

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -304,12 +304,25 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         }
     }
 
+    // ── Section order is a logical reading flow (see StructuredPRDView, which
+    // mirrors it): Product Overview → Target Users → MVP Scope → Features →
+    // UX → Metrics → Risks → Technical Architecture → Data Model → State
+    // Machines → NFRs → reference appendix. This ordering is presentation-only;
+    // downstream artifacts consume the StructuredPRD object by field, not this
+    // markdown, so blocks may be reordered freely without affecting generation.
+
+    // ── Product Overview ────────────────────────────────────────────────
     // Vision (always present in legacy spec)
     lines.push('## Vision');
     lines.push(prd.vision);
     lines.push('');
 
-    // Product Thesis
+    // Core Problem
+    lines.push('## Core Problem');
+    lines.push(prd.coreProblem);
+    lines.push('');
+
+    // Product Thesis (the "why this / why now / differentiation" solution rationale)
     if (prd.productThesis) {
         lines.push('## Product Thesis');
         lines.push(`**Why this should exist:** ${prd.productThesis.whyExist}`);
@@ -328,7 +341,14 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('');
     }
 
-    // Target Users + JTBD
+    // Principles
+    if (prd.principles?.length) {
+        lines.push('## Product Principles');
+        renderPrinciples(prd.principles).forEach(l => lines.push(l));
+        lines.push('');
+    }
+
+    // ── Target Users ────────────────────────────────────────────────────
     if (prd.jtbd?.length) {
         lines.push('## Target Users & Jobs-to-be-Done');
         renderJtbdTable(prd.jtbd).forEach(l => lines.push(l));
@@ -339,31 +359,29 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('');
     }
 
-    // Core Problem
-    lines.push('## Core Problem');
-    lines.push(prd.coreProblem);
-    lines.push('');
-
-    // Principles
-    if (prd.principles?.length) {
-        lines.push('## Product Principles');
-        renderPrinciples(prd.principles).forEach(l => lines.push(l));
+    // ── MVP Scope (what ships first — placed before the full feature detail) ─
+    if (prd.mvpScope) {
+        lines.push('## MVP Scope');
+        if (prd.mvpScope.rationale) {
+            lines.push(`> [!DECISION] ${prd.mvpScope.rationale}`);
+            lines.push('');
+        }
+        lines.push('**MVP — ship first:**');
+        prd.mvpScope.mvp.forEach(i => lines.push(`- \`[MVP]\` ${i}`));
+        if (prd.mvpScope.v1?.length) {
+            lines.push('');
+            lines.push('**V1 — soon after launch:**');
+            prd.mvpScope.v1.forEach(i => lines.push(`- \`[V1]\` ${i}`));
+        }
+        if (prd.mvpScope.later?.length) {
+            lines.push('');
+            lines.push('**Later — defer:**');
+            prd.mvpScope.later.forEach(i => lines.push(`- \`[Later]\` ${i}`));
+        }
         lines.push('');
     }
 
-    // User Loops
-    if (prd.userLoops?.length) {
-        lines.push('## Core User Loops');
-        renderUserLoops(prd.userLoops).forEach(l => lines.push(l));
-        lines.push('');
-    }
-
-    // UX Architecture
-    if (prd.uxPages?.length) {
-        lines.push('## UX Architecture');
-        renderUxPages(prd.uxPages).forEach(l => lines.push(l));
-    }
-
+    // ── Core Features ───────────────────────────────────────────────────
     // Feature Systems
     if (prd.featureSystems?.length) {
         lines.push('## Feature Systems');
@@ -386,6 +404,53 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
     lines.push('## Detailed Features');
     prd.features.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
 
+    // ── User Experience ─────────────────────────────────────────────────
+    // UX Architecture
+    if (prd.uxPages?.length) {
+        lines.push('## UX Architecture');
+        renderUxPages(prd.uxPages).forEach(l => lines.push(l));
+    }
+
+    // User Loops
+    if (prd.userLoops?.length) {
+        lines.push('## Core User Loops');
+        renderUserLoops(prd.userLoops).forEach(l => lines.push(l));
+        lines.push('');
+    }
+
+    // ── Success Metrics ─────────────────────────────────────────────────
+    if (prd.successMetrics?.length) {
+        lines.push('## Success Metrics');
+        renderMetrics(prd.successMetrics).forEach(l => lines.push(l));
+        lines.push('');
+    }
+
+    // ── Risks ───────────────────────────────────────────────────────────
+    if (prd.risksDetailed?.length) {
+        lines.push('## Risks');
+        renderRisksDetailed(prd.risksDetailed).forEach(l => lines.push(l));
+        lines.push('');
+    } else if (prd.risks?.length) {
+        lines.push('## Risks');
+        prd.risks.forEach(r => lines.push(`- ${r}`));
+        lines.push('');
+    }
+
+    // ── Technical Architecture ──────────────────────────────────────────
+    lines.push('## Architecture');
+    lines.push(prd.architecture);
+    lines.push('');
+    if (prd.architectureFlows?.length) {
+        lines.push('### Example Flows');
+        renderArchFlows(prd.architectureFlows).forEach(l => lines.push(l));
+    }
+
+    // Roles
+    if (prd.roles?.length) {
+        lines.push('## Permissions & Roles');
+        renderRoles(prd.roles).forEach(l => lines.push(l));
+    }
+
     // Data Model
     if (prd.richDataModel?.entities?.length) {
         lines.push('## Data Model');
@@ -398,21 +463,6 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         prd.stateMachines.forEach(m => renderStateMachine(m).forEach(l => lines.push(l)));
     }
 
-    // Roles
-    if (prd.roles?.length) {
-        lines.push('## Permissions & Roles');
-        renderRoles(prd.roles).forEach(l => lines.push(l));
-    }
-
-    // Architecture
-    lines.push('## Architecture');
-    lines.push(prd.architecture);
-    lines.push('');
-    if (prd.architectureFlows?.length) {
-        lines.push('### Example Flows');
-        renderArchFlows(prd.architectureFlows).forEach(l => lines.push(l));
-    }
-
     // NFRs
     if (prd.nonFunctionalRequirements?.length) {
         lines.push('## Non-Functional Requirements');
@@ -420,46 +470,7 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('');
     }
 
-    // Risks
-    if (prd.risksDetailed?.length) {
-        lines.push('## Risks');
-        renderRisksDetailed(prd.risksDetailed).forEach(l => lines.push(l));
-        lines.push('');
-    } else if (prd.risks?.length) {
-        lines.push('## Risks');
-        prd.risks.forEach(r => lines.push(`- ${r}`));
-        lines.push('');
-    }
-
-    // MVP Scope
-    if (prd.mvpScope) {
-        lines.push('## MVP Scope');
-        if (prd.mvpScope.rationale) {
-            lines.push(`> [!DECISION] ${prd.mvpScope.rationale}`);
-            lines.push('');
-        }
-        lines.push('**MVP — ship first:**');
-        prd.mvpScope.mvp.forEach(i => lines.push(`- \`[MVP]\` ${i}`));
-        if (prd.mvpScope.v1?.length) {
-            lines.push('');
-            lines.push('**V1 — soon after launch:**');
-            prd.mvpScope.v1.forEach(i => lines.push(`- \`[V1]\` ${i}`));
-        }
-        if (prd.mvpScope.later?.length) {
-            lines.push('');
-            lines.push('**Later — defer:**');
-            prd.mvpScope.later.forEach(i => lines.push(`- \`[Later]\` ${i}`));
-        }
-        lines.push('');
-    }
-
-    // Success Metrics
-    if (prd.successMetrics?.length) {
-        lines.push('## Success Metrics');
-        renderMetrics(prd.successMetrics).forEach(l => lines.push(l));
-        lines.push('');
-    }
-
+    // ── Appendix / Reference Material ───────────────────────────────────
     // Constraints
     if (prd.constraints?.length) {
         lines.push('## Constraints');
@@ -487,7 +498,7 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('');
     }
 
-    // Assumptions — last so they're easy to find
+    // Assumptions & Open Questions — last so they're easy to find
     if (prd.assumptions?.length) {
         lines.push('## Assumptions');
         prd.assumptions.forEach(a => {


### PR DESCRIPTION
## Summary

Reorganizes the PRD that Synapse generates into a more logical, scannable reading order for humans and AI coding agents — **without changing the product definition, scope, or any downstream artifact contract.**

"The PRD" here is the document Synapse produces. Its section order lives in **two mirrored renderers**:
- `src/lib/services/prdMarkdownRenderer.ts` (`renderPremiumMarkdown` — export / `responseText` / progressive render)
- `src/components/StructuredPRDView.tsx` + `src/components/prd/PremiumSections.tsx` (in-app view)

Both were reordered identically. Section blocks were **moved verbatim** — no content rewrites.

### New reading order

| # | Section (recommended) | Synapse sections mapped |
|---|---|---|
| 1 | Executive Summary | Executive Summary + Implementation Summary |
| 2 | Product Overview | Vision → Core Problem → Product Thesis → Product Principles |
| 3 | Target Users | Target Users & Jobs-to-be-Done |
| 4 | MVP Scope | MVP Scope *(moved up from near the bottom)* |
| 5 | Core Features | Feature Systems + Detailed Features |
| 6 | User Experience | UX Architecture + Core User Loops |
| 7 | Success Metrics | Success Metrics |
| 8 | Risks / Open Questions | Risks |
| 9 | Technical Architecture | Architecture + Example Flows + Permissions & Roles |
| 10 | Data Model | Data Model *(moved after Architecture)* |
| 11 | State Machines | State Machines |
| 12 | Non-Functional Requirements | NFRs *(markdown export)* |
| 13/14 | Appendix / Reference | Constraints, Domain Entities, Primary Actions, Assumptions |

## Reorganization report

**Sections moved**
- MVP Scope: moved up to sit right after Target Users (was down near Success Metrics).
- Data Model / State Machines: moved to sit *after* Technical Architecture (were before it), grouping all technical reference material together.
- Success Metrics / Risks: moved up ahead of the technical block so product-level content leads.
- Core Problem: moved adjacent to Vision (Product Overview grouping); Product Thesis follows as the "solution rationale".
- UX Architecture + Core User Loops: grouped together as the User Experience block.

**Duplicate sections merged** — none. The generator emits disjoint, single-purpose sections, so there was no redundant content to consolidate.

**Content removed** — none. Every section, heading, and field is preserved; blocks were moved, not rewritten.

**Assumptions made**
- "The PRD" = the PRD Synapse generates (no standalone PRD document exists in the repo; branch is `prd-reorganize-structure`).
- The recommended "Executive Summary" maps to Executive Summary + the synthesized Implementation Summary (kept together at the top as the at-a-glance layer).
- "Risks / Open Questions" and the confidence-tagged **Assumptions** are related; Assumptions were left in the reference appendix (their long-standing position) rather than merged into Risks — see below.

## Why this is safe for downstream artifacts

- Downstream artifacts and mockups consume the **`StructuredPRD` object by field** (`structuredPRD.vision`, `.features`, `.architecture`, …); `coreArtifactService` builds its own fixed-order summary. Render order never reaches generation.
- The section-generation **DAG** (`DEFAULT_PRD_SECTIONS`, true-data-dependency edges) is **untouched** — reading order ≠ generation order.
- **No** feature IDs, screen IDs/names, flow IDs, component IDs, field names, or heading text were changed.
- The `#prd-features` anchor (referenced by `ImplementationSummarySection`) and all `prd-*` anchor ids are unchanged.

## Improvements not made (to stay safe)

- **Merging Vision / Problem / Thesis / Principles under one "Product Overview" H2 wrapper** — would restructure the section/anchor markup and could affect any TOC/outline parsing of headings. Kept as adjacent sections instead (logical grouping via order).
- **Renaming display headings** (e.g. "Architecture" → "Technical Architecture", "UX Architecture" → "User Experience") — low value and the `responseText` markdown headings are surfaced/exported, so I left heading text stable to avoid any parsing surprises.
- **Moving Assumptions into the Risks block** — Assumptions are confidence-tagged reference material and have always rendered in the appendix; relocating them is a semantic re-grouping, not a pure move, so it was left in place.

## Docs

- Documented the reading-order-vs-DAG-order distinction and the **two-renderers-must-stay-in-sync** rule in `CLAUDE.md`.

## Testing

- `npm run build` ✅ (tsc -b && vite build)
- `npm run lint` ✅
- `npm test` ✅ 719/719 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kEn9oLAN6QXWVbAp4Poez

---
_Generated by [Claude Code](https://claude.ai/code/session_016kEn9oLAN6QXWVbAp4Poez)_