### PR TITLE
Consolidate Screen Inventory + Mockups into a screen-centric Experience workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -977,8 +977,23 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   Shared priority-chip styles live in `src/components/renderers/screenPriority.ts`
   (own module — the react-refresh/only-export-components rule forbids constant
   exports from component files).
-- **Navigation state is local to `ArtifactWorkspace`** (`selectedScreenSlug` +
-  `screenTab`); no URL routes. Screen journey nodes in **User Flows** navigate
+- **Screen metadata edits are an overlay, never a content rewrite.** User
+  edits (name / purpose / userIntent / priority / notes) are stored per
+  canonical screen id in the screen_inventory **ArtifactVersion's
+  `metadata.screenEdits`** (`ScreenMetadataEdit` / `readScreenEdits` in
+  `screenExperience.ts`, persisted via the existing
+  `updateArtifactVersionMetadata` — the prompt_pack `promptEdits` pattern).
+  `buildScreenIndex` applies the overlay to produce the *effective*
+  `item.screen` while keeping `item.baseScreen` (stored content) as the source
+  of every join and image key — so **renames cannot orphan mockups, flow refs,
+  or uploaded images**. `ScreenImageGallery`/`ScreenCard` take a
+  `storageName`/`imageStorageName` (the base generated name) so upload buckets
+  keep their original slug after a display rename. An overlay equal to the
+  generated content clears itself (saved as null); "Reset to generated"
+  removes it. Edits are per-version — regenerating the inventory starts clean,
+  same as promptEdits. Do NOT rewrite `ArtifactVersion.content` for edits.
+- **Navigation state is local to `ArtifactWorkspace`** (`selectedScreenId` —
+  the canonical id — + `screenTab`); no URL routes. Screen journey nodes in **User Flows** navigate
   to Screen Detail when the node is a `screen` kind AND its slug is in
   `availableScreenSlugs` (threaded through `ArtifactContentRenderer` →
   `UserFlowsRenderer` → `FlowJourney.onNavigateToScreen`); otherwise the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -998,6 +998,21 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   `availableScreenSlugs` (threaded through `ArtifactContentRenderer` →
   `UserFlowsRenderer` → `FlowJourney.onNavigateToScreen`); otherwise the
   original scroll-to-step behavior is preserved.
+- **Mockup coverage is explicit and overlay-based.** The Screens list shows
+  "Mockups: X of N screens covered". Uncovered screens get an **Add to
+  mockups** action (Mockups tab) and the list header offers a confirmed
+  **Generate missing mockups** batch. Both write user-added `MockupScreen`s
+  into the *current* mockup ArtifactVersion's **`metadata.extraScreens`**
+  overlay (`readExtraMockupScreens`/`mergeExtraScreens`/
+  `mockupScreenFromInventoryScreen` in `mockupParsing.ts`) — **never a new
+  ArtifactVersion**, because per-screen images are keyed by
+  `versionId:screenId:quality`, so appending a version would orphan every
+  existing render. Adding coverage is free; **image generation is never
+  automatic** — it's the standard per-screen action, or the batch flow which
+  fires low-quality drafts only after an explicit cost-labeled confirm and
+  only when an OpenAI key exists (keyless → upload sheets). Every consumer of
+  a mockup payload in the workspace must read the *effective* payload
+  (`mergeExtraScreens(tryParsePayload(v), v.metadata)`).
 - **Status/fallbacks:** the Screens sidebar dot and generation/error states map
   to the **`screen_inventory` slot** (its retry re-runs that slot, since it no
   longer has its own row); the Mockups tab surfaces the `mockup` slot's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -940,18 +940,32 @@ layer only**: the `screen_inventory`, `user_flows`, and `mockup` artifacts keep
 generating, persisting, and versioning exactly as before — no schema, prompt,
 pipeline, sync, or snapshot change. Do not add persisted state for this view.
 
+- **Stable screen ids** — every screen has a canonical `ScreenItem.id`,
+  stamped by `assignStableScreenIds` inside `normalizeScreenInventory`
+  (`src/lib/screenInventoryNormalize.ts`): existing content id → slug of the
+  name → deterministic `-2`/`-3` suffix on duplicates, in document order.
+  Because generation persists the normalized shape, **new inventories store
+  their ids**, while legacy artifacts derive the *same* ids on every read (no
+  regeneration/migration required — derivation is deterministic from stored
+  content and never from a user-facing rename). `MockupScreen.sourceScreenId`
+  (optional, back-compat) records the inventory screen a mockup screen was
+  derived from (`generateMockup` stamps it; `mockupParsing.coerceScreen`
+  round-trips it).
 - **Join layer** — `src/lib/screenExperience.ts` (pure; no store/IDB/React;
   unit-tested in `src/lib/__tests__/screenExperience.test.ts`).
   `buildScreenIndex(inventory, flows, mockupPayload)` joins the three parsed
-  artifact contents into a `ScreenExperienceIndex` keyed by
-  **`slugifyScreenName(name)`** — the same slug the per-screen image stores
-  use, and the only cross-artifact screen identity that exists (there is no
-  persisted screen id). Flow steps match by exact slug of the parsed
-  `[Screen Name]` step title (`stepScreenSlug`); mockup screens match by
-  slugified `MockupScreen.name`. Missing artifacts degrade gracefully; a
-  missing inventory returns the module-level `EMPTY_SCREEN_EXPERIENCE_INDEX`
-  (stable reference — Selector-stability rule). Slug collisions keep the first
-  screen and are surfaced via `index.collisions` (warning banner in the list).
+  artifact contents into a `ScreenExperienceIndex` with **`byId` (canonical,
+  rename-safe) and `bySlug` (name-based, first-wins)** lookups. Mockup screens
+  match by `sourceScreenId` first, then slugified `MockupScreen.name` (legacy
+  fallback). Flow steps are markdown and only know names, so they match by
+  exact slug of the parsed `[Screen Name]` step title (`stepScreenSlug`).
+  Screen selection/navigation uses the **id**; per-screen images stay keyed by
+  the slug of the *stored* (generated) name, so both survive display renames.
+  Missing artifacts degrade gracefully; a missing inventory returns the
+  module-level `EMPTY_SCREEN_EXPERIENCE_INDEX` (stable reference —
+  Selector-stability rule). Slug collisions keep **all** screens as items
+  (unique ids), resolve `bySlug` to the first, and are surfaced via
+  `index.collisions` (warning banner in the list).
 - **Views** — `src/components/experience/`: `ScreenListView` (sectioned list of
   all inventory screens with flow-ref/mockup coverage chips),
   `ScreenDetailView` + `ScreenDetailTabs` (per-screen **Overview / Flow /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -883,11 +883,12 @@ User prompt → HomePage.handleCreateProject() → PreflightModeChoice
 
 ### Post-finalization transition (Mark Final → Assets)
 
-The artifact sidebar is organized into four workflow-named sections —
-**Project Foundation** (PRD), **UX & Design** (User Flows, Screen Inventory,
-Mockups, Design System), **Architecture** (Data Model), and
-**Development** (Developer Prompts, Build Plan) — driven by `ARTIFACT_GROUPS` in
-`ArtifactWorkspace.tsx`. Grouping is purely visual; `CoreArtifactSubtype` ids
+The artifact sidebar is organized into five workflow-named sections —
+**Project Foundation** (PRD), **Experience** (User Flows, Screens — see "The
+Experience workspace" below), **Design** (Design System), **Architecture**
+(Data Model), and **Development** (Developer Prompts, Build Plan) — driven by
+`ARTIFACT_GROUPS` in `ArtifactWorkspace.tsx`. Grouping is purely visual;
+`CoreArtifactSubtype` ids
 (`'data_model'`, `'component_inventory'`, `'design_system'`, `'prompt_pack'`,
 `'implementation_plan'`) are unchanged so persisted artifacts, generation, and
 per-artifact model overrides keep working. **`component_inventory` (UI Components)
@@ -924,11 +925,58 @@ check of the 7 core artifacts + mockups) **without** switching stage. Its
 `ArtifactWorkspace` as `autoOpenIntent`. `ArtifactWorkspace` consumes it once
 (via `onAutoOpenConsumed`): it auto-selects the first **non-PRD** artifact —
 preferring `done`, then `generating`, then `queued`, else the first slot in
-`ARTIFACT_GROUPS` order (user_flows → screen_inventory → mockup → … →
+`ARTIFACT_GROUPS` order (user_flows → screens → design_system → … →
 implementation_plan) — and opens the mobile drawer (`useIsMobile`-gated, so it
 never reopens after the user closes it; desktop keeps the persistent side rail). While the overall run is in
 flight, an idle slot renders a centered `BuildAssetsLoading` ("Creating your
 build assets…") instead of an empty state.
+
+### The Experience workspace (Screens) — read-side consolidation
+
+The old **Screen Inventory** and **Mockups** sidebar rows are consolidated into
+one screen-centric **Screens** view (`selected === 'screens'`, a
+`WorkspaceSelection` value, NOT an artifact slot). **This is a read-side view
+layer only**: the `screen_inventory`, `user_flows`, and `mockup` artifacts keep
+generating, persisting, and versioning exactly as before — no schema, prompt,
+pipeline, sync, or snapshot change. Do not add persisted state for this view.
+
+- **Join layer** — `src/lib/screenExperience.ts` (pure; no store/IDB/React;
+  unit-tested in `src/lib/__tests__/screenExperience.test.ts`).
+  `buildScreenIndex(inventory, flows, mockupPayload)` joins the three parsed
+  artifact contents into a `ScreenExperienceIndex` keyed by
+  **`slugifyScreenName(name)`** — the same slug the per-screen image stores
+  use, and the only cross-artifact screen identity that exists (there is no
+  persisted screen id). Flow steps match by exact slug of the parsed
+  `[Screen Name]` step title (`stepScreenSlug`); mockup screens match by
+  slugified `MockupScreen.name`. Missing artifacts degrade gracefully; a
+  missing inventory returns the module-level `EMPTY_SCREEN_EXPERIENCE_INDEX`
+  (stable reference — Selector-stability rule). Slug collisions keep the first
+  screen and are surfaced via `index.collisions` (warning banner in the list).
+- **Views** — `src/components/experience/`: `ScreenListView` (sectioned list of
+  all inventory screens with flow-ref/mockup coverage chips),
+  `ScreenDetailView` + `ScreenDetailTabs` (per-screen **Overview / Flow /
+  Mockups** tabs). They reuse existing pieces rather than duplicating them:
+  Overview = the exported `ScreenCard` from `ScreenInventoryRenderer` (+ the
+  upload gallery); Flow = `FlowJourney`/`StepCard`/`FeatureDetailDrawer` with
+  the current screen's steps highlighted (`highlightedStepIndices`); Mockups =
+  `MockupScreenImage` (which internally routes to the manual upload sheet).
+  Shared priority-chip styles live in `src/components/renderers/screenPriority.ts`
+  (own module — the react-refresh/only-export-components rule forbids constant
+  exports from component files).
+- **Navigation state is local to `ArtifactWorkspace`** (`selectedScreenSlug` +
+  `screenTab`); no URL routes. Screen journey nodes in **User Flows** navigate
+  to Screen Detail when the node is a `screen` kind AND its slug is in
+  `availableScreenSlugs` (threaded through `ArtifactContentRenderer` →
+  `UserFlowsRenderer` → `FlowJourney.onNavigateToScreen`); otherwise the
+  original scroll-to-step behavior is preserved.
+- **Status/fallbacks:** the Screens sidebar dot and generation/error states map
+  to the **`screen_inventory` slot** (its retry re-runs that slot, since it no
+  longer has its own row); the Mockups tab surfaces the `mockup` slot's
+  generating/error states. A screen_inventory version whose content isn't
+  parseable structured JSON (legacy markdown) falls back to the standalone
+  `ScreenInventoryRenderer` path inside the Screens view. The legacy
+  `screen_inventory` and `mockup` renderMain branches remain intact and
+  internally reachable — do not delete them.
 
 ### Implementation tasks (plan → tracked checklist)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1023,6 +1023,20 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   only when an OpenAI key exists (keyless → upload sheets). Every consumer of
   a mockup payload in the workspace must read the *effective* payload
   (`mergeExtraScreens(tryParsePayload(v), v.metadata)`).
+- **Reference validation is advisory, never blocking.** `buildScreenIndex`
+  emits `index.issues` (`ScreenReferenceIssue`): `unmatched_flow_step`
+  (screen-kind journey steps matching no screen, grouped per name),
+  `unmatched_mockup_screen`, `slug_collision`, and `legacy_name_match`
+  (mockup matched by name only — works, but rename-fragile). The Screens list
+  renders them in the collapsed `ReferenceWarningsPanel`
+  (`src/components/experience/ReferenceWarningsPanel.tsx`) with two persisted
+  repairs: **Relink/Pin** writes `metadata.screenLinks`
+  (mockupScreenId → canonical screenId) on the **mockup** version — the
+  highest-priority mockup match, above `sourceScreenId` and name — and
+  **Ignore** appends the issue key to `metadata.dismissedScreenIssues` on the
+  **inventory** version. Matching runs in three passes (links →
+  sourceScreenId → name) so an explicit repair always beats a coincidental
+  name match. Rendering must never be gated on validation results.
 - **Status/fallbacks:** the Screens sidebar dot and generation/error states map
   to the **`screen_inventory` slot** (its retry re-runs that slot, since it no
   longer has its own row); the Mockups tab surfaces the `mockup` slot's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -992,8 +992,18 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   generated content clears itself (saved as null); "Reset to generated"
   removes it. Edits are per-version — regenerating the inventory starts clean,
   same as promptEdits. Do NOT rewrite `ArtifactVersion.content` for edits.
-- **Navigation state is local to `ArtifactWorkspace`** (`selectedScreenId` —
-  the canonical id — + `screenTab`); no URL routes. Screen journey nodes in **User Flows** navigate
+- **Screen selection is URL-addressable:** `/p/:projectId?screen=<canonical
+  id>[&screenTab=flow|mockups]`. The query param is the **single source of
+  truth** for the open Screen Detail (via `useSearchParams`); the rendered
+  view is *derived* (`activeSelection = screen param ? 'screens' : selected`)
+  — never synced by a setState-in-effect. Deep links, refresh, and browser
+  back/forward all work; tab switches use `replace` so history is one entry
+  per screen; unknown/stale ids miss `byId` and fall back to the list;
+  unrelated query params (debug flags) are preserved. `ProjectWorkspace` has a
+  one-shot mount effect that switches a deep-linked project to the `workspace`
+  stage when the spine is final (otherwise the param is inert). Artifact-row
+  selection (`selected`) stays local component state — only the screen
+  dimension lives in the URL. Screen journey nodes in **User Flows** navigate
   to Screen Detail when the node is a `screen` kind AND its slug is in
   `availableScreenSlugs` (threaded through `ArtifactContentRenderer` →
   `UserFlowsRenderer` → `FlowJourney.onNavigateToScreen`); otherwise the

--- a/README.md
+++ b/README.md
@@ -172,6 +172,20 @@ that touches it with the screen highlighted in the journey diagram, and its
 mockup). Clicking a screen node in a User Flow jumps straight to that screen's
 page, so the working mental model is "I'm working on this screen."
 
+Screens are joined across artifacts by **stable ids**, so you can safely
+**edit a screen's name, purpose, intent, priority, and notes** without
+detaching its mockups, flow references, or uploaded images — edits are an
+overlay; the generated artifact is never rewritten and one click restores it.
+The Screens list shows **mockup coverage** ("Mockups: 3 of 12 screens
+covered"); uncovered screens get an **Add to mockups** action (generation
+stays explicit and cost-labeled — nothing is billed without confirmation), and
+a **Generate missing mockups** batch sits behind a confirm. Every screen page
+is **deep-linkable** (`?screen=…`), with working browser back/forward. A
+lightweight validation panel flags broken or ambiguous references (a flow step
+naming a missing screen, a mockup that lost its match, duplicate screen names)
+with one-click **relink / pin / ignore** repairs — warnings never block
+rendering.
+
 Each artifact is routed to the right model by complexity — Flash for simpler
 artifacts, Pro for complex reasoning — and you can override the model **per
 artifact** in Settings → **Artifact Generation Models** (the PRD itself routes

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ schemas and render as card grids and entity tables rather than raw markdown. Eve
 refinement** ("add error states to each screen"), and surfaces **quality
 warnings** if the output looks truncated or malformed.
 
+The workspace presents the experience artifacts screen-first: an **Experience**
+section holds **User Flows** and **Screens** — a consolidated, screen-centric
+view where each screen from the Screen Inventory gets its own detail page with
+**Overview / Flow / Mockups** tabs (its inventory spec, every user-flow step
+that touches it with the screen highlighted in the journey diagram, and its
+mockup). Clicking a screen node in a User Flow jumps straight to that screen's
+page, so the working mental model is "I'm working on this screen."
+
 Each artifact is routed to the right model by complexity — Flash for simpler
 artifacts, Pro for complex reasoning — and you can override the model **per
 artifact** in Settings → **Artifact Generation Models** (the PRD itself routes

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -188,11 +188,10 @@ export function ArtifactWorkspace({
     const [designRegenConfirm, setDesignRegenConfirm] = useState<
         { nextVersion: number } | null
     >(null);
-    // Experience workspace (Screens) navigation state. `selectedScreenSlug`
-    // is the open Screen Detail (null = the Screens list view); `screenTab`
-    // is its active tab. Local component state only — no URL routing in the
-    // MVP, mirroring how `selected` itself works.
-    const [selectedScreenSlug, setSelectedScreenSlug] = useState<string | null>(null);
+    // Experience workspace (Screens) navigation state. `selectedScreenId`
+    // is the open Screen Detail (null = the Screens list view) keyed by the
+    // stable canonical screen id; `screenTab` is its active tab.
+    const [selectedScreenId, setSelectedScreenId] = useState<string | null>(null);
     const [screenTab, setScreenTab] = useState<ScreenDetailTab>('overview');
 
     const job = getJob(projectId);
@@ -326,14 +325,20 @@ export function ArtifactWorkspace({
         });
     };
 
-    // Open a screen's detail view — used by the Screens list, the Screens
-    // sidebar row (via handleSelect resetting to the list), and screen nodes
-    // in the User Flows journey diagram.
-    const handleNavigateToScreen = (slug: string) => {
+    // Open a screen's detail view by its stable canonical id (Screens list,
+    // deep links).
+    const handleOpenScreen = (screenId: string) => {
         setSelected('screens');
-        setSelectedScreenSlug(slug);
+        setSelectedScreenId(screenId);
         setScreenTab('overview');
         setMobileSidebarOpen(false);
+    };
+
+    // Slug-based entry point for User Flows journey nodes (flows are markdown
+    // and only know screen names) — resolved to the canonical id here.
+    const handleNavigateToScreen = (slug: string) => {
+        const item = screenIndex.bySlug.get(slug);
+        if (item) handleOpenScreen(item.id);
     };
 
     // Persist a newly-chosen visual direction, then surface the regenerate
@@ -467,8 +472,8 @@ export function ArtifactWorkspace({
                 );
             }
 
-            const detailItem = selectedScreenSlug
-                ? screenIndex.bySlug.get(selectedScreenSlug)
+            const detailItem = selectedScreenId
+                ? screenIndex.byId.get(selectedScreenId)
                 : undefined;
             if (detailItem) {
                 return (
@@ -476,7 +481,7 @@ export function ArtifactWorkspace({
                         item={detailItem}
                         activeTab={screenTab}
                         onTabChange={setScreenTab}
-                        onBack={() => setSelectedScreenSlug(null)}
+                        onBack={() => setSelectedScreenId(null)}
                         onNavigateToScreen={handleNavigateToScreen}
                         availableScreenSlugs={screenIndex.availableSlugs}
                         screenImageContext={invScreenImageContext}
@@ -551,7 +556,7 @@ export function ArtifactWorkspace({
                             </button>
                         </div>
                     )}
-                    <ScreenListView index={screenIndex} onSelectScreen={handleNavigateToScreen} />
+                    <ScreenListView index={screenIndex} onSelectScreen={handleOpenScreen} />
                 </div>
             );
         }
@@ -808,7 +813,7 @@ export function ArtifactWorkspace({
         setSelected(key);
         // Any sidebar selection (including re-clicking "Screens") lands on the
         // top of that view, closing an open Screen Detail.
-        setSelectedScreenSlug(null);
+        setSelectedScreenId(null);
         setMobileSidebarOpen(false);
     };
 

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -32,8 +32,10 @@ import { hasOpenAIKey } from '../lib/openaiClient';
 import { useMockupImageStore } from '../store/mockupImageStore';
 import { selectPreferredDesignTokens, selectPreferredDesignSystem } from '../lib/designTokens';
 import {
-    buildScreenIndex, readScreenEdits, type ScreenMetadataEdit,
+    buildScreenIndex, readScreenEdits, readScreenLinks, readDismissedScreenIssues,
+    type ScreenMetadataEdit,
 } from '../lib/screenExperience';
+import { ReferenceWarningsPanel } from './experience/ReferenceWarningsPanel';
 import { parseScreenInventory } from '../lib/screenInventoryNormalize';
 import { parseFlows } from './renderers/userFlows/parseFlow';
 import type { ParsedFlow } from './renderers/userFlows/types';
@@ -268,8 +270,38 @@ export function ArtifactWorkspace({
     const screenIndex = useMemo(() => {
         const inventory = invPreferred ? parseScreenInventory(invPreferred.content) : null;
         const flows = flowsPreferred ? parseFlows(flowsPreferred.content) : EMPTY_FLOWS;
-        return buildScreenIndex(inventory, flows, mockupPayload, readScreenEdits(invPreferred?.metadata));
-    }, [invPreferred, flowsPreferred, mockupPayload]);
+        return buildScreenIndex(
+            inventory,
+            flows,
+            mockupPayload,
+            readScreenEdits(invPreferred?.metadata),
+            readScreenLinks(mockupPreferred?.metadata),
+        );
+    }, [invPreferred, flowsPreferred, mockupPayload, mockupPreferred]);
+
+    // Validation issues minus the user's persisted dismissals.
+    const visibleScreenIssues = useMemo(() => {
+        const dismissed = readDismissedScreenIssues(invPreferred?.metadata);
+        return screenIndex.issues.filter(i => !dismissed.has(i.key));
+    }, [screenIndex, invPreferred]);
+
+    // Repair: pin/relink a mockup screen to a canonical screen (persisted on
+    // the mockup version — survives renames and name drift thereafter).
+    const handleRelinkMockupScreen = (mockupScreenId: string, screenId: string) => {
+        if (!mockupArtifact || !mockupPreferred) return;
+        const links = { ...readScreenLinks(mockupPreferred.metadata), [mockupScreenId]: screenId };
+        updateArtifactVersionMetadata(projectId, mockupArtifact.id, mockupPreferred.id, { screenLinks: links });
+    };
+
+    // Repair: hide a warning (current behavior is kept — nothing else changes).
+    const handleDismissScreenIssue = (issueKey: string) => {
+        if (!invArtifact || !invPreferred) return;
+        const dismissed = new Set(readDismissedScreenIssues(invPreferred.metadata));
+        dismissed.add(issueKey);
+        updateArtifactVersionMetadata(projectId, invArtifact.id, invPreferred.id, {
+            dismissedScreenIssues: Array.from(dismissed),
+        });
+    };
 
     // Persist (or clear, with null) one screen's metadata edit overlay.
     const handleSaveScreenEdit = (screenId: string, edit: ScreenMetadataEdit | null) => {
@@ -679,6 +711,16 @@ export function ArtifactWorkspace({
                             >
                                 <RefreshCcw size={12} /> Regenerate Mockup
                             </button>
+                        </div>
+                    )}
+                    {visibleScreenIssues.length > 0 && (
+                        <div className="max-w-3xl xl:max-w-5xl mx-auto">
+                            <ReferenceWarningsPanel
+                                issues={visibleScreenIssues}
+                                screenOptions={screenIndex.items.map(i => ({ id: i.id, name: i.screen.name }))}
+                                onRelink={mockupArtifact && mockupPreferred ? handleRelinkMockupScreen : undefined}
+                                onDismiss={invArtifact && invPreferred ? handleDismissScreenIssue : undefined}
+                            />
                         </div>
                     )}
                     <ScreenListView

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
     RefreshCcw, Menu, X, ListChecks, History,
@@ -196,11 +197,44 @@ export function ArtifactWorkspace({
     const [designRegenConfirm, setDesignRegenConfirm] = useState<
         { nextVersion: number } | null
     >(null);
-    // Experience workspace (Screens) navigation state. `selectedScreenId`
-    // is the open Screen Detail (null = the Screens list view) keyed by the
-    // stable canonical screen id; `screenTab` is its active tab.
-    const [selectedScreenId, setSelectedScreenId] = useState<string | null>(null);
-    const [screenTab, setScreenTab] = useState<ScreenDetailTab>('overview');
+    // Experience workspace (Screens) navigation state — URL-addressable:
+    // /p/:projectId?screen=<canonical id>[&screenTab=flow|mockups]. The URL
+    // is the single source of truth for which screen is open, so deep links,
+    // refresh, and browser back/forward all work without a state↔URL sync
+    // effect (which would also trip react-hooks/set-state-in-effect). An
+    // invalid/stale id simply misses `byId` and falls back to the list.
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selectedScreenId = searchParams.get('screen');
+    const rawScreenTab = searchParams.get('screenTab');
+    const screenTab: ScreenDetailTab =
+        rawScreenTab === 'flow' || rawScreenTab === 'mockups' ? rawScreenTab : 'overview';
+
+    // Update the screen params, preserving unrelated query params (debug
+    // flags etc). `replace` is used for tab switches so history stays one
+    // entry per screen, not per tab click.
+    const setScreenParams = (
+        screenId: string | null,
+        tab: ScreenDetailTab = 'overview',
+        opts?: { replace?: boolean },
+    ) => {
+        setSearchParams(prev => {
+            const next = new URLSearchParams(prev);
+            if (screenId) {
+                next.set('screen', screenId);
+                if (tab !== 'overview') next.set('screenTab', tab);
+                else next.delete('screenTab');
+            } else {
+                next.delete('screen');
+                next.delete('screenTab');
+            }
+            return next;
+        }, { replace: opts?.replace });
+    };
+
+    // The rendered selection: an open screen param always means the Screens
+    // view (derived — never synced), so back/forward re-entering ?screen=…
+    // reopens the detail page even if another artifact row was selected.
+    const activeSelection: WorkspaceSelection = selectedScreenId ? 'screens' : selected;
 
     const job = getJob(projectId);
 
@@ -347,10 +381,11 @@ export function ArtifactWorkspace({
         });
     }, [projectId, spineVersionId, prdContent, structuredPRD, projectPlatform]);
 
-    // Scroll the content pane back to the top on every page switch.
+    // Scroll the content pane back to the top on every page switch (including
+    // opening/closing a screen detail page).
     useEffect(() => {
         mainRef.current?.scrollTo({ top: 0 });
-    }, [selected]);
+    }, [activeSelection, selectedScreenId]);
 
     const slotStatusFor = (key: WorkspaceSelection): GenerationStatus => {
         if (key === 'prd') return 'done';
@@ -410,11 +445,11 @@ export function ArtifactWorkspace({
     };
 
     // Open a screen's detail view by its stable canonical id (Screens list,
-    // deep links).
+    // flow-node navigation). Pushes a history entry so browser Back returns
+    // to the previous view.
     const handleOpenScreen = (screenId: string) => {
         setSelected('screens');
-        setSelectedScreenId(screenId);
-        setScreenTab('overview');
+        setScreenParams(screenId);
         setMobileSidebarOpen(false);
     };
 
@@ -473,7 +508,7 @@ export function ArtifactWorkspace({
     };
 
     const renderMain = () => {
-        if (selected === 'prd') {
+        if (activeSelection === 'prd') {
             return (
                 <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto">
                     <StructuredPRDView
@@ -487,7 +522,7 @@ export function ArtifactWorkspace({
         }
 
         // --- Experience → Screens (read-side consolidation) -----------------
-        if (selected === 'screens') {
+        if (activeSelection === 'screens') {
             const screensStatus = slotStatusFor('screens'); // = screen_inventory slot
             const screensError = slotErrorFor('screens');
             if (screensStatus === 'queued' || screensStatus === 'generating') {
@@ -564,8 +599,8 @@ export function ArtifactWorkspace({
                     <ScreenDetailView
                         item={detailItem}
                         activeTab={screenTab}
-                        onTabChange={setScreenTab}
-                        onBack={() => setSelectedScreenId(null)}
+                        onTabChange={(tab) => setScreenParams(detailItem.id, tab, { replace: true })}
+                        onBack={() => setScreenParams(null)}
                         onNavigateToScreen={handleNavigateToScreen}
                         availableScreenSlugs={screenIndex.availableSlugs}
                         screenImageContext={invScreenImageContext}
@@ -661,26 +696,26 @@ export function ArtifactWorkspace({
             );
         }
 
-        const status = slotStatusFor(selected);
-        const error = slotErrorFor(selected);
+        const status = slotStatusFor(activeSelection);
+        const error = slotErrorFor(activeSelection);
 
         if (status === 'queued' || status === 'generating') {
-            const meta = selected === 'mockup' ? null : getArtifactMeta(selected);
-            const stages = selected === 'mockup' ? MOCKUP_GENERATION_STAGES : getArtifactStages(selected);
-            const displayName = selected === 'mockup' ? 'Mockup' : (meta?.title ?? selected);
+            const meta = activeSelection === 'mockup' ? null : getArtifactMeta(activeSelection);
+            const stages = activeSelection === 'mockup' ? MOCKUP_GENERATION_STAGES : getArtifactStages(activeSelection);
+            const displayName = activeSelection === 'mockup' ? 'Mockup' : (meta?.title ?? activeSelection);
             const title = status === 'queued'
                 ? `Queued: ${displayName}`
-                : selected === 'mockup'
+                : activeSelection === 'mockup'
                     ? 'Designing your product interface'
                     : `Generating ${displayName}`;
             return (
                 <div className="max-w-2xl mx-auto">
                     <GenerationProgress
                         stages={stages}
-                        variant={selected === 'mockup' ? 'creative' : 'systematic'}
+                        variant={activeSelection === 'mockup' ? 'creative' : 'systematic'}
                         title={title}
                         subtitle={status === 'queued' ? 'Queued — will start as a generation slot frees up' : undefined}
-                        history={job?.slots[selected]?.progressLog ?? []}
+                        history={job?.slots[activeSelection]?.progressLog ?? []}
                     />
                 </div>
             );
@@ -700,7 +735,7 @@ export function ArtifactWorkspace({
                             )}
                             <button
                                 type="button"
-                                onClick={() => handleRetrySlot(selected)}
+                                onClick={() => handleRetrySlot(activeSelection)}
                                 className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
                             >
                                 <RefreshCcw size={14} /> Retry
@@ -720,7 +755,7 @@ export function ArtifactWorkspace({
         }
 
         // status === 'done' or 'idle' — try to render the existing artifact.
-        if (selected === 'mockup') {
+        if (activeSelection === 'mockup') {
             const mockup = getArtifacts(projectId, 'mockup')[0];
             const preferred = mockup ? getPreferredVersion(projectId, mockup.id) : undefined;
             if (!mockup || !preferred) {
@@ -802,7 +837,7 @@ export function ArtifactWorkspace({
         }
 
         // Core artifact done state.
-        const subtype = selected;
+        const subtype = activeSelection;
         const artifact = getArtifacts(projectId, 'core_artifact').find(a => a.subtype === subtype);
         const preferred = artifact ? getPreferredVersion(projectId, artifact.id) : undefined;
         if (!artifact || !preferred) {
@@ -909,12 +944,13 @@ export function ArtifactWorkspace({
         );
     };
 
-    const selectedMeta = slotMetas.find(s => s.key === selected);
+    const selectedMeta = slotMetas.find(s => s.key === activeSelection);
     const handleSelect = (key: WorkspaceSelection) => {
         setSelected(key);
         // Any sidebar selection (including re-clicking "Screens") lands on the
-        // top of that view, closing an open Screen Detail.
-        setSelectedScreenId(null);
+        // top of that view, closing an open Screen Detail (clears the URL
+        // params, so Back can return to the screen).
+        if (selectedScreenId) setScreenParams(null);
         setMobileSidebarOpen(false);
     };
 
@@ -976,7 +1012,7 @@ export function ArtifactWorkspace({
                                 <ul>
                                     {groupSlots.map(slot => {
                                         const status = slotStatusFor(slot.key);
-                                        const isSel = selected === slot.key;
+                                        const isSel = activeSelection === slot.key;
                                         const Icon = slot.icon;
                                         return (
                                             <li key={slot.key}>
@@ -1027,9 +1063,9 @@ export function ArtifactWorkspace({
                     <span className="text-sm font-semibold text-neutral-800 truncate">
                         {selectedMeta?.title ?? 'Artifacts'}
                     </span>
-                    {selected !== 'prd' && (
+                    {activeSelection !== 'prd' && (
                         <span className="ml-auto shrink-0">
-                            <StatusDot status={slotStatusFor(selected)} />
+                            <StatusDot status={slotStatusFor(activeSelection)} />
                         </span>
                     )}
                 </div>

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -449,9 +449,12 @@ export function ArtifactWorkspace({
             // parseable structured JSON (old markdown artifacts). Render it
             // through the standalone renderer so the content stays reachable
             // instead of dead-ending on an empty Screens list.
-            if (screenIndex.items.length === 0 && invPreferred) {
+            if (screenIndex.items.length === 0 && invPreferred && invArtifact) {
                 return (
-                    <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto">
+                    <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto space-y-4">
+                        <div className="flex items-center justify-start">
+                            {renderVersionControls(invArtifact.id, invPreferred)}
+                        </div>
                         <div className="bg-white rounded-xl border border-neutral-200 shadow-sm p-6 prose prose-sm prose-neutral max-w-none overflow-auto">
                             <ArtifactContentRenderer
                                 subtype="screen_inventory"
@@ -484,8 +487,73 @@ export function ArtifactWorkspace({
                     />
                 );
             }
-            // Stale slug (e.g. inventory regenerated) falls back to the list.
-            return <ScreenListView index={screenIndex} onSelectScreen={handleNavigateToScreen} />;
+
+            // Artifact-level controls for the two source artifacts that no
+            // longer have their own sidebar rows: Screen Inventory version
+            // history / staleness, and Mockup version history / regenerate
+            // (incl. the design-system drift prompt). Without these here the
+            // consolidation would orphan restore + regenerate flows.
+            const mockupDesignRef = mockupPreferred?.sourceRefs.find(
+                r => r.sourceType === 'core_artifact' && typeof r.anchorInfo === 'string',
+            );
+            const currentDesignForScreens = selectPreferredDesignSystem(useProjectStore.getState(), projectId);
+            const screensDesignDrift = !!mockupDesignRef
+                && !!currentDesignForScreens?.tokensHash
+                && currentDesignForScreens.tokensHash !== mockupDesignRef.anchorInfo;
+
+            // Stale screen id (e.g. inventory regenerated) falls back to the list.
+            return (
+                <div className="space-y-4">
+                    {(invPreferred || mockupPreferred) && (
+                        <div className="max-w-3xl xl:max-w-5xl mx-auto flex items-center justify-between gap-2 flex-wrap">
+                            <div className="flex items-center gap-2 flex-wrap">
+                                {invArtifact && invPreferred && renderVersionControls(invArtifact.id, invPreferred)}
+                            </div>
+                            {mockupArtifact && mockupPreferred && (
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <button
+                                        type="button"
+                                        onClick={() => setVersionHistoryArtifactId(mockupArtifact.id)}
+                                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
+                                    >
+                                        <History size={12} /> Mockup history
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => setMockupRegenConfirm({ nextVersion: mockupPreferred.versionNumber + 1 })}
+                                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
+                                    >
+                                        <RefreshCcw size={12} /> Regenerate Mockup
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                    {screensDesignDrift && mockupPreferred && (
+                        <div className="max-w-3xl xl:max-w-5xl mx-auto flex items-start justify-between gap-3 flex-wrap rounded-lg border border-amber-200 bg-amber-50 p-3">
+                            <div className="flex items-start gap-2 min-w-0">
+                                <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-600" />
+                                <div className="min-w-0">
+                                    <p className="text-sm font-medium text-amber-900">
+                                        Design system changed since these mockups were generated
+                                    </p>
+                                    <p className="text-xs text-amber-700 mt-0.5">
+                                        Regenerate the mockups to apply the new visual direction.
+                                    </p>
+                                </div>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => setMockupRegenConfirm({ nextVersion: mockupPreferred.versionNumber + 1 })}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-amber-600 hover:bg-amber-700 text-white rounded-md transition shrink-0"
+                            >
+                                <RefreshCcw size={12} /> Regenerate Mockup
+                            </button>
+                        </div>
+                    )}
+                    <ScreenListView index={screenIndex} onSelectScreen={handleNavigateToScreen} />
+                </div>
+            );
         }
 
         const status = slotStatusFor(selected);

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
     RefreshCcw, Menu, X, ListChecks, History,
-    Layers, Database, Code2,
+    Layers, Database, Code2, AppWindow, Palette,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -24,6 +24,13 @@ import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
 import { DesignDirectionControl } from './DesignDirectionControl';
 import { tryParsePayload, extractMockupSettings } from '../lib/mockupParsing';
 import { selectPreferredDesignTokens, selectPreferredDesignSystem } from '../lib/designTokens';
+import { buildScreenIndex } from '../lib/screenExperience';
+import { parseScreenInventory } from '../lib/screenInventoryNormalize';
+import { parseFlows } from './renderers/userFlows/parseFlow';
+import type { ParsedFlow } from './renderers/userFlows/types';
+import { ScreenListView } from './experience/ScreenListView';
+import { ScreenDetailView } from './experience/ScreenDetailView';
+import type { ScreenDetailTab } from './experience/ScreenDetailTabs';
 import type {
     ArtifactSlotKey, CoreArtifactSubtype, ProjectPlatform, StructuredPRD, GenerationStatus,
     ProjectTask,
@@ -34,6 +41,9 @@ import type {
 // render and bail out with React #185 (Maximum update depth) for any project
 // without saved tasks — e.g. the demo project on first load.
 const EMPTY_TASKS: ProjectTask[] = [];
+
+// Stable empty flows list for the screen-experience join memo.
+const EMPTY_FLOWS: ParsedFlow[] = [];
 
 interface ArtifactWorkspaceProps {
     projectId: string;
@@ -49,7 +59,10 @@ interface ArtifactWorkspaceProps {
     onAutoOpenConsumed?: () => void;
 }
 
-type WorkspaceSelection = 'prd' | ArtifactSlotKey;
+// 'screens' is the Experience workspace's screen-centric view — a read-side
+// join over screen_inventory + user_flows + mockup (src/lib/screenExperience.ts),
+// not an artifact slot of its own.
+type WorkspaceSelection = 'prd' | ArtifactSlotKey | 'screens';
 
 interface SlotMeta {
     key: WorkspaceSelection;
@@ -66,21 +79,25 @@ interface ArtifactGroup {
 }
 
 // Sidebar grouping is purely visual — subtype IDs are unchanged. Order within
-// a group is the order rows render in. The "Project Foundation → UX & Design
-// → Architecture → Development" sequence tells the product-build story; keep
-// it in sync with the README/tour if either changes.
+// a group is the order rows render in. The "Project Foundation → Experience →
+// Design → Architecture → Development" sequence tells the product-build story;
+// keep it in sync with the README/tour if either changes.
 const ARTIFACT_GROUPS: ArtifactGroup[] = [
     { id: 'foundation', title: 'Project Foundation', icon: FileText, items: ['prd'] },
     {
-        id: 'design',
-        title: 'UX & Design',
+        id: 'experience',
+        title: 'Experience',
         icon: Layers,
-        // 'component_inventory' (UI Components) lives in this group but is hidden
-        // from the assets list at materialization time — see buildSlotMetas and
-        // HIDDEN_ARTIFACT_SUBTYPES. It still generates for mockups; it just
-        // never renders a sidebar row. Revisit — see docs/backlog/BACKLOG.md §6.
-        items: ['user_flows', 'screen_inventory', 'mockup', 'component_inventory', 'design_system'],
+        // 'screens' consolidates the old Screen Inventory + Mockups sidebar rows
+        // into one screen-centric view (list → per-screen Overview/Flow/Mockups
+        // tabs). The screen_inventory and mockup artifacts still generate and
+        // persist unchanged — renderMain's legacy branches remain internally
+        // reachable as fallbacks; they just no longer render sidebar rows.
+        // 'component_inventory' also still generates (mockups consume it) but is
+        // a hidden subtype — see HIDDEN_ARTIFACT_SUBTYPES / docs/backlog §6.
+        items: ['user_flows', 'screens'],
     },
+    { id: 'design', title: 'Design', icon: Palette, items: ['design_system'] },
     { id: 'architecture', title: 'Architecture', icon: Database, items: ['data_model'] },
     { id: 'development', title: 'Development', icon: Code2, items: ['prompt_pack', 'implementation_plan'] },
 ];
@@ -89,6 +106,7 @@ function buildSlotMetas(): SlotMeta[] {
     const base: Record<WorkspaceSelection, SlotMeta> = {
         prd: { key: 'prd', title: 'PRD', description: 'Final product requirements document', icon: FileText },
         mockup: { key: 'mockup', title: 'Mockups', description: 'Interactive UI mockups', icon: Image },
+        screens: { key: 'screens', title: 'Screens', description: 'Screen-by-screen experience workspace', icon: AppWindow },
     } as Record<WorkspaceSelection, SlotMeta>;
     for (const meta of CORE_ARTIFACT_DISPLAY_ORDER) {
         base[meta.subtype as WorkspaceSelection] = {
@@ -104,7 +122,9 @@ function buildSlotMetas(): SlotMeta[] {
     // so they render no row anywhere in the workspace.
     return ARTIFACT_GROUPS.flatMap(group =>
         group.items
-            .filter(key => key === 'prd' || key === 'mockup' || !isHiddenArtifactSubtype(key))
+            .filter(key =>
+                key === 'prd' || key === 'mockup' || key === 'screens'
+                || !isHiddenArtifactSubtype(key))
             .map(key => base[key]),
     );
 }
@@ -168,8 +188,71 @@ export function ArtifactWorkspace({
     const [designRegenConfirm, setDesignRegenConfirm] = useState<
         { nextVersion: number } | null
     >(null);
+    // Experience workspace (Screens) navigation state. `selectedScreenSlug`
+    // is the open Screen Detail (null = the Screens list view); `screenTab`
+    // is its active tab. Local component state only — no URL routing in the
+    // MVP, mirroring how `selected` itself works.
+    const [selectedScreenSlug, setSelectedScreenSlug] = useState<string | null>(null);
+    const [screenTab, setScreenTab] = useState<ScreenDetailTab>('overview');
 
     const job = getJob(projectId);
+
+    // --- Experience (Screens) join layer ------------------------------------
+    // Preferred versions of the three experience artifacts. The version
+    // objects are stable references in the store until a new version lands,
+    // so they are safe useMemo dependencies.
+    const coreArtifacts = getArtifacts(projectId, 'core_artifact');
+    const invArtifact = coreArtifacts.find(a => a.subtype === 'screen_inventory');
+    const invPreferred = invArtifact ? getPreferredVersion(projectId, invArtifact.id) : undefined;
+    const flowsArtifact = coreArtifacts.find(a => a.subtype === 'user_flows');
+    const flowsPreferred = flowsArtifact ? getPreferredVersion(projectId, flowsArtifact.id) : undefined;
+    const mockupArtifact = getArtifacts(projectId, 'mockup')[0];
+    const mockupPreferred = mockupArtifact ? getPreferredVersion(projectId, mockupArtifact.id) : undefined;
+
+    const mockupPayload = useMemo(
+        () => (mockupPreferred ? tryParsePayload(mockupPreferred) : null),
+        [mockupPreferred],
+    );
+
+    // Read-side screen index: joins the parsed screen_inventory, user_flows,
+    // and mockup contents by slugified screen name. Pure + memoized — nothing
+    // is persisted, and missing artifacts degrade to a stable empty index.
+    const screenIndex = useMemo(() => {
+        const inventory = invPreferred ? parseScreenInventory(invPreferred.content) : null;
+        const flows = flowsPreferred ? parseFlows(flowsPreferred.content) : EMPTY_FLOWS;
+        return buildScreenIndex(inventory, flows, mockupPayload);
+    }, [invPreferred, flowsPreferred, mockupPayload]);
+
+    // Per-screen upload-gallery context for the detail view's Overview tab —
+    // mirrors the context the standalone screen_inventory branch builds below.
+    const invScreenImageContext = invArtifact && invPreferred
+        ? {
+            projectId,
+            artifactId: invArtifact.id,
+            artifactVersionId: invPreferred.id,
+            productTitle: structuredPRD.productName ?? getProject(projectId)?.name ?? 'this product',
+            productSummary: structuredPRD.executiveSummary ?? structuredPRD.vision,
+            designTokens,
+            platformHint: (projectPlatform === 'app'
+                ? 'mobile'
+                : projectPlatform === 'web'
+                    ? 'desktop'
+                    : 'responsive') as 'mobile' | 'desktop' | 'responsive',
+        }
+        : undefined;
+
+    // Mockups-tab context for the detail view. Absent when the mockup
+    // artifact is missing or its payload is unparseable — the tab shows an
+    // empty state instead.
+    const mockupDetailContext = mockupArtifact && mockupPreferred && mockupPayload
+        ? {
+            projectId,
+            artifactId: mockupArtifact.id,
+            versionId: mockupPreferred.id,
+            payload: mockupPayload,
+            settings: extractMockupSettings(mockupPreferred),
+        }
+        : undefined;
 
     // Auto-resume any slots that didn't finish before the last unmount /
     // page reload. The job state is transient (stripped from persisted
@@ -188,12 +271,15 @@ export function ArtifactWorkspace({
 
     const slotStatusFor = (key: WorkspaceSelection): GenerationStatus => {
         if (key === 'prd') return 'done';
-        const fromJob = job?.slots[key]?.status;
+        // 'screens' is a derived view over screen_inventory — surface that
+        // slot's status so the sidebar dot tracks the screens' source artifact.
+        const slotKey: ArtifactSlotKey = key === 'screens' ? 'screen_inventory' : key;
+        const fromJob = job?.slots[slotKey]?.status;
         if (fromJob && fromJob !== 'idle') return fromJob;
         // No active job state — derive from artifact presence so previously
         // completed artifacts still show as "Ready" after the job is cleared.
-        const type = key === 'mockup' ? 'mockup' : 'core_artifact';
-        const subtype: CoreArtifactSubtype | undefined = key === 'mockup' ? undefined : key;
+        const type = slotKey === 'mockup' ? 'mockup' : 'core_artifact';
+        const subtype: CoreArtifactSubtype | undefined = slotKey === 'mockup' ? undefined : slotKey;
         const artifacts = getArtifacts(projectId, type);
         const existing = subtype ? artifacts.find(a => a.subtype === subtype) : artifacts[0];
         if (existing && existing.currentVersionId) return 'done';
@@ -202,7 +288,8 @@ export function ArtifactWorkspace({
 
     const slotErrorFor = (key: WorkspaceSelection) => {
         if (key === 'prd') return undefined;
-        return job?.slots[key]?.error;
+        const slotKey: ArtifactSlotKey = key === 'screens' ? 'screen_inventory' : key;
+        return job?.slots[slotKey]?.error;
     };
 
     // Post-finalization auto-open. Runs once each time the parent arms
@@ -226,8 +313,10 @@ export function ArtifactWorkspace({
 
     // Drives the in-pane "Creating your build assets…" placeholder so an
     // idle slot doesn't read as empty while siblings are still in flight.
-    const isActive = slotMetas.some(s => {
-        const status = slotStatusFor(s.key);
+    // 'mockup' no longer renders a sidebar row (it lives inside the Screens
+    // view), so it's re-added here explicitly to keep the in-flight signal.
+    const isActive = ([...slotMetas.map(s => s.key), 'mockup'] as WorkspaceSelection[]).some(key => {
+        const status = slotStatusFor(key);
         return status === 'generating' || status === 'queued';
     });
 
@@ -235,6 +324,16 @@ export function ArtifactWorkspace({
         artifactJobController.retrySlot(slot, {
             projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
         });
+    };
+
+    // Open a screen's detail view — used by the Screens list, the Screens
+    // sidebar row (via handleSelect resetting to the list), and screen nodes
+    // in the User Flows journey diagram.
+    const handleNavigateToScreen = (slug: string) => {
+        setSelected('screens');
+        setSelectedScreenSlug(slug);
+        setScreenTab('overview');
+        setMobileSidebarOpen(false);
     };
 
     // Persist a newly-chosen visual direction, then surface the regenerate
@@ -296,6 +395,97 @@ export function ArtifactWorkspace({
                     />
                 </div>
             );
+        }
+
+        // --- Experience → Screens (read-side consolidation) -----------------
+        if (selected === 'screens') {
+            const screensStatus = slotStatusFor('screens'); // = screen_inventory slot
+            const screensError = slotErrorFor('screens');
+            if (screensStatus === 'queued' || screensStatus === 'generating') {
+                return (
+                    <div className="max-w-2xl mx-auto">
+                        <GenerationProgress
+                            stages={getArtifactStages('screen_inventory')}
+                            variant="systematic"
+                            title={screensStatus === 'queued' ? 'Queued: Screens' : 'Generating Screen Inventory'}
+                            subtitle={screensStatus === 'queued' ? 'Queued — will start as a generation slot frees up' : undefined}
+                            history={job?.slots.screen_inventory?.progressLog ?? []}
+                        />
+                    </div>
+                );
+            }
+            if (screensStatus === 'error' || screensStatus === 'interrupted') {
+                // The Screens view is fed by screen_inventory, so its retry
+                // re-runs that slot (there is no standalone sidebar row for it
+                // anymore).
+                return (
+                    <div className="max-w-2xl mx-auto bg-white border border-neutral-200 rounded-xl p-6 shadow-sm">
+                        <div className="flex items-start gap-3">
+                            <AlertTriangle size={20} className={screensStatus === 'error' ? 'text-red-500' : 'text-amber-500'} />
+                            <div className="flex-1 min-w-0">
+                                <h3 className="font-semibold text-neutral-900">
+                                    {screensStatus === 'error' ? 'Screen Inventory generation failed' : 'Screen Inventory generation interrupted'}
+                                </h3>
+                                {screensError?.message && (
+                                    <p className="text-sm text-neutral-600 mt-1 break-words">{screensError.message}</p>
+                                )}
+                                <button
+                                    type="button"
+                                    onClick={() => handleRetrySlot('screen_inventory')}
+                                    className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
+                                >
+                                    <RefreshCcw size={14} /> Retry
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                );
+            }
+            if (screensStatus === 'idle' && isActive) {
+                return <BuildAssetsLoading />;
+            }
+
+            // Legacy fallback: a screen_inventory version exists but isn't
+            // parseable structured JSON (old markdown artifacts). Render it
+            // through the standalone renderer so the content stays reachable
+            // instead of dead-ending on an empty Screens list.
+            if (screenIndex.items.length === 0 && invPreferred) {
+                return (
+                    <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto">
+                        <div className="bg-white rounded-xl border border-neutral-200 shadow-sm p-6 prose prose-sm prose-neutral max-w-none overflow-auto">
+                            <ArtifactContentRenderer
+                                subtype="screen_inventory"
+                                content={invPreferred.content}
+                                screenImageContext={invScreenImageContext}
+                                projectId={projectId}
+                            />
+                        </div>
+                    </div>
+                );
+            }
+
+            const detailItem = selectedScreenSlug
+                ? screenIndex.bySlug.get(selectedScreenSlug)
+                : undefined;
+            if (detailItem) {
+                return (
+                    <ScreenDetailView
+                        item={detailItem}
+                        activeTab={screenTab}
+                        onTabChange={setScreenTab}
+                        onBack={() => setSelectedScreenSlug(null)}
+                        onNavigateToScreen={handleNavigateToScreen}
+                        availableScreenSlugs={screenIndex.availableSlugs}
+                        screenImageContext={invScreenImageContext}
+                        mockupContext={mockupDetailContext}
+                        mockupStatus={slotStatusFor('mockup')}
+                        onRetryMockup={() => handleRetrySlot('mockup')}
+                        features={structuredPRD.features}
+                    />
+                );
+            }
+            // Stale slug (e.g. inventory regenerated) falls back to the list.
+            return <ScreenListView index={screenIndex} onSelectScreen={handleNavigateToScreen} />;
         }
 
         const status = slotStatusFor(selected);
@@ -532,6 +722,8 @@ export function ArtifactWorkspace({
                         domainEntities={subtype === 'user_flows' ? structuredPRD.domainEntities : undefined}
                         featureSystems={subtype === 'user_flows' ? structuredPRD.featureSystems : undefined}
                         implementationPlan={subtype === 'user_flows' ? structuredPRD.implementationPlan : undefined}
+                        onNavigateToScreen={subtype === 'user_flows' ? handleNavigateToScreen : undefined}
+                        availableScreenSlugs={subtype === 'user_flows' ? screenIndex.availableSlugs : undefined}
                         promptEdits={promptEdits}
                         onUpdatePromptEdits={handleUpdatePromptEdits}
                         generatedAt={subtype === 'prompt_pack' ? preferred.createdAt : undefined}
@@ -546,6 +738,9 @@ export function ArtifactWorkspace({
     const selectedMeta = slotMetas.find(s => s.key === selected);
     const handleSelect = (key: WorkspaceSelection) => {
         setSelected(key);
+        // Any sidebar selection (including re-clicking "Screens") lands on the
+        // top of that view, closing an open Screen Detail.
+        setSelectedScreenSlug(null);
         setMobileSidebarOpen(false);
     };
 

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -22,7 +22,13 @@ import { StalenessBadge } from './StalenessBadge';
 import { VersionHistoryPanel, type VersionEntry } from './versions';
 import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
 import { DesignDirectionControl } from './DesignDirectionControl';
-import { tryParsePayload, extractMockupSettings } from '../lib/mockupParsing';
+import { v4 as uuidv4 } from 'uuid';
+import {
+    tryParsePayload, extractMockupSettings, mergeExtraScreens,
+    mockupScreenFromInventoryScreen, readExtraMockupScreens,
+} from '../lib/mockupParsing';
+import { hasOpenAIKey } from '../lib/openaiClient';
+import { useMockupImageStore } from '../store/mockupImageStore';
 import { selectPreferredDesignTokens, selectPreferredDesignSystem } from '../lib/designTokens';
 import {
     buildScreenIndex, readScreenEdits, type ScreenMetadataEdit,
@@ -34,8 +40,8 @@ import { ScreenListView } from './experience/ScreenListView';
 import { ScreenDetailView } from './experience/ScreenDetailView';
 import type { ScreenDetailTab } from './experience/ScreenDetailTabs';
 import type {
-    ArtifactSlotKey, CoreArtifactSubtype, ProjectPlatform, StructuredPRD, GenerationStatus,
-    ProjectTask,
+    ArtifactSlotKey, CoreArtifactSubtype, MockupScreen, ProjectPlatform, StructuredPRD,
+    GenerationStatus, ProjectTask,
 } from '../types';
 
 // Stable empty reference for the tasks selector. Returning `[]` literal each
@@ -210,10 +216,14 @@ export function ArtifactWorkspace({
     const mockupArtifact = getArtifacts(projectId, 'mockup')[0];
     const mockupPreferred = mockupArtifact ? getPreferredVersion(projectId, mockupArtifact.id) : undefined;
 
-    const mockupPayload = useMemo(
-        () => (mockupPreferred ? tryParsePayload(mockupPreferred) : null),
-        [mockupPreferred],
-    );
+    // Effective mockup payload: stored screens + the version's user-added
+    // extraScreens overlay (metadata — keeps the version id, so existing
+    // per-screen images stay keyed correctly).
+    const mockupPayload = useMemo(() => {
+        if (!mockupPreferred) return null;
+        const parsed = tryParsePayload(mockupPreferred);
+        return parsed ? mergeExtraScreens(parsed, mockupPreferred.metadata) : null;
+    }, [mockupPreferred]);
 
     // Read-side screen index: joins the parsed screen_inventory, user_flows,
     // and mockup contents by canonical screen id / slug. Pure + memoized —
@@ -235,6 +245,65 @@ export function ArtifactWorkspace({
         if (edit) next[screenId] = edit;
         else delete next[screenId];
         updateArtifactVersionMetadata(projectId, invArtifact.id, invPreferred.id, { screenEdits: next });
+    };
+
+    // --- Mockup coverage actions --------------------------------------------
+    // Add inventory screens to the CURRENT mockup version's extraScreens
+    // overlay. No AI call happens here — image generation stays an explicit
+    // per-screen action (or the confirmed batch below), so adding coverage is
+    // free. Returns the appended MockupScreen specs.
+    const addScreensToMockups = (screenIds: string[]): MockupScreen[] => {
+        if (!mockupArtifact || !mockupPreferred) return [];
+        const existing = readExtraMockupScreens(mockupPreferred.metadata);
+        const appended: MockupScreen[] = [];
+        for (const id of screenIds) {
+            const item = screenIndex.byId.get(id);
+            if (!item || item.mockupScreen) continue; // already covered
+            if (existing.some(e => e.sourceScreenId === item.id)) continue;
+            const mockup = mockupScreenFromInventoryScreen(item.baseScreen, uuidv4(), item.id);
+            existing.push(mockup);
+            appended.push(mockup);
+        }
+        if (appended.length > 0) {
+            updateArtifactVersionMetadata(projectId, mockupArtifact.id, mockupPreferred.id, {
+                extraScreens: existing,
+            });
+        }
+        return appended;
+    };
+
+    const handleAddScreenToMockups = (screenId: string) => {
+        addScreensToMockups([screenId]);
+    };
+
+    // Confirmed batch: add every uncovered screen, then (only with an OpenAI
+    // key) kick off low-quality draft generation per screen. Each generation
+    // is individually tracked and cancellable via the standard per-screen
+    // panel; failures leave that screen on its generate/upload placeholder.
+    const [missingMockupsConfirm, setMissingMockupsConfirm] = useState<{ count: number } | null>(null);
+    const handleGenerateMissingMockups = () => {
+        const missing = screenIndex.items.filter(i => !i.mockupScreen).map(i => i.id);
+        if (missing.length === 0 || !mockupArtifact || !mockupPreferred || !mockupPayload) {
+            setMissingMockupsConfirm(null);
+            return;
+        }
+        const appended = addScreensToMockups(missing);
+        setMissingMockupsConfirm(null);
+        if (!hasOpenAIKey()) return; // screens now show the upload sheet instead
+        const settings = extractMockupSettings(mockupPreferred);
+        const payloadForPrompt = { ...mockupPayload, screens: [...mockupPayload.screens, ...appended] };
+        const imageStore = useMockupImageStore.getState();
+        for (const mockup of appended) {
+            void imageStore.generate({
+                projectId,
+                artifactId: mockupArtifact.id,
+                versionId: mockupPreferred.id,
+                screen: mockup,
+                payload: payloadForPrompt,
+                settings,
+                quality: 'low',
+            });
+        }
     };
 
     // Per-screen upload-gallery context for the detail view's Overview tab —
@@ -505,6 +574,11 @@ export function ArtifactWorkspace({
                         onRetryMockup={() => handleRetrySlot('mockup')}
                         features={structuredPRD.features}
                         onSaveScreenEdit={invArtifact && invPreferred ? handleSaveScreenEdit : undefined}
+                        onAddToMockups={
+                            mockupDetailContext && !detailItem.mockupScreen
+                                ? () => handleAddScreenToMockups(detailItem.id)
+                                : undefined
+                        }
                     />
                 );
             }
@@ -572,7 +646,17 @@ export function ArtifactWorkspace({
                             </button>
                         </div>
                     )}
-                    <ScreenListView index={screenIndex} onSelectScreen={handleOpenScreen} />
+                    <ScreenListView
+                        index={screenIndex}
+                        onSelectScreen={handleOpenScreen}
+                        onGenerateMissingMockups={
+                            mockupDetailContext
+                                ? () => setMissingMockupsConfirm({
+                                    count: screenIndex.items.filter(i => !i.mockupScreen).length,
+                                })
+                                : undefined
+                        }
+                    />
                 </div>
             );
         }
@@ -642,7 +726,8 @@ export function ArtifactWorkspace({
             if (!mockup || !preferred) {
                 return <EmptyState message="No mockup yet" />;
             }
-            const payload = tryParsePayload(preferred);
+            const parsed = tryParsePayload(preferred);
+            const payload = parsed ? mergeExtraScreens(parsed, preferred.metadata) : null;
             if (!payload) {
                 return (
                     <div className="bg-white rounded-xl border border-neutral-200 p-5 prose prose-sm prose-neutral max-w-none overflow-auto max-h-[600px]">
@@ -1005,6 +1090,63 @@ export function ArtifactWorkspace({
                                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white hover:bg-indigo-700 rounded-md transition"
                             >
                                 <RefreshCcw size={13} /> Regenerate
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {missingMockupsConfirm && (
+                <div
+                    className="fixed inset-0 z-50 bg-black/40 flex items-end md:items-center justify-center p-4"
+                    onClick={() => setMissingMockupsConfirm(null)}
+                    role="presentation"
+                >
+                    <div
+                        className="bg-white rounded-xl shadow-xl border border-neutral-200 w-full max-w-sm overflow-hidden"
+                        onClick={(e) => e.stopPropagation()}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="missing-mockups-title"
+                    >
+                        <div className="px-5 pt-5 pb-3">
+                            <h3 id="missing-mockups-title" className="text-base font-bold text-neutral-900">
+                                Generate missing mockups
+                            </h3>
+                            <p className="text-sm text-neutral-700 mt-1">
+                                Adds {missingMockupsConfirm.count} uncovered{' '}
+                                {missingMockupsConfirm.count === 1 ? 'screen' : 'screens'} to the current
+                                mockup set.
+                            </p>
+                            {hasOpenAIKey() ? (
+                                <p className="text-xs text-amber-700 mt-2">
+                                    A low-quality draft image will be generated per screen via OpenAI
+                                    gpt-image-2 — {missingMockupsConfirm.count} paid image{' '}
+                                    {missingMockupsConfirm.count === 1 ? 'call' : 'calls'} billed to your
+                                    own key (typically a few cents each). You can cancel any screen
+                                    while it&rsquo;s generating.
+                                </p>
+                            ) : (
+                                <p className="text-xs text-neutral-500 mt-2">
+                                    No OpenAI key is configured, so nothing will be generated — each
+                                    added screen shows a copyable prompt and an upload sheet instead.
+                                </p>
+                            )}
+                        </div>
+                        <div className="px-5 pb-4 flex items-center justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setMissingMockupsConfirm(null)}
+                                className="px-3 py-1.5 text-sm text-neutral-700 hover:bg-neutral-100 rounded-md transition"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleGenerateMissingMockups}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white hover:bg-indigo-700 rounded-md transition"
+                            >
+                                <Image size={13} /> {hasOpenAIKey() ? 'Add & generate' : 'Add screens'}
                             </button>
                         </div>
                     </div>

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -24,7 +24,9 @@ import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
 import { DesignDirectionControl } from './DesignDirectionControl';
 import { tryParsePayload, extractMockupSettings } from '../lib/mockupParsing';
 import { selectPreferredDesignTokens, selectPreferredDesignSystem } from '../lib/designTokens';
-import { buildScreenIndex } from '../lib/screenExperience';
+import {
+    buildScreenIndex, readScreenEdits, type ScreenMetadataEdit,
+} from '../lib/screenExperience';
 import { parseScreenInventory } from '../lib/screenInventoryNormalize';
 import { parseFlows } from './renderers/userFlows/parseFlow';
 import type { ParsedFlow } from './renderers/userFlows/types';
@@ -214,13 +216,26 @@ export function ArtifactWorkspace({
     );
 
     // Read-side screen index: joins the parsed screen_inventory, user_flows,
-    // and mockup contents by slugified screen name. Pure + memoized — nothing
-    // is persisted, and missing artifacts degrade to a stable empty index.
+    // and mockup contents by canonical screen id / slug. Pure + memoized —
+    // nothing new is persisted here, and missing artifacts degrade to a
+    // stable empty index. `screenEdits` is the per-version user overlay
+    // (metadata.screenEdits — the promptEdits pattern); a save patches the
+    // version metadata, which swaps the invPreferred reference and recomputes.
     const screenIndex = useMemo(() => {
         const inventory = invPreferred ? parseScreenInventory(invPreferred.content) : null;
         const flows = flowsPreferred ? parseFlows(flowsPreferred.content) : EMPTY_FLOWS;
-        return buildScreenIndex(inventory, flows, mockupPayload);
+        return buildScreenIndex(inventory, flows, mockupPayload, readScreenEdits(invPreferred?.metadata));
     }, [invPreferred, flowsPreferred, mockupPayload]);
+
+    // Persist (or clear, with null) one screen's metadata edit overlay.
+    const handleSaveScreenEdit = (screenId: string, edit: ScreenMetadataEdit | null) => {
+        if (!invArtifact || !invPreferred) return;
+        const current = readScreenEdits(invPreferred.metadata);
+        const next: Record<string, ScreenMetadataEdit> = { ...current };
+        if (edit) next[screenId] = edit;
+        else delete next[screenId];
+        updateArtifactVersionMetadata(projectId, invArtifact.id, invPreferred.id, { screenEdits: next });
+    };
 
     // Per-screen upload-gallery context for the detail view's Overview tab —
     // mirrors the context the standalone screen_inventory branch builds below.
@@ -489,6 +504,7 @@ export function ArtifactWorkspace({
                         mockupStatus={slotStatusFor('mockup')}
                         onRetryMockup={() => handleRetrySlot('mockup')}
                         features={structuredPRD.features}
+                        onSaveScreenEdit={invArtifact && invPreferred ? handleSaveScreenEdit : undefined}
                     />
                 );
             }

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -646,6 +646,18 @@ export function ArtifactWorkspace({
                                 ? () => handleAddScreenToMockups(detailItem.id)
                                 : undefined
                         }
+                        unmatchedMockups={
+                            mockupPayload && !detailItem.mockupScreen
+                                ? mockupPayload.screens
+                                    .filter(s => !screenIndex.items.some(i => i.mockupScreen?.id === s.id))
+                                    .map(s => ({ id: s.id, name: s.name }))
+                                : undefined
+                        }
+                        onLinkMockup={
+                            mockupArtifact && mockupPreferred && !detailItem.mockupScreen
+                                ? (mockupScreenId) => handleRelinkMockupScreen(mockupScreenId, detailItem.id)
+                                : undefined
+                        }
                     />
                 );
             }

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -141,6 +141,26 @@ export function ProjectWorkspace() {
         }
     }, [projectId, projectExists, navigate]);
 
+    // Deep link: /p/:id?screen=<canonical id> targets a screen in the
+    // Experience workspace (ArtifactWorkspace reads the param). currentStage
+    // is persisted per project, so a shared/bookmarked screen URL would
+    // otherwise open on whatever stage the project was last left in. One-shot
+    // on mount — never fights later user navigation. If the workspace isn't
+    // available (spine not final / blocked), the param is simply inert.
+    useEffect(() => {
+        if (!projectId) return;
+        if (!new URLSearchParams(window.location.search).get('screen')) return;
+        const store = useProjectStore.getState();
+        const proj = store.getProject(projectId);
+        const spine = store.getLatestSpine(projectId);
+        if (!proj || proj.currentStage === 'workspace') return;
+        if (spine?.isFinal && spine.structuredPRD && spine.safetyReview?.status !== 'blocked') {
+            store.setProjectStage(projectId, 'workspace');
+        }
+        // Mount-only by design (store read via getState, not deps): reacting
+        // to later param changes would yank the stage from under the user.
+    }, [projectId]);
+
     if (!projectId) return <div>Invalid Project</div>;
 
     const project = getProject(projectId);

--- a/src/components/experience/ReferenceWarningsPanel.tsx
+++ b/src/components/experience/ReferenceWarningsPanel.tsx
@@ -1,0 +1,127 @@
+// Non-blocking reference-validation panel for the Screens list. Surfaces the
+// join layer's findings (unmatched flow steps / mockup screens, slug
+// collisions, name-only legacy matches) with low-risk repairs: relink a
+// mockup screen to a canonical screen (persisted to metadata.screenLinks) or
+// ignore a warning (persisted to metadata.dismissedScreenIssues). Rendering
+// is never blocked by validation — this panel is purely advisory and
+// collapsed by default.
+
+import { useState } from 'react';
+import { AlertTriangle, Check, ChevronDown, ChevronRight, EyeOff, Link2 } from 'lucide-react';
+import type { ScreenReferenceIssue, ScreenReferenceIssueKind } from '../../lib/screenExperience';
+
+const KIND_META: Record<ScreenReferenceIssueKind, { label: string; chip: string }> = {
+    unmatched_flow_step: { label: 'Flow', chip: 'bg-amber-100 text-amber-800' },
+    unmatched_mockup_screen: { label: 'Mockup', chip: 'bg-red-50 text-red-700' },
+    slug_collision: { label: 'Naming', chip: 'bg-amber-100 text-amber-800' },
+    legacy_name_match: { label: 'Legacy match', chip: 'bg-neutral-100 text-neutral-600' },
+};
+
+interface Props {
+    issues: ScreenReferenceIssue[];
+    /** Canonical screens offered as relink targets. */
+    screenOptions: Array<{ id: string; name: string }>;
+    onRelink?: (mockupScreenId: string, screenId: string) => void;
+    onDismiss?: (issueKey: string) => void;
+}
+
+export function ReferenceWarningsPanel({ issues, screenOptions, onRelink, onDismiss }: Props) {
+    const [open, setOpen] = useState(false);
+    if (issues.length === 0) return null;
+
+    return (
+        <div className="rounded-lg border border-amber-200 bg-amber-50/60">
+            <button
+                type="button"
+                onClick={() => setOpen(!open)}
+                aria-expanded={open}
+                className="w-full px-4 py-2.5 flex items-center justify-between gap-2 text-left"
+            >
+                <span className="inline-flex items-center gap-2 text-xs font-medium text-amber-900">
+                    <AlertTriangle size={13} className="text-amber-600 shrink-0" />
+                    {issues.length} {issues.length === 1 ? 'reference needs' : 'references need'} review
+                </span>
+                {open
+                    ? <ChevronDown size={14} className="text-amber-500 shrink-0" />
+                    : <ChevronRight size={14} className="text-amber-500 shrink-0" />}
+            </button>
+            {open && (
+                <ul className="px-4 pb-3 space-y-2">
+                    {issues.map(issue => (
+                        <IssueRow
+                            key={issue.key}
+                            issue={issue}
+                            screenOptions={screenOptions}
+                            onRelink={onRelink}
+                            onDismiss={onDismiss}
+                        />
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+function IssueRow({
+    issue, screenOptions, onRelink, onDismiss,
+}: {
+    issue: ScreenReferenceIssue;
+    screenOptions: Array<{ id: string; name: string }>;
+    onRelink?: (mockupScreenId: string, screenId: string) => void;
+    onDismiss?: (issueKey: string) => void;
+}) {
+    // Default the relink target to the current match (legacy matches) so a
+    // one-click "Relink" pins the existing behavior with a stable link.
+    const [target, setTarget] = useState(issue.screenId ?? '');
+    const meta = KIND_META[issue.kind];
+    const canRelink = Boolean(onRelink && issue.mockupScreenId && screenOptions.length > 0);
+
+    return (
+        <li className="bg-white rounded-md border border-amber-200/70 p-2.5 text-xs">
+            <div className="flex items-start gap-2">
+                <span className={`shrink-0 text-[9px] font-semibold uppercase tracking-wider px-1 py-0.5 rounded mt-0.5 ${meta.chip}`}>
+                    {meta.label}
+                </span>
+                <span className="min-w-0 flex-1 text-neutral-800">{issue.message}</span>
+            </div>
+            <div className="mt-2 flex items-center gap-2 flex-wrap justify-end">
+                {canRelink && (
+                    <>
+                        <select
+                            value={target}
+                            onChange={e => setTarget(e.target.value)}
+                            aria-label="Screen to link this mockup to"
+                            className="text-xs border border-neutral-300 rounded-md px-1.5 py-1 max-w-[220px]"
+                        >
+                            <option value="">Choose screen…</option>
+                            {screenOptions.map(s => (
+                                <option key={s.id} value={s.id}>{s.name}</option>
+                            ))}
+                        </select>
+                        <button
+                            type="button"
+                            disabled={!target}
+                            onClick={() => {
+                                if (issue.mockupScreenId && target) onRelink?.(issue.mockupScreenId, target);
+                            }}
+                            className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        >
+                            {issue.kind === 'legacy_name_match' ? <Check size={11} /> : <Link2 size={11} />}
+                            {issue.kind === 'legacy_name_match' ? 'Pin link' : 'Relink'}
+                        </button>
+                    </>
+                )}
+                {onDismiss && (
+                    <button
+                        type="button"
+                        onClick={() => onDismiss(issue.key)}
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-neutral-500 hover:bg-neutral-100 transition"
+                        title="Hide this warning (the current behavior is kept)"
+                    >
+                        <EyeOff size={11} /> Ignore
+                    </button>
+                )}
+            </div>
+        </li>
+    );
+}

--- a/src/components/experience/ScreenDetailTabs.tsx
+++ b/src/components/experience/ScreenDetailTabs.tsx
@@ -1,0 +1,65 @@
+// Presentational tab strip for the Screen Detail view (Experience workspace).
+// Controlled — the active tab lives in ArtifactWorkspace's local state so
+// navigation from a flow node can land on a specific tab. Mirrors the
+// underline-tab idiom already used by ProjectWorkspace's right-rail tabs.
+
+export type ScreenDetailTab = 'overview' | 'flow' | 'mockups';
+
+interface Props {
+    active: ScreenDetailTab;
+    onChange: (tab: ScreenDetailTab) => void;
+    /** Number of flow steps referencing this screen — shown as a count chip. */
+    flowRefCount: number;
+    /** Whether a matching mockup screen exists — shown as a subtle dot. */
+    hasMockup: boolean;
+}
+
+const TABS: Array<{ id: ScreenDetailTab; label: string }> = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'flow', label: 'Flow' },
+    { id: 'mockups', label: 'Mockups' },
+];
+
+export function ScreenDetailTabs({ active, onChange, flowRefCount, hasMockup }: Props) {
+    return (
+        <div
+            role="tablist"
+            aria-label="Screen detail sections"
+            className="flex items-center gap-1 border-b border-neutral-200"
+        >
+            {TABS.map(tab => {
+                const selected = tab.id === active;
+                return (
+                    <button
+                        key={tab.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={selected}
+                        onClick={() => onChange(tab.id)}
+                        className={`inline-flex items-center gap-1.5 px-3 py-2 -mb-px text-sm font-medium border-b-2 transition ${
+                            selected
+                                ? 'border-indigo-600 text-indigo-700'
+                                : 'border-transparent text-neutral-500 hover:text-neutral-800 hover:border-neutral-300'
+                        }`}
+                    >
+                        {tab.label}
+                        {tab.id === 'flow' && flowRefCount > 0 && (
+                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full tabular-nums ${
+                                selected ? 'bg-indigo-100 text-indigo-700' : 'bg-neutral-100 text-neutral-500'
+                            }`}>
+                                {flowRefCount}
+                            </span>
+                        )}
+                        {tab.id === 'mockups' && hasMockup && (
+                            <span
+                                className="w-1.5 h-1.5 rounded-full bg-emerald-500"
+                                title="A mockup exists for this screen"
+                                aria-hidden="true"
+                            />
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -67,13 +67,20 @@ interface Props {
      * to the generated content). Absent → the detail view stays read-only.
      */
     onSaveScreenEdit?: (screenId: string, edit: ScreenMetadataEdit | null) => void;
+    /**
+     * Adds this (uncovered) screen to the current mockup set — a free
+     * metadata-overlay write; image generation stays a separate explicit,
+     * cost-labeled action on the resulting panel. Absent when the screen is
+     * already covered or no mockup artifact exists.
+     */
+    onAddToMockups?: () => void;
 }
 
 export function ScreenDetailView({
     item, activeTab, onTabChange, onBack,
     onNavigateToScreen, availableScreenSlugs,
     screenImageContext, mockupContext, mockupStatus, onRetryMockup,
-    features, onSaveScreenEdit,
+    features, onSaveScreenEdit, onAddToMockups,
 }: Props) {
     const { screen } = item;
     const priority = stylablePriority(screen.priority);
@@ -213,6 +220,7 @@ export function ScreenDetailView({
                     mockupContext={mockupContext}
                     mockupStatus={mockupStatus}
                     onRetryMockup={onRetryMockup}
+                    onAddToMockups={onAddToMockups}
                 />
             )}
         </div>
@@ -434,12 +442,13 @@ function FlowTab({
 // --- Mockups tab ------------------------------------------------------------
 
 function MockupsTab({
-    item, mockupContext, mockupStatus, onRetryMockup,
+    item, mockupContext, mockupStatus, onRetryMockup, onAddToMockups,
 }: {
     item: ScreenExperienceItem;
     mockupContext?: ScreenDetailMockupContext;
     mockupStatus?: GenerationStatus;
     onRetryMockup?: () => void;
+    onAddToMockups?: () => void;
 }) {
     if (mockupContext && item.mockupScreen) {
         return (
@@ -493,8 +502,19 @@ function MockupsTab({
                 No mockup has been generated for this screen yet.
             </p>
             <p className="text-xs text-neutral-500 mt-1 max-w-sm mx-auto">
-                Current mockup generation may only cover key screens.
+                Mockup generation covers the key screens by default. Add this screen to the
+                mockup set to generate an AI image or upload your own — adding it is free;
+                image generation stays a separate, clearly-priced action.
             </p>
+            {onAddToMockups && (
+                <button
+                    type="button"
+                    onClick={onAddToMockups}
+                    className="mt-4 inline-flex items-center gap-1.5 text-sm px-4 py-2 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 transition font-medium"
+                >
+                    <ImageIcon size={14} /> Add to mockups
+                </button>
+            )}
         </div>
     );
 }

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -1,0 +1,333 @@
+// Screen Detail — the "I am working on this screen" page of the Experience
+// workspace. Joins the three experience artifacts for ONE screen:
+//   Overview → the existing ScreenCard (screen_inventory details + upload
+//              gallery), unchanged presentation;
+//   Flow     → every user_flows flow that references this screen, rendered
+//              with the existing FlowJourney/StepCard pieces and the current
+//              screen's steps highlighted;
+//   Mockups  → the matching MockupScreenImage (which internally routes to the
+//              manual upload sheet per the image-source mode), or an honest
+//              empty state — mockup generation only covers key screens.
+// Read-only except for behavior the reused components already support
+// (image generate/upload). All data arrives via props from ArtifactWorkspace;
+// this component never queries artifacts from the store itself.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, ArrowLeft, Image as ImageIcon, Loader2, RefreshCcw, Workflow } from 'lucide-react';
+import type {
+    Feature, GenerationStatus, MockupPayload, MockupSettings,
+} from '../../types';
+import {
+    groupFlowRefsByFlow,
+    type ScreenExperienceItem,
+    type ScreenFlowGroup,
+} from '../../lib/screenExperience';
+import { ScreenCard } from '../renderers/ScreenInventoryRenderer';
+import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
+import type { ScreenImageGalleryContext } from '../renderers/ScreenImageGallery';
+import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
+import { FlowJourney } from '../renderers/userFlows/FlowJourney';
+import { StepCard } from '../renderers/userFlows/StepCard';
+import { FeatureDetailDrawer } from '../renderers/userFlows/FeatureDetailDrawer';
+import type { FeatureRef, FlowIssue } from '../renderers/userFlows/types';
+import { MockupScreenImage } from '../mockups/MockupScreenImage';
+import { ScreenDetailTabs, type ScreenDetailTab } from './ScreenDetailTabs';
+
+/** Everything the Mockups tab needs to render the reused mockup components. */
+export interface ScreenDetailMockupContext {
+    projectId: string;
+    artifactId: string;
+    versionId: string;
+    payload: MockupPayload;
+    settings: MockupSettings;
+}
+
+interface Props {
+    item: ScreenExperienceItem;
+    activeTab: ScreenDetailTab;
+    onTabChange: (tab: ScreenDetailTab) => void;
+    onBack: () => void;
+    /** Navigate to another screen's detail (flow-node clicks). */
+    onNavigateToScreen: (slug: string) => void;
+    availableScreenSlugs: ReadonlySet<string>;
+    /** Overview upload gallery context — absent for legacy inventories. */
+    screenImageContext?: ScreenImageGalleryContext;
+    /** Mockups tab context — absent when no parseable mockup artifact exists. */
+    mockupContext?: ScreenDetailMockupContext;
+    /** Mockup generation slot status, for honest Mockups-tab empty states. */
+    mockupStatus?: GenerationStatus;
+    onRetryMockup?: () => void;
+    /** Canonical feature catalog for StepCard feature chips + the drawer. */
+    features?: Feature[];
+}
+
+export function ScreenDetailView({
+    item, activeTab, onTabChange, onBack,
+    onNavigateToScreen, availableScreenSlugs,
+    screenImageContext, mockupContext, mockupStatus, onRetryMockup,
+    features,
+}: Props) {
+    const { screen } = item;
+    const priority = stylablePriority(screen.priority);
+
+    // Hydrate the per-screen upload gallery (Overview tab) exactly like the
+    // standalone ScreenInventoryRenderer does.
+    const loadForArtifactVersion = useScreenInventoryImageStore(s => s.loadForArtifactVersion);
+    const artifactVersionId = screenImageContext?.artifactVersionId;
+    useEffect(() => {
+        if (artifactVersionId) void loadForArtifactVersion(artifactVersionId);
+    }, [artifactVersionId, loadForArtifactVersion]);
+
+    const flowGroups = useMemo(
+        () => groupFlowRefsByFlow(item.relatedFlows),
+        [item.relatedFlows],
+    );
+
+    return (
+        <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-4">
+            <div>
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 hover:text-indigo-700 transition"
+                >
+                    <ArrowLeft size={13} /> All screens
+                </button>
+                <div className="mt-2 flex items-start justify-between gap-3 flex-wrap">
+                    <div className="min-w-0">
+                        <h2 className="text-lg font-bold text-neutral-900 leading-tight">
+                            {screen.name}
+                        </h2>
+                        <p className="text-[11px] uppercase tracking-wide text-neutral-400 mt-0.5">
+                            {item.sectionTitle}
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                        {screen.type && screen.type !== 'screen' && (
+                            <span className="text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded">
+                                {screen.type}
+                            </span>
+                        )}
+                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PRIORITY_STYLES[priority]}`}>
+                            {priority}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <ScreenDetailTabs
+                active={activeTab}
+                onChange={onTabChange}
+                flowRefCount={item.relatedFlows.length}
+                hasMockup={Boolean(item.mockupScreen)}
+            />
+
+            {activeTab === 'overview' && (
+                <ScreenCard screen={screen} imageContext={screenImageContext} />
+            )}
+
+            {activeTab === 'flow' && (
+                <FlowTab
+                    item={item}
+                    flowGroups={flowGroups}
+                    onNavigateToScreen={onNavigateToScreen}
+                    availableScreenSlugs={availableScreenSlugs}
+                    features={features}
+                />
+            )}
+
+            {activeTab === 'mockups' && (
+                <MockupsTab
+                    item={item}
+                    mockupContext={mockupContext}
+                    mockupStatus={mockupStatus}
+                    onRetryMockup={onRetryMockup}
+                />
+            )}
+        </div>
+    );
+}
+
+// --- Flow tab ---------------------------------------------------------------
+
+function FlowTab({
+    item, flowGroups, onNavigateToScreen, availableScreenSlugs, features,
+}: {
+    item: ScreenExperienceItem;
+    flowGroups: ScreenFlowGroup[];
+    onNavigateToScreen: (slug: string) => void;
+    availableScreenSlugs: ReadonlySet<string>;
+    features?: Feature[];
+}) {
+    // Feature-chip drawer, mirroring UserFlowsRenderer's wiring so StepCard
+    // chips stay functional inside the detail view.
+    const featuresById = useMemo(() => {
+        if (!features) return undefined;
+        const map = new Map<string, Feature>();
+        for (const f of features) {
+            map.set(f.id.toLowerCase().replace(/-/g, ''), f);
+        }
+        return map;
+    }, [features]);
+    const [drawerRef, setDrawerRef] = useState<FeatureRef | null>(null);
+    const [drawerPinned, setDrawerPinned] = useState(false);
+    const onSelectFeature = useCallback((refToken: FeatureRef) => setDrawerRef(refToken), []);
+    const onCloseDrawer = useCallback(() => {
+        if (drawerPinned) return;
+        setDrawerRef(null);
+    }, [drawerPinned]);
+    const onTogglePin = useCallback(() => setDrawerPinned(p => !p), []);
+
+    if (flowGroups.length === 0) {
+        return (
+            <div className="bg-white rounded-xl border border-dashed border-neutral-300 p-8 text-center">
+                <Workflow size={20} className="text-neutral-300 mx-auto mb-2" />
+                <p className="text-sm font-medium text-neutral-700">
+                    No user flow currently references this screen.
+                </p>
+                <p className="text-xs text-neutral-500 mt-1">
+                    Flow steps link to screens by their exact screen name
+                    (&ldquo;[{item.screen.name}] — action → response&rdquo;).
+                </p>
+            </div>
+        );
+    }
+
+    const drawerFeature = drawerRef ? featuresById?.get(drawerRef.id) : undefined;
+    const allFlows = flowGroups.map(g => g.flow);
+
+    return (
+        <div className="not-prose space-y-6">
+            {flowGroups.map(group => {
+                const highlighted = new Set(group.steps.map(s => s.stepIndex));
+                // Per-step issue links, mirroring UserFlowsRenderer.
+                const inlineByStep = new Map<number, FlowIssue[]>();
+                const issuesByStep = new Map<number, number>();
+                for (const issue of group.flow.issues) {
+                    if (typeof issue.linkedStepIndex !== 'number') continue;
+                    const list = inlineByStep.get(issue.linkedStepIndex) ?? [];
+                    list.push(issue);
+                    inlineByStep.set(issue.linkedStepIndex, list);
+                    issuesByStep.set(
+                        issue.linkedStepIndex,
+                        (issuesByStep.get(issue.linkedStepIndex) ?? 0) + 1,
+                    );
+                }
+                return (
+                    <section key={group.flowIndex}>
+                        <header className="mb-2 flex items-baseline justify-between gap-2 flex-wrap">
+                            <h3 className="text-sm font-semibold text-neutral-800">
+                                {group.flow.title}
+                            </h3>
+                            <span className="text-[11px] text-neutral-400">
+                                Flow {group.flowIndex + 1} · appears in{' '}
+                                {group.steps.length === 1
+                                    ? `step ${group.steps[0].stepIndex + 1}`
+                                    : `${group.steps.length} steps`}
+                            </span>
+                        </header>
+                        {group.flow.goal && (
+                            <p className="text-xs text-neutral-500 mb-3">{group.flow.goal}</p>
+                        )}
+                        <FlowJourney
+                            flowIndex={group.flowIndex}
+                            steps={group.flow.steps}
+                            issuesByStep={issuesByStep}
+                            highlightedStepIndices={highlighted}
+                            onNavigateToScreen={onNavigateToScreen}
+                            availableScreenSlugs={availableScreenSlugs}
+                        />
+                        {group.steps.map(({ step, stepIndex }) => (
+                            <StepCard
+                                key={stepIndex}
+                                flowIndex={group.flowIndex}
+                                step={step}
+                                inlineIssues={inlineByStep.get(stepIndex) ?? []}
+                                featuresById={featuresById}
+                                onSelectFeature={onSelectFeature}
+                            />
+                        ))}
+                    </section>
+                );
+            })}
+
+            <FeatureDetailDrawer
+                open={drawerRef !== null}
+                refToken={drawerRef}
+                feature={drawerFeature}
+                flows={allFlows}
+                onClose={onCloseDrawer}
+                pinned={drawerPinned}
+                onTogglePin={onTogglePin}
+            />
+        </div>
+    );
+}
+
+// --- Mockups tab ------------------------------------------------------------
+
+function MockupsTab({
+    item, mockupContext, mockupStatus, onRetryMockup,
+}: {
+    item: ScreenExperienceItem;
+    mockupContext?: ScreenDetailMockupContext;
+    mockupStatus?: GenerationStatus;
+    onRetryMockup?: () => void;
+}) {
+    if (mockupContext && item.mockupScreen) {
+        return (
+            <div className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
+                <MockupScreenImage
+                    projectId={mockupContext.projectId}
+                    artifactId={mockupContext.artifactId}
+                    versionId={mockupContext.versionId}
+                    screen={item.mockupScreen}
+                    payload={mockupContext.payload}
+                    settings={mockupContext.settings}
+                />
+            </div>
+        );
+    }
+
+    if (mockupStatus === 'generating' || mockupStatus === 'queued') {
+        return (
+            <div className="bg-white rounded-xl border border-neutral-200 p-8 text-center">
+                <Loader2 size={20} className="text-indigo-500 animate-spin mx-auto mb-2" />
+                <p className="text-sm font-medium text-neutral-700">Mockups are being generated…</p>
+                <p className="text-xs text-neutral-500 mt-1">
+                    Check back once the run completes to see whether this screen is covered.
+                </p>
+            </div>
+        );
+    }
+
+    if (mockupStatus === 'error' || mockupStatus === 'interrupted') {
+        return (
+            <div className="bg-white rounded-xl border border-neutral-200 p-8 text-center">
+                <AlertTriangle size={20} className="text-amber-500 mx-auto mb-2" />
+                <p className="text-sm font-medium text-neutral-700">Mockup generation didn&rsquo;t finish.</p>
+                {onRetryMockup && (
+                    <button
+                        type="button"
+                        onClick={onRetryMockup}
+                        className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
+                    >
+                        <RefreshCcw size={14} /> Retry mockup generation
+                    </button>
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className="bg-white rounded-xl border border-dashed border-neutral-300 p-8 text-center">
+            <ImageIcon size={20} className="text-neutral-300 mx-auto mb-2" />
+            <p className="text-sm font-medium text-neutral-700">
+                No mockup has been generated for this screen yet.
+            </p>
+            <p className="text-xs text-neutral-500 mt-1 max-w-sm mx-auto">
+                Current mockup generation may only cover key screens.
+            </p>
+        </div>
+    );
+}

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -13,14 +13,17 @@
 // this component never queries artifacts from the store itself.
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, ArrowLeft, Image as ImageIcon, Loader2, RefreshCcw, Workflow } from 'lucide-react';
+import {
+    AlertTriangle, ArrowLeft, Image as ImageIcon, Loader2, Pencil, RefreshCcw, RotateCcw, Workflow,
+} from 'lucide-react';
 import type {
-    Feature, GenerationStatus, MockupPayload, MockupSettings,
+    Feature, GenerationStatus, MockupPayload, MockupSettings, ScreenPriority,
 } from '../../types';
 import {
     groupFlowRefsByFlow,
     type ScreenExperienceItem,
     type ScreenFlowGroup,
+    type ScreenMetadataEdit,
 } from '../../lib/screenExperience';
 import { ScreenCard } from '../renderers/ScreenInventoryRenderer';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
@@ -59,16 +62,22 @@ interface Props {
     onRetryMockup?: () => void;
     /** Canonical feature catalog for StepCard feature chips + the drawer. */
     features?: Feature[];
+    /**
+     * Persists a metadata edit overlay for this screen (null clears it back
+     * to the generated content). Absent → the detail view stays read-only.
+     */
+    onSaveScreenEdit?: (screenId: string, edit: ScreenMetadataEdit | null) => void;
 }
 
 export function ScreenDetailView({
     item, activeTab, onTabChange, onBack,
     onNavigateToScreen, availableScreenSlugs,
     screenImageContext, mockupContext, mockupStatus, onRetryMockup,
-    features,
+    features, onSaveScreenEdit,
 }: Props) {
     const { screen } = item;
     const priority = stylablePriority(screen.priority);
+    const [editing, setEditing] = useState(false);
 
     // Hydrate the per-screen upload gallery (Overview tab) exactly like the
     // standalone ScreenInventoryRenderer does.
@@ -82,6 +91,8 @@ export function ScreenDetailView({
         () => groupFlowRefsByFlow(item.relatedFlows),
         [item.relatedFlows],
     );
+
+    const renamed = item.isEdited && item.screen.name !== item.baseScreen.name;
 
     return (
         <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-4">
@@ -100,9 +111,19 @@ export function ScreenDetailView({
                         </h2>
                         <p className="text-[11px] uppercase tracking-wide text-neutral-400 mt-0.5">
                             {item.sectionTitle}
+                            {renamed && (
+                                <span className="normal-case tracking-normal text-neutral-400">
+                                    {' '}· generated as &ldquo;{item.baseScreen.name}&rdquo;
+                                </span>
+                            )}
                         </p>
                     </div>
                     <div className="flex items-center gap-1.5 shrink-0">
+                        {item.isEdited && (
+                            <span className="text-[10px] uppercase tracking-wide text-violet-700 bg-violet-50 ring-1 ring-violet-200 px-1.5 py-0.5 rounded">
+                                Edited
+                            </span>
+                        )}
                         {screen.type && screen.type !== 'screen' && (
                             <span className="text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded">
                                 {screen.type}
@@ -123,7 +144,57 @@ export function ScreenDetailView({
             />
 
             {activeTab === 'overview' && (
-                <ScreenCard screen={screen} imageContext={screenImageContext} />
+                <div className="space-y-3">
+                    {onSaveScreenEdit && !editing && (
+                        <div className="flex items-center justify-end gap-2">
+                            {item.isEdited && (
+                                <button
+                                    type="button"
+                                    onClick={() => onSaveScreenEdit(item.id, null)}
+                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-neutral-600 hover:bg-neutral-100 rounded-md transition"
+                                    title="Discard your edits and show the generated content"
+                                >
+                                    <RotateCcw size={12} /> Reset to generated
+                                </button>
+                            )}
+                            <button
+                                type="button"
+                                onClick={() => setEditing(true)}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
+                            >
+                                <Pencil size={12} /> Edit details
+                            </button>
+                        </div>
+                    )}
+                    {onSaveScreenEdit && editing ? (
+                        <ScreenEditForm
+                            item={item}
+                            onSave={(edit) => {
+                                onSaveScreenEdit(item.id, edit);
+                                setEditing(false);
+                            }}
+                            onCancel={() => setEditing(false)}
+                        />
+                    ) : (
+                        <>
+                            <ScreenCard
+                                screen={screen}
+                                imageContext={screenImageContext}
+                                imageStorageName={item.baseScreen.name}
+                            />
+                            {item.edit?.notes && (
+                                <div className="bg-violet-50/60 rounded-lg border border-violet-200 p-3">
+                                    <div className="text-[10px] uppercase tracking-wide text-violet-600 mb-1">
+                                        Notes
+                                    </div>
+                                    <p className="text-xs text-neutral-700 whitespace-pre-wrap">
+                                        {item.edit.notes}
+                                    </p>
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
             )}
 
             {activeTab === 'flow' && (
@@ -144,6 +215,102 @@ export function ScreenDetailView({
                     onRetryMockup={onRetryMockup}
                 />
             )}
+        </div>
+    );
+}
+
+// --- Overview edit form -------------------------------------------------------
+
+const EDIT_PRIORITIES: ScreenPriority[] = ['P0', 'P1', 'P2', 'P3'];
+
+/**
+ * Minimal, rename-safe metadata editor. Saves an overlay (see
+ * ScreenMetadataEdit) containing only the fields that differ from the stored
+ * generated screen — an overlay equal to the generated content saves as null,
+ * clearing the edit. The generated artifact content is never rewritten.
+ */
+function ScreenEditForm({
+    item, onSave, onCancel,
+}: {
+    item: ScreenExperienceItem;
+    onSave: (edit: ScreenMetadataEdit | null) => void;
+    onCancel: () => void;
+}) {
+    const { screen, baseScreen } = item;
+    const [name, setName] = useState(screen.name);
+    const [purpose, setPurpose] = useState(screen.purpose ?? '');
+    const [userIntent, setUserIntent] = useState(screen.userIntent ?? '');
+    const [priority, setPriority] = useState<ScreenPriority>(stylablePriority(screen.priority));
+    const [notes, setNotes] = useState(item.edit?.notes ?? '');
+
+    const handleSave = () => {
+        const edit: ScreenMetadataEdit = {};
+        const trimmedName = name.trim();
+        if (trimmedName && trimmedName !== baseScreen.name) edit.name = trimmedName;
+        if (purpose !== (baseScreen.purpose ?? '')) edit.purpose = purpose;
+        if (userIntent !== (baseScreen.userIntent ?? '')) edit.userIntent = userIntent;
+        if (priority !== stylablePriority(baseScreen.priority)) edit.priority = priority;
+        if (notes.trim()) edit.notes = notes;
+        onSave(Object.keys(edit).length > 0 ? edit : null);
+    };
+
+    const field = 'w-full text-sm border border-neutral-300 rounded-md px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-300';
+
+    return (
+        <div className="bg-white rounded-lg border border-indigo-200 p-4 space-y-3">
+            <p className="text-[11px] text-neutral-500">
+                Edits are saved as an overlay on this artifact version — the generated
+                content is kept, and mockups, flows, and uploaded images stay attached
+                even when you rename the screen.
+            </p>
+            <label className="block">
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Name</span>
+                <input className={field} value={name} onChange={e => setName(e.target.value)} />
+            </label>
+            <label className="block">
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Purpose</span>
+                <textarea className={field} rows={2} value={purpose} onChange={e => setPurpose(e.target.value)} />
+            </label>
+            <label className="block">
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">User intent</span>
+                <textarea className={field} rows={2} value={userIntent} onChange={e => setUserIntent(e.target.value)} />
+            </label>
+            <label className="block">
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Priority</span>
+                <select
+                    className={field}
+                    value={priority}
+                    onChange={e => setPriority(e.target.value as ScreenPriority)}
+                >
+                    {EDIT_PRIORITIES.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+            </label>
+            <label className="block">
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Notes (internal)</span>
+                <textarea
+                    className={field}
+                    rows={2}
+                    placeholder="Anything the team should know about this screen…"
+                    value={notes}
+                    onChange={e => setNotes(e.target.value)}
+                />
+            </label>
+            <div className="flex items-center justify-end gap-2 pt-1">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="px-3 py-1.5 text-xs text-neutral-600 hover:bg-neutral-100 rounded-md transition"
+                >
+                    Cancel
+                </button>
+                <button
+                    type="button"
+                    onClick={handleSave}
+                    className="px-3 py-1.5 text-xs bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition font-medium"
+                >
+                    Save
+                </button>
+            </div>
         </div>
     );
 }

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -14,7 +14,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-    AlertTriangle, ArrowLeft, Image as ImageIcon, Loader2, Pencil, RefreshCcw, RotateCcw, Workflow,
+    AlertTriangle, ArrowLeft, Image as ImageIcon, Link2, Loader2, Pencil, RefreshCcw, RotateCcw, Workflow,
 } from 'lucide-react';
 import type {
     Feature, GenerationStatus, MockupPayload, MockupSettings, ScreenPriority,
@@ -74,13 +74,18 @@ interface Props {
      * already covered or no mockup artifact exists.
      */
     onAddToMockups?: () => void;
+    /** Orphaned mockup screens (matched to no canonical screen) offered for
+     * relinking to THIS screen from its Mockups tab. */
+    unmatchedMockups?: Array<{ id: string; name: string }>;
+    /** Persists a screenLinks repair binding the chosen mockup to this screen. */
+    onLinkMockup?: (mockupScreenId: string) => void;
 }
 
 export function ScreenDetailView({
     item, activeTab, onTabChange, onBack,
     onNavigateToScreen, availableScreenSlugs,
     screenImageContext, mockupContext, mockupStatus, onRetryMockup,
-    features, onSaveScreenEdit, onAddToMockups,
+    features, onSaveScreenEdit, onAddToMockups, unmatchedMockups, onLinkMockup,
 }: Props) {
     const { screen } = item;
     const priority = stylablePriority(screen.priority);
@@ -221,6 +226,8 @@ export function ScreenDetailView({
                     mockupStatus={mockupStatus}
                     onRetryMockup={onRetryMockup}
                     onAddToMockups={onAddToMockups}
+                    unmatchedMockups={unmatchedMockups}
+                    onLinkMockup={onLinkMockup}
                 />
             )}
         </div>
@@ -443,13 +450,17 @@ function FlowTab({
 
 function MockupsTab({
     item, mockupContext, mockupStatus, onRetryMockup, onAddToMockups,
+    unmatchedMockups, onLinkMockup,
 }: {
     item: ScreenExperienceItem;
     mockupContext?: ScreenDetailMockupContext;
     mockupStatus?: GenerationStatus;
     onRetryMockup?: () => void;
     onAddToMockups?: () => void;
+    unmatchedMockups?: Array<{ id: string; name: string }>;
+    onLinkMockup?: (mockupScreenId: string) => void;
 }) {
+    const [linkTarget, setLinkTarget] = useState('');
     if (mockupContext && item.mockupScreen) {
         return (
             <div className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
@@ -514,6 +525,35 @@ function MockupsTab({
                 >
                     <ImageIcon size={14} /> Add to mockups
                 </button>
+            )}
+            {onLinkMockup && unmatchedMockups && unmatchedMockups.length > 0 && (
+                <div className="mt-5 pt-4 border-t border-neutral-200 max-w-sm mx-auto">
+                    <p className="text-[11px] text-neutral-500 mb-2">
+                        Or link an existing mockup that lost its screen match
+                        (e.g. after a regeneration renamed things):
+                    </p>
+                    <div className="flex items-center justify-center gap-2 flex-wrap">
+                        <select
+                            value={linkTarget}
+                            onChange={e => setLinkTarget(e.target.value)}
+                            aria-label="Orphaned mockup to link to this screen"
+                            className="text-xs border border-neutral-300 rounded-md px-2 py-1.5 max-w-[220px]"
+                        >
+                            <option value="">Choose mockup…</option>
+                            {unmatchedMockups.map(m => (
+                                <option key={m.id} value={m.id}>{m.name}</option>
+                            ))}
+                        </select>
+                        <button
+                            type="button"
+                            disabled={!linkTarget}
+                            onClick={() => linkTarget && onLinkMockup(linkTarget)}
+                            className="inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded-md bg-neutral-100 hover:bg-neutral-200 text-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        >
+                            <Link2 size={12} /> Link mockup
+                        </button>
+                    </div>
+                </div>
             )}
         </div>
     );

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -4,7 +4,7 @@
 // what the other experience artifacts say about each screen (flow-step count,
 // mockup coverage) and click through to the Screen Detail view.
 
-import { AlertTriangle, AppWindow, ChevronRight, Image as ImageIcon, Workflow } from 'lucide-react';
+import { AppWindow, ChevronRight, Image as ImageIcon, Workflow } from 'lucide-react';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 
@@ -60,18 +60,9 @@ export function ScreenListView({ index, onSelectScreen, onGenerateMissingMockups
                 )}
             </div>
 
-            {index.collisions.length > 0 && (
-                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
-                    <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-600" />
-                    <p className="text-xs text-amber-800">
-                        Some screens share the same normalized name
-                        {' '}({index.collisions.map(c => c.names.join(' / ')).join('; ')}).
-                        Only the first of each is listed — consider renaming them in the
-                        Screen Inventory so every screen is distinct.
-                    </p>
-                </div>
-            )}
-
+            {/* Slug collisions and other reference problems surface in the
+                ReferenceWarningsPanel rendered above this list (with repair
+                and dismiss actions), not as a separate banner here. */}
             {index.sections.map((section, sectionIdx) => (
                 <section key={sectionIdx}>
                     <header className="mb-3">

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -10,7 +10,8 @@ import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 
 interface Props {
     index: ScreenExperienceIndex;
-    onSelectScreen: (slug: string) => void;
+    /** Opens the Screen Detail view — keyed by the stable canonical id. */
+    onSelectScreen: (screenId: string) => void;
 }
 
 export function ScreenListView({ index, onSelectScreen }: Props) {
@@ -58,8 +59,8 @@ export function ScreenListView({ index, onSelectScreen }: Props) {
                     </header>
                     <ul className="grid grid-cols-1 lg:grid-cols-2 gap-3">
                         {section.items.map(item => (
-                            <li key={item.slug}>
-                                <ScreenRow item={item} onSelect={() => onSelectScreen(item.slug)} />
+                            <li key={item.id}>
+                                <ScreenRow item={item} onSelect={() => onSelectScreen(item.id)} />
                             </li>
                         ))}
                     </ul>

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -88,6 +88,11 @@ function ScreenRow({ item, onSelect }: { item: ScreenExperienceItem; onSelect: (
                     {screen.name}
                 </h4>
                 <div className="flex items-center gap-1.5 shrink-0">
+                    {item.isEdited && (
+                        <span className="text-[10px] uppercase tracking-wide text-violet-700 bg-violet-50 ring-1 ring-violet-200 px-1.5 py-0.5 rounded">
+                            Edited
+                        </span>
+                    )}
                     {screen.type && screen.type !== 'screen' && (
                         <span className="text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded">
                             {screen.type}

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -12,9 +12,15 @@ interface Props {
     index: ScreenExperienceIndex;
     /** Opens the Screen Detail view — keyed by the stable canonical id. */
     onSelectScreen: (screenId: string) => void;
+    /**
+     * Opens the confirmed "Generate missing mockups" flow. Absent (no mockup
+     * artifact yet / unparseable payload) the button is hidden. Nothing is
+     * generated without this explicit confirmation.
+     */
+    onGenerateMissingMockups?: () => void;
 }
 
-export function ScreenListView({ index, onSelectScreen }: Props) {
+export function ScreenListView({ index, onSelectScreen, onGenerateMissingMockups }: Props) {
     if (index.items.length === 0) {
         return (
             <div className="max-w-xl mx-auto bg-white rounded-xl border border-dashed border-neutral-300 p-10 text-center">
@@ -29,8 +35,31 @@ export function ScreenListView({ index, onSelectScreen }: Props) {
         );
     }
 
+    const coveredCount = index.items.filter(i => i.mockupScreen).length;
+    const missingCount = index.items.length - coveredCount;
+
     return (
         <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-8">
+            {/* Mockup coverage summary — makes partial coverage explicit
+                instead of leaving users to discover empty Mockups tabs. */}
+            <div className="flex items-center justify-between gap-2 flex-wrap rounded-lg border border-neutral-200 bg-white px-4 py-2.5">
+                <span className="inline-flex items-center gap-2 text-xs text-neutral-600">
+                    <ImageIcon size={13} className={coveredCount > 0 ? 'text-emerald-500' : 'text-neutral-300'} />
+                    <span>
+                        Mockups: <span className="font-semibold text-neutral-800">{coveredCount} of {index.items.length}</span> screens covered
+                    </span>
+                </span>
+                {onGenerateMissingMockups && missingCount > 0 && (
+                    <button
+                        type="button"
+                        onClick={onGenerateMissingMockups}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
+                    >
+                        <ImageIcon size={12} /> Generate missing mockups ({missingCount})
+                    </button>
+                )}
+            </div>
+
             {index.collisions.length > 0 && (
                 <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
                     <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-600" />

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -1,0 +1,127 @@
+// Canonical screen list for the Experience workspace. Read-only: every row is
+// derived from the screen_inventory artifact via the pure join layer
+// (src/lib/screenExperience.ts) — nothing here writes to the store. Rows show
+// what the other experience artifacts say about each screen (flow-step count,
+// mockup coverage) and click through to the Screen Detail view.
+
+import { AlertTriangle, AppWindow, ChevronRight, Image as ImageIcon, Workflow } from 'lucide-react';
+import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
+import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
+
+interface Props {
+    index: ScreenExperienceIndex;
+    onSelectScreen: (slug: string) => void;
+}
+
+export function ScreenListView({ index, onSelectScreen }: Props) {
+    if (index.items.length === 0) {
+        return (
+            <div className="max-w-xl mx-auto bg-white rounded-xl border border-dashed border-neutral-300 p-10 text-center">
+                <div className="w-12 h-12 rounded-full bg-indigo-50 flex items-center justify-center mx-auto mb-3">
+                    <AppWindow size={20} className="text-indigo-500" />
+                </div>
+                <h3 className="text-sm font-semibold text-neutral-800">No screens yet</h3>
+                <p className="text-xs text-neutral-500 mt-1">
+                    Generate a Screen Inventory to see screens.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-8">
+            {index.collisions.length > 0 && (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                    <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-600" />
+                    <p className="text-xs text-amber-800">
+                        Some screens share the same normalized name
+                        {' '}({index.collisions.map(c => c.names.join(' / ')).join('; ')}).
+                        Only the first of each is listed — consider renaming them in the
+                        Screen Inventory so every screen is distinct.
+                    </p>
+                </div>
+            )}
+
+            {index.sections.map((section, sectionIdx) => (
+                <section key={sectionIdx}>
+                    <header className="mb-3">
+                        <h3 className="text-base font-semibold text-neutral-800">
+                            <span className="text-neutral-400 font-normal mr-2">{sectionIdx + 1}.</span>
+                            {section.title}
+                        </h3>
+                        {section.description && (
+                            <p className="text-xs text-neutral-500 mt-1">{section.description}</p>
+                        )}
+                        <div className="mt-1 text-[11px] uppercase tracking-wide text-neutral-400">
+                            {section.items.length} {section.items.length === 1 ? 'screen' : 'screens'}
+                        </div>
+                    </header>
+                    <ul className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                        {section.items.map(item => (
+                            <li key={item.slug}>
+                                <ScreenRow item={item} onSelect={() => onSelectScreen(item.slug)} />
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+            ))}
+        </div>
+    );
+}
+
+function ScreenRow({ item, onSelect }: { item: ScreenExperienceItem; onSelect: () => void }) {
+    const { screen } = item;
+    const priority = stylablePriority(screen.priority);
+    const flowCount = item.relatedFlows.length;
+    const entryCount = screen.entryPoints?.length ?? 0;
+    const exitCount = screen.exitPaths?.length ?? 0;
+
+    return (
+        <button
+            type="button"
+            onClick={onSelect}
+            className="w-full text-left bg-white rounded-lg border border-neutral-200 p-4 hover:border-indigo-300 hover:shadow-sm transition group"
+        >
+            <div className="flex items-start justify-between gap-2">
+                <h4 className="font-semibold text-neutral-800 text-sm leading-tight group-hover:text-indigo-700 transition-colors">
+                    {screen.name}
+                </h4>
+                <div className="flex items-center gap-1.5 shrink-0">
+                    {screen.type && screen.type !== 'screen' && (
+                        <span className="text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded">
+                            {screen.type}
+                        </span>
+                    )}
+                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PRIORITY_STYLES[priority]}`}>
+                        {priority}
+                    </span>
+                </div>
+            </div>
+
+            {screen.purpose && (
+                <p className="text-xs leading-relaxed text-neutral-600 mt-2 line-clamp-2">
+                    {screen.purpose}
+                </p>
+            )}
+
+            <div className="mt-3 flex items-center gap-3 flex-wrap text-[11px] text-neutral-500">
+                <span className="inline-flex items-center gap-1" title="User-flow steps referencing this screen">
+                    <Workflow size={11} className={flowCount > 0 ? 'text-indigo-500' : 'text-neutral-300'} />
+                    {flowCount > 0
+                        ? `${flowCount} flow ${flowCount === 1 ? 'step' : 'steps'}`
+                        : 'No flow refs'}
+                </span>
+                <span className="inline-flex items-center gap-1" title="Mockup coverage">
+                    <ImageIcon size={11} className={item.mockupScreen ? 'text-emerald-500' : 'text-neutral-300'} />
+                    {item.mockupScreen ? 'Mockup' : 'No mockup'}
+                </span>
+                {(entryCount > 0 || exitCount > 0) && (
+                    <span title="Entry / exit paths">
+                        {entryCount} in · {exitCount} out
+                    </span>
+                )}
+                <ChevronRight size={13} className="ml-auto text-neutral-300 group-hover:text-indigo-400 transition-colors" aria-hidden />
+            </div>
+        </button>
+    );
+}

--- a/src/components/renderers/ScreenImageGallery.tsx
+++ b/src/components/renderers/ScreenImageGallery.tsx
@@ -24,9 +24,16 @@ export interface ScreenImageGalleryContext {
 interface Props {
     screen: ScreenItem;
     context: ScreenImageGalleryContext;
+    /**
+     * Name used for image storage/lookup (slug derivation + upload bucket).
+     * Defaults to `screen.name`. The Experience workspace passes the screen's
+     * *stored generated* name here while `screen` carries the display-edited
+     * one, so renaming a screen never orphans its uploaded images.
+     */
+    storageName?: string;
 }
 
-export function ScreenImageGallery({ screen, context }: Props) {
+export function ScreenImageGallery({ screen, context, storageName }: Props) {
     const { projectId, artifactId, artifactVersionId, productTitle, productSummary, designTokens, platformHint } = context;
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [copied, setCopied] = useState(false);
@@ -38,7 +45,8 @@ export function ScreenImageGallery({ screen, context }: Props) {
     // changed snapshot under Object.is — that loops setState and trips
     // React error #185 (max update depth).
     const allImages = useScreenInventoryImageStore(s => s.images);
-    const screenSlug = slugifyScreenName(screen.name);
+    const storageScreenName = storageName ?? screen.name;
+    const screenSlug = slugifyScreenName(storageScreenName);
     const versions = useMemo(() => {
         return Object.values(allImages)
             .filter(r => r.artifactVersionId === artifactVersionId && r.screenSlug === screenSlug)
@@ -64,8 +72,8 @@ export function ScreenImageGallery({ screen, context }: Props) {
 
     const handleFile = (file: File | null | undefined) => {
         if (!file) return;
-        if (error) clearError(artifactVersionId, screen.name);
-        void upload({ projectId, artifactId, artifactVersionId, screenName: screen.name, file, prompt });
+        if (error) clearError(artifactVersionId, storageScreenName);
+        void upload({ projectId, artifactId, artifactVersionId, screenName: storageScreenName, file, prompt });
     };
 
     return (

--- a/src/components/renderers/ScreenInventoryRenderer.tsx
+++ b/src/components/renderers/ScreenInventoryRenderer.tsx
@@ -114,12 +114,18 @@ function JourneyRow({ steps }: { steps: string[] }) {
 
 // Exported so the Experience workspace's Screen Detail "Overview" tab renders
 // the exact same per-screen block as the standalone Screen Inventory renderer.
+// `imageStorageName` (optional) is the stored generated name the upload
+// gallery keys images by — the Experience workspace passes it so display
+// renames never orphan uploads. Omitted (standalone renderer), the gallery
+// keys by `screen.name` exactly as before.
 export function ScreenCard({
     screen,
     imageContext,
+    imageStorageName,
 }: {
     screen: ScreenItem;
     imageContext?: ScreenImageGalleryContext;
+    imageStorageName?: string;
 }) {
     const ui = screen.coreUIElements && screen.coreUIElements.length > 0
         ? screen.coreUIElements
@@ -205,7 +211,9 @@ export function ScreenCard({
                 <LinkedFeatures refs={screen.featureRefs} />
             )}
 
-            {imageContext && <ScreenImageGallery screen={screen} context={imageContext} />}
+            {imageContext && (
+                <ScreenImageGallery screen={screen} context={imageContext} storageName={imageStorageName} />
+            )}
         </article>
     );
 }

--- a/src/components/renderers/ScreenInventoryRenderer.tsx
+++ b/src/components/renderers/ScreenInventoryRenderer.tsx
@@ -1,22 +1,16 @@
 import { useEffect, type ReactNode } from 'react';
 import { AlertTriangle, ChevronRight, ArrowRight } from 'lucide-react';
-import type { ExitPath, ScreenItem, ScreenPriority, ScreenState } from '../../types';
+import type { ExitPath, ScreenItem, ScreenState } from '../../types';
 import { ScreenImageGallery, type ScreenImageGalleryContext } from './ScreenImageGallery';
 import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
 import { parseScreenInventory } from '../../lib/screenInventoryNormalize';
+import { PRIORITY_STYLES, stylablePriority } from './screenPriority';
 
 interface Props {
     content: string;
     /** When supplied, each screen card gets a copy-prompt + image-upload gallery. */
     imageContext?: ScreenImageGalleryContext;
 }
-
-const PRIORITY_STYLES: Record<ScreenPriority, string> = {
-    P0: 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-200',
-    P1: 'bg-sky-100 text-sky-700 ring-1 ring-sky-200',
-    P2: 'bg-neutral-100 text-neutral-600 ring-1 ring-neutral-200',
-    P3: 'bg-neutral-50 text-neutral-400 ring-1 ring-neutral-100',
-};
 
 export function ScreenInventoryRenderer({ content, imageContext }: Props) {
     const inventory = parseScreenInventory(content);
@@ -118,7 +112,9 @@ function JourneyRow({ steps }: { steps: string[] }) {
     );
 }
 
-function ScreenCard({
+// Exported so the Experience workspace's Screen Detail "Overview" tab renders
+// the exact same per-screen block as the standalone Screen Inventory renderer.
+export function ScreenCard({
     screen,
     imageContext,
 }: {
@@ -128,9 +124,7 @@ function ScreenCard({
     const ui = screen.coreUIElements && screen.coreUIElements.length > 0
         ? screen.coreUIElements
         : screen.components ?? [];
-    const priority = (screen.priority in PRIORITY_STYLES
-        ? screen.priority
-        : 'P1') as ScreenPriority;
+    const priority = stylablePriority(screen.priority);
 
     const hasNavigation = (screen.entryPoints?.length ?? 0) > 0
         || (screen.exitPaths?.length ?? 0) > 0;

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -36,6 +36,10 @@ interface DispatchProps {
     domainEntities?: DomainEntity[];
     featureSystems?: FeatureSystem[];
     implementationPlan?: ImplementationPlan;
+    /** Only consumed by `user_flows`: Experience-workspace wiring so screen
+     * journey nodes can open the matching Screen Detail view. */
+    onNavigateToScreen?: (screenSlug: string) => void;
+    availableScreenSlugs?: ReadonlySet<string>;
     /** Only consumed by `prompt_pack`; per-prompt user edit overlay keyed by index. */
     promptEdits?: Record<number, string>;
     /** Only consumed by `prompt_pack`; persists the new edit overlay. */
@@ -82,6 +86,8 @@ export function ArtifactContentRenderer({
     domainEntities,
     featureSystems,
     implementationPlan,
+    onNavigateToScreen,
+    availableScreenSlugs,
     promptEdits,
     onUpdatePromptEdits,
     generatedAt,
@@ -108,6 +114,8 @@ export function ArtifactContentRenderer({
                 domainEntities={domainEntities}
                 featureSystems={featureSystems}
                 implementationPlan={implementationPlan}
+                onNavigateToScreen={onNavigateToScreen}
+                availableScreenSlugs={availableScreenSlugs}
             />
         );
     }

--- a/src/components/renderers/screenPriority.ts
+++ b/src/components/renderers/screenPriority.ts
@@ -1,0 +1,17 @@
+// Shared priority-chip styling for screen surfaces (Screen Inventory cards,
+// Experience workspace list rows and detail header). Lives in its own module
+// (not in ScreenInventoryRenderer.tsx) so component files keep exporting only
+// components — the react-refresh/only-export-components rule.
+
+import type { ScreenPriority } from '../../types';
+
+export const PRIORITY_STYLES: Record<ScreenPriority, string> = {
+    P0: 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-200',
+    P1: 'bg-sky-100 text-sky-700 ring-1 ring-sky-200',
+    P2: 'bg-neutral-100 text-neutral-600 ring-1 ring-neutral-200',
+    P3: 'bg-neutral-50 text-neutral-400 ring-1 ring-neutral-100',
+};
+
+/** Coerce a possibly-legacy priority value to one that has a style entry. */
+export const stylablePriority = (priority: string): ScreenPriority =>
+    (priority in PRIORITY_STYLES ? priority : 'P1') as ScreenPriority;

--- a/src/components/renderers/userFlows/FlowJourney.tsx
+++ b/src/components/renderers/userFlows/FlowJourney.tsx
@@ -1,13 +1,25 @@
 import {
     AppWindow, Cog, GitBranch, Layers, MousePointerClick, Sparkles, Workflow,
 } from 'lucide-react';
-import type { ParsedStep, FlowJourneyNodeKind } from './types';
+import type { FlowJourneyNode, ParsedStep, FlowJourneyNodeKind } from './types';
 import { buildJourneyNodes, NODE_KIND_LABEL, nodeKindStyle } from './journeyNode';
+import { stepScreenSlug } from '../../../lib/screenExperience';
 
 interface Props {
     flowIndex: number;
     steps: ParsedStep[];
     issuesByStep: Map<number, number>;
+    /**
+     * Experience-workspace wiring (all optional — default behavior is
+     * unchanged). When a clicked node is a `screen` node whose slugified
+     * title exists in `availableScreenSlugs`, `onNavigateToScreen` fires
+     * instead of the scroll-to-step default. Other nodes keep scrolling.
+     */
+    onNavigateToScreen?: (screenSlug: string) => void;
+    availableScreenSlugs?: ReadonlySet<string>;
+    /** Step indices to visually emphasize (the current screen in a Screen
+     * Detail "Flow" tab). */
+    highlightedStepIndices?: ReadonlySet<number>;
 }
 
 const KIND_ICON: Record<FlowJourneyNodeKind, typeof AppWindow> = {
@@ -53,12 +65,25 @@ function Legend() {
     );
 }
 
-export function FlowJourney({ flowIndex, steps, issuesByStep }: Props) {
+export function FlowJourney({
+    flowIndex, steps, issuesByStep,
+    onNavigateToScreen, availableScreenSlugs, highlightedStepIndices,
+}: Props) {
     if (steps.length === 0) return null;
     const nodes = buildJourneyNodes(steps);
 
-    const handleClick = (stepIndex: number) => {
-        const el = document.getElementById(`flow-${flowIndex}-step-${stepIndex}`);
+    const handleClick = (node: FlowJourneyNode) => {
+        // Screen nodes with a matching canonical screen navigate to that
+        // screen's detail view; everything else keeps the scroll behavior.
+        if (onNavigateToScreen && availableScreenSlugs && node.kind === 'screen') {
+            const step = steps.find(s => s.index === node.stepIndex);
+            const slug = step ? stepScreenSlug(step) : null;
+            if (slug && availableScreenSlugs.has(slug)) {
+                onNavigateToScreen(slug);
+                return;
+            }
+        }
+        const el = document.getElementById(`flow-${flowIndex}-step-${node.stepIndex}`);
         if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
 
@@ -80,6 +105,7 @@ export function FlowJourney({ flowIndex, steps, issuesByStep }: Props) {
                         const style = nodeKindStyle(node.kind);
                         const altCount = issuesByStep.get(node.stepIndex) ?? 0;
                         const isLast = i === nodes.length - 1;
+                        const highlighted = highlightedStepIndices?.has(node.stepIndex) ?? false;
                         return (
                             <li
                                 key={node.stepIndex}
@@ -87,8 +113,11 @@ export function FlowJourney({ flowIndex, steps, issuesByStep }: Props) {
                             >
                                 <button
                                     type="button"
-                                    onClick={() => handleClick(node.stepIndex)}
-                                    className={`group relative w-40 text-left rounded-xl border ${style.border} ${style.bg} hover:ring-2 hover:ring-offset-1 hover:ring-indigo-300 transition px-3 py-2.5 flex flex-col`}
+                                    onClick={() => handleClick(node)}
+                                    aria-current={highlighted ? 'true' : undefined}
+                                    className={`group relative w-40 text-left rounded-xl border ${style.border} ${style.bg} hover:ring-2 hover:ring-offset-1 hover:ring-indigo-300 transition px-3 py-2.5 flex flex-col ${
+                                        highlighted ? 'ring-2 ring-offset-1 ring-indigo-500' : ''
+                                    }`}
                                 >
                                     <div className="flex items-center justify-between gap-1 mb-1">
                                         <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-white/80 text-[10px] font-bold text-neutral-700 border border-neutral-200">

--- a/src/components/renderers/userFlows/UserFlowsRenderer.tsx
+++ b/src/components/renderers/userFlows/UserFlowsRenderer.tsx
@@ -27,6 +27,11 @@ interface Props {
     domainEntities?: DomainEntity[];
     featureSystems?: FeatureSystem[];
     implementationPlan?: ImplementationPlan;
+    /** Experience-workspace wiring: clicking a screen journey node whose slug
+     * exists in `availableScreenSlugs` opens that screen's detail view. Both
+     * optional — omitted, the journey keeps its scroll-only behavior. */
+    onNavigateToScreen?: (screenSlug: string) => void;
+    availableScreenSlugs?: ReadonlySet<string>;
 }
 
 const TTV_RE = /<\s*(\d+(?:\.\d+)?)\s*(s|sec|seconds|m|min|minutes|h|hr|hours)\b|\b(\d+(?:\.\d+)?)\s*(s|sec|seconds|m|min|minutes|h|hr|hours)\s+to\s+value\b/i;
@@ -43,6 +48,7 @@ function inferTimeToValue(sources: Array<string | undefined>): string | null {
 
 export function UserFlowsRenderer({
     content, features, uxPages, domainEntities, featureSystems, implementationPlan,
+    onNavigateToScreen, availableScreenSlugs,
 }: Props) {
     const flows = useMemo(() => parseFlows(content), [content]);
     const featuresById = useMemo(() => {
@@ -138,6 +144,8 @@ export function UserFlowsRenderer({
                     flowIndex={safeIndex}
                     steps={flow.steps}
                     issuesByStep={issuesByStep}
+                    onNavigateToScreen={onNavigateToScreen}
+                    availableScreenSlugs={availableScreenSlugs}
                 />
 
                 {flow.steps.length > 0 && (

--- a/src/components/renderers/userFlows/__tests__/FlowJourney.test.tsx
+++ b/src/components/renderers/userFlows/__tests__/FlowJourney.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FlowJourney } from '../FlowJourney';
+import { parseFlows } from '../parseFlow';
+
+// "Landing Page" / "Dashboard" / "Unknown View" all infer as `screen` journey
+// nodes (SCREEN_HINTS: page/dashboard/view), so navigation eligibility is
+// decided purely by slug membership in availableScreenSlugs.
+const MARKDOWN = `### Flow: Onboarding
+**Goal:** Reach the dashboard.
+**Steps:**
+1. [Landing Page] — User taps Get started → System routes to sign-in
+2. [Unknown View] — User wanders → System shrugs
+3. [Dashboard] — User arrives → System loads workspace
+**Success Outcome:** Done.`;
+
+const steps = parseFlows(MARKDOWN)[0].steps;
+const SLUGS: ReadonlySet<string> = new Set(['landing-page', 'dashboard']);
+
+describe('FlowJourney screen-node navigation', () => {
+    it('navigates when a screen node matches an available slug', () => {
+        const onNavigate = vi.fn();
+        render(
+            <FlowJourney
+                flowIndex={0}
+                steps={steps}
+                issuesByStep={new Map()}
+                onNavigateToScreen={onNavigate}
+                availableScreenSlugs={SLUGS}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /Landing Page/ }));
+        expect(onNavigate).toHaveBeenCalledWith('landing-page');
+    });
+
+    it('falls back to scroll behavior for screen nodes with no matching slug', () => {
+        const onNavigate = vi.fn();
+        render(
+            <FlowJourney
+                flowIndex={0}
+                steps={steps}
+                issuesByStep={new Map()}
+                onNavigateToScreen={onNavigate}
+                availableScreenSlugs={SLUGS}
+            />,
+        );
+        // "Unknown View" is a screen node, but its slug isn't available.
+        fireEvent.click(screen.getByRole('button', { name: /Unknown View/ }));
+        expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('keeps the default behavior when navigation props are omitted', () => {
+        render(
+            <FlowJourney flowIndex={0} steps={steps} issuesByStep={new Map()} />,
+        );
+        // No matching StepCard exists in this render, so the click is a no-op
+        // (getElementById miss) — it must not throw.
+        fireEvent.click(screen.getByRole('button', { name: /Landing Page/ }));
+    });
+
+    it('marks highlighted steps with aria-current', () => {
+        render(
+            <FlowJourney
+                flowIndex={0}
+                steps={steps}
+                issuesByStep={new Map()}
+                highlightedStepIndices={new Set([2])}
+            />,
+        );
+        expect(screen.getByRole('button', { name: /Dashboard/ })).toHaveAttribute('aria-current', 'true');
+        expect(screen.getByRole('button', { name: /Landing Page/ })).not.toHaveAttribute('aria-current');
+    });
+});

--- a/src/lib/__tests__/mockupExtraScreens.test.ts
+++ b/src/lib/__tests__/mockupExtraScreens.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+    mergeExtraScreens,
+    mockupScreenFromInventoryScreen,
+    readExtraMockupScreens,
+} from '../mockupParsing';
+import type { MockupPayload, ScreenItem } from '../../types';
+
+const BASE_PAYLOAD: MockupPayload = {
+    version: 'mockup_spec_v1',
+    title: 'T',
+    summary: 'S',
+    screens: [
+        { id: 'uuid-1', name: 'Dashboard', purpose: 'Main.', sourceScreenId: 'dashboard' },
+    ],
+};
+
+describe('readExtraMockupScreens', () => {
+    it('reads valid extra screens and drops malformed entries', () => {
+        const extras = readExtraMockupScreens({
+            extraScreens: [
+                { id: 'uuid-2', name: 'Settings', purpose: 'Prefs.', sourceScreenId: 'settings' },
+                { name: 'No id' },          // dropped: missing id
+                'garbage',                   // dropped: not an object
+            ],
+        });
+        expect(extras).toHaveLength(1);
+        expect(extras[0].id).toBe('uuid-2');
+        expect(extras[0].sourceScreenId).toBe('settings');
+    });
+
+    it('returns empty for missing/invalid metadata', () => {
+        expect(readExtraMockupScreens(undefined)).toEqual([]);
+        expect(readExtraMockupScreens({ extraScreens: 'nope' })).toEqual([]);
+    });
+});
+
+describe('mergeExtraScreens', () => {
+    it('appends extras after the stored screens', () => {
+        const merged = mergeExtraScreens(BASE_PAYLOAD, {
+            extraScreens: [{ id: 'uuid-2', name: 'Settings', purpose: 'Prefs.', sourceScreenId: 'settings' }],
+        });
+        expect(merged.screens.map(s => s.id)).toEqual(['uuid-1', 'uuid-2']);
+    });
+
+    it('dedupes by screen id and by sourceScreenId', () => {
+        const merged = mergeExtraScreens(BASE_PAYLOAD, {
+            extraScreens: [
+                { id: 'uuid-1', name: 'Dashboard', purpose: 'Dup id.' },
+                { id: 'uuid-9', name: 'Dash v2', purpose: 'Dup source.', sourceScreenId: 'dashboard' },
+                { id: 'uuid-2', name: 'Settings', purpose: 'Fresh.', sourceScreenId: 'settings' },
+            ],
+        });
+        expect(merged.screens.map(s => s.id)).toEqual(['uuid-1', 'uuid-2']);
+    });
+
+    it('returns the SAME payload reference when there is nothing to merge', () => {
+        expect(mergeExtraScreens(BASE_PAYLOAD, undefined)).toBe(BASE_PAYLOAD);
+        expect(mergeExtraScreens(BASE_PAYLOAD, { extraScreens: [] })).toBe(BASE_PAYLOAD);
+    });
+});
+
+describe('mockupScreenFromInventoryScreen', () => {
+    it('maps inventory fields the same way generateMockup does', () => {
+        const screen: ScreenItem = {
+            id: 'scr-settings',
+            name: 'Settings',
+            priority: 'P2',
+            type: 'screen',
+            purpose: 'Preferences.',
+            userIntent: 'Tune my experience.',
+            coreUIElements: Array.from({ length: 15 }, (_, i) => `el-${i}`),
+        };
+        const mockup = mockupScreenFromInventoryScreen(screen, 'uuid-5', 'scr-settings');
+        expect(mockup).toMatchObject({
+            id: 'uuid-5',
+            name: 'Settings',
+            purpose: 'Preferences.',
+            userIntent: 'Tune my experience.',
+            priority: 'P2',
+            sourceScreenId: 'scr-settings',
+        });
+        // Capped at 12 elements, mirroring generateMockup.
+        expect(mockup.coreUIElements).toHaveLength(12);
+    });
+
+    it('falls back to legacy components and drops legacy priorities', () => {
+        const screen: ScreenItem = {
+            name: 'Old Screen',
+            priority: 'core',
+            purpose: 'Legacy.',
+            components: ['a', 'b'],
+        };
+        const mockup = mockupScreenFromInventoryScreen(screen, 'uuid-6', 'old-screen');
+        expect(mockup.coreUIElements).toEqual(['a', 'b']);
+        expect(mockup.priority).toBeUndefined();
+    });
+});

--- a/src/lib/__tests__/screenExperience.test.ts
+++ b/src/lib/__tests__/screenExperience.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import {
+    EMPTY_SCREEN_EXPERIENCE_INDEX,
+    buildScreenIndex,
+    groupFlowRefsByFlow,
+    stepScreenSlug,
+} from '../screenExperience';
+import { parseScreenInventory } from '../screenInventoryNormalize';
+import { parseFlows } from '../../components/renderers/userFlows/parseFlow';
+import type { MockupPayload, ScreenInventoryContent } from '../../types';
+
+const INVENTORY: ScreenInventoryContent = {
+    sections: [
+        {
+            title: 'Onboarding',
+            description: 'First-run journey',
+            flowSummary: 'Landing Page → Sign In → Dashboard',
+            screens: [
+                {
+                    name: 'Landing Page',
+                    priority: 'P0',
+                    purpose: 'Introduce the product.',
+                    entryPoints: ['Direct URL'],
+                    exitPaths: [{ label: 'Get started', target: 'Sign In' }],
+                },
+                {
+                    name: 'Sign In',
+                    priority: 'P0',
+                    purpose: 'Authenticate the user.',
+                },
+                {
+                    name: 'Sign In Confirmation',
+                    priority: 'P2',
+                    purpose: 'Confirm a magic-link sign-in.',
+                },
+            ],
+        },
+        {
+            title: 'Core',
+            screens: [
+                { name: 'Dashboard', priority: 'P0', purpose: 'Main workspace.' },
+                { name: 'Settings', priority: 'P2', purpose: 'Preferences.' },
+            ],
+        },
+    ],
+};
+
+const FLOWS_MARKDOWN = `### Flow: Onboarding
+**Goal:** Get from landing to the dashboard.
+**Preconditions:** None.
+**Steps:**
+1. [Landing Page] — User taps Get started → System routes to sign-in
+2. [Sign In] — User authenticates → System creates a session
+3. [Dashboard] — User lands on the dashboard → System loads workspace
+**Success Outcome:** User reaches the dashboard.
+
+### Flow: Session recovery
+**Goal:** Recover an expired session.
+**Preconditions:** Session expired.
+**Steps:**
+1. [Sign In] — User re-authenticates → System restores the session
+2. [Dashboard] — User resumes work → System rehydrates state
+**Success Outcome:** Session restored.`;
+
+const MOCKUP_PAYLOAD: MockupPayload = {
+    version: 'mockup_spec_v1',
+    title: 'Test — UI Mockups',
+    summary: 'Test mockups.',
+    screens: [
+        { id: 'uuid-1', name: 'Landing Page', purpose: 'Introduce the product.' },
+        { id: 'uuid-2', name: 'Dashboard', purpose: 'Main workspace.' },
+        // Drifted mockup screen with no inventory counterpart — must be ignored.
+        { id: 'uuid-3', name: 'Unknown Screen', purpose: 'Renamed since generation.' },
+    ],
+};
+
+describe('stepScreenSlug', () => {
+    it('slugs the bracketed step title', () => {
+        expect(stepScreenSlug({ title: 'Landing Page' })).toBe('landing-page');
+    });
+
+    it('strips markdown backticks before slugging', () => {
+        expect(stepScreenSlug({ title: '`Import Dashboard`' })).toBe('import-dashboard');
+    });
+
+    it('returns null for steps without a usable title', () => {
+        expect(stepScreenSlug({ title: undefined })).toBeNull();
+        expect(stepScreenSlug({ title: '' })).toBeNull();
+        // Would otherwise hit slugifyScreenName's `'screen'` fallback and
+        // false-match a screen literally slugged "screen".
+        expect(stepScreenSlug({ title: '``' })).toBeNull();
+    });
+});
+
+describe('buildScreenIndex', () => {
+    it('joins screens, flows, and mockups by slug', () => {
+        const flows = parseFlows(FLOWS_MARKDOWN);
+        const index = buildScreenIndex(INVENTORY, flows, MOCKUP_PAYLOAD);
+
+        expect(index.items).toHaveLength(5);
+        expect(index.availableSlugs.has('landing-page')).toBe(true);
+
+        const landing = index.bySlug.get('landing-page');
+        expect(landing?.screen.purpose).toBe('Introduce the product.');
+        expect(landing?.sectionTitle).toBe('Onboarding');
+        expect(landing?.relatedFlows).toHaveLength(1);
+        expect(landing?.relatedFlows[0].flow.title).toBe('Onboarding');
+        expect(landing?.relatedFlows[0].stepIndex).toBe(0);
+        expect(landing?.mockupScreen?.id).toBe('uuid-1');
+
+        // Sign In appears in both flows.
+        const signIn = index.bySlug.get('sign-in');
+        expect(signIn?.relatedFlows).toHaveLength(2);
+        expect(signIn?.relatedFlows.map(r => r.flowIndex)).toEqual([0, 1]);
+        expect(signIn?.mockupScreen).toBeUndefined();
+
+        expect(index.collisions).toEqual([]);
+    });
+
+    it('preserves inventory section grouping', () => {
+        const index = buildScreenIndex(INVENTORY, [], null);
+        expect(index.sections.map(s => s.title)).toEqual(['Onboarding', 'Core']);
+        expect(index.sections[0].items.map(i => i.slug)).toEqual([
+            'landing-page', 'sign-in', 'sign-in-confirmation',
+        ]);
+        expect(index.sections[0].flowSummary).toBe('Landing Page → Sign In → Dashboard');
+    });
+
+    it('does not cross-match screens with similar names', () => {
+        const flows = parseFlows(FLOWS_MARKDOWN);
+        const index = buildScreenIndex(INVENTORY, flows, MOCKUP_PAYLOAD);
+        // "Sign In Confirmation" must not inherit "Sign In" flows or mockups.
+        const confirmation = index.bySlug.get('sign-in-confirmation');
+        expect(confirmation).toBeDefined();
+        expect(confirmation?.relatedFlows).toEqual([]);
+        expect(confirmation?.mockupScreen).toBeUndefined();
+    });
+
+    it('handles a missing inventory with the stable empty index', () => {
+        const flows = parseFlows(FLOWS_MARKDOWN);
+        expect(buildScreenIndex(null, flows, MOCKUP_PAYLOAD)).toBe(EMPTY_SCREEN_EXPERIENCE_INDEX);
+        expect(buildScreenIndex({ sections: [] }, flows, null)).toBe(EMPTY_SCREEN_EXPERIENCE_INDEX);
+        // Referential stability across calls — selector-safe.
+        expect(buildScreenIndex(null, [], null)).toBe(buildScreenIndex(null, [], null));
+    });
+
+    it('handles missing flows and missing mockups gracefully', () => {
+        const index = buildScreenIndex(INVENTORY, [], null);
+        expect(index.items).toHaveLength(5);
+        for (const item of index.items) {
+            expect(item.relatedFlows).toEqual([]);
+            expect(item.mockupScreen).toBeUndefined();
+        }
+    });
+
+    it('ignores mockup screens that no longer match an inventory screen', () => {
+        const index = buildScreenIndex(INVENTORY, [], MOCKUP_PAYLOAD);
+        const matched = index.items.filter(i => i.mockupScreen);
+        expect(matched.map(i => i.slug).sort()).toEqual(['dashboard', 'landing-page']);
+    });
+
+    it('accepts legacy inventory shapes via parseScreenInventory normalization', () => {
+        const legacyJson = JSON.stringify({
+            groups: [
+                {
+                    name: 'Main',
+                    screens: [
+                        {
+                            name: 'Home',
+                            priority: 'core',
+                            purpose: 'Legacy home screen.',
+                            navigationTo: ['Detail'],
+                        },
+                    ],
+                },
+            ],
+        });
+        const normalized = parseScreenInventory(legacyJson);
+        expect(normalized).not.toBeNull();
+        const index = buildScreenIndex(normalized, [], null);
+        expect(index.items).toHaveLength(1);
+        expect(index.items[0].slug).toBe('home');
+        expect(index.items[0].screen.priority).toBe('P0');
+        expect(index.sections[0].title).toBe('Main');
+    });
+
+    it('detects slug collisions and keeps the first screen', () => {
+        const colliding: ScreenInventoryContent = {
+            sections: [
+                {
+                    title: 'A',
+                    screens: [
+                        { name: 'Sign-In', priority: 'P0', purpose: 'First.' },
+                        { name: 'Sign In', priority: 'P1', purpose: 'Second.' },
+                    ],
+                },
+            ],
+        };
+        const index = buildScreenIndex(colliding, [], null);
+        expect(index.items).toHaveLength(1);
+        expect(index.bySlug.get('sign-in')?.screen.purpose).toBe('First.');
+        expect(index.collisions).toEqual([
+            { slug: 'sign-in', names: ['Sign-In', 'Sign In'] },
+        ]);
+    });
+
+    it('routes colliding-slug flow steps to the first (kept) screen', () => {
+        const colliding: ScreenInventoryContent = {
+            sections: [
+                {
+                    title: 'A',
+                    screens: [
+                        { name: 'Sign-In', priority: 'P0', purpose: 'First.' },
+                        { name: 'Sign In', priority: 'P1', purpose: 'Second.' },
+                    ],
+                },
+            ],
+        };
+        const flows = parseFlows(FLOWS_MARKDOWN);
+        const index = buildScreenIndex(colliding, flows, null);
+        expect(index.bySlug.get('sign-in')?.relatedFlows).toHaveLength(2);
+    });
+});
+
+describe('groupFlowRefsByFlow', () => {
+    it('groups multiple step refs of the same flow together', () => {
+        const flows = parseFlows(`### Flow: Loop
+**Goal:** Repeat visits to the dashboard.
+**Steps:**
+1. [Dashboard] — User opens → System loads
+2. [Settings] — User tweaks → System saves
+3. [Dashboard] — User returns → System refreshes
+**Success Outcome:** Done.`);
+        const index = buildScreenIndex(INVENTORY, flows, null);
+        const dashboard = index.bySlug.get('dashboard');
+        expect(dashboard?.relatedFlows).toHaveLength(2);
+        const groups = groupFlowRefsByFlow(dashboard!.relatedFlows);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].flow.title).toBe('Loop');
+        expect(groups[0].steps.map(s => s.stepIndex)).toEqual([0, 2]);
+    });
+
+    it('returns an empty list for no refs', () => {
+        expect(groupFlowRefsByFlow([])).toEqual([]);
+    });
+});

--- a/src/lib/__tests__/screenExperience.test.ts
+++ b/src/lib/__tests__/screenExperience.test.ts
@@ -184,7 +184,7 @@ describe('buildScreenIndex', () => {
         expect(index.sections[0].title).toBe('Main');
     });
 
-    it('detects slug collisions and keeps the first screen', () => {
+    it('detects slug collisions, keeps both screens, and resolves slug lookups to the first', () => {
         const colliding: ScreenInventoryContent = {
             sections: [
                 {
@@ -197,7 +197,11 @@ describe('buildScreenIndex', () => {
             ],
         };
         const index = buildScreenIndex(colliding, [], null);
-        expect(index.items).toHaveLength(1);
+        // Both screens survive as distinct items with unique canonical ids.
+        expect(index.items).toHaveLength(2);
+        expect(index.byId.get('sign-in')?.screen.purpose).toBe('First.');
+        expect(index.byId.get('sign-in-2')?.screen.purpose).toBe('Second.');
+        // Name-based lookups stay first-wins.
         expect(index.bySlug.get('sign-in')?.screen.purpose).toBe('First.');
         expect(index.collisions).toEqual([
             { slug: 'sign-in', names: ['Sign-In', 'Sign In'] },
@@ -219,6 +223,70 @@ describe('buildScreenIndex', () => {
         const flows = parseFlows(FLOWS_MARKDOWN);
         const index = buildScreenIndex(colliding, flows, null);
         expect(index.bySlug.get('sign-in')?.relatedFlows).toHaveLength(2);
+    });
+});
+
+describe('stable screen ids', () => {
+    it('derives canonical ids (content id first, else slug) and exposes byId', () => {
+        const inv: ScreenInventoryContent = {
+            sections: [
+                {
+                    title: 'A',
+                    screens: [
+                        { id: 'model-id-1', name: 'Landing Page', priority: 'P0', purpose: 'X.' },
+                        { name: 'Dashboard', priority: 'P0', purpose: 'Y.' },
+                    ],
+                },
+            ],
+        };
+        const index = buildScreenIndex(inv, [], null);
+        expect(index.byId.get('model-id-1')?.slug).toBe('landing-page');
+        expect(index.byId.get('dashboard')?.screen.purpose).toBe('Y.');
+        expect(index.items.map(i => i.id)).toEqual(['model-id-1', 'dashboard']);
+    });
+
+    it('matches mockup screens by sourceScreenId ahead of name (rename-safe)', () => {
+        const inv: ScreenInventoryContent = {
+            sections: [
+                {
+                    title: 'A',
+                    screens: [
+                        { id: 'scr-dash', name: 'Dashboard', priority: 'P0', purpose: 'Main.' },
+                    ],
+                },
+            ],
+        };
+        const payload: MockupPayload = {
+            version: 'mockup_spec_v1',
+            title: 'T',
+            summary: 'S',
+            screens: [
+                // Name has drifted (would NOT slug-match "Dashboard"), but the
+                // stable id still resolves it.
+                { id: 'uuid-9', name: 'Dashboard (v2 layout)', purpose: 'Main.', sourceScreenId: 'scr-dash' },
+            ],
+        };
+        const index = buildScreenIndex(inv, [], payload);
+        expect(index.byId.get('scr-dash')?.mockupScreen?.id).toBe('uuid-9');
+    });
+
+    it('normalization stamps deterministic ids on legacy inventories (no regeneration needed)', () => {
+        const legacyJson = JSON.stringify({
+            sections: [
+                {
+                    title: 'A',
+                    screens: [
+                        { name: 'Home', priority: 'P0', purpose: 'X.' },
+                        { name: 'Home', priority: 'P1', purpose: 'Dup.' },
+                    ],
+                },
+            ],
+        });
+        const first = parseScreenInventory(legacyJson);
+        const second = parseScreenInventory(legacyJson);
+        // Deterministic across reads — same ids every time.
+        expect(first?.sections[0].screens.map(s => s.id)).toEqual(['home', 'home-2']);
+        expect(second?.sections[0].screens.map(s => s.id)).toEqual(['home', 'home-2']);
     });
 });
 

--- a/src/lib/__tests__/screenExperience.test.ts
+++ b/src/lib/__tests__/screenExperience.test.ts
@@ -3,6 +3,7 @@ import {
     EMPTY_SCREEN_EXPERIENCE_INDEX,
     buildScreenIndex,
     groupFlowRefsByFlow,
+    readScreenEdits,
     stepScreenSlug,
 } from '../screenExperience';
 import { parseScreenInventory } from '../screenInventoryNormalize';
@@ -287,6 +288,64 @@ describe('stable screen ids', () => {
         // Deterministic across reads — same ids every time.
         expect(first?.sections[0].screens.map(s => s.id)).toEqual(['home', 'home-2']);
         expect(second?.sections[0].screens.map(s => s.id)).toEqual(['home', 'home-2']);
+    });
+});
+
+describe('screen metadata edit overlay (rename safety)', () => {
+    it('applies edits for display while keeping joins on the stored content', () => {
+        const flows = parseFlows(FLOWS_MARKDOWN);
+        const edits = {
+            'sign-in': { name: 'Authentication', purpose: 'Edited purpose.', priority: 'P1' as const },
+        };
+        const index = buildScreenIndex(INVENTORY, flows, MOCKUP_PAYLOAD, edits);
+        const item = index.byId.get('sign-in');
+        // Display fields reflect the overlay…
+        expect(item?.screen.name).toBe('Authentication');
+        expect(item?.screen.purpose).toBe('Edited purpose.');
+        expect(item?.screen.priority).toBe('P1');
+        expect(item?.isEdited).toBe(true);
+        // …but the stored screen, slug, and joins are untouched by the rename.
+        expect(item?.baseScreen.name).toBe('Sign In');
+        expect(item?.slug).toBe('sign-in');
+        expect(item?.relatedFlows).toHaveLength(2);
+        // A rename must also not steal another screen's identity: the edited
+        // display name does NOT create a bySlug entry for "authentication".
+        expect(index.bySlug.get('authentication')).toBeUndefined();
+    });
+
+    it('renaming a screen keeps its mockup attached (id/base-name join)', () => {
+        const edits = { 'landing-page': { name: 'Welcome Splash' } };
+        const index = buildScreenIndex(INVENTORY, [], MOCKUP_PAYLOAD, edits);
+        const item = index.byId.get('landing-page');
+        expect(item?.screen.name).toBe('Welcome Splash');
+        expect(item?.mockupScreen?.id).toBe('uuid-1');
+    });
+
+    it('screens without an edit stay pristine (screen === baseScreen)', () => {
+        const index = buildScreenIndex(INVENTORY, [], null, { 'sign-in': { purpose: 'X' } });
+        const untouched = index.byId.get('dashboard');
+        expect(untouched?.isEdited).toBe(false);
+        expect(untouched?.screen).toBe(untouched?.baseScreen);
+    });
+});
+
+describe('readScreenEdits', () => {
+    it('extracts a valid overlay and drops malformed entries', () => {
+        const edits = readScreenEdits({
+            screenEdits: {
+                'scr-1': { name: '  Renamed  ', purpose: 'P', priority: 'P2', notes: 'n' },
+                'scr-2': { priority: 'not-a-priority', name: '   ' },
+                'scr-3': 'garbage',
+            },
+        });
+        expect(edits['scr-1']).toEqual({ name: 'Renamed', purpose: 'P', priority: 'P2', notes: 'n' });
+        expect(edits['scr-2']).toBeUndefined();
+        expect(edits['scr-3']).toBeUndefined();
+    });
+
+    it('returns the stable empty map for missing/invalid metadata', () => {
+        expect(readScreenEdits(undefined)).toBe(readScreenEdits({}));
+        expect(readScreenEdits({ screenEdits: 'nope' })).toBe(readScreenEdits(undefined));
     });
 });
 

--- a/src/lib/__tests__/screenExperience.test.ts
+++ b/src/lib/__tests__/screenExperience.test.ts
@@ -3,7 +3,9 @@ import {
     EMPTY_SCREEN_EXPERIENCE_INDEX,
     buildScreenIndex,
     groupFlowRefsByFlow,
+    readDismissedScreenIssues,
     readScreenEdits,
+    readScreenLinks,
     stepScreenSlug,
 } from '../screenExperience';
 import { parseScreenInventory } from '../screenInventoryNormalize';
@@ -346,6 +348,100 @@ describe('readScreenEdits', () => {
     it('returns the stable empty map for missing/invalid metadata', () => {
         expect(readScreenEdits(undefined)).toBe(readScreenEdits({}));
         expect(readScreenEdits({ screenEdits: 'nope' })).toBe(readScreenEdits(undefined));
+    });
+});
+
+describe('reference validation issues', () => {
+    it('flags screen-looking flow steps that match no screen (grouped per name)', () => {
+        const flows = parseFlows(`### Flow: Broken
+**Goal:** Test.
+**Steps:**
+1. [Onboarding Setup Page] — User starts → System shows setup
+2. [Onboarding Setup Page] — User retries → System shows setup again
+3. [Dashboard] — User lands → System loads
+**Success Outcome:** Done.`);
+        const index = buildScreenIndex(INVENTORY, flows, null);
+        const flowIssues = index.issues.filter(i => i.kind === 'unmatched_flow_step');
+        // Two steps, one missing screen → ONE grouped issue.
+        expect(flowIssues).toHaveLength(1);
+        expect(flowIssues[0].key).toBe('flowstep:onboarding-setup-page');
+        expect(flowIssues[0].message).toContain('Onboarding Setup Page');
+    });
+
+    it('flags unmatched mockup screens as repairable issues', () => {
+        const payload: MockupPayload = {
+            version: 'mockup_spec_v1',
+            title: 'T',
+            summary: 'S',
+            screens: [{ id: 'uuid-x', name: 'Totally Renamed Screen', purpose: 'Drifted.' }],
+        };
+        const index = buildScreenIndex(INVENTORY, [], payload);
+        const issue = index.issues.find(i => i.kind === 'unmatched_mockup_screen');
+        expect(issue?.mockupScreenId).toBe('uuid-x');
+    });
+
+    it('flags name-only mockup matches as legacy (informational) issues', () => {
+        const index = buildScreenIndex(INVENTORY, [], MOCKUP_PAYLOAD);
+        const legacy = index.issues.filter(i => i.kind === 'legacy_name_match');
+        // uuid-1 (Landing Page) and uuid-2 (Dashboard) match by name only.
+        expect(legacy.map(i => i.mockupScreenId).sort()).toEqual(['uuid-1', 'uuid-2']);
+        // The current match is preserved and exposed for one-click pinning.
+        expect(legacy[0].screenId).toBeDefined();
+    });
+
+    it('does not flag sourceScreenId matches as legacy', () => {
+        const payload: MockupPayload = {
+            version: 'mockup_spec_v1',
+            title: 'T',
+            summary: 'S',
+            screens: [{ id: 'uuid-1', name: 'Landing Page', purpose: 'X.', sourceScreenId: 'landing-page' }],
+        };
+        const index = buildScreenIndex(INVENTORY, [], payload);
+        expect(index.issues.filter(i => i.kind === 'legacy_name_match')).toEqual([]);
+    });
+
+    it('emits a slug_collision issue alongside the collisions list', () => {
+        const colliding: ScreenInventoryContent = {
+            sections: [
+                {
+                    title: 'A',
+                    screens: [
+                        { name: 'Sign-In', priority: 'P0', purpose: 'First.' },
+                        { name: 'Sign In', priority: 'P1', purpose: 'Second.' },
+                    ],
+                },
+            ],
+        };
+        const index = buildScreenIndex(colliding, [], null);
+        const issue = index.issues.find(i => i.kind === 'slug_collision');
+        expect(issue?.key).toBe('collision:sign-in');
+        expect(issue?.message).toContain('Sign-In');
+    });
+});
+
+describe('screen links (relink repairs)', () => {
+    it('an explicit link outranks sourceScreenId and name matching', () => {
+        const payload: MockupPayload = {
+            version: 'mockup_spec_v1',
+            title: 'T',
+            summary: 'S',
+            screens: [
+                // Name matches "Dashboard", but the user linked it to Settings.
+                { id: 'uuid-7', name: 'Dashboard', purpose: 'X.' },
+            ],
+        };
+        const index = buildScreenIndex(INVENTORY, [], payload, {}, { 'uuid-7': 'settings' });
+        expect(index.byId.get('settings')?.mockupScreen?.id).toBe('uuid-7');
+        expect(index.byId.get('dashboard')?.mockupScreen).toBeUndefined();
+        // A linked match is neither legacy nor unmatched.
+        expect(index.issues.filter(i => i.mockupScreenId === 'uuid-7')).toEqual([]);
+    });
+
+    it('readScreenLinks / readDismissedScreenIssues tolerate junk and stay stable when empty', () => {
+        expect(readScreenLinks({ screenLinks: { a: 'scr-1', b: 42, c: '' } })).toEqual({ a: 'scr-1' });
+        expect(readScreenLinks(undefined)).toBe(readScreenLinks({ screenLinks: 'junk' }));
+        expect(readDismissedScreenIssues({ dismissedScreenIssues: ['k1', 7, ''] }).has('k1')).toBe(true);
+        expect(readDismissedScreenIssues(undefined)).toBe(readDismissedScreenIssues({}));
     });
 });
 

--- a/src/lib/mockupParsing.ts
+++ b/src/lib/mockupParsing.ts
@@ -46,6 +46,9 @@ const coerceScreen = (raw: unknown): MockupScreen | null => {
         coreUIElements: stringArray(s.coreUIElements),
         componentRefs: stringArray(s.componentRefs),
         notes: typeof s.notes === 'string' ? s.notes : undefined,
+        sourceScreenId: typeof s.sourceScreenId === 'string' && s.sourceScreenId.length > 0
+            ? s.sourceScreenId
+            : undefined,
     };
 };
 

--- a/src/lib/mockupParsing.ts
+++ b/src/lib/mockupParsing.ts
@@ -6,6 +6,7 @@ import type {
     MockupScope,
     MockupScreen,
     MockupSettings,
+    ScreenItem,
     ScreenPriority,
     ScreenType,
 } from '../types';
@@ -78,6 +79,67 @@ export function tryParsePayload(version: ArtifactVersion): MockupPayload | null 
     } catch {
         return null;
     }
+}
+
+/**
+ * User-added mockup screens for a version, stored as an overlay in
+ * `metadata.extraScreens` (never by rewriting `content`). Appending a screen
+ * to the CURRENT version's overlay keeps the version id — and therefore every
+ * already-generated/uploaded image key — intact, unlike appending a whole new
+ * ArtifactVersion. Invalid entries are dropped defensively.
+ */
+export function readExtraMockupScreens(
+    metadata: Record<string, unknown> | undefined,
+): MockupScreen[] {
+    const raw = metadata?.extraScreens;
+    if (!Array.isArray(raw)) return [];
+    return raw
+        .map((s: unknown) => coerceScreen(s))
+        .filter((s: MockupScreen | null): s is MockupScreen => s !== null);
+}
+
+/**
+ * Effective payload = stored payload + the version's extraScreens overlay
+ * (deduped by screen id and by sourceScreenId so a screen can't be added
+ * twice). Returns the SAME payload reference when there is nothing to merge —
+ * memo/selector friendly.
+ */
+export function mergeExtraScreens(
+    payload: MockupPayload,
+    metadata: Record<string, unknown> | undefined,
+): MockupPayload {
+    const extras = readExtraMockupScreens(metadata).filter(extra =>
+        !payload.screens.some(s =>
+            s.id === extra.id
+            || (extra.sourceScreenId && s.sourceScreenId === extra.sourceScreenId)),
+    );
+    if (extras.length === 0) return payload;
+    return { ...payload, screens: [...payload.screens, ...extras] };
+}
+
+/**
+ * Build a MockupScreen spec from a (normalized) inventory screen — the same
+ * field mapping generateMockup uses, for user-initiated per-screen coverage.
+ * `id` is caller-supplied (a fresh uuid) so this stays pure/deterministic.
+ */
+export function mockupScreenFromInventoryScreen(
+    screen: ScreenItem,
+    id: string,
+    sourceScreenId: string,
+): MockupScreen {
+    const ui = screen.coreUIElements ?? screen.components;
+    return {
+        id,
+        name: screen.name,
+        purpose: screen.purpose,
+        userIntent: screen.userIntent,
+        priority: typeof screen.priority === 'string' && VALID_PRIORITIES.has(screen.priority)
+            ? (screen.priority as ScreenPriority)
+            : undefined,
+        type: screen.type,
+        coreUIElements: ui?.slice(0, 12),
+        sourceScreenId,
+    };
 }
 
 /** Safely extract MockupSettings from version metadata, falling back to

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -39,6 +39,13 @@ export interface ScreenFlowRef {
 
 /** A canonical screen plus everything the other artifacts say about it. */
 export interface ScreenExperienceItem {
+    /**
+     * Stable canonical screen id — the rename-safe join/selection key.
+     * Normally stamped by `assignStableScreenIds` during inventory
+     * normalization; derived here with the same precedence (content id →
+     * unique slug) as a safety net for inventories that skipped it.
+     */
+    id: string;
     slug: string;
     screen: ScreenItem;
     /** Title of the inventory section the screen belongs to. */
@@ -64,6 +71,10 @@ export interface ScreenSlugCollision {
 
 export interface ScreenExperienceIndex {
     items: ScreenExperienceItem[];
+    /** Canonical lookup — id is the stable, rename-safe key. */
+    byId: Map<string, ScreenExperienceItem>;
+    /** Name-based lookup for artifacts that only know names (flow steps,
+     * legacy mockups). First screen wins on slug collision. */
     bySlug: Map<string, ScreenExperienceItem>;
     sections: ScreenExperienceSection[];
     collisions: ScreenSlugCollision[];
@@ -76,6 +87,7 @@ export interface ScreenExperienceIndex {
 // for the same empty state — see the Selector-stability rule in CLAUDE.md.
 export const EMPTY_SCREEN_EXPERIENCE_INDEX: ScreenExperienceIndex = {
     items: [],
+    byId: new Map(),
     bySlug: new Map(),
     sections: [],
     collisions: [],
@@ -119,6 +131,7 @@ export function buildScreenIndex(
     }
 
     const items: ScreenExperienceItem[] = [];
+    const byId = new Map<string, ScreenExperienceItem>();
     const bySlug = new Map<string, ScreenExperienceItem>();
     const namesBySlug = new Map<string, string[]>();
     const sections: ScreenExperienceSection[] = [];
@@ -131,14 +144,27 @@ export function buildScreenIndex(
             const names = namesBySlug.get(slug) ?? [];
             names.push(screen.name);
             namesBySlug.set(slug, names);
-            if (bySlug.has(slug)) continue; // first occurrence wins
+            // Canonical id: normalization (assignStableScreenIds) stamps one;
+            // derive the same way here for inventories that bypassed it, and
+            // unique-ify defensively so byId never drops a screen.
+            const baseId = (typeof screen.id === 'string' && screen.id.trim()) || slug;
+            let id = baseId;
+            let n = 2;
+            while (byId.has(id)) {
+                id = `${baseId}-${n}`;
+                n += 1;
+            }
             const item: ScreenExperienceItem = {
+                id,
                 slug,
                 screen,
                 sectionTitle: section.title,
                 relatedFlows: [],
             };
-            bySlug.set(slug, item);
+            byId.set(id, item);
+            // Name-keyed lookup keeps first-wins semantics on collisions
+            // (later same-name screens still exist as items, keyed by id).
+            if (!bySlug.has(slug)) bySlug.set(slug, item);
             items.push(item);
             sectionItems.push(item);
         }
@@ -156,7 +182,7 @@ export function buildScreenIndex(
 
     // Join flow steps by exact slug of the parsed step title. Substring /
     // fuzzy matching is deliberately avoided: "Sign In" must not match
-    // "Sign In Confirmation".
+    // "Sign In Confirmation". (Flows are markdown and only know names.)
     flows.forEach((flow, flowIndex) => {
         for (const step of flow.steps) {
             const slug = stepScreenSlug(step);
@@ -167,13 +193,17 @@ export function buildScreenIndex(
         }
     });
 
-    // Join mockup screens by slugified mockup screen name. A mockup screen
-    // that matches no inventory screen is simply not surfaced here (it stays
-    // visible in the legacy mockup viewer).
+    // Join mockup screens: stable `sourceScreenId` wins (rename-safe, stamped
+    // by generateMockup on new payloads); legacy payloads fall back to
+    // slugified-name matching. A mockup screen that matches nothing is not
+    // surfaced here (it stays visible in the legacy mockup viewer).
     if (mockupPayload) {
         for (const mockupScreen of mockupPayload.screens) {
-            if (!mockupScreen.name) continue;
-            const item = bySlug.get(slugifyScreenName(mockupScreen.name));
+            const byStableId = mockupScreen.sourceScreenId
+                ? byId.get(mockupScreen.sourceScreenId)
+                : undefined;
+            const item = byStableId
+                ?? (mockupScreen.name ? bySlug.get(slugifyScreenName(mockupScreen.name)) : undefined);
             if (item && !item.mockupScreen) item.mockupScreen = mockupScreen;
         }
     }
@@ -185,6 +215,7 @@ export function buildScreenIndex(
 
     return {
         items,
+        byId,
         bySlug,
         sections,
         collisions,

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -20,12 +20,68 @@ import type {
     MockupScreen,
     ScreenInventoryContent,
     ScreenItem,
+    ScreenPriority,
 } from '../types';
 import { slugifyScreenName } from './screenInventoryImageStore';
 import type {
     ParsedFlow,
     ParsedStep,
 } from '../components/renderers/userFlows/types';
+
+/**
+ * User edit overlay for one screen, keyed by the canonical screen id and
+ * stored on the screen_inventory ArtifactVersion as `metadata.screenEdits`
+ * (the same overlay pattern as prompt_pack's `metadata.promptEdits`). The
+ * generated content is never rewritten: renames change only the *displayed*
+ * name, while every join and image key derives from the stored generated
+ * name — which is what makes renames unable to orphan relationships.
+ */
+export interface ScreenMetadataEdit {
+    name?: string;
+    purpose?: string;
+    userIntent?: string;
+    priority?: ScreenPriority;
+    /** Free-form user notes shown on the screen's Overview tab. */
+    notes?: string;
+}
+
+export type ScreenEditsMap = Record<string, ScreenMetadataEdit>;
+
+const VALID_EDIT_PRIORITIES: ReadonlySet<string> = new Set(['P0', 'P1', 'P2', 'P3']);
+
+/** Safely extract the screenEdits overlay from ArtifactVersion metadata. */
+export function readScreenEdits(metadata: Record<string, unknown> | undefined): ScreenEditsMap {
+    const raw = metadata?.screenEdits;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return EMPTY_SCREEN_EDITS;
+    const out: ScreenEditsMap = {};
+    for (const [id, value] of Object.entries(raw as Record<string, unknown>)) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+        const v = value as Record<string, unknown>;
+        const edit: ScreenMetadataEdit = {};
+        if (typeof v.name === 'string' && v.name.trim()) edit.name = v.name.trim();
+        if (typeof v.purpose === 'string') edit.purpose = v.purpose;
+        if (typeof v.userIntent === 'string') edit.userIntent = v.userIntent;
+        if (typeof v.priority === 'string' && VALID_EDIT_PRIORITIES.has(v.priority)) {
+            edit.priority = v.priority as ScreenPriority;
+        }
+        if (typeof v.notes === 'string') edit.notes = v.notes;
+        if (Object.keys(edit).length > 0) out[id] = edit;
+    }
+    return Object.keys(out).length > 0 ? out : EMPTY_SCREEN_EDITS;
+}
+
+export const EMPTY_SCREEN_EDITS: ScreenEditsMap = {};
+
+/** Apply an edit overlay to a stored screen, producing the effective screen. */
+function applyScreenEdit(base: ScreenItem, edit: ScreenMetadataEdit | undefined): ScreenItem {
+    if (!edit) return base;
+    const effective: ScreenItem = { ...base };
+    if (edit.name) effective.name = edit.name;
+    if (edit.purpose !== undefined) effective.purpose = edit.purpose;
+    if (edit.userIntent !== undefined) effective.userIntent = edit.userIntent;
+    if (edit.priority) effective.priority = edit.priority;
+    return effective;
+}
 
 /** One flow step that references a screen (matched by slug of the step title). */
 export interface ScreenFlowRef {
@@ -46,8 +102,19 @@ export interface ScreenExperienceItem {
      * unique slug) as a safety net for inventories that skipped it.
      */
     id: string;
+    /** Slug of the STORED generated name — the image/flow join key. Stable
+     * across display renames. */
     slug: string;
+    /** Effective screen: stored content with the user's edit overlay applied.
+     * Views render this. */
     screen: ScreenItem;
+    /** The stored generated screen, untouched by edits. Joins and image keys
+     * derive from this — pass its name to image galleries as `storageName`. */
+    baseScreen: ScreenItem;
+    /** True when a user edit overlay applies to this screen. */
+    isEdited: boolean;
+    /** The applied edit overlay (when isEdited). */
+    edit?: ScreenMetadataEdit;
     /** Title of the inventory section the screen belongs to. */
     sectionTitle: string;
     relatedFlows: ScreenFlowRef[];
@@ -120,11 +187,14 @@ export function stepScreenSlug(step: Pick<ParsedStep, 'title'>): string | null {
  * → the stable empty index; no flows/mockup → items with empty relations).
  * On slug collision the first screen in inventory order wins `bySlug`; the
  * colliding names are surfaced in `collisions` for the UI to warn about.
+ * `edits` is the per-version user overlay (`readScreenEdits`) — it changes
+ * only what views display; every join key stays derived from stored content.
  */
 export function buildScreenIndex(
     inventory: ScreenInventoryContent | null,
     flows: readonly ParsedFlow[],
     mockupPayload: MockupPayload | null,
+    edits: ScreenEditsMap = EMPTY_SCREEN_EDITS,
 ): ScreenExperienceIndex {
     if (!inventory || !inventory.sections || inventory.sections.length === 0) {
         return EMPTY_SCREEN_EXPERIENCE_INDEX;
@@ -154,10 +224,14 @@ export function buildScreenIndex(
                 id = `${baseId}-${n}`;
                 n += 1;
             }
+            const edit = edits[id];
             const item: ScreenExperienceItem = {
                 id,
                 slug,
-                screen,
+                screen: applyScreenEdit(screen, edit),
+                baseScreen: screen,
+                isEdited: Boolean(edit),
+                edit,
                 sectionTitle: section.title,
                 relatedFlows: [],
             };

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -1,0 +1,215 @@
+// Pure join layer for the screen-centric Experience workspace.
+//
+// The Experience view treats each Screen (from the screen_inventory artifact)
+// as the canonical object and joins the other two experience artifacts onto it
+// **at render time**:
+//
+//   - user_flows steps reference screens via the bracketed `[Screen Name]`
+//     step-title convention (see parseFlow.ts / the user_flows prompt);
+//   - mockup screens copy their `name` from the inventory screen they were
+//     derived from (see mockupService.generateMockup).
+//
+// There is no persisted screen id anywhere, so the MVP join key is the same
+// slug the per-screen image stores already use: `slugifyScreenName(name)`.
+// Nothing here is persisted — this module is a read-side index over artifact
+// contents that already live in the store. It must stay pure (no Zustand, no
+// IDB, no React) so it can be unit-tested in isolation.
+
+import type {
+    MockupPayload,
+    MockupScreen,
+    ScreenInventoryContent,
+    ScreenItem,
+} from '../types';
+import { slugifyScreenName } from './screenInventoryImageStore';
+import type {
+    ParsedFlow,
+    ParsedStep,
+} from '../components/renderers/userFlows/types';
+
+/** One flow step that references a screen (matched by slug of the step title). */
+export interface ScreenFlowRef {
+    flow: ParsedFlow;
+    /** Index of the flow within the parsed user_flows document. */
+    flowIndex: number;
+    step: ParsedStep;
+    /** `step.index` hoisted for convenience (StepCard anchors key off it). */
+    stepIndex: number;
+}
+
+/** A canonical screen plus everything the other artifacts say about it. */
+export interface ScreenExperienceItem {
+    slug: string;
+    screen: ScreenItem;
+    /** Title of the inventory section the screen belongs to. */
+    sectionTitle: string;
+    relatedFlows: ScreenFlowRef[];
+    /** The matching mockup screen spec, when the mockup payload covers it. */
+    mockupScreen?: MockupScreen;
+}
+
+/** Inventory section grouping preserved for the Screens list view. */
+export interface ScreenExperienceSection {
+    title: string;
+    description?: string;
+    flowSummary?: string;
+    items: ScreenExperienceItem[];
+}
+
+/** Two or more distinct screen names collapsing to one slug. */
+export interface ScreenSlugCollision {
+    slug: string;
+    names: string[];
+}
+
+export interface ScreenExperienceIndex {
+    items: ScreenExperienceItem[];
+    bySlug: Map<string, ScreenExperienceItem>;
+    sections: ScreenExperienceSection[];
+    collisions: ScreenSlugCollision[];
+    /** Slugs with a canonical screen — used to gate flow-node navigation. */
+    availableSlugs: ReadonlySet<string>;
+}
+
+// Stable empty index. Returned for every "no inventory" case so consumers
+// (and any memo/selector holding the result) never see a fresh allocation
+// for the same empty state — see the Selector-stability rule in CLAUDE.md.
+export const EMPTY_SCREEN_EXPERIENCE_INDEX: ScreenExperienceIndex = {
+    items: [],
+    bySlug: new Map(),
+    sections: [],
+    collisions: [],
+    availableSlugs: new Set(),
+};
+
+/** Strip surrounding markdown backticks (step titles are often `` `Name` ``). */
+const stripBackticks = (text: string): string => text.replace(/^`+|`+$/g, '').trim();
+
+/**
+ * Slug of the screen a parsed flow step points at, or null when the step has
+ * no usable title. Guarding the empty title matters because
+ * `slugifyScreenName('')` falls back to the literal `'screen'`, which could
+ * otherwise false-match a real screen that slugs to the same value.
+ */
+export function stepScreenSlug(step: Pick<ParsedStep, 'title'>): string | null {
+    const title = step.title ? stripBackticks(step.title) : '';
+    if (!title) return null;
+    return slugifyScreenName(title);
+}
+
+/**
+ * Build the screen-centric index by joining the three experience artifacts.
+ * All inputs are the *normalized/parsed* artifact contents:
+ *   - `inventory`: `parseScreenInventory(version.content)` (never raw legacy
+ *     JSON — normalization maps `groups[]`/legacy priorities upstream);
+ *   - `flows`: `parseFlows(version.content)`;
+ *   - `mockupPayload`: `tryParsePayload(version)`.
+ * Any of them may be null/empty; the index degrades gracefully (no inventory
+ * → the stable empty index; no flows/mockup → items with empty relations).
+ * On slug collision the first screen in inventory order wins `bySlug`; the
+ * colliding names are surfaced in `collisions` for the UI to warn about.
+ */
+export function buildScreenIndex(
+    inventory: ScreenInventoryContent | null,
+    flows: readonly ParsedFlow[],
+    mockupPayload: MockupPayload | null,
+): ScreenExperienceIndex {
+    if (!inventory || !inventory.sections || inventory.sections.length === 0) {
+        return EMPTY_SCREEN_EXPERIENCE_INDEX;
+    }
+
+    const items: ScreenExperienceItem[] = [];
+    const bySlug = new Map<string, ScreenExperienceItem>();
+    const namesBySlug = new Map<string, string[]>();
+    const sections: ScreenExperienceSection[] = [];
+
+    for (const section of inventory.sections) {
+        const sectionItems: ScreenExperienceItem[] = [];
+        for (const screen of section.screens ?? []) {
+            if (!screen.name) continue;
+            const slug = slugifyScreenName(screen.name);
+            const names = namesBySlug.get(slug) ?? [];
+            names.push(screen.name);
+            namesBySlug.set(slug, names);
+            if (bySlug.has(slug)) continue; // first occurrence wins
+            const item: ScreenExperienceItem = {
+                slug,
+                screen,
+                sectionTitle: section.title,
+                relatedFlows: [],
+            };
+            bySlug.set(slug, item);
+            items.push(item);
+            sectionItems.push(item);
+        }
+        if (sectionItems.length > 0) {
+            sections.push({
+                title: section.title,
+                description: section.description,
+                flowSummary: section.flowSummary,
+                items: sectionItems,
+            });
+        }
+    }
+
+    if (items.length === 0) return EMPTY_SCREEN_EXPERIENCE_INDEX;
+
+    // Join flow steps by exact slug of the parsed step title. Substring /
+    // fuzzy matching is deliberately avoided: "Sign In" must not match
+    // "Sign In Confirmation".
+    flows.forEach((flow, flowIndex) => {
+        for (const step of flow.steps) {
+            const slug = stepScreenSlug(step);
+            if (!slug) continue;
+            const item = bySlug.get(slug);
+            if (!item) continue;
+            item.relatedFlows.push({ flow, flowIndex, step, stepIndex: step.index });
+        }
+    });
+
+    // Join mockup screens by slugified mockup screen name. A mockup screen
+    // that matches no inventory screen is simply not surfaced here (it stays
+    // visible in the legacy mockup viewer).
+    if (mockupPayload) {
+        for (const mockupScreen of mockupPayload.screens) {
+            if (!mockupScreen.name) continue;
+            const item = bySlug.get(slugifyScreenName(mockupScreen.name));
+            if (item && !item.mockupScreen) item.mockupScreen = mockupScreen;
+        }
+    }
+
+    const collisions: ScreenSlugCollision[] = [];
+    for (const [slug, names] of namesBySlug) {
+        if (names.length > 1) collisions.push({ slug, names });
+    }
+
+    return {
+        items,
+        bySlug,
+        sections,
+        collisions,
+        availableSlugs: new Set(bySlug.keys()),
+    };
+}
+
+/** Flow refs for one screen regrouped per flow (a screen can appear in
+ * several steps of the same flow — the Flow tab renders one section per
+ * flow, not per step). */
+export interface ScreenFlowGroup {
+    flow: ParsedFlow;
+    flowIndex: number;
+    steps: Array<{ step: ParsedStep; stepIndex: number }>;
+}
+
+export function groupFlowRefsByFlow(refs: readonly ScreenFlowRef[]): ScreenFlowGroup[] {
+    const byFlow = new Map<number, ScreenFlowGroup>();
+    for (const ref of refs) {
+        let group = byFlow.get(ref.flowIndex);
+        if (!group) {
+            group = { flow: ref.flow, flowIndex: ref.flowIndex, steps: [] };
+            byFlow.set(ref.flowIndex, group);
+        }
+        group.steps.push({ step: ref.step, stepIndex: ref.stepIndex });
+    }
+    return Array.from(byFlow.values());
+}

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -27,6 +27,7 @@ import type {
     ParsedFlow,
     ParsedStep,
 } from '../components/renderers/userFlows/types';
+import { inferNodeKind } from '../components/renderers/userFlows/journeyNode';
 
 /**
  * User edit overlay for one screen, keyed by the canonical screen id and
@@ -136,6 +137,64 @@ export interface ScreenSlugCollision {
     names: string[];
 }
 
+// --- Reference validation ----------------------------------------------------
+
+export type ScreenReferenceIssueKind =
+    /** A flow step that *looks like* a screen (journey node kind `screen`)
+     * references a name no canonical screen matches. */
+    | 'unmatched_flow_step'
+    /** A mockup screen matched no canonical screen (renamed/regenerated
+     * inventory, or drifted mockup payload). Repairable via relink. */
+    | 'unmatched_mockup_screen'
+    /** Two screens collapse to one slug — name-based references are
+     * ambiguous between them. */
+    | 'slug_collision'
+    /** A mockup screen matched by name only (no stable id / explicit link) —
+     * works today, but a future rename would detach it. Informational. */
+    | 'legacy_name_match';
+
+export interface ScreenReferenceIssue {
+    /** Stable key for dismissal persistence. */
+    key: string;
+    kind: ScreenReferenceIssueKind;
+    message: string;
+    /** The mockup screen involved (set for mockup-related kinds) — relink target. */
+    mockupScreenId?: string;
+    /** The canonical screen involved, when one exists. */
+    screenId?: string;
+}
+
+/**
+ * Explicit mockup-screen → canonical-screen repairs, stored on the mockup
+ * ArtifactVersion as `metadata.screenLinks` (mockupScreenId → screenId).
+ * Highest-priority join key — survives both renames and name drift.
+ */
+export function readScreenLinks(metadata: Record<string, unknown> | undefined): Record<string, string> {
+    const raw = metadata?.screenLinks;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return EMPTY_SCREEN_LINKS;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+        if (typeof v === 'string' && v) out[k] = v;
+    }
+    return Object.keys(out).length > 0 ? out : EMPTY_SCREEN_LINKS;
+}
+
+export const EMPTY_SCREEN_LINKS: Record<string, string> = {};
+
+/**
+ * Dismissed validation-issue keys, stored on the screen_inventory
+ * ArtifactVersion as `metadata.dismissedScreenIssues` (the Screens view's
+ * home artifact). Per-version, like every other overlay.
+ */
+export function readDismissedScreenIssues(metadata: Record<string, unknown> | undefined): ReadonlySet<string> {
+    const raw = metadata?.dismissedScreenIssues;
+    if (!Array.isArray(raw)) return EMPTY_DISMISSED_ISSUES;
+    const keys = raw.filter((k): k is string => typeof k === 'string' && k.length > 0);
+    return keys.length > 0 ? new Set(keys) : EMPTY_DISMISSED_ISSUES;
+}
+
+export const EMPTY_DISMISSED_ISSUES: ReadonlySet<string> = new Set();
+
 export interface ScreenExperienceIndex {
     items: ScreenExperienceItem[];
     /** Canonical lookup — id is the stable, rename-safe key. */
@@ -147,6 +206,9 @@ export interface ScreenExperienceIndex {
     collisions: ScreenSlugCollision[];
     /** Slugs with a canonical screen — used to gate flow-node navigation. */
     availableSlugs: ReadonlySet<string>;
+    /** Non-blocking reference-validation findings (see kinds above). Full,
+     * undismissed set — callers filter against readDismissedScreenIssues. */
+    issues: ScreenReferenceIssue[];
 }
 
 // Stable empty index. Returned for every "no inventory" case so consumers
@@ -159,6 +221,7 @@ export const EMPTY_SCREEN_EXPERIENCE_INDEX: ScreenExperienceIndex = {
     sections: [],
     collisions: [],
     availableSlugs: new Set(),
+    issues: [],
 };
 
 /** Strip surrounding markdown backticks (step titles are often `` `Name` ``). */
@@ -189,12 +252,15 @@ export function stepScreenSlug(step: Pick<ParsedStep, 'title'>): string | null {
  * colliding names are surfaced in `collisions` for the UI to warn about.
  * `edits` is the per-version user overlay (`readScreenEdits`) — it changes
  * only what views display; every join key stays derived from stored content.
+ * `screenLinks` (`readScreenLinks`) are explicit user repairs mapping a
+ * mockup screen id to a canonical screen id — the highest-priority match.
  */
 export function buildScreenIndex(
     inventory: ScreenInventoryContent | null,
     flows: readonly ParsedFlow[],
     mockupPayload: MockupPayload | null,
     edits: ScreenEditsMap = EMPTY_SCREEN_EDITS,
+    screenLinks: Record<string, string> = EMPTY_SCREEN_LINKS,
 ): ScreenExperienceIndex {
     if (!inventory || !inventory.sections || inventory.sections.length === 0) {
         return EMPTY_SCREEN_EXPERIENCE_INDEX;
@@ -254,37 +320,94 @@ export function buildScreenIndex(
 
     if (items.length === 0) return EMPTY_SCREEN_EXPERIENCE_INDEX;
 
+    const issues: ScreenReferenceIssue[] = [];
+
     // Join flow steps by exact slug of the parsed step title. Substring /
     // fuzzy matching is deliberately avoided: "Sign In" must not match
     // "Sign In Confirmation". (Flows are markdown and only know names.)
+    // Screen-looking steps that match nothing become validation issues —
+    // grouped per missing name so ten steps don't produce ten warnings.
+    const unmatchedFlowSlugs = new Map<string, string>(); // slug → display name
     flows.forEach((flow, flowIndex) => {
         for (const step of flow.steps) {
             const slug = stepScreenSlug(step);
             if (!slug) continue;
             const item = bySlug.get(slug);
-            if (!item) continue;
-            item.relatedFlows.push({ flow, flowIndex, step, stepIndex: step.index });
+            if (item) {
+                item.relatedFlows.push({ flow, flowIndex, step, stepIndex: step.index });
+            } else if (inferNodeKind(step) === 'screen' && step.title) {
+                unmatchedFlowSlugs.set(slug, step.title);
+            }
         }
     });
+    for (const [slug, name] of unmatchedFlowSlugs) {
+        issues.push({
+            key: `flowstep:${slug}`,
+            kind: 'unmatched_flow_step',
+            message: `Flow step "${name}" could not be matched to a screen.`,
+        });
+    }
 
-    // Join mockup screens: stable `sourceScreenId` wins (rename-safe, stamped
-    // by generateMockup on new payloads); legacy payloads fall back to
-    // slugified-name matching. A mockup screen that matches nothing is not
-    // surfaced here (it stays visible in the legacy mockup viewer).
+    // Join mockup screens in three priority passes so an explicit repair or
+    // stable id always beats a coincidental name match by another screen:
+    //   1. explicit user link (metadata.screenLinks — a persisted repair),
+    //   2. stable sourceScreenId (stamped on newly generated payloads),
+    //   3. slugified name (legacy fallback — flagged as such).
+    // A mockup screen that matches nothing becomes a repairable issue (it
+    // stays visible in the legacy mockup viewer either way).
     if (mockupPayload) {
+        const unmatched: MockupScreen[] = [];
+        const attach = (item: ScreenExperienceItem | undefined, mockupScreen: MockupScreen): boolean => {
+            if (!item || item.mockupScreen) return false;
+            item.mockupScreen = mockupScreen;
+            return true;
+        };
+        const pending: MockupScreen[] = [];
         for (const mockupScreen of mockupPayload.screens) {
-            const byStableId = mockupScreen.sourceScreenId
-                ? byId.get(mockupScreen.sourceScreenId)
-                : undefined;
-            const item = byStableId
-                ?? (mockupScreen.name ? bySlug.get(slugifyScreenName(mockupScreen.name)) : undefined);
-            if (item && !item.mockupScreen) item.mockupScreen = mockupScreen;
+            const linked = screenLinks[mockupScreen.id];
+            if (linked && attach(byId.get(linked), mockupScreen)) continue;
+            pending.push(mockupScreen);
+        }
+        const nameFallback: MockupScreen[] = [];
+        for (const mockupScreen of pending) {
+            if (mockupScreen.sourceScreenId && attach(byId.get(mockupScreen.sourceScreenId), mockupScreen)) continue;
+            nameFallback.push(mockupScreen);
+        }
+        for (const mockupScreen of nameFallback) {
+            const item = mockupScreen.name ? bySlug.get(slugifyScreenName(mockupScreen.name)) : undefined;
+            if (attach(item, mockupScreen)) {
+                issues.push({
+                    key: `legacy:${mockupScreen.id}`,
+                    kind: 'legacy_name_match',
+                    message: `Mockup "${mockupScreen.name}" is matched by name only — a rename would detach it. Relink to pin it to its screen.`,
+                    mockupScreenId: mockupScreen.id,
+                    screenId: item?.id,
+                });
+            } else {
+                unmatched.push(mockupScreen);
+            }
+        }
+        for (const mockupScreen of unmatched) {
+            issues.push({
+                key: `mockup:${mockupScreen.id}`,
+                kind: 'unmatched_mockup_screen',
+                message: `Mockup "${mockupScreen.name}" could not be matched to a screen.`,
+                mockupScreenId: mockupScreen.id,
+            });
         }
     }
 
     const collisions: ScreenSlugCollision[] = [];
     for (const [slug, names] of namesBySlug) {
-        if (names.length > 1) collisions.push({ slug, names });
+        if (names.length > 1) {
+            collisions.push({ slug, names });
+            issues.push({
+                key: `collision:${slug}`,
+                kind: 'slug_collision',
+                message: `"${names.join('" and "')}" share the same normalized name — name-based references are ambiguous between them.`,
+                screenId: bySlug.get(slug)?.id,
+            });
+        }
     }
 
     return {
@@ -294,6 +417,7 @@ export function buildScreenIndex(
         sections,
         collisions,
         availableSlugs: new Set(bySlug.keys()),
+        issues,
     };
 }
 

--- a/src/lib/screenInventoryNormalize.ts
+++ b/src/lib/screenInventoryNormalize.ts
@@ -23,6 +23,7 @@ import type {
     ScreenState,
     ScreenType,
 } from '../types';
+import { slugifyScreenName } from './screenInventoryImageStore';
 
 const LEGACY_PRIORITY_MAP: Record<LegacyScreenPriority, ScreenPriority> = {
     core: 'P0',
@@ -52,7 +53,7 @@ export function normalizeScreenInventory(raw: unknown): ScreenInventoryContent |
             .map(normalizeSection)
             .filter((s): s is ScreenInventorySection => s !== null);
         if (sections.length === 0) return null;
-        return { sections };
+        return { sections: assignStableScreenIds(sections) };
     }
 
     if (Array.isArray(obj.groups)) {
@@ -66,10 +67,45 @@ export function normalizeScreenInventory(raw: unknown): ScreenInventoryContent |
             })
             .filter((s): s is ScreenInventorySection => s !== null);
         if (sections.length === 0) return null;
-        return { sections };
+        return { sections: assignStableScreenIds(sections) };
     }
 
     return null;
+}
+
+/**
+ * Stamp a stable, unique `id` onto every screen (the canonical screen
+ * identity for cross-artifact joins — see src/lib/screenExperience.ts).
+ * Derivation is deterministic from the stored content, so legacy artifacts
+ * with no ids resolve to the SAME ids on every read without regeneration,
+ * and newly generated artifacts persist them (generation re-serializes the
+ * normalized shape). Precedence per screen:
+ *   1. an existing non-empty `id` from the content (model-emitted or a
+ *      previously persisted derived id),
+ *   2. the slug of the screen name (the join key images already use),
+ *   3. the literal 'screen' fallback slugify provides.
+ * Duplicates (either duplicate content ids or same-name screens) get a
+ * deterministic `-2`, `-3`… suffix in document order. Never derived from a
+ * user-facing rename — display-name edits are an overlay and do not touch
+ * the stored content this reads.
+ */
+export function assignStableScreenIds(sections: ScreenInventorySection[]): ScreenInventorySection[] {
+    const used = new Set<string>();
+    for (const section of sections) {
+        for (const screen of section.screens) {
+            const fromContent = typeof screen.id === 'string' ? screen.id.trim() : '';
+            const base = fromContent || slugifyScreenName(screen.name);
+            let candidate = base;
+            let n = 2;
+            while (used.has(candidate)) {
+                candidate = `${base}-${n}`;
+                n += 1;
+            }
+            used.add(candidate);
+            screen.id = candidate;
+        }
+    }
+    return sections;
 }
 
 function normalizeSection(raw: unknown): ScreenInventorySection | null {

--- a/src/lib/services/mockupService.ts
+++ b/src/lib/services/mockupService.ts
@@ -219,6 +219,10 @@ export const generateMockup = (
             type: item.type,
             coreUIElements: uiElements?.slice(0, 12),
             componentRefs,
+            // Canonical inventory screen id (stamped by assignStableScreenIds
+            // in screenInventoryNormalize) — the rename-safe join key the
+            // Experience workspace prefers over name matching.
+            sourceScreenId: item.id,
         };
     });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -889,6 +889,11 @@ export type MockupScreen = {
     coreUIElements?: string[];   // semantic UI elements present on this screen
     componentRefs?: string[];    // component names from component_inventory used here
     notes?: string;              // optional assumptions / callouts
+    // Canonical id of the screen_inventory screen this mockup was derived
+    // from (stamped by assignStableScreenIds — see screenInventoryNormalize /
+    // screenExperience). Optional & backward-compatible: legacy payloads lack
+    // it and the Experience join falls back to slugified-name matching.
+    sourceScreenId?: string;
 };
 
 export type MockupPayload = {


### PR DESCRIPTION
## Summary

Consolidates the experience artifacts (User Flows / Screen Inventory / Mockups) into a **screen-centric Experience workspace**, then hardens it: stable screen ids, rename-safe editing, explicit mockup coverage, deep-linkable screens, and reference validation with repairs.

```
Experience
  ├── User Flows
  └── Screens  →  Screen Detail (?screen=<id>&screenTab=…)
                    ├── Overview   (inventory spec + editable metadata + upload gallery)
                    ├── Flow       (every referencing flow, current screen highlighted)
                    └── Mockups    (mockup panel, Add-to-mockups, or link an orphan)
```

**Everything is additive and backward-compatible.** The `screen_inventory`, `user_flows`, and `mockup` artifacts generate, persist, version, sync, and snapshot exactly as before — no schema, prompt, or generation-pipeline changes. All new user state rides in `ArtifactVersion.metadata` overlays (the existing `promptEdits` pattern): `screenEdits`, `extraScreens`, `screenLinks`, `dismissedScreenIssues`.

## Commits (one per phase)

1. **Consolidate Screen Inventory + Mockups into a screen-centric Experience workspace** — the read-side MVP: pure join layer (`src/lib/screenExperience.ts`), Screens list + tabbed detail views, flow-node → screen navigation.
2. **Restore Screen Inventory / Mockup artifact-level controls in the Screens view** — addresses the Codex P2 review: version history / staleness / Regenerate Mockup / design-drift banner now live in the Screens list header.
3. **Add stable screen ids for UX artifact joins** — deterministic canonical ids stamped in `normalizeScreenInventory` (new generations persist them; legacy artifacts derive identical ids on read — no migration); `MockupScreen.sourceScreenId`; id-first joins; duplicate-name screens survive as distinct items.
4. **Support rename-safe screen metadata edits** — name/purpose/intent/priority/notes editing via a `metadata.screenEdits` overlay keyed by canonical id. Joins and image keys derive from the *stored* generated name, so renames can't orphan mockups, flow refs, or uploads. Save/Cancel + Reset-to-generated.
5. **Add mockup coverage states for screens** — "Mockups: X of N screens covered", per-screen **Add to mockups** (a free `metadata.extraScreens` overlay write on the *current* version so existing images stay keyed), and a confirmed, cost-labeled **Generate missing mockups** batch (never automatic; keyless → upload sheets; per-screen cancellable).
6. **Add URL-addressable screen selection** — `?screen=<id>[&screenTab=…]` is the single source of truth (derived view, no sync effects); deep links, refresh, back/forward all work; invalid ids fall back to the list; `ProjectWorkspace` switches a deep-linked finalized project to the workspace stage.
7. **Add UX artifact reference validation** — non-blocking "N references need review" panel: unmatched flow steps (screen-kind nodes only, grouped per name), unmatched mockup screens, slug collisions, legacy name-only matches. Repairs: **Relink/Pin** (persisted `screenLinks`, highest-priority match) and **Ignore** (persisted dismissals).
8. **Add minimal editable screen actions** — link an orphaned mockup directly from a screen's Mockups tab; README documents the new capabilities.

## Verification

- `npm run build` (`tsc -b && vite build`) ✅
- `npm run lint` ✅
- `npm test` — **759 tests passing** (40 new: join/ids/edits/links/issues in `screenExperience.test.ts`, `mockupExtraScreens.test.ts`, `FlowJourney.test.tsx`)

## Backward compatibility

- Legacy inventories (no ids, `groups[]` shape, legacy priorities) derive stable ids deterministically at read time — no regeneration required.
- Legacy mockups keep matching by slugified name (flagged as informational "legacy match" with a one-click Pin).
- Existing generated/uploaded images keep their keys (slug of the stored generated name; extraScreens never bumps the version id).
- Existing artifact URLs unchanged; the new query params are additive.
- Legacy markdown inventories fall back to the standalone renderer inside the Screens view; the old `screen_inventory`/`mockup` render branches remain intact.

## Known remaining limitations

- Flow steps are markdown, so flow↔screen matching stays name-based by design (unmatched steps are surfaced, but not yet relinkable — would need a flow-side overlay).
- Mockup regeneration replaces the payload wholesale (new version), so extras/links start fresh per version, consistent with the existing per-version overlay model.
- "Create placeholder screen" repair deliberately skipped (would rewrite generated content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8La8g8i1xwLzY7mhPSntH