### PR TITLE
Design system selection during project setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,8 +476,11 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       PRD run is untouched; the step is purely a view swap, so generation never
       waits on the choice). Gating is the pure, unit-tested
       `shouldShowDesignSetup` (`src/lib/designSetup.ts`): never for legacy
-      projects (no flag), the demo, blocked spines, or failed runs (the error
-      card + Try Again must stay reachable). The step shows static
+      projects (no flag), the demo, blocked spines, or failed runs — full
+      (`generationError`) *and* partial (`generationMeta.failedSections`;
+      plus the transient `hasFailedSection` guard in `ProjectWorkspace`) —
+      because the error card / incomplete-PRD banner and their retry
+      affordances must stay reachable. The step shows static
       `previewTokens`-driven preview cards (no AI/image calls), a rule-based
       **Recommended** badge (`src/lib/designPresetRecommendation.ts` — keyword
       scoring over idea + clarification answers, `saas_minimal` fallback), and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,11 +449,15 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     neutral style hint so legacy projects still get a working prompt. Do **not**
     re-duplicate design-system prose into a prompt builder — reuse the brief.
   - **Design System Presets (`src/lib/designSystemPresets.ts`).** A
-    visual-direction choice (`SaaS Minimal`, `AI Workspace`, `Editorial /
-    Learning`, `Developer Tool`, `Consumer Mobile`, `Custom / Generate for me`)
-    surfaced by `DesignSystemPresetChoice` on the Mark-as-Final edge in
-    `ProjectWorkspace` (only when a real project hasn't picked one yet). The
-    chosen id is stored on `Project.designSystemPreset`
+    visual-direction choice (`Modern SaaS`, `Enterprise Professional`,
+    `AI Workspace`, `Minimal Editorial`, `Developer / Technical`,
+    `Consumer Mobile`, `Creative Studio`, `Custom / Generate for me`). Preset
+    **ids are stable and persisted** (`saas_minimal`, `editorial_learning`,
+    `developer_tool`, … — never rename an id; labels are display-only). Each
+    concrete preset also carries setup-step metadata (`tone`,
+    `recommendedUseCases`, `visualTraits`, `previewTokens` — presentation-only,
+    never fed to generation; only `directive` steers the model). The chosen id
+    is stored on `Project.designSystemPreset`
     (`setProjectDesignSystemPreset`) and read at generation time by
     `artifactJobController.runCoreArtifactSlot` off the project (NOT threaded
     through every call site) and passed to `generateCoreArtifact`, which injects
@@ -463,6 +467,31 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     and the external copy-prompt, keeping the project visually consistent. The
     `DesignSystemRenderer` shows a banner explaining this coupling and that
     regenerating may shift downstream mockups/screen prompts.
+    - **Setup-stage selection (`src/components/setup/DesignSetupStep.tsx`) is
+      the primary picker.** New projects stamp `Project.needsDesignSetup: true`
+      in `createProject`; while that flag is set and no preset is chosen, the
+      workspace PRD stage renders `DesignSetupStep` **instead of** the PRD/
+      progress view — after the preflight clarification flow (if any) completes
+      and therefore exactly while PRD generation runs in the background (the
+      PRD run is untouched; the step is purely a view swap, so generation never
+      waits on the choice). Gating is the pure, unit-tested
+      `shouldShowDesignSetup` (`src/lib/designSetup.ts`): never for legacy
+      projects (no flag), the demo, blocked spines, or failed runs (the error
+      card + Try Again must stay reachable). The step shows static
+      `previewTokens`-driven preview cards (no AI/image calls), a rule-based
+      **Recommended** badge (`src/lib/designPresetRecommendation.ts` — keyword
+      scoring over idea + clarification answers, `saas_minimal` fallback), and
+      preselects the user's saved **default preset**
+      (`src/lib/designPresetPreference.ts`, localStorage
+      `SYNAPSE_DEFAULT_DESIGN_PRESET`, written only via the explicit "Use this
+      as my default" checkbox). Choosing calls `setProjectDesignSystemPreset`
+      (which also clears `needsDesignSetup` — from any picker); "Decide later"
+      calls `markDesignSetupComplete` and defers to the finalize gate.
+    - **The Mark-as-Final gate (`DesignSystemPresetChoice` in
+      `ProjectWorkspace`) is now the fallback**, still shown when a real
+      project reaches finalize with no preset (setup skipped, or a legacy
+      project) — so visual artifact generation still never starts without an
+      explicit preset decision.
     - **Post-finalization re-selection.** The preset is **no longer one-time**.
       Because the Mark-as-Final gate only fires once (and never for projects
       finalized before presets existed), the **Design System artifact** carries a
@@ -866,6 +895,10 @@ User prompt → HomePage.handleCreateProject() → PreflightModeChoice
               Pass A streams structured JSON → onPartial paints draft
               ↓
               SpineVersion stored, currentStage='prd'
+              ↓ (new projects: needsDesignSetup)
+              DesignSetupStep — pick a visual direction while the PRD
+              generates in the background (see "Design System Presets")
+              ↓
   PRD stage:       SelectableSpine / StructuredPRDView — text selection →
                    branch creation → AI conversation → consolidateBranch()
                    merges into spine (local or doc-wide scope, see

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Before generation, an **optional preflight clarification** step can ask you a
 **Generate Immediately**. Answers (and anything you skip) feed straight into
 the PRD prompt as authoritative intent.
 
+The moment your answers are in, **PRD generation starts in the background** —
+and while it runs, Synapse asks you to **choose a visual direction** for the
+project from a set of design presets, each with a static token-driven preview
+(colors, type, buttons, layout shapes). Synapse **recommends** one based on
+what you're building — a music app suggests *Creative Studio*, a CRM suggests
+*Enterprise Professional* — but any preset can be chosen, and you can save one
+as your **default for future projects** (defaults are preselected next time).
+You can also skip and decide later, at the latest when marking the PRD final.
+
 ### 2. AI builds the spec, section by section
 
 <img width="100%" alt="PRD generation progress timeline — sections generated wave by wave" src="public/screenshots/tour-spec.png" />
@@ -143,15 +152,17 @@ feedback event — with diffs where it matters.
 <img width="100%" alt="Mark the PRD as final to generate every downstream asset in parallel" src="public/screenshots/tour-assets.png" />
 
 Mark your PRD as final and Synapse generates all the assets you need to build —
-in parallel, from that single source of truth. Just before generation, you pick
-a **Design System Preset** (SaaS Minimal, AI Workspace, Editorial / Learning,
-Developer Tool, Consumer Mobile, or *Custom / Generate for me*) that sets the
-project's visual direction. The choice is stored on the project and steers the
-**Design System** artifact — and through it, both the internal mockups and the
-prompts you copy for external image tools, so everything stays visually
-consistent. You can change the visual direction later from the **Design System**
-artifact and regenerate it; when its tokens change, Synapse flags the affected
-mockups and offers to regenerate them so they pick up the new direction.
+in parallel, from that single source of truth. The **Design System Preset**
+(Modern SaaS, Enterprise Professional, AI Workspace, Minimal Editorial,
+Developer / Technical, Consumer Mobile, Creative Studio, or *Custom / Generate
+for me*) you picked during project setup sets the project's visual direction;
+if you skipped that step, Synapse asks just before generation. The choice is
+stored on the project and steers the **Design System** artifact — and through
+it, both the internal mockups and the prompts you copy for external image
+tools, so everything stays visually consistent. You can change the visual
+direction later from the **Design System** artifact and regenerate it; when its
+tokens change, Synapse flags the affected mockups and offers to regenerate them
+so they pick up the new direction.
 
 - **Screen Inventory** and **User Flows**
 - **Design System**

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -25,6 +25,8 @@ import { StructuredPRDView } from './StructuredPRDView';
 import { SafetyReviewView } from './SafetyReviewView';
 import { SafetyBoundariesCard } from './SafetyBoundariesCard';
 import { PreflightView } from './preflight/PreflightView';
+import { DesignSetupStep } from './setup/DesignSetupStep';
+import { shouldShowDesignSetup } from '../lib/designSetup';
 import { ArtifactWorkspace } from './ArtifactWorkspace';
 import { FinalizationSuccessModal } from './FinalizationSuccessModal';
 import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
@@ -215,6 +217,24 @@ export function ProjectWorkspace() {
         && !activeSpine.preflightSession.completed
         && !activeSpine.structuredPRD
         && activeSpine.safetyReview?.status !== 'blocked';
+
+    // Setup-stage design selection: right after clarification (or immediately,
+    // on the Generate Immediately path), while PRD generation runs in the
+    // background, a fresh project picks its visual direction. Replaces the
+    // PRD/progress view until the user chooses or skips; never shown for
+    // legacy projects, the demo, blocked spines, or failed runs (see
+    // shouldShowDesignSetup).
+    const showDesignSetup = !showPreflight && !isOldVersion
+        && shouldShowDesignSetup(project, activeSpine);
+
+    // Idea + clarification text feeding the rule-based preset recommendation.
+    const designRecommendationText = showDesignSetup
+        ? [
+            activeSpine?.promptText,
+            activeSpine?.preflightSession?.summary,
+            ...(activeSpine?.preflightSession?.questions.map((q) => q.answer ?? '') ?? []),
+        ].filter(Boolean).join('\n')
+        : '';
 
     // Human-friendly version label
     const getVersionLabel = (spineId: string) => {
@@ -845,7 +865,14 @@ export function ProjectWorkspace() {
                                 platform={project?.platform}
                             />
                         )}
-                        {pipelineStage === 'prd' && !showPreflight && (
+                        {pipelineStage === 'prd' && showDesignSetup && activeSpine && (
+                            <DesignSetupStep
+                                projectId={projectId}
+                                recommendationText={designRecommendationText}
+                                prdGenerating={isPRDActivelyGenerating}
+                            />
+                        )}
+                        {pipelineStage === 'prd' && !showPreflight && !showDesignSetup && (
                             <>
                                 {/* Feedback items from mockups/artifacts */}
                                 <FeedbackItemsList

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -223,8 +223,11 @@ export function ProjectWorkspace() {
     // background, a fresh project picks its visual direction. Replaces the
     // PRD/progress view until the user chooses or skips; never shown for
     // legacy projects, the demo, blocked spines, or failed runs (see
-    // shouldShowDesignSetup).
-    const showDesignSetup = !showPreflight && !isOldVersion
+    // shouldShowDesignSetup). `hasFailedSection` additionally yields on a
+    // *transient* section failure (the live grid errors before the persisted
+    // failedSections meta lands on the spine) so the progress timeline's
+    // "Run again" affordance is never hidden behind the setup step.
+    const showDesignSetup = !showPreflight && !isOldVersion && !hasFailedSection
         && shouldShowDesignSetup(project, activeSpine);
 
     // Idea + clarification text feeding the rule-based preset recommendation.

--- a/src/components/__tests__/DesignDirectionControl.test.tsx
+++ b/src/components/__tests__/DesignDirectionControl.test.tsx
@@ -15,7 +15,7 @@ describe('DesignDirectionControl', () => {
                 onRegenerate={() => {}}
             />,
         );
-        expect(screen.getByText('SaaS Minimal')).toBeTruthy();
+        expect(screen.getByText('Modern SaaS')).toBeTruthy();
     });
 
     it('falls back to an "AI decides" note when no preset is set', () => {

--- a/src/components/__tests__/DesignSetupStep.test.tsx
+++ b/src/components/__tests__/DesignSetupStep.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DesignSetupStep } from '../setup/DesignSetupStep';
+import { useProjectStore } from '../../store/projectStore';
+import { DESIGN_SYSTEM_PRESETS } from '../../lib/designSystemPresets';
+import { getDefaultDesignPreset, setDefaultDesignPreset } from '../../lib/designPresetPreference';
+
+// The setup-stage design selection step: shown while the PRD generates in the
+// background. Verifies recommendation badging, default preselection,
+// selection storage, default persistence, and the skip path.
+
+const createProject = (): string =>
+    useProjectStore.getState().createProject('Test', 'Build something').projectId;
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+    localStorage.clear();
+});
+
+describe('DesignSetupStep', () => {
+    it('shows the preparing copy while the PRD generates, and every preset card', () => {
+        render(
+            <DesignSetupStep
+                projectId={createProject()}
+                recommendationText="a productivity tool"
+                prdGenerating
+            />,
+        );
+        expect(screen.getByText(/Synapse is preparing your PRD/i)).toBeTruthy();
+        for (const preset of DESIGN_SYSTEM_PRESETS) {
+            expect(screen.getByText(preset.label)).toBeTruthy();
+        }
+    });
+
+    it('shows the ready copy once the PRD has finished', () => {
+        render(
+            <DesignSetupStep
+                projectId={createProject()}
+                recommendationText=""
+                prdGenerating={false}
+            />,
+        );
+        expect(screen.getByText(/Your PRD is ready/i)).toBeTruthy();
+    });
+
+    it('recommends and preselects a preset from the project idea', () => {
+        render(
+            <DesignSetupStep
+                projectId={createProject()}
+                recommendationText="A music app for DJs to build playlists"
+                prdGenerating
+            />,
+        );
+        const recommendedCard = screen.getByText('Recommended').closest('button')!;
+        expect(recommendedCard.textContent).toContain('Creative Studio');
+        expect(recommendedCard.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('preselects a saved default while still badging the recommendation', () => {
+        setDefaultDesignPreset('developer_tool');
+        render(
+            <DesignSetupStep
+                projectId={createProject()}
+                recommendationText="A music app for DJs"
+                prdGenerating
+            />,
+        );
+        const defaultCard = screen.getByText('Your default').closest('button')!;
+        expect(defaultCard.textContent).toContain('Developer / Technical');
+        expect(defaultCard.getAttribute('aria-pressed')).toBe('true');
+        // The recommendation stays visible but is not selected.
+        const recommendedCard = screen.getByText('Recommended').closest('button')!;
+        expect(recommendedCard.textContent).toContain('Creative Studio');
+        expect(recommendedCard.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('stores the chosen preset on the project without touching the saved default', () => {
+        setDefaultDesignPreset('developer_tool');
+        const projectId = createProject();
+        render(
+            <DesignSetupStep projectId={projectId} recommendationText="A music app" prdGenerating />,
+        );
+        // Pick a preset different from both default and recommendation.
+        fireEvent.click(screen.getByText('Consumer Mobile').closest('button')!);
+        fireEvent.click(screen.getByText(/Continue with Consumer Mobile/i));
+
+        const project = useProjectStore.getState().projects[projectId];
+        expect(project.designSystemPreset).toBe('consumer_mobile');
+        expect(project.needsDesignSetup).toBe(false);
+        // Default unchanged: the user did not tick the checkbox.
+        expect(getDefaultDesignPreset()).toBe('developer_tool');
+    });
+
+    it('saves the choice as the future default when explicitly opted in', () => {
+        const projectId = createProject();
+        render(
+            <DesignSetupStep projectId={projectId} recommendationText="" prdGenerating />,
+        );
+        fireEvent.click(screen.getByText('Minimal Editorial').closest('button')!);
+        fireEvent.click(screen.getByLabelText(/Use this as my default/i));
+        fireEvent.click(screen.getByText(/Continue with Minimal Editorial/i));
+
+        expect(getDefaultDesignPreset()).toBe('editorial_learning');
+        expect(useProjectStore.getState().projects[projectId].designSystemPreset)
+            .toBe('editorial_learning');
+    });
+
+    it('"Decide later" dismisses the step without storing a preset', () => {
+        const projectId = createProject();
+        render(
+            <DesignSetupStep projectId={projectId} recommendationText="" prdGenerating />,
+        );
+        fireEvent.click(screen.getByText('Decide later'));
+
+        const project = useProjectStore.getState().projects[projectId];
+        expect(project.needsDesignSetup).toBe(false);
+        expect(project.designSystemPreset).toBeUndefined();
+        expect(getDefaultDesignPreset()).toBeNull();
+    });
+});

--- a/src/components/setup/DesignSetupStep.tsx
+++ b/src/components/setup/DesignSetupStep.tsx
@@ -1,0 +1,302 @@
+import { useMemo, useState } from 'react';
+import { Check, CheckCircle2, Loader2, Sparkles, Wand2 } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import {
+    DESIGN_SYSTEM_PRESETS,
+    type DesignSystemPreset,
+    type PresetPreviewTokens,
+} from '../../lib/designSystemPresets';
+import { recommendDesignSystemPresetId } from '../../lib/designPresetRecommendation';
+import { getDefaultDesignPreset, setDefaultDesignPreset } from '../../lib/designPresetPreference';
+
+interface DesignSetupStepProps {
+    projectId: string;
+    /**
+     * Idea + clarification text driving the rule-based recommendation
+     * (original prompt, preflight summary, and answers, joined).
+     */
+    recommendationText: string;
+    /** Whether the background PRD run is still working (drives the header copy). */
+    prdGenerating: boolean;
+}
+
+/**
+ * Setup-stage design selection. Shown in the workspace right after
+ * clarification answers are submitted — while PRD generation is already
+ * running in the background — and until the user picks a visual direction or
+ * skips. Choosing here stores the preset on the project so the design system,
+ * mockups, and copied screen prompts all follow it from the start; skipping
+ * falls back to the original Mark-as-Final preset gate.
+ */
+export function DesignSetupStep({ projectId, recommendationText, prdGenerating }: DesignSetupStepProps) {
+    const setProjectDesignSystemPreset = useProjectStore((s) => s.setProjectDesignSystemPreset);
+    const markDesignSetupComplete = useProjectStore((s) => s.markDesignSetupComplete);
+
+    const recommendedId = useMemo(
+        () => recommendDesignSystemPresetId(recommendationText),
+        [recommendationText],
+    );
+    // Captured once on mount: the saved default (if any) preselects; the
+    // recommendation still gets its badge either way.
+    const [defaultPresetId] = useState<string | null>(() => getDefaultDesignPreset());
+    const [selectedId, setSelectedId] = useState<string>(defaultPresetId ?? recommendedId);
+    const [saveAsDefault, setSaveAsDefault] = useState(false);
+
+    const selectedPreset = DESIGN_SYSTEM_PRESETS.find((p) => p.id === selectedId);
+
+    const handleContinue = () => {
+        if (!selectedPreset) return;
+        // Persist the default first (explicit opt-in only), then the project
+        // choice — which also settles the setup step in the store.
+        if (saveAsDefault) setDefaultDesignPreset(selectedPreset.id);
+        setProjectDesignSystemPreset(projectId, selectedPreset.id);
+    };
+
+    const handleSkip = () => {
+        markDesignSetupComplete(projectId);
+    };
+
+    return (
+        <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-6 md:p-10 mb-8">
+            {/* Background-generation status */}
+            <div
+                className={`flex items-center gap-2.5 rounded-xl border px-4 py-3 mb-6 text-sm ${
+                    prdGenerating
+                        ? 'bg-indigo-50 border-indigo-100 text-indigo-800'
+                        : 'bg-emerald-50 border-emerald-100 text-emerald-800'
+                }`}
+                role="status"
+            >
+                {prdGenerating ? (
+                    <>
+                        <Loader2 size={16} className="animate-spin shrink-0 text-indigo-500" />
+                        <span>
+                            Synapse is preparing your PRD. While that runs, choose a visual
+                            direction for your project.
+                        </span>
+                    </>
+                ) : (
+                    <>
+                        <CheckCircle2 size={16} className="shrink-0 text-emerald-500" />
+                        <span>Your PRD is ready. Choose a visual direction to continue.</span>
+                    </>
+                )}
+            </div>
+
+            <h2 className="text-xl md:text-2xl font-semibold text-neutral-900">
+                Choose your visual direction
+            </h2>
+            <p className="mt-2 text-sm text-neutral-500 max-w-2xl">
+                This becomes the project&apos;s design system. Mockups and the prompts you copy
+                for external image tools will follow it, so everything stays visually
+                consistent. You can change it later from the Design System artifact.
+            </p>
+
+            <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {DESIGN_SYSTEM_PRESETS.map((preset) => (
+                    <PresetCard
+                        key={preset.id}
+                        preset={preset}
+                        selected={preset.id === selectedId}
+                        recommended={preset.id === recommendedId}
+                        isDefault={preset.id === defaultPresetId}
+                        onSelect={() => setSelectedId(preset.id)}
+                    />
+                ))}
+            </div>
+
+            {/* Action bar — pinned near the bottom with safe-area inset,
+                mirroring the preflight cards */}
+            <div
+                className="sticky bottom-0 mt-6 flex flex-wrap items-center gap-3 bg-white/95 backdrop-blur pt-4 border-t border-neutral-100"
+                style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 0.25rem)' }}
+            >
+                <label className="flex items-center gap-2 text-sm text-neutral-600 cursor-pointer select-none min-h-[44px]">
+                    <input
+                        type="checkbox"
+                        checked={saveAsDefault}
+                        onChange={(e) => setSaveAsDefault(e.target.checked)}
+                        className="h-4 w-4 rounded border-neutral-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    Use this as my default for future projects
+                </label>
+                <div className="flex-1" />
+                <button
+                    onClick={handleSkip}
+                    className="px-4 py-3 min-h-[44px] rounded-xl text-sm font-medium text-neutral-500 hover:bg-neutral-100 transition"
+                >
+                    Decide later
+                </button>
+                <button
+                    onClick={handleContinue}
+                    disabled={!selectedPreset}
+                    className="inline-flex items-center gap-1.5 px-6 py-3 min-h-[44px] rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 transition disabled:opacity-60"
+                >
+                    <Sparkles size={16} />
+                    Continue with {selectedPreset?.label ?? 'selection'}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+// --- Cards ------------------------------------------------------------------
+
+interface PresetCardProps {
+    preset: DesignSystemPreset;
+    selected: boolean;
+    recommended: boolean;
+    isDefault: boolean;
+    onSelect: () => void;
+}
+
+function PresetCard({ preset, selected, recommended, isDefault, onSelect }: PresetCardProps) {
+    return (
+        <button
+            onClick={onSelect}
+            aria-pressed={selected}
+            className={`text-left rounded-2xl border p-3 transition group ${
+                selected
+                    ? 'border-indigo-500 ring-2 ring-indigo-200 bg-indigo-50/40'
+                    : 'border-neutral-200 hover:border-indigo-300 bg-white'
+            }`}
+        >
+            {preset.previewTokens ? (
+                <PresetPreview tokens={preset.previewTokens} />
+            ) : (
+                <CustomPreviewPlaceholder />
+            )}
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-neutral-900 text-sm">{preset.label}</span>
+                {recommended && (
+                    <span className="text-[11px] font-medium text-indigo-700 bg-indigo-100 px-2 py-0.5 rounded-full">
+                        Recommended
+                    </span>
+                )}
+                {isDefault && (
+                    <span className="text-[11px] font-medium text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">
+                        Your default
+                    </span>
+                )}
+                {selected && (
+                    <span className="ml-auto inline-flex items-center justify-center w-5 h-5 rounded-full bg-indigo-600 text-white shrink-0">
+                        <Check size={12} />
+                    </span>
+                )}
+            </div>
+            {preset.tone && (
+                <p className="mt-0.5 text-xs font-medium text-neutral-500">{preset.tone}</p>
+            )}
+            <p className="mt-1 text-xs text-neutral-500 leading-relaxed">{preset.detail}</p>
+            {preset.recommendedUseCases && preset.recommendedUseCases.length > 0 && (
+                <p className="mt-1.5 text-[11px] text-neutral-400">
+                    Great for: {preset.recommendedUseCases.join(' · ')}
+                </p>
+            )}
+        </button>
+    );
+}
+
+/**
+ * Static mini-layout rendered purely from the preset's preview tokens — no AI
+ * call, no images. Top bar + sidebar + heading/body type sample + primary
+ * button + mock content card + color swatches.
+ */
+function PresetPreview({ tokens }: { tokens: PresetPreviewTokens }) {
+    const cardRadius = Math.min(tokens.radius, 12);
+    return (
+        <div
+            aria-hidden
+            className="pointer-events-none select-none overflow-hidden rounded-xl border"
+            style={{ background: tokens.background, borderColor: tokens.border, fontFamily: tokens.fontFamily }}
+        >
+            {/* Header shape */}
+            <div
+                className="flex items-center gap-1.5 px-2.5 py-1.5 border-b"
+                style={{ background: tokens.surface, borderColor: tokens.border }}
+            >
+                <span className="w-2 h-2 rounded-full" style={{ background: tokens.primary }} />
+                <span className="h-1.5 w-10 rounded-full" style={{ background: tokens.border }} />
+                <span className="ml-auto h-1.5 w-5 rounded-full" style={{ background: tokens.border }} />
+            </div>
+            <div className="flex gap-2 p-2.5">
+                {/* Sidebar shape */}
+                <div
+                    className="w-9 shrink-0 p-1.5 space-y-1.5 border"
+                    style={{ background: tokens.surface, borderColor: tokens.border, borderRadius: cardRadius }}
+                >
+                    <span className="block h-1 rounded-full" style={{ background: tokens.primary }} />
+                    <span className="block h-1 rounded-full" style={{ background: tokens.border }} />
+                    <span className="block h-1 rounded-full" style={{ background: tokens.border }} />
+                </div>
+                <div className="flex-1 min-w-0">
+                    {/* Typography sample */}
+                    <div
+                        className="text-[11px] leading-tight truncate"
+                        style={{ color: tokens.text, fontWeight: tokens.headingWeight }}
+                    >
+                        Aa — Heading
+                    </div>
+                    <div className="text-[9px] truncate" style={{ color: tokens.mutedText }}>
+                        Body copy sample text
+                    </div>
+                    {/* Sample button */}
+                    <div className="mt-1.5 flex items-center gap-1.5">
+                        <span
+                            className="px-2 py-0.5 text-[9px] font-medium"
+                            style={{
+                                background: tokens.primary,
+                                color: tokens.primaryText,
+                                borderRadius: cardRadius,
+                            }}
+                        >
+                            Button
+                        </span>
+                        <span
+                            className="px-2 py-0.5 text-[9px] border"
+                            style={{
+                                color: tokens.mutedText,
+                                borderColor: tokens.border,
+                                borderRadius: cardRadius,
+                            }}
+                        >
+                            Action
+                        </span>
+                    </div>
+                    {/* Mock content card */}
+                    <div
+                        className="mt-1.5 p-1.5 space-y-1 border"
+                        style={{ background: tokens.surface, borderColor: tokens.border, borderRadius: cardRadius }}
+                    >
+                        <span className="block h-1 w-3/4 rounded-full" style={{ background: tokens.mutedText, opacity: 0.5 }} />
+                        <span className="block h-1 w-1/2 rounded-full" style={{ background: tokens.mutedText, opacity: 0.3 }} />
+                    </div>
+                </div>
+            </div>
+            {/* Color swatches */}
+            <div className="flex items-center gap-1 px-2.5 pb-2">
+                {[tokens.primary, tokens.text, tokens.mutedText, tokens.surface].map((c, i) => (
+                    <span
+                        key={i}
+                        className="w-3.5 h-3.5 rounded-full border"
+                        style={{ background: c, borderColor: tokens.border }}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function CustomPreviewPlaceholder() {
+    return (
+        <div
+            aria-hidden
+            className="pointer-events-none select-none rounded-xl border border-dashed border-neutral-300 bg-neutral-50 flex flex-col items-center justify-center gap-1.5 py-8"
+        >
+            <Wand2 size={18} className="text-neutral-400" />
+            <span className="text-[10px] text-neutral-500">
+                Synapse designs it from your PRD
+            </span>
+        </div>
+    );
+}

--- a/src/lib/__tests__/designPresetPreference.test.ts
+++ b/src/lib/__tests__/designPresetPreference.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    clearDefaultDesignPreset,
+    getDefaultDesignPreset,
+    setDefaultDesignPreset,
+} from '../designPresetPreference';
+
+describe('default design preset preference', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('returns null when nothing is saved', () => {
+        expect(getDefaultDesignPreset()).toBeNull();
+    });
+
+    it('round-trips a valid preset id', () => {
+        setDefaultDesignPreset('creative_studio');
+        expect(getDefaultDesignPreset()).toBe('creative_studio');
+    });
+
+    it('refuses to save an unknown preset id', () => {
+        setDefaultDesignPreset('not-a-preset');
+        expect(getDefaultDesignPreset()).toBeNull();
+    });
+
+    it('ignores a stale stored id that no longer resolves to a preset', () => {
+        localStorage.setItem('SYNAPSE_DEFAULT_DESIGN_PRESET', 'retired_preset');
+        expect(getDefaultDesignPreset()).toBeNull();
+    });
+
+    it('clears the saved default', () => {
+        setDefaultDesignPreset('consumer_mobile');
+        clearDefaultDesignPreset();
+        expect(getDefaultDesignPreset()).toBeNull();
+    });
+});

--- a/src/lib/__tests__/designPresetRecommendation.test.ts
+++ b/src/lib/__tests__/designPresetRecommendation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+    FALLBACK_DESIGN_PRESET_ID,
+    recommendDesignSystemPreset,
+    recommendDesignSystemPresetId,
+} from '../designPresetRecommendation';
+import { getDesignSystemPreset } from '../designSystemPresets';
+
+describe('recommendDesignSystemPreset', () => {
+    it('maps music / creator / media ideas to Creative Studio', () => {
+        expect(recommendDesignSystemPresetId(
+            'A DJ app for building playlists and mixing music with friends',
+        )).toBe('creative_studio');
+        expect(recommendDesignSystemPresetId(
+            'A portfolio site builder for photography artists',
+        )).toBe('creative_studio');
+    });
+
+    it('maps CRM / finance / enterprise ideas to Enterprise Professional', () => {
+        expect(recommendDesignSystemPresetId(
+            'A CRM for tracking sales pipelines and invoicing',
+        )).toBe('enterprise_professional');
+        expect(recommendDesignSystemPresetId(
+            'An internal tool for HR payroll and compliance reporting',
+        )).toBe('enterprise_professional');
+    });
+
+    it('maps habit / wellness / lifestyle ideas to Consumer Mobile', () => {
+        expect(recommendDesignSystemPresetId(
+            'A habit tracker with meditation and sleep goals',
+        )).toBe('consumer_mobile');
+        expect(recommendDesignSystemPresetId(
+            'A mobile recipe and meal planning app for consumers',
+        )).toBe('consumer_mobile');
+    });
+
+    it('maps developer / API / technical ideas to Developer / Technical', () => {
+        expect(recommendDesignSystemPresetId(
+            'An API workbench with a CLI for testing developer SDKs',
+        )).toBe('developer_tool');
+        expect(recommendDesignSystemPresetId(
+            'An observability dashboard for monitoring infrastructure',
+        )).toBe('developer_tool');
+    });
+
+    it('maps notes / research / learning ideas to Minimal Editorial', () => {
+        expect(recommendDesignSystemPresetId(
+            'A note-taking app for research and study with flashcards',
+        )).toBe('editorial_learning');
+        expect(recommendDesignSystemPresetId(
+            'A knowledge base for writing and reading documentation',
+        )).toBe('editorial_learning');
+    });
+
+    it('falls back to Modern SaaS when nothing matches', () => {
+        expect(recommendDesignSystemPresetId(
+            'A tool that helps teams get things done together',
+        )).toBe(FALLBACK_DESIGN_PRESET_ID);
+        expect(recommendDesignSystemPresetId('')).toBe(FALLBACK_DESIGN_PRESET_ID);
+        expect(recommendDesignSystemPresetId('   ')).toBe(FALLBACK_DESIGN_PRESET_ID);
+    });
+
+    it('scores by distinct keyword count so the dominant theme wins', () => {
+        // One developer word vs several creative words.
+        const { presetId, matchedTerms } = recommendDesignSystemPreset(
+            'A music studio app for artists to publish songs, with an API',
+        );
+        expect(presetId).toBe('creative_studio');
+        expect(matchedTerms).toContain('music');
+        expect(matchedTerms.length).toBeGreaterThan(1);
+    });
+
+    it('matches whole words only', () => {
+        // "smart" must not trigger the creative "art" keyword.
+        expect(recommendDesignSystemPresetId('A smart scheduling assistant'))
+            .toBe(FALLBACK_DESIGN_PRESET_ID);
+    });
+
+    it('always returns a real preset id', () => {
+        for (const text of ['', 'music app', 'crm', 'random words here']) {
+            const id = recommendDesignSystemPresetId(text);
+            expect(getDesignSystemPreset(id), text).toBeDefined();
+        }
+    });
+});

--- a/src/lib/__tests__/designSetup.test.ts
+++ b/src/lib/__tests__/designSetup.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowDesignSetup } from '../designSetup';
+import { DEMO_PROJECT_ID } from '../../data/demoProject';
+import type { PreflightSession, Project, SpineVersion, StructuredPRD } from '../../types';
+
+const baseProject = (overrides: Partial<Project> = {}): Project => ({
+    id: 'p1',
+    name: 'Test',
+    createdAt: 1,
+    needsDesignSetup: true,
+    ...overrides,
+});
+
+const baseSpine = (overrides: Partial<SpineVersion> = {}): SpineVersion => ({
+    id: 'v1',
+    projectId: 'p1',
+    promptText: 'Build a music app',
+    responseText: 'Generating PRD...',
+    createdAt: 1,
+    isLatest: true,
+    isFinal: false,
+    ...overrides,
+});
+
+const activePreflight = (overrides: Partial<PreflightSession> = {}): PreflightSession => ({
+    mode: 'quick',
+    originalIdea: 'Build a music app',
+    questions: [],
+    currentQuestionIndex: 0,
+    status: 'answering',
+    completed: false,
+    ...overrides,
+});
+
+const fakePrd = { vision: 'v' } as StructuredPRD;
+
+describe('shouldShowDesignSetup', () => {
+    it('shows for a fresh project while the PRD generates in the background', () => {
+        expect(shouldShowDesignSetup(baseProject(), baseSpine())).toBe(true);
+    });
+
+    it('keeps showing after the PRD completes, until the user picks or skips', () => {
+        expect(shouldShowDesignSetup(baseProject(), baseSpine({ structuredPRD: fakePrd })))
+            .toBe(true);
+    });
+
+    it('waits for clarification: hidden while a preflight session is still open', () => {
+        const spine = baseSpine({ preflightSession: activePreflight() });
+        expect(shouldShowDesignSetup(baseProject(), spine)).toBe(false);
+    });
+
+    it('takes over once clarification answers are submitted (session completed)', () => {
+        // "Generate PRD" marks the session completed and starts generation —
+        // the design step must appear at that transition, before any PRD lands.
+        const spine = baseSpine({
+            preflightSession: activePreflight({ status: 'completed', completed: true }),
+        });
+        expect(shouldShowDesignSetup(baseProject(), spine)).toBe(true);
+    });
+
+    it('hides once a preset is chosen', () => {
+        const project = baseProject({ designSystemPreset: 'creative_studio' });
+        expect(shouldShowDesignSetup(project, baseSpine())).toBe(false);
+    });
+
+    it('hides when setup was explicitly skipped', () => {
+        expect(shouldShowDesignSetup(baseProject({ needsDesignSetup: false }), baseSpine()))
+            .toBe(false);
+    });
+
+    it('never shows for legacy projects without the setup flag', () => {
+        expect(shouldShowDesignSetup(baseProject({ needsDesignSetup: undefined }), baseSpine()))
+            .toBe(false);
+    });
+
+    it('never shows for the demo project', () => {
+        const project = baseProject({ id: DEMO_PROJECT_ID });
+        expect(shouldShowDesignSetup(project, baseSpine({ projectId: DEMO_PROJECT_ID })))
+            .toBe(false);
+    });
+
+    it('yields to the safety review screen for blocked spines', () => {
+        const spine = baseSpine({
+            safetyReview: {
+                status: 'blocked',
+                classification: 'disallowed',
+                detectedConcerns: [],
+                userFacingReason: 'no',
+                safeAlternatives: [],
+                reviewedAt: 1,
+            },
+        });
+        expect(shouldShowDesignSetup(baseProject(), spine)).toBe(false);
+    });
+
+    it('yields to the error card when generation failed', () => {
+        const spine = baseSpine({
+            generationError: { message: 'boom', category: 'network', timestamp: 1 },
+        });
+        expect(shouldShowDesignSetup(baseProject(), spine)).toBe(false);
+    });
+
+    it('handles missing project or spine', () => {
+        expect(shouldShowDesignSetup(undefined, baseSpine())).toBe(false);
+        expect(shouldShowDesignSetup(baseProject(), undefined)).toBe(false);
+    });
+});

--- a/src/lib/__tests__/designSetup.test.ts
+++ b/src/lib/__tests__/designSetup.test.ts
@@ -93,6 +93,25 @@ describe('shouldShowDesignSetup', () => {
         expect(shouldShowDesignSetup(baseProject(), spine)).toBe(false);
     });
 
+    it('yields to the incomplete-PRD banner on a partial-failure run', () => {
+        // Some sections failed but the pipeline returned a partial PRD — no
+        // generationError is set; the failure lives in generationMeta. The PRD
+        // view owns the recovery UI (per-section "Run again"), so the setup
+        // step must not cover it.
+        const meta = { passes: [], totalMs: 100, revised: false, schemaVersion: 2 };
+        const spine = baseSpine({
+            structuredPRD: fakePrd,
+            generationMeta: { ...meta, failedSections: ['ux_design'] },
+        });
+        expect(shouldShowDesignSetup(baseProject(), spine)).toBe(false);
+        // An empty failed list is a clean run — the step shows normally.
+        const cleanSpine = baseSpine({
+            structuredPRD: fakePrd,
+            generationMeta: { ...meta, failedSections: [] },
+        });
+        expect(shouldShowDesignSetup(baseProject(), cleanSpine)).toBe(true);
+    });
+
     it('yields to the error card when generation failed', () => {
         const spine = baseSpine({
             generationError: { message: 'boom', category: 'network', timestamp: 1 },

--- a/src/lib/__tests__/designSystemPresets.test.ts
+++ b/src/lib/__tests__/designSystemPresets.test.ts
@@ -7,14 +7,16 @@ import {
 } from '../designSystemPresets';
 
 describe('design system presets', () => {
-    it('exposes the six expected presets including a custom option', () => {
+    it('exposes the expected presets including a custom option', () => {
         const ids = DESIGN_SYSTEM_PRESETS.map(p => p.id);
         expect(ids).toEqual([
             'saas_minimal',
+            'enterprise_professional',
             'ai_workspace',
             'editorial_learning',
             'developer_tool',
             'consumer_mobile',
+            'creative_studio',
             'custom',
         ]);
     });
@@ -23,6 +25,8 @@ describe('design system presets', () => {
         const directive = getDesignSystemPresetDirective('saas_minimal');
         expect(directive.length).toBeGreaterThan(20);
         expect(directive).toMatch(/SaaS/i);
+        expect(getDesignSystemPresetDirective('enterprise_professional')).toMatch(/enterprise/i);
+        expect(getDesignSystemPresetDirective('creative_studio')).toMatch(/creative/i);
     });
 
     it('returns an empty directive for custom / unknown / missing ids (no steering)', () => {
@@ -33,9 +37,28 @@ describe('design system presets', () => {
 
     it('resolves preset metadata and labels', () => {
         expect(getDesignSystemPreset('ai_workspace')?.label).toBe('AI Workspace');
-        expect(getDesignSystemPresetLabel('developer_tool')).toBe('Developer Tool');
+        expect(getDesignSystemPresetLabel('developer_tool')).toBe('Developer / Technical');
+        expect(getDesignSystemPresetLabel('saas_minimal')).toBe('Modern SaaS');
         // Unknown id falls back to the raw id rather than throwing.
         expect(getDesignSystemPresetLabel('mystery')).toBe('mystery');
         expect(getDesignSystemPresetLabel(undefined)).toBeUndefined();
+    });
+
+    it('carries setup-step metadata (tone + preview tokens) on every concrete preset', () => {
+        for (const preset of DESIGN_SYSTEM_PRESETS) {
+            if (preset.id === 'custom') {
+                expect(preset.previewTokens).toBeUndefined();
+                continue;
+            }
+            expect(preset.tone, preset.id).toBeTruthy();
+            expect(preset.recommendedUseCases?.length, preset.id).toBeGreaterThan(0);
+            expect(preset.visualTraits?.length, preset.id).toBeGreaterThan(0);
+            const tokens = preset.previewTokens;
+            expect(tokens, preset.id).toBeDefined();
+            expect(tokens!.primary).toMatch(/^#/);
+            expect(tokens!.background).toMatch(/^#/);
+            expect(tokens!.radius).toBeGreaterThanOrEqual(0);
+            expect(tokens!.fontFamily.length).toBeGreaterThan(0);
+        }
     });
 });

--- a/src/lib/designPresetPreference.ts
+++ b/src/lib/designPresetPreference.ts
@@ -1,0 +1,37 @@
+// The user's saved default design preset for FUTURE projects. Persisted in
+// localStorage (same simple-preference pattern as SYNAPSE_MOCKUP_IMAGE_MODE in
+// artifactModelSettings.ts). The default only preselects the setup step's
+// choice — it is never written to a project without an explicit Continue, and
+// it is only changed when the user explicitly ticks "Use this as my default".
+
+import { getDesignSystemPreset } from './designSystemPresets';
+
+const DEFAULT_DESIGN_PRESET_KEY = 'SYNAPSE_DEFAULT_DESIGN_PRESET';
+
+/** The saved default preset id, or null when unset/invalid/unavailable. */
+export const getDefaultDesignPreset = (): string | null => {
+    try {
+        const v = localStorage.getItem(DEFAULT_DESIGN_PRESET_KEY);
+        // Ignore ids that no longer resolve to a preset (e.g. stale storage).
+        return v && getDesignSystemPreset(v) ? v : null;
+    } catch {
+        return null;
+    }
+};
+
+export const setDefaultDesignPreset = (presetId: string): void => {
+    try {
+        if (!getDesignSystemPreset(presetId)) return;
+        localStorage.setItem(DEFAULT_DESIGN_PRESET_KEY, presetId);
+    } catch {
+        /* best-effort preference — ignore quota/availability errors */
+    }
+};
+
+export const clearDefaultDesignPreset = (): void => {
+    try {
+        localStorage.removeItem(DEFAULT_DESIGN_PRESET_KEY);
+    } catch {
+        /* ignore */
+    }
+};

--- a/src/lib/designPresetRecommendation.ts
+++ b/src/lib/designPresetRecommendation.ts
@@ -1,0 +1,104 @@
+// Rule-based design-preset recommendation for the setup step. Deliberately
+// NOT an AI call — the recommendation must render instantly while the PRD
+// generates in the background, and a keyword heuristic over the idea +
+// clarification answers is plenty to pick a sensible starting direction.
+// The user can always choose any preset; this only drives the "Recommended"
+// badge and the initial selection when no saved default exists.
+
+/** Preset recommended when nothing else matches. */
+export const FALLBACK_DESIGN_PRESET_ID = 'saas_minimal';
+
+interface RecommendationRule {
+    presetId: string;
+    /** Word-boundary keyword alternatives (may contain spaces). */
+    keywords: string[];
+}
+
+// Order matters only for ties: earlier rules win when match counts are equal.
+const RULES: RecommendationRule[] = [
+    {
+        presetId: 'creative_studio',
+        keywords: [
+            'music', 'audio', 'dj', 'song', 'songs', 'playlist', 'podcast', 'band',
+            'video', 'film', 'photo', 'photos', 'photography', 'camera',
+            'art', 'artist', 'artists', 'creator', 'creators', 'creative',
+            'studio', 'portfolio', 'media', 'illustration', 'animation', 'gallery',
+        ],
+    },
+    {
+        presetId: 'enterprise_professional',
+        keywords: [
+            'crm', 'sales', 'operations', 'admin', 'finance', 'financial',
+            'accounting', 'invoice', 'invoicing', 'enterprise', 'erp', 'hr',
+            'payroll', 'compliance', 'procurement', 'analytics', 'reporting',
+            'internal tool', 'internal tools', 'back office', 'back-office',
+        ],
+    },
+    {
+        presetId: 'consumer_mobile',
+        keywords: [
+            'habit', 'habits', 'wellness', 'fitness', 'workout', 'health',
+            'lifestyle', 'consumer', 'mobile', 'social', 'dating', 'travel',
+            'recipe', 'recipes', 'meal', 'meditation', 'sleep', 'mindfulness',
+        ],
+    },
+    {
+        presetId: 'developer_tool',
+        keywords: [
+            'developer', 'developers', 'dev tool', 'dev tools', 'api', 'apis',
+            'sdk', 'cli', 'code', 'coding', 'ide', 'devops', 'infrastructure',
+            'workbench', 'llm', 'agent', 'agents', 'terminal', 'git',
+            'database', 'dashboard', 'dashboards', 'monitoring', 'observability',
+            'technical',
+        ],
+    },
+    {
+        presetId: 'editorial_learning',
+        keywords: [
+            'notes', 'note-taking', 'note taking', 'research', 'writing',
+            'writer', 'writers', 'blog', 'journal', 'journaling', 'learning',
+            'course', 'courses', 'education', 'study', 'studying', 'knowledge',
+            'reading', 'book', 'books', 'wiki', 'documentation', 'flashcard',
+            'flashcards',
+        ],
+    },
+];
+
+const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildRuleRegex = (keywords: string[]): RegExp =>
+    new RegExp(`\\b(?:${keywords.map(escapeRegex).join('|')})\\b`, 'gi');
+
+export interface DesignPresetRecommendation {
+    presetId: string;
+    /** Distinct keywords that drove the pick (empty for the fallback). */
+    matchedTerms: string[];
+}
+
+/**
+ * Recommend a design preset for a project from its idea + clarification text.
+ * Scores each rule by the number of DISTINCT keywords it matches; the highest
+ * score wins (ties break by rule order). No match at all → `saas_minimal`,
+ * the safe general-purpose default.
+ */
+export function recommendDesignSystemPreset(text: string): DesignPresetRecommendation {
+    if (!text || !text.trim()) {
+        return { presetId: FALLBACK_DESIGN_PRESET_ID, matchedTerms: [] };
+    }
+    let best: DesignPresetRecommendation | null = null;
+    let bestScore = 0;
+    for (const rule of RULES) {
+        const matches = text.match(buildRuleRegex(rule.keywords)) ?? [];
+        const distinct = [...new Set(matches.map(m => m.toLowerCase()))];
+        if (distinct.length > bestScore) {
+            bestScore = distinct.length;
+            best = { presetId: rule.presetId, matchedTerms: distinct };
+        }
+    }
+    return best ?? { presetId: FALLBACK_DESIGN_PRESET_ID, matchedTerms: [] };
+}
+
+/** Convenience wrapper returning only the preset id. */
+export function recommendDesignSystemPresetId(text: string): string {
+    return recommendDesignSystemPreset(text).presetId;
+}

--- a/src/lib/designSetup.ts
+++ b/src/lib/designSetup.ts
@@ -1,0 +1,34 @@
+// Pure gating logic for the setup-stage design selection step. Kept out of
+// ProjectWorkspace so the setup-flow state transitions are unit-testable.
+
+import type { Project, SpineVersion } from '../types';
+import { DEMO_PROJECT_ID } from '../data/demoProject';
+
+/**
+ * Whether the workspace should render the design-selection setup step for
+ * this project/spine instead of the PRD view.
+ *
+ * The step shows only for projects created through the new-project flow
+ * (`needsDesignSetup`) that haven't chosen a preset yet, once clarification
+ * (preflight) is out of the way — i.e. exactly while PRD generation runs in
+ * the background, and until the user picks or skips even if the PRD finishes
+ * first. It never shows for legacy projects (no flag → finalize-edge gate
+ * keeps its original behavior), the demo, blocked spines, or a spine whose
+ * generation failed (the error card + Try Again must stay reachable).
+ */
+export function shouldShowDesignSetup(
+    project: Project | undefined,
+    spine: SpineVersion | undefined,
+): boolean {
+    if (!project || !spine) return false;
+    if (project.id === DEMO_PROJECT_ID) return false;
+    if (!project.needsDesignSetup) return false;
+    if (project.designSystemPreset) return false;
+    if (spine.safetyReview?.status === 'blocked') return false;
+    if (spine.generationError) return false;
+    // Clarification questions come first; the design step takes over the
+    // moment the preflight session completes (PRD generation kicks off then).
+    const preflight = spine.preflightSession;
+    if (preflight && !preflight.completed && !spine.structuredPRD) return false;
+    return true;
+}

--- a/src/lib/designSetup.ts
+++ b/src/lib/designSetup.ts
@@ -14,7 +14,9 @@ import { DEMO_PROJECT_ID } from '../data/demoProject';
  * the background, and until the user picks or skips even if the PRD finishes
  * first. It never shows for legacy projects (no flag → finalize-edge gate
  * keeps its original behavior), the demo, blocked spines, or a spine whose
- * generation failed (the error card + Try Again must stay reachable).
+ * generation failed — fully (generationError) or partially (persisted
+ * generationMeta.failedSections) — because the error card / incomplete-PRD
+ * banner and their Try Again / Run again affordances must stay reachable.
  */
 export function shouldShowDesignSetup(
     project: Project | undefined,
@@ -26,6 +28,13 @@ export function shouldShowDesignSetup(
     if (project.designSystemPreset) return false;
     if (spine.safetyReview?.status === 'blocked') return false;
     if (spine.generationError) return false;
+    // A partial-failure run settles WITHOUT a generationError: the pipeline
+    // returns a partial PRD and records the failed section ids instead. The
+    // PRD view owns the recovery UI for that state (the amber incomplete-PRD
+    // banner with per-section "Run again"), so the setup step must yield —
+    // otherwise it would claim the PRD is ready and hide recovery until the
+    // user makes an unrelated design choice.
+    if (spine.generationMeta?.failedSections?.length) return false;
     // Clarification questions come first; the design step takes over the
     // moment the preflight session completes (PRD generation kicks off then).
     const preflight = spine.preflightSession;

--- a/src/lib/designSystemPresets.ts
+++ b/src/lib/designSystemPresets.ts
@@ -1,9 +1,14 @@
-// Design System Presets — a one-time visual-direction choice made before
-// artifact generation. The selected preset id is stored on the Project
-// (`Project.designSystemPreset`) and read at design-system generation time
-// (`coreArtifactService` via `artifactJobController`) so that every downstream
-// consumer — internal mockups, the Screen Inventory copy-prompt, uploaded
-// external mockups — stays anchored to the same visual language.
+// Design System Presets — the project's visual-direction choice. The selected
+// preset id is stored on the Project (`Project.designSystemPreset`) and read at
+// design-system generation time (`coreArtifactService` via
+// `artifactJobController`) so that every downstream consumer — internal
+// mockups, the Screen Inventory copy-prompt, uploaded external mockups — stays
+// anchored to the same visual language.
+//
+// The choice is made during project setup (`DesignSetupStep`, shown while the
+// PRD generates in the background) with the Mark-as-Final gate in
+// `ProjectWorkspace` as the fallback for users who skipped setup and for
+// legacy projects that predate the setup step.
 //
 // Presets only *steer* generation; the Gemini design-system pass still adapts
 // the chosen direction to the product's domain and audience. "Custom /
@@ -11,7 +16,44 @@
 // PRD-only behavior for users who'd rather let the model decide.
 
 import type { LucideIcon } from 'lucide-react';
-import { LayoutGrid, Sparkles, BookOpen, Terminal, Smartphone, Wand2 } from 'lucide-react';
+import {
+    LayoutGrid,
+    Briefcase,
+    Sparkles,
+    BookOpen,
+    Terminal,
+    Smartphone,
+    Palette,
+    Wand2,
+} from 'lucide-react';
+
+/**
+ * Tokens for the lightweight static preview card shown in the setup step.
+ * These are presentation-only — they never feed generation (the `directive`
+ * does that) — so they can be tuned freely without affecting stored projects.
+ */
+export interface PresetPreviewTokens {
+    /** Page background. */
+    background: string;
+    /** Card / sidebar surface. */
+    surface: string;
+    /** Primary text color. */
+    text: string;
+    /** Secondary / muted text color. */
+    mutedText: string;
+    /** Brand accent — primary buttons and active states. */
+    primary: string;
+    /** Text color on the primary accent. */
+    primaryText: string;
+    /** Border / divider color. */
+    border: string;
+    /** Representative corner radius in px. */
+    radius: number;
+    /** CSS font stack used for the preview's type sample. */
+    fontFamily: string;
+    /** Heading font weight for the type sample. */
+    headingWeight: number;
+}
 
 export interface DesignSystemPreset {
     /** Stable id persisted on the project. Never rename — older projects store it. */
@@ -29,17 +71,66 @@ export interface DesignSystemPreset {
      * "Custom / Generate for me" (no steering → original behavior).
      */
     directive: string;
+    // --- Setup-step metadata (optional — 'custom' has no visual identity of
+    // its own, so it carries none of these). ---
+    /** Three-word feel, e.g. "Clean, neutral, polished". */
+    tone?: string;
+    /** Product categories this direction suits. */
+    recommendedUseCases?: string[];
+    /** Short visual traits shown on the preview card. */
+    visualTraits?: string[];
+    /** Tokens for the static mini-layout preview. */
+    previewTokens?: PresetPreviewTokens;
 }
 
 export const DESIGN_SYSTEM_PRESETS: DesignSystemPreset[] = [
     {
         id: 'saas_minimal',
-        label: 'SaaS Minimal',
+        label: 'Modern SaaS',
         subtitle: 'Clean B2B',
-        detail: 'Restrained, professional, whitespace-forward. Great for dashboards and admin tools.',
+        detail: 'Clean, neutral, polished. A great default for productivity and B2B apps.',
         icon: LayoutGrid,
         directive:
             'Adopt a restrained, professional B2B SaaS aesthetic: a neutral grayscale surface system with a single confident brand accent, generous whitespace, crisp ~1px borders, small-to-medium radii (6–10px), and a clean sans-serif UI face (Inter or system-ui). Subtle, low shadows. Prioritize clarity, legibility, and density over decoration.',
+        tone: 'Clean, neutral, polished',
+        recommendedUseCases: ['Productivity tools', 'B2B apps', 'Dashboards'],
+        visualTraits: ['Neutral surfaces', 'One confident accent', 'Generous whitespace'],
+        previewTokens: {
+            background: '#f8fafc',
+            surface: '#ffffff',
+            text: '#0f172a',
+            mutedText: '#64748b',
+            primary: '#4f46e5',
+            primaryText: '#ffffff',
+            border: '#e2e8f0',
+            radius: 8,
+            fontFamily: "'Inter', system-ui, sans-serif",
+            headingWeight: 600,
+        },
+    },
+    {
+        id: 'enterprise_professional',
+        label: 'Enterprise Professional',
+        subtitle: 'Dense, structured',
+        detail: 'Structured and conservative. Suits CRM, admin, analytics, and internal tools.',
+        icon: Briefcase,
+        directive:
+            'Adopt a conservative, enterprise-grade aesthetic: structured, information-dense layouts, a restrained blue-leaning corporate palette on cool neutral surfaces, small radii (2–6px), crisp 1px borders with table-friendly styling, and a workhorse UI sans (Segoe UI, Roboto, or Inter). Minimal shadows and decoration. Favor scannability, dense data tables, filters, and predictable convention-driven patterns over visual novelty.',
+        tone: 'Dense, structured, conservative',
+        recommendedUseCases: ['CRM', 'Admin & analytics', 'Internal tools'],
+        visualTraits: ['Information-dense tables', 'Corporate blue accent', 'Small radii'],
+        previewTokens: {
+            background: '#f1f5f9',
+            surface: '#ffffff',
+            text: '#1e293b',
+            mutedText: '#475569',
+            primary: '#1d4ed8',
+            primaryText: '#ffffff',
+            border: '#cbd5e1',
+            radius: 4,
+            fontFamily: "'Segoe UI', system-ui, sans-serif",
+            headingWeight: 600,
+        },
     },
     {
         id: 'ai_workspace',
@@ -49,33 +140,117 @@ export const DESIGN_SYSTEM_PRESETS: DesignSystemPreset[] = [
         icon: Sparkles,
         directive:
             'Adopt a modern AI-workspace aesthetic: calm, slightly cool neutral surfaces with one vivid, saturated brand accent (e.g. indigo/violet/teal) reserved for primary actions and active states. Soft, layered elevation, medium radii (10–16px), a contemporary geometric sans (Inter, Outfit, or Manrope). Focused and uncluttered, with clear hierarchy for conversational/canvas layouts.',
+        tone: 'Calm, focused, modern',
+        recommendedUseCases: ['AI assistants', 'Agent tools', 'Canvas workspaces'],
+        visualTraits: ['Cool neutral surfaces', 'Vivid saturated accent', 'Soft layered depth'],
+        previewTokens: {
+            background: '#12141c',
+            surface: '#1b1e2b',
+            text: '#e5e7ef',
+            mutedText: '#9aa1b5',
+            primary: '#8b5cf6',
+            primaryText: '#ffffff',
+            border: '#2a2e42',
+            radius: 12,
+            fontFamily: "'Manrope', 'Inter', sans-serif",
+            headingWeight: 600,
+        },
     },
     {
         id: 'editorial_learning',
-        label: 'Editorial / Learning',
-        subtitle: 'Readable, warm',
-        detail: 'Reading-first typography, warm neutrals, comfortable rhythm. For content and courses.',
+        label: 'Minimal Editorial',
+        subtitle: 'Readable, calm',
+        detail: 'Calm, typography-forward. For writing, research, learning, and knowledge products.',
         icon: BookOpen,
         directive:
             'Adopt an editorial, reading-first aesthetic: warm off-white/paper neutrals, a comfortable serif or humanist-sans for body text with strong typographic hierarchy, generous line-height and spacing, and a single muted accent for links and actions. Soft or minimal shadows, gentle radii (4–8px). Optimize for sustained reading and content density without crowding.',
+        tone: 'Calm, warm, typography-forward',
+        recommendedUseCases: ['Writing & research', 'Learning products', 'Knowledge bases'],
+        visualTraits: ['Paper-warm neutrals', 'Reading-first type', 'Muted single accent'],
+        previewTokens: {
+            background: '#faf7f2',
+            surface: '#ffffff',
+            text: '#292524',
+            mutedText: '#78716c',
+            primary: '#9a3412',
+            primaryText: '#ffffff',
+            border: '#e7e0d6',
+            radius: 6,
+            fontFamily: "Georgia, 'Times New Roman', serif",
+            headingWeight: 700,
+        },
     },
     {
         id: 'developer_tool',
-        label: 'Developer Tool',
-        subtitle: 'Dense, technical',
-        detail: 'Dark-leaning, monospace accents, compact spacing. For IDEs, CLIs, and infra UIs.',
+        label: 'Developer / Technical',
+        subtitle: 'Precise, functional',
+        detail: 'Code-adjacent and compact. For API tools, dashboards, and AI workbenches.',
         icon: Terminal,
         directive:
             'Adopt a developer-tool aesthetic: dark-leaning, high-contrast neutral surfaces with a precise functional accent (often green/blue/amber), compact spacing for information density, small radii (2–6px), and a monospace face for code, identifiers, and data. Minimal, sharp shadows. Favor legibility of dense technical content and status/state colors over visual flourish.',
+        tone: 'Precise, functional, code-adjacent',
+        recommendedUseCases: ['API tools', 'Technical dashboards', 'AI workbenches'],
+        visualTraits: ['Dark high-contrast surfaces', 'Monospace details', 'Compact density'],
+        previewTokens: {
+            background: '#0d1117',
+            surface: '#161b22',
+            text: '#e6edf3',
+            mutedText: '#8b949e',
+            primary: '#2ea043',
+            primaryText: '#ffffff',
+            border: '#30363d',
+            radius: 4,
+            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            headingWeight: 600,
+        },
     },
     {
         id: 'consumer_mobile',
         label: 'Consumer Mobile',
         subtitle: 'Bold, friendly',
-        detail: 'Vivid color, rounded shapes, big tap targets. For lifestyle and social apps.',
+        detail: 'Friendly, spacious, colorful. For habit, wellness, lifestyle, and mobile-first products.',
         icon: Smartphone,
         directive:
             'Adopt a consumer-mobile aesthetic: vivid, friendly color with a high-energy brand accent, large rounded shapes (16–24px radii), bold rounded sans typography, generous tap targets, and playful but tasteful elevation. Mobile-first layouts with prominent primary actions. Energetic and approachable while staying accessible.',
+        tone: 'Friendly, spacious, colorful',
+        recommendedUseCases: ['Habit & wellness', 'Lifestyle apps', 'Mobile-first products'],
+        visualTraits: ['Vivid friendly color', 'Large rounded shapes', 'Big tap targets'],
+        previewTokens: {
+            background: '#fff7f5',
+            surface: '#ffffff',
+            text: '#1f2937',
+            mutedText: '#6b7280',
+            primary: '#ec4899',
+            primaryText: '#ffffff',
+            border: '#fde4e1',
+            radius: 20,
+            fontFamily: "'Nunito', system-ui, sans-serif",
+            headingWeight: 700,
+        },
+    },
+    {
+        id: 'creative_studio',
+        label: 'Creative Studio',
+        subtitle: 'Expressive, bold',
+        detail: 'Expressive and media-forward. For music, design, creator, and portfolio tools.',
+        icon: Palette,
+        directive:
+            'Adopt an expressive, media-forward creative aesthetic: bold typography with strong display headings, rich dark or saturated surfaces that let imagery, cover art, and media shine, a vivid expressive accent (magenta/violet/electric blue), generous radii (12–20px), and confident use of large imagery and canvases. Layouts may be asymmetric and editorial. Energetic and stylish while keeping controls legible and accessible.',
+        tone: 'Expressive, bold, media-forward',
+        recommendedUseCases: ['Music & audio', 'Creator & design tools', 'Portfolios'],
+        visualTraits: ['Media-forward surfaces', 'Bold display type', 'Vivid expressive accent'],
+        previewTokens: {
+            background: '#18121f',
+            surface: '#241a30',
+            text: '#f5edff',
+            mutedText: '#a795c0',
+            primary: '#d946ef',
+            primaryText: '#ffffff',
+            border: '#3a2b4d',
+            radius: 14,
+            fontFamily: "'Space Grotesk', 'Inter', sans-serif",
+            headingWeight: 700,
+        },
     },
     {
         id: 'custom',

--- a/src/store/__tests__/designSetupState.test.ts
+++ b/src/store/__tests__/designSetupState.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+// Setup-stage design selection state on the project: new projects owe the
+// setup step; choosing a preset (from any UI) or explicitly skipping settles
+// it. Legacy projects are untouched.
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+    localStorage.clear();
+});
+
+describe('design setup project state', () => {
+    it('stamps needsDesignSetup on newly created projects', () => {
+        const { projectId } = useProjectStore.getState().createProject('Test', 'Build a music app');
+        expect(useProjectStore.getState().projects[projectId].needsDesignSetup).toBe(true);
+        expect(useProjectStore.getState().projects[projectId].designSystemPreset).toBeUndefined();
+    });
+
+    it('choosing a preset stores it and settles the setup step', () => {
+        const { projectId } = useProjectStore.getState().createProject('Test', 'idea');
+        useProjectStore.getState().setProjectDesignSystemPreset(projectId, 'creative_studio');
+        const project = useProjectStore.getState().projects[projectId];
+        expect(project.designSystemPreset).toBe('creative_studio');
+        expect(project.needsDesignSetup).toBe(false);
+    });
+
+    it('markDesignSetupComplete skips the step without choosing a preset', () => {
+        const { projectId } = useProjectStore.getState().createProject('Test', 'idea');
+        useProjectStore.getState().markDesignSetupComplete(projectId);
+        const project = useProjectStore.getState().projects[projectId];
+        expect(project.needsDesignSetup).toBe(false);
+        expect(project.designSystemPreset).toBeUndefined();
+    });
+
+    it('both actions are no-ops for unknown projects', () => {
+        const before = useProjectStore.getState().projects;
+        useProjectStore.getState().setProjectDesignSystemPreset('nope', 'custom');
+        useProjectStore.getState().markDesignSetupComplete('nope');
+        expect(useProjectStore.getState().projects).toEqual(before);
+    });
+});

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -21,6 +21,7 @@ export type ProjectSlice = {
     getHistoryEvents: ProjectState['getHistoryEvents'];
     setProjectStage: ProjectState['setProjectStage'];
     setProjectDesignSystemPreset: ProjectState['setProjectDesignSystemPreset'];
+    markDesignSetupComplete: ProjectState['markDesignSetupComplete'];
     loadDemoProject: ProjectState['loadDemoProject'];
 };
 
@@ -35,6 +36,10 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             id: projectId,
             name,
             createdAt: now,
+            // New projects owe a setup-stage design selection (shown while the
+            // PRD generates). Legacy persisted projects lack the flag and keep
+            // the finalize-edge preset gate as their only prompt.
+            needsDesignSetup: true,
             ...(platform && { platform }),
         };
 
@@ -132,7 +137,22 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
             return {
                 projects: {
                     ...state.projects,
-                    [projectId]: { ...project, designSystemPreset: presetId },
+                    // A chosen preset settles the setup step no matter which UI
+                    // it came from (setup step, finalize gate, design artifact).
+                    [projectId]: { ...project, designSystemPreset: presetId, needsDesignSetup: false },
+                },
+            };
+        });
+    },
+
+    markDesignSetupComplete: (projectId: string) => {
+        set((state) => {
+            const project = state.projects[projectId];
+            if (!project) return state;
+            return {
+                projects: {
+                    ...state.projects,
+                    [projectId]: { ...project, needsDesignSetup: false },
                 },
             };
         });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -55,7 +55,14 @@ export interface ProjectState {
     setProjectStage: (projectId: string, stage: PipelineStage) => void;
 
     // Stores the chosen design-system preset id (see DESIGN_SYSTEM_PRESETS).
+    // Also clears `needsDesignSetup` — a chosen preset settles the setup step
+    // regardless of which UI it was picked from.
     setProjectDesignSystemPreset: (projectId: string, presetId: string) => void;
+
+    // Dismisses the setup-stage design selection step without choosing a
+    // preset ("decide later") — the Mark-as-Final gate still asks before
+    // assets generate.
+    markDesignSetupComplete: (projectId: string) => void;
 
     // Demo project hydration. Returns the stable DEMO_PROJECT_ID and whether
     // a demo snapshot was available. When `available` is false, the home

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,11 @@ export type Project = {
     // mockups and the Screen Inventory copy-prompt. Optional — legacy projects
     // and the demo have none and behave exactly as before.
     designSystemPreset?: string;
+    // True while the setup-stage design selection step (DesignSetupStep) is
+    // still owed for this project. Stamped by `createProject`, cleared when a
+    // preset is chosen (any path) or the user explicitly skips. Optional —
+    // legacy projects and the demo have none and never see the setup step.
+    needsDesignSetup?: boolean;
 };
 
 export type BranchMessage = {


### PR DESCRIPTION
## Summary

Moves design-system preset selection into the initial project setup flow: right after clarification answers are submitted (or immediately on the Generate Immediately path), **PRD generation starts in the background** and the workspace shows a new **Design Setup** step where the user picks the project's visual direction — instead of first being asked at Mark-as-Final.

### What changed

- **Preset definitions** (`src/lib/designSystemPresets.ts`): added `Enterprise Professional` and `Creative Studio`; relabeled existing presets to Modern SaaS / Minimal Editorial / Developer / Technical (**ids unchanged** — persisted projects keep working); each concrete preset now carries `tone`, `recommendedUseCases`, `visualTraits`, and `previewTokens` (presentation-only; only `directive` feeds generation).
- **Recommendation helper** (`src/lib/designPresetRecommendation.ts`): rule-based keyword scoring over the idea + clarification answers (music/creator → Creative Studio, CRM/finance → Enterprise Professional, habits/wellness → Consumer Mobile, API/dev → Developer / Technical, notes/learning → Minimal Editorial; Modern SaaS fallback). No AI call — renders instantly while the PRD generates.
- **Default preference** (`src/lib/designPresetPreference.ts`): `SYNAPSE_DEFAULT_DESIGN_PRESET` localStorage preference, written only via the explicit "Use this as my default for future projects" checkbox; preselected on future projects.
- **Project state**: new projects stamp `Project.needsDesignSetup: true` in `createProject`; `setProjectDesignSystemPreset` now also settles the flag (from any picker); new `markDesignSetupComplete` action backs "Decide later". Gating is the pure, unit-tested `shouldShowDesignSetup` (`src/lib/designSetup.ts`).
- **UI** (`src/components/setup/DesignSetupStep.tsx`): full-card step in the workspace PRD stage with a live "Synapse is preparing your PRD…" / "Your PRD is ready" status, static token-driven preview cards (no AI/image calls), Recommended + Your default badges, save-as-default checkbox, and a skip.

### What deliberately did NOT change

- **PRD generation flow is untouched** — it already starts fire-and-forget when clarification answers are submitted; the setup step is purely a view swap, so generation never waits on the choice.
- **Visual-artifact gating is preserved** — assets still only generate at Mark-as-Final, and the existing finalize-edge `DesignSystemPresetChoice` gate remains as the fallback for skips and legacy projects, so visual generation never runs without an explicit preset decision.
- **Downstream threading is unchanged** — the preset steers `design_system` generation (directive injection in `coreArtifactService`), and mockups + the Screen Inventory copy-prompt already consume it via the shared Design System Brief.
- Legacy projects (no `needsDesignSetup` flag), the demo, blocked spines, and failed runs never see the new step.

### Tests

- `designSystemPresets.test.ts` — new preset ids, directives, setup metadata/preview tokens
- `designPresetRecommendation.test.ts` — category mappings, distinct-match scoring, whole-word matching, fallback
- `designPresetPreference.test.ts` — save/load/clear, invalid + stale id handling
- `designSetup.test.ts` — setup-step gating transitions (preflight → completed, preset chosen, skip, legacy, demo, blocked, error)
- `designSetupState.test.ts` — store flag stamping/clearing
- `DesignSetupStep.test.tsx` — recommendation badge, default preselection, preset storage, default persistence, skip path

`npm run build`, `npm run lint`, and `npm test` (110 files / 796 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRyg6GcCUbb94jdVbAhRav

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRyg6GcCUbb94jdVbAhRav)_