### PR TITLE
Consolidate Developer Prompts + Build Plan into one Implementation Plan artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,7 +518,11 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       so the user must regenerate to pull the new visual direction through.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
-    implementation_plan, prompt_pack, design_system). **Per-artifact model
+    implementation_plan, prompt_pack, design_system). **`prompt_pack` is
+    RETIRED from new generation** (see "Consolidated Implementation Plan"
+    below): it stays in the subtype union, pipeline, and complexity map so
+    legacy persisted artifacts keep working, but new runs never generate it.
+    **Per-artifact model
     routing (`src/lib/artifactModelSettings.ts`):** the routing brain lives in
     `artifactModelSettings.ts` (not coreArtifactService) so the Settings UI and
     the generation pipeline share one source of truth. Each subtype is tagged in
@@ -578,26 +582,25 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     `scroll-mt-*` id matching an outline item. This **replaced the old
     wrapping "pill" nav** (`SectionTabs`) on the first two pages and the old
     permanent left rail on Developer Prompts — do not reintroduce pills or a
-    side rail there; `SectionTabs` survives only for the Implementation Plan
-    renderer. When a document-style artifact needs in-page nav, reuse
+    side rail there; `SectionTabs` survives only in the Implementation Plan
+    renderer's legacy-markdown fallback path. When a document-style artifact
+    needs in-page nav, reuse
     `ArtifactOutlineNav`/`useArtifactOutline` rather than introducing another
     navigation style.
     The `prompt_pack` (**Developer Prompts**) renderer
-    (`PromptPackRenderer.tsx`) is now a vertical **document** driven by the
-    shared outline (one card per `### N. Title`), so the prompt body uses the
-    full page width instead of a permanent left rail. Each card has a light
-    header (Prompt N · Title · Category · "Generated <date>"), only **Edit** +
-    **Copy Prompt** actions (Reset surfaces inside edit mode when modified),
-    the prompt body rendered exactly as before (mono `whitespace-pre-wrap`,
-    unchanged), and a single supporting card below it — **Expected Output**
-    (trailing `**Expected Output:**`), rendered only when present — plus a
-    subtle "Safe to regenerate / Creates Version X" callout. **The generated
-    prompts are agent-agnostic** — the `prompt_pack` generation prompt
-    (`coreArtifactService.ts`) must never name or recommend a specific coding
-    agent (Cursor, Claude Code, ChatGPT, Copilot), and the renderer no longer
-    parses/shows a Target Tool, Reason/User Intent, Dependencies, or Key
-    Implementation Areas block. `generatedAt` (version `createdAt`) and
-    `versionNumber` thread through `ArtifactContentRenderer`.
+    (`PromptPackRenderer.tsx`) survives only for legacy persisted artifacts
+    (the subtype is retired — no sidebar row, no new generation): a vertical
+    document driven by the shared outline (one card per `### N. Title`), with
+    Edit + Copy Prompt actions and a per-prompt `promptEdits` metadata
+    overlay. Its markdown parser lives in
+    `src/lib/services/promptPackParser.ts`, shared with the implementation-
+    plan adapter (which is how legacy Developer Prompts surface inside the
+    consolidated view). **Generated prompts are agent-agnostic** — neither
+    the legacy prompt_pack prompt nor the implementation_plan prompt-pack
+    instructions (`coreArtifactService.ts`) may name or recommend a specific
+    coding agent (Cursor, Claude Code, ChatGPT, Copilot). `generatedAt`
+    (version `createdAt`) and `versionNumber` thread through
+    `ArtifactContentRenderer`.
   - `branchService.ts` — branch consolidation back into the spine.
   - `preflightService.ts` — optional pre-PRD clarification (see "Preflight
     clarification" below). `generatePreflightQuestions()` (safety-gated) and
@@ -922,9 +925,9 @@ User prompt → HomePage.handleCreateProject() → PreflightModeChoice
 The artifact sidebar is organized into five workflow-named sections —
 **Project Foundation** (PRD), **Experience** (User Flows, Screens — see "The
 Experience workspace" below), **Design** (Design System), **Architecture**
-(Data Model), and **Development** (Developer Prompts, Build Plan) — driven by
-`ARTIFACT_GROUPS` in `ArtifactWorkspace.tsx`. Grouping is purely visual;
-`CoreArtifactSubtype` ids
+(Data Model), and **Development** (Implementation Plan — see "Consolidated
+Implementation Plan" below) — driven by `ARTIFACT_GROUPS` in
+`ArtifactWorkspace.tsx`. Grouping is purely visual; `CoreArtifactSubtype` ids
 (`'data_model'`, `'component_inventory'`, `'design_system'`, `'prompt_pack'`,
 `'implementation_plan'`) are unchanged so persisted artifacts, generation, and
 per-artifact model overrides keep working. **`component_inventory` (UI Components)
@@ -943,7 +946,15 @@ slots so an errored hidden slot isn't retried invisibly on every remount — but
 `startAll` still includes hidden slots in its pending set, so they're best-effort
 generated alongside visible ones. A hidden artifact must never gate readiness or
 be the sole reason a run resumes. To re-expose one, remove it from
-`HIDDEN_ARTIFACT_SUBTYPES`. See `docs/backlog/BACKLOG.md` §6. `title`/`description` in
+`HIDDEN_ARTIFACT_SUBTYPES`. See `docs/backlog/BACKLOG.md` §6.
+**`prompt_pack` (Developer Prompts) is a *retired* artifact**
+(`RETIRED_ARTIFACT_SUBTYPES` / `isRetiredArtifactSubtype`, same module) —
+stronger than hidden: retired subtypes are excluded from new generation runs
+(`pendingSlotsForSpine`), from `assetsReady`, from `buildSlotMetas`, and from
+the Settings model list, while the pipeline meta / renderer / export path stay
+for legacy persisted artifacts. A retired subtype must never be a dependency
+of an active one (its dep would starve in the layer filter — regression test
+in `coreArtifactPipeline.test.ts`). `title`/`description` in
 `CORE_ARTIFACT_PIPELINE` are display-only labels that may be renamed freely; the
 sidebar's iteration order (and the mobile-header / auto-open order)
 all derive from `ARTIFACT_GROUPS`, not `displayOrder`. There is no
@@ -955,7 +966,8 @@ Marking a spine final must not dump the user back on something that looks like
 the PRD again. `ProjectWorkspace.handleToggleFinal` (on the finalize edge)
 starts artifact generation and shows `FinalizationSuccessModal` ("PRD
 Finalized" — *being created* vs *ready*, keyed off an `assetsReady` presence
-check of the 7 core artifacts + mockups) **without** switching stage. Its
+check of the non-hidden, non-retired core artifacts + mockups) **without**
+switching stage. Its
 **Open Assets** action (`handleOpenAssets`) switches `currentStage` to
 `workspace` and arms a one-shot `finalizeAutoOpen` flag passed to
 `ArtifactWorkspace` as `autoOpenIntent`. `ArtifactWorkspace` consumes it once
@@ -966,6 +978,63 @@ implementation_plan) — and opens the mobile drawer (`useIsMobile`-gated, so it
 never reopens after the user closes it; desktop keeps the persistent side rail). While the overall run is in
 flight, an idle slot renders a centered `BuildAssetsLoading` ("Creating your
 build assets…") instead of an empty state.
+
+### Consolidated Implementation Plan (Development section)
+
+The old **Developer Prompts** (`prompt_pack`) and **Build Plan**
+(`implementation_plan`) rows are consolidated into one **Implementation Plan**
+artifact (subtype id still `implementation_plan` — no new subtype, so
+persisted artifacts, version history, snapshots, sync, model routing, and
+Convert-to-Tasks all keep working). See
+`docs/IMPLEMENTATION_PLAN_CONSOLIDATION.md` for the audit + design.
+
+- **Data shape.** `StructuredImplementationPlan` (in `src/types`) gained
+  all-optional consolidated fields: plan `summary`
+  (`ImplementationPlanSummary`), `globalQualityGates`, and per-milestone
+  `objective`/`priority`/`estimatedEffort`/`dependencies`/`linkedArtifacts`/
+  `promptPacks` (`ImplementationPromptPack`)/`qualityGates`
+  (`ImplementationQualityGate`)/`validationCommands`/`definitionOfDone`.
+  Storage format is unchanged: markdown + trailing ```` ```json synapse-plan ````
+  fence; the readable markdown keeps the legacy
+  Milestone/Goal/Deliverables/Dependencies headings (artifactValidation and
+  the legacy parser depend on them) and full prompt bodies live only in the
+  fence JSON.
+- **Adapter, not migration.** `src/lib/services/implementationPlanAdapter.ts`
+  (`buildConsolidatedPlan`, pure, unit-tested) builds the render-time
+  `ConsolidatedImplementationPlan` view model from any combination of: native
+  consolidated plan, legacy structured plan, legacy markdown-only plan,
+  and/or a legacy `prompt_pack` artifact. Legacy prompts become prompt packs
+  attached to milestones by conservative token matching (≥2 shared meaningful
+  tokens; unmatched → a labeled **Unassigned Prompt Packs** group); legacy
+  plan-wide Definition of Done → categorized global quality gates; legacy
+  Architecture → summary stack; Risks → readiness warnings. `readiness` and
+  `traceability` are always **derived, never persisted/generated**. The
+  legacy prompt-card parser is shared via
+  `src/lib/services/promptPackParser.ts` (extracted from
+  `PromptPackRenderer`).
+- **Renderer.** `ImplementationPlanRenderer` routes through the adapter into
+  `renderers/implementationPlan/ConsolidatedPlanView.tsx` (tabs: Overview /
+  Milestones / Prompt Packs / Quality Gates / Traceability + copy actions:
+  per-prompt, per-milestone, all packs, whole plan as markdown via the
+  adapter's helpers). Fence-less, milestone-less content falls back to the
+  old timeline / plain markdown. `ArtifactWorkspace` threads the legacy
+  standalone prompt_pack artifact's preferred content in as
+  `promptPackContent` (via `ArtifactContentRenderer`).
+- **Generation.** The `implementation_plan` prompt + Gemini schema
+  (`artifactSchemas.ts`) emit the consolidated shape with **milestone-centered
+  prompt packs** (self-contained, agent-agnostic, fixed heading structure:
+  Goal / Relevant Synapse Artifacts / Scope / Out of Scope / Implementation
+  Steps / Acceptance Criteria / Quality Gates / Validation Commands / Commit
+  Guidance; no triple backticks inside bodies — they'd collide with the
+  markdown fences). It has true data deps on `screen_inventory` +
+  `data_model` (NOT `user_flows` — that edge would make the active pipeline 3
+  layers deep; the pipeline-shape tests assert ≥3-wide layer 1 and ≤2 layers
+  over the **active** pipeline). New runs never generate `prompt_pack` (see
+  the retired-subtype rules above).
+- The demo project is a **cloud snapshot** and carries the legacy
+  two-artifact shape until the owner re-pins a regenerated snapshot; the
+  adapter is what keeps it rendering consolidated in the meantime. Do not add
+  persisted state for the consolidated view.
 
 ### The Experience workspace (Screens) — read-side consolidation
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,13 @@ so they pick up the new direction.
 - **Screen Inventory** and **User Flows**
 - **Design System**
 - **Data Model** schemas with entities, fields, and relationships
-- **Build Plan** and **Developer Prompts**
+- **Implementation Plan** — a consolidated build guide: small milestones, each
+  with linked screens/entities, implementation tasks, **copy-ready prompt
+  packs** for your coding agent, **quality gates**, validation commands, and a
+  definition of done, plus a traceability view connecting milestones →
+  screens → data models → prompt packs → gates. (Projects generated before the
+  consolidation had separate *Build Plan* and *Developer Prompts* artifacts;
+  they're merged into this view automatically — nothing is lost or migrated.)
 
 Two of them (`screen_inventory`, `data_model`) use Gemini JSON mode with explicit
 schemas and render as card grids and entity tables rather than raw markdown. Every artifact tracks
@@ -233,10 +239,10 @@ address the critique without regenerating the whole document.
 
 #### Track implementation progress
 
-The Build Plan converts into a tracked task checklist — no LLM call,
+The Implementation Plan converts into a tracked task checklist — no LLM call,
 derived deterministically from the plan. Review and edit the extracted tasks,
 **save them to the project**, and a progress checklist appears on the
-Build Plan: a `done / total` progress bar, a per-task status toggle
+Implementation Plan: a `done / total` progress bar, a per-task status toggle
 (to do → in progress → done), and expandable acceptance criteria. Export the
 tasks to **Markdown** or **GitHub issues**; created GitHub issues are linked
 back to each task so you can jump straight to them. Progress persists across
@@ -321,7 +327,7 @@ graph TD
     H --> J(Screen Inventory)
     H --> K(Data Model)
     H --> L(Design System)
-    H --> M(Build Plan)
+    H --> M(Implementation Plan)
 ```
 
 ## Tech stack

--- a/docs/IMPLEMENTATION_PLAN_CONSOLIDATION.md
+++ b/docs/IMPLEMENTATION_PLAN_CONSOLIDATION.md
@@ -1,0 +1,129 @@
+# Development-artifact consolidation: audit & plan
+
+Consolidates the two Development assets — **Developer Prompts** (`prompt_pack`)
+and **Build Plan** (`implementation_plan`) — into one **Implementation Plan**
+artifact that connects milestones, tasks, prompt packs, linked artifacts,
+quality gates, validation commands, and definitions of done.
+
+## Phase 1 audit — where everything lives today
+
+### Definitions & pipeline
+- `src/types/index.ts` — `CoreArtifactSubtype` includes `implementation_plan`
+  and `prompt_pack`; `StructuredImplementationPlan` (overview / milestones /
+  tasks / architecture / risks / definitionOfDone) is the structured plan shape.
+  NOTE: `implementation_plan` is *also* a PRD **section id** in
+  `prdSchemas.ts` / `prdSectionPrompts.ts` / `progressivePrdGeneration.ts` — a
+  separate namespace; untouched by this work.
+- `src/lib/coreArtifactPipeline.ts` — `CORE_ARTIFACT_PIPELINE` metas:
+  `prompt_pack` (title "Developer Prompts", dependsOn implementation_plan +
+  design_system + data_model) and `implementation_plan` (title "Build Plan",
+  no deps). `HIDDEN_ARTIFACT_SUBTYPES` (= still generated, no UI row) exists
+  for `component_inventory`.
+- `src/components/ArtifactWorkspace.tsx` — `ARTIFACT_GROUPS` Development group
+  = `['prompt_pack', 'implementation_plan']`; implementation_plan rows get the
+  Convert-to-Tasks button + `TaskChecklist`; prompt_pack rows get the
+  `promptEdits` metadata overlay wiring.
+
+### Generation
+- `src/lib/services/coreArtifactService.ts` — per-subtype prompts.
+  `implementation_plan` generates via Gemini JSON mode
+  (`implementationPlanSchema` in `src/lib/schemas/artifactSchemas.ts`) and is
+  serialized by `implementationPlanToMarkdown()`: legacy-parseable markdown +
+  trailing ```` ```json synapse-plan ```` fence. `prompt_pack` generates
+  free-form markdown (`### N. Title` / `**Category:**` / fenced prompt body).
+- `src/lib/services/artifactJobController.ts` — `ALL_SLOT_KEYS` derives from
+  `CORE_ARTIFACT_PIPELINE`; `pendingSlotsForSpine` decides what generates;
+  `resumeIfNeeded` gates on visible slots; `MOCKUP_DEPENDENCIES` does NOT
+  include either subtype.
+- `src/lib/artifactModelSettings.ts` — complexity: `implementation_plan: high`,
+  `prompt_pack: low`. Settings UI `ArtifactModelsSection` iterates
+  `CORE_ARTIFACT_DISPLAY_ORDER`.
+- `src/components/generationStages.ts` — per-subtype progress labels.
+
+### Parsing / rendering
+- `src/lib/services/implementationPlanParser.ts` — pure parser: structured
+  fence extraction + legacy `### Milestone N:` markdown regex parse.
+- `src/components/renderers/ImplementationPlanRenderer.tsx` — structured tabbed
+  view (Tasks/Architecture/Risks/DoD) or legacy timeline.
+- `src/components/renderers/PromptPackRenderer.tsx` — parses prompt cards
+  inline (private `parsePromptPack`), outline nav, copy/edit per prompt.
+- `src/components/renderers/index.tsx` — `ArtifactContentRenderer` dispatch.
+
+### Downstream consumers
+- Convert to Tasks: `src/lib/services/taskExtractor.ts`
+  (`extractTasksFromMarkdown` auto-detects fence vs legacy markdown) +
+  `ConvertToTasksModal` + `tasksSlice`.
+- Export: `ExportModal.tsx` + `src/lib/exportHandoff.ts` (titles from pipeline
+  metas; no subtype literals).
+- Validation: `src/lib/artifactValidation.ts` — required headings
+  (`implementation_plan`: Milestone/Goal/Deliverables/Dependencies;
+  `prompt_pack`: Prompt/Category/Target) + synapse-plan fence check.
+- `ProjectWorkspace.assetsReady` — presence check over non-hidden
+  `CORE_ARTIFACT_DISPLAY_ORDER` subtypes + mockups.
+
+### Demo / fixtures / docs
+- The demo project is a **cloud snapshot** (`/api/snapshots?demo=1`); the repo
+  holds no static artifact fixture (`src/data/demoProject.ts` is just the id).
+  Old snapshots therefore keep the legacy two-artifact shape until the owner
+  re-pins a regenerated snapshot — the render-time adapter (below) is what
+  keeps them working and consolidated.
+- Tour copy: `src/components/tour/tourData.ts` (implementation_plan +
+  prompt_pack asset cards). Screenshot script:
+  `scripts/capture-demo-screenshots.mjs`. Docs: `docs/artifact-flow.md`,
+  `README.md`, `CLAUDE.md`.
+- Tests: `implementationPlanParser.test.ts`, `taskExtractor.test.ts`,
+  `artifactModelSettings.test.ts`, `artifactModelRouting.test.ts`,
+  `exportHandoff.test.ts`, `artifactOrchestration.test.ts`,
+  `buildGenerationSteps.test.ts`.
+
+## Design decisions (risk-minimizing)
+
+1. **Reuse the existing `implementation_plan` subtype** as the consolidated
+   artifact (retitled "Implementation Plan"). No new subtype → persisted
+   artifacts, version history, snapshots, sync, model routing, and the
+   Convert-to-Tasks flow all keep working. The storage format stays
+   "markdown + `json synapse-plan` fence".
+2. **Extend `StructuredImplementationPlan` additively** — optional `summary`,
+   `readiness`, `globalQualityGates`, and per-milestone `objective`, `phase`,
+   `priority`, `estimatedEffort`, `dependencies`, `linkedArtifacts`,
+   `promptPacks`, `qualityGates`, `validationCommands`, `definitionOfDone`.
+   Old fenced plans simply lack the new fields.
+3. **Render-time adapter, no data migration.**
+   `implementationPlanAdapter.ts` builds a normalized
+   `ConsolidatedImplementationPlan` view model from any of: native new-shape
+   plan; legacy structured plan + legacy prompt_pack markdown; legacy
+   markdown-only plan; prompt_pack only. Legacy prompts become prompt packs
+   attached to milestones by best-effort title/keyword matching, else an
+   "Unassigned Prompt Packs" group. Legacy DoD → quality gates; architecture →
+   summary stack; risks → readiness warnings. Traceability and readiness are
+   *derived*, never generated.
+4. **Retire `prompt_pack` from new generation and the sidebar** via a new
+   `RETIRED_ARTIFACT_SUBTYPES` set in `coreArtifactPipeline.ts` (distinct from
+   HIDDEN, which still generates). Retired subtypes: excluded from
+   `pendingSlotsForSpine` (never generated/resumed), from `assetsReady`, from
+   `buildSlotMetas`, and from the Settings model list. The meta stays in
+   `CORE_ARTIFACT_PIPELINE` so legacy persisted artifacts keep their title,
+   renderer, export path, and `getArtifactMeta` never throws.
+5. **Legacy prompt_pack content is consumed, not orphaned**: the Implementation
+   Plan view reads the project's existing prompt_pack artifact (when present)
+   through the adapter, so old projects see their prompts inside the
+   consolidated view instead of a separate card.
+6. **Generation prompt/schema updated in place** for `implementation_plan` to
+   emit milestone-centered prompt packs (coding-agent-ready body), quality
+   gates, validation commands, and DoD; it gains dependencies on
+   `screen_inventory` + `data_model` so links/prompts use real names.
+   `implementationPlanToMarkdown` keeps the legacy headings (validation +
+   legacy parsers unaffected) and appends the new sections.
+
+## Phase plan / commit cadence
+
+1. Audit note (this doc).
+2. Additive types + Gemini schema extension.
+3. Adapter/normalizer + prompt-pack parser extraction + unit tests.
+4. Assets-page consolidation (retired subtype wiring).
+5. Consolidated renderer (Overview / Roadmap & Milestones / Prompt Packs /
+   Quality Gates / Traceability / export-copy actions).
+6. Generation prompt + deps + progress labels.
+7. Tour/demo copy + screenshot script + docs (README, CLAUDE.md,
+   artifact-flow).
+8. Tests + `npm run lint` + `npm run build` + `npm test`.

--- a/docs/artifact-flow.md
+++ b/docs/artifact-flow.md
@@ -102,8 +102,8 @@ Seven core artifact types ship in the bundle:
 | `component_inventory` | Categorized cards (`renderers/ComponentInventoryRenderer.tsx`) |
 | `user_flows` | Markdown |
 | `design_system` | Markdown |
-| `implementation_plan` | Markdown |
-| `prompt_pack` | Markdown |
+| `implementation_plan` | Consolidated plan view — milestones, prompt packs, quality gates, traceability (`renderers/implementationPlan/ConsolidatedPlanView.tsx`, adapted by `lib/services/implementationPlanAdapter.ts`) |
+| `prompt_pack` | **Retired** (`RETIRED_ARTIFACT_SUBTYPES`) — no longer generated; legacy artifacts render via `PromptPackRenderer` and are consumed into the Implementation Plan view |
 
 Clicking **Generate All** now executes a dependency-aware pipeline using
 `CORE_ARTIFACT_PIPELINE` from `src/lib/coreArtifactPipeline.ts`.
@@ -113,9 +113,11 @@ Artifacts are generated in a deterministic order:
 2. `user_flows`
 3. `component_inventory`
 4. `data_model`
-5. `implementation_plan`
-6. `design_system`
-7. `prompt_pack`
+5. `design_system`
+6. `implementation_plan` (depends on `screen_inventory` + `data_model`)
+
+`prompt_pack` is retired from new runs — the Implementation Plan carries
+milestone-centered prompt packs natively.
 
 Each call to `generateCoreArtifact()` receives context from already
 generated dependencies (`generatedArtifacts`) so prompts are grounded in
@@ -152,9 +154,10 @@ Each generation creates an `ArtifactVersion` linked to its source
 | 2 | `user_flows` | PRD + `screen_inventory` excerpt | Goal/preconditions/steps/success/error paths | Cross-artifact check for feature propagation + error coverage |
 | 3 | `component_inventory` | PRD + `screen_inventory` + `user_flows` | Reusable component catalog with usage mapping | Structural + cross-artifact consistency warnings |
 | 4 | `data_model` | PRD + `user_flows` | Entities, fields, relationships, API endpoint implications | Structural + explicit API-surface check |
-| 5 | `implementation_plan` | PRD + `component_inventory` + `data_model` | Milestones, dependencies, DoD, feature traceability map | Feature-traceability coverage warning |
+| 5 | `implementation_plan` | PRD + `screen_inventory` + `data_model` | Milestones with objectives, priorities, linked artifacts, prompt packs, quality gates, validation commands, DoD | Feature-traceability coverage warning |
 | 6 | `design_system` | PRD + `component_inventory` | Tokens/patterns/states/layout guidance | Structural format checks |
-| 7 | `prompt_pack` | PRD + `implementation_plan` + `design_system` + `data_model` | Downstream prompts with canonical feature/entity references | Cross-artifact genericness + traceability warnings |
+
+(`prompt_pack` retired — prompt packs are generated inside `implementation_plan` milestones.)
 
 ### Audit-derived quality controls
 

--- a/scripts/capture-demo-screenshots.mjs
+++ b/scripts/capture-demo-screenshots.mjs
@@ -78,8 +78,9 @@ const ARTIFACTS = [
     { slug: 'ui-components', label: 'UI Components' },
     { slug: 'design-system', label: 'Design System' },
     { slug: 'data-model', label: 'Data Model' },
-    { slug: 'developer-prompts', label: 'Developer Prompts' },
-    { slug: 'build-plan', label: 'Build Plan' },
+    // Developer Prompts + Build Plan consolidated into one Implementation
+    // Plan artifact (milestones + prompt packs + quality gates).
+    { slug: 'implementation-plan', label: 'Implementation Plan' },
 ];
 
 // Mockups render images and can be slow; give them extra settle time.

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -920,6 +920,16 @@ export function ArtifactWorkspace({
         const promptEdits = subtype === 'prompt_pack'
             ? ((preferred.metadata?.promptEdits as Record<number, string> | undefined) ?? {})
             : undefined;
+        // Legacy projects may hold a standalone prompt_pack artifact (retired
+        // subtype, no sidebar row). The Implementation Plan view consumes its
+        // content through the adapter so those prompts appear as prompt packs.
+        const legacyPromptPackContent = subtype === 'implementation_plan'
+            ? (() => {
+                const packArtifact = getArtifacts(projectId, 'core_artifact').find(a => a.subtype === 'prompt_pack');
+                const packPreferred = packArtifact ? getPreferredVersion(projectId, packArtifact.id) : undefined;
+                return packPreferred?.content;
+            })()
+            : undefined;
         const handleUpdatePromptEdits = subtype === 'prompt_pack'
             ? (next: Record<number, string>) => {
                 updateArtifactVersionMetadata(projectId, artifact.id, preferred.id, { promptEdits: next });
@@ -992,6 +1002,7 @@ export function ArtifactWorkspace({
                         implementationPlan={subtype === 'user_flows' ? structuredPRD.implementationPlan : undefined}
                         onNavigateToScreen={subtype === 'user_flows' ? handleNavigateToScreen : undefined}
                         availableScreenSlugs={subtype === 'user_flows' ? screenIndex.availableSlugs : undefined}
+                        promptPackContent={legacyPromptPackContent}
                         promptEdits={promptEdits}
                         onUpdatePromptEdits={handleUpdatePromptEdits}
                         generatedAt={subtype === 'prompt_pack' ? preferred.createdAt : undefined}

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -10,7 +10,7 @@ import remarkGfm from 'remark-gfm';
 import { useProjectStore } from '../store/projectStore';
 import { useIsMobile } from '../lib/useIsMobile';
 import { artifactJobController } from '../lib/services/artifactJobController';
-import { CORE_ARTIFACT_DISPLAY_ORDER, getArtifactMeta, isHiddenArtifactSubtype } from '../lib/coreArtifactPipeline';
+import { CORE_ARTIFACT_DISPLAY_ORDER, getArtifactMeta, isHiddenArtifactSubtype, isRetiredArtifactSubtype } from '../lib/coreArtifactPipeline';
 import { ArtifactContentRenderer } from './renderers';
 import { StructuredPRDView } from './StructuredPRDView';
 import { MockupViewer } from './mockups/MockupViewer';
@@ -110,7 +110,12 @@ const ARTIFACT_GROUPS: ArtifactGroup[] = [
     },
     { id: 'design', title: 'Design', icon: Palette, items: ['design_system'] },
     { id: 'architecture', title: 'Architecture', icon: Database, items: ['data_model'] },
-    { id: 'development', title: 'Development', icon: Code2, items: ['prompt_pack', 'implementation_plan'] },
+    // Development consolidates the old Developer Prompts + Build Plan rows
+    // into one Implementation Plan artifact (milestones + prompt packs +
+    // quality gates). Legacy prompt_pack artifacts still exist in storage —
+    // the Implementation Plan view consumes them through
+    // implementationPlanAdapter rather than rendering a separate row.
+    { id: 'development', title: 'Development', icon: Code2, items: ['implementation_plan'] },
 ];
 
 function buildSlotMetas(): SlotMeta[] {
@@ -135,7 +140,7 @@ function buildSlotMetas(): SlotMeta[] {
         group.items
             .filter(key =>
                 key === 'prd' || key === 'mockup' || key === 'screens'
-                || !isHiddenArtifactSubtype(key))
+                || (!isHiddenArtifactSubtype(key) && !isRetiredArtifactSubtype(key)))
             .map(key => base[key]),
     );
 }

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -30,7 +30,7 @@ import { shouldShowDesignSetup } from '../lib/designSetup';
 import { ArtifactWorkspace } from './ArtifactWorkspace';
 import { FinalizationSuccessModal } from './FinalizationSuccessModal';
 import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
-import { CORE_ARTIFACT_DISPLAY_ORDER, isHiddenArtifactSubtype } from '../lib/coreArtifactPipeline';
+import { CORE_ARTIFACT_DISPLAY_ORDER, isHiddenArtifactSubtype, isRetiredArtifactSubtype } from '../lib/coreArtifactPipeline';
 import { HistoryView } from './HistoryView';
 import { VersionHistoryPanel, VersionCompareView, RevertConfirmModal, type VersionEntry } from './versions';
 import { ExportModal } from './ExportModal';
@@ -487,7 +487,9 @@ export function ProjectWorkspace() {
         // retry them, so a hidden slot erroring would otherwise leave the
         // finalize success modal stuck reporting "assets are being created".
         const coreReady = CORE_ARTIFACT_DISPLAY_ORDER
-            .filter(meta => !isHiddenArtifactSubtype(meta.subtype))
+            // Retired subtypes (prompt_pack) no longer generate at all, so
+            // they must not gate readiness either.
+            .filter(meta => !isHiddenArtifactSubtype(meta.subtype) && !isRetiredArtifactSubtype(meta.subtype))
             .every(meta =>
                 getArtifacts(projectId, 'core_artifact').some(a => a.subtype === meta.subtype && a.currentVersionId),
             );

--- a/src/components/__tests__/ImplementationPlanRenderer.test.tsx
+++ b/src/components/__tests__/ImplementationPlanRenderer.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImplementationPlanRenderer } from '../renderers/ImplementationPlanRenderer';
+import type { StructuredImplementationPlan } from '../../types';
+
+// jsdom lacks the async clipboard API; the copy buttons fall back to
+// execCommand, which jsdom also stubs. Provide a spyable writeText.
+beforeEach(() => {
+    Object.assign(navigator, {
+        clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+});
+
+function fencePlan(plan: StructuredImplementationPlan): string {
+    return `# Implementation Plan\n\n\`\`\`json synapse-plan\n${JSON.stringify(plan)}\n\`\`\``;
+}
+
+const NATIVE_PLAN: StructuredImplementationPlan = {
+    overview: { summary: 'Build in thin slices.' },
+    summary: {
+        buildStrategy: 'Walking skeleton first.',
+        stackSummary: ['React + Vite'],
+        criticalPath: ['Project Setup', 'Core Loop'],
+    },
+    milestones: [
+        {
+            id: 'm_setup',
+            name: 'Project Setup',
+            goal: 'Scaffold the app.',
+            priority: 'critical',
+            estimatedEffort: '2 days',
+            linkedArtifacts: { screens: ['Landing Page'], dataModels: ['User'] },
+            tasks: [{ id: 't1', title: 'Initialize Vite app', status: 'todo' }],
+            promptPacks: [
+                {
+                    id: 'pp_setup',
+                    title: 'Scaffold the project',
+                    purpose: 'Create the initial repo structure.',
+                    prompt: '# Prompt: Scaffold\n## Goal\nSet up Vite.',
+                    acceptanceCriteria: ['App boots locally'],
+                    recommendedCommitMessage: 'chore: scaffold project',
+                },
+            ],
+            qualityGates: [
+                { id: 'qg1', title: 'Lint passes clean', category: 'testing', required: true },
+            ],
+            validationCommands: ['npm run lint'],
+            definitionOfDone: ['CI green on main'],
+        },
+    ],
+    globalQualityGates: [
+        { id: 'g1', title: 'All P0 screens implemented', category: 'functional', required: true },
+    ],
+    architecture: ['SPA with serverless API'],
+    risks: [{ description: 'API rate limits' }],
+};
+
+const LEGACY_MARKDOWN = `# Implementation Plan
+
+### Milestone 1: Foundation (Week 1)
+**Goal:** Set up the project.
+**Key Deliverables:**
+- [ ] Initialize repository
+`;
+
+const LEGACY_PROMPT_PACK = `### 1. Implement the foundation repository setup
+**Category:** UI Implementation
+**Prompt:**
+\`\`\`
+# Task
+Set up the repository foundation and initialize the project.
+\`\`\`
+**Expected Output:** A working scaffold.
+`;
+
+describe('ImplementationPlanRenderer (consolidated view)', () => {
+    it('renders the tabbed consolidated view for a native plan', () => {
+        render(<ImplementationPlanRenderer content={fencePlan(NATIVE_PLAN)} />);
+        // Tabs
+        expect(screen.getByRole('button', { name: /^Overview$/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Milestones/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Prompt Packs/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Quality Gates/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Traceability/ })).toBeInTheDocument();
+        // Overview content
+        expect(screen.getByText('Ready to build')).toBeInTheDocument();
+        expect(screen.getByText('Walking skeleton first.')).toBeInTheDocument();
+        expect(screen.getByText('React + Vite')).toBeInTheDocument();
+        expect(screen.getByText(/Project Setup → Core Loop/)).toBeInTheDocument();
+    });
+
+    it('shows milestone detail with tasks, gates, validation commands, and DoD', () => {
+        render(<ImplementationPlanRenderer content={fencePlan(NATIVE_PLAN)} />);
+        fireEvent.click(screen.getByRole('button', { name: /Milestones/ }));
+        // First milestone is expanded by default.
+        expect(screen.getByText('Initialize Vite app')).toBeInTheDocument();
+        expect(screen.getByText('Lint passes clean')).toBeInTheDocument();
+        expect(screen.getByText(/npm run lint/)).toBeInTheDocument();
+        expect(screen.getByText('CI green on main')).toBeInTheDocument();
+        expect(screen.getByText(/Landing Page/)).toBeInTheDocument();
+    });
+
+    it('copies the prompt pack body via the clipboard', async () => {
+        render(<ImplementationPlanRenderer content={fencePlan(NATIVE_PLAN)} />);
+        fireEvent.click(screen.getByRole('button', { name: /Prompt Packs/ }));
+        const copyButtons = screen.getAllByRole('button', { name: /Copy Prompt/ });
+        fireEvent.click(copyButtons[0]);
+        await vi.waitFor(() => {
+            expect(navigator.clipboard.writeText).toHaveBeenCalled();
+        });
+        const copied = vi.mocked(navigator.clipboard.writeText).mock.calls[0][0];
+        expect(copied).toContain('# Prompt: Scaffold');
+        expect(copied).toContain('chore: scaffold project');
+    });
+
+    it('groups quality gates by category with global/milestone attribution', () => {
+        render(<ImplementationPlanRenderer content={fencePlan(NATIVE_PLAN)} />);
+        fireEvent.click(screen.getByRole('button', { name: /Quality Gates/ }));
+        expect(screen.getByText('All P0 screens implemented')).toBeInTheDocument();
+        expect(screen.getByText('Global gate')).toBeInTheDocument();
+        expect(screen.getByText('Milestone: Project Setup')).toBeInTheDocument();
+    });
+
+    it('renders traceability rows from milestone links', () => {
+        render(<ImplementationPlanRenderer content={fencePlan(NATIVE_PLAN)} />);
+        fireEvent.click(screen.getByRole('button', { name: /Traceability/ }));
+        // Desktop table + mobile cards both render (visibility is CSS-only in
+        // jsdom), so the milestone title appears at least once.
+        expect(screen.getAllByText('Project Setup').length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Landing Page/).length).toBeGreaterThan(0);
+    });
+
+    it('adapts a legacy markdown plan + legacy prompt_pack into the consolidated view', () => {
+        render(
+            <ImplementationPlanRenderer
+                content={LEGACY_MARKDOWN}
+                promptPackContent={LEGACY_PROMPT_PACK}
+            />,
+        );
+        // Legacy adaptation is flagged for review, never blocked.
+        expect(screen.getByText('Needs review')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: /Prompt Packs/ }));
+        expect(screen.getByText('Implement the foundation repository setup')).toBeInTheDocument();
+    });
+
+    it('falls back to plain markdown when content has no milestones or fence', () => {
+        render(<ImplementationPlanRenderer content={'Just some prose about the build.'} />);
+        expect(screen.getByText(/Just some prose/)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Traceability/ })).not.toBeInTheDocument();
+    });
+
+    it('does not crash on malformed fence JSON', () => {
+        const malformed = '# Plan\n\n```json synapse-plan\n{ not valid json\n```\n';
+        render(<ImplementationPlanRenderer content={malformed} />);
+        // Falls through to plain markdown rendering of the body.
+        expect(screen.queryByRole('button', { name: /Traceability/ })).not.toBeInTheDocument();
+    });
+});

--- a/src/components/generationStages.ts
+++ b/src/components/generationStages.ts
@@ -80,7 +80,8 @@ export function getArtifactStages(subtype: string): ProgressStage[] {
             return [
                 { label: 'Scoping build phases...', minDuration: 2500 },
                 { label: 'Sequencing milestones...', minDuration: 3000 },
-                { label: 'Drafting implementation roadmap...', minDuration: 3500 },
+                { label: 'Writing milestone prompt packs...', minDuration: 3500 },
+                { label: 'Attaching quality gates...', minDuration: 3500 },
             ];
         case 'data_model':
             return [

--- a/src/components/renderers/ImplementationPlanRenderer.tsx
+++ b/src/components/renderers/ImplementationPlanRenderer.tsx
@@ -1,49 +1,39 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Calendar, ChevronRight, Flag, Layers, Target, Users } from 'lucide-react';
 import { SectionTabs, type SectionTabItem } from '../SectionTabs';
-import type {
-    StructuredImplementationPlan,
-    ImplementationPlanMilestone,
-    ImplementationPlanTask,
-    TaskStatus,
-} from '../../types';
 import {
     parseImplementationPlan,
     parseMilestoneBody,
     type ParsedMilestone,
 } from '../../lib/services/implementationPlanParser';
+import { buildConsolidatedPlan } from '../../lib/services/implementationPlanAdapter';
+import { ConsolidatedPlanView } from './implementationPlan/ConsolidatedPlanView';
 
 // Render an `implementation_plan` artifact.
 //
-// New artifacts include a trailing ```json synapse-plan fence — when present,
-// we render the structured tabbed UI (Tasks / Architecture / Risks / DoD).
-// Legacy artifacts (no fence) fall through to the original milestone-regex
-// timeline so older projects in localStorage keep rendering unchanged.
+// The primary path is the consolidated Implementation Plan view
+// (Overview / Milestones / Prompt Packs / Quality Gates / Traceability),
+// built by `implementationPlanAdapter` from the artifact content plus — for
+// legacy projects — the old standalone `prompt_pack` artifact's content
+// (threaded through `promptPackContent`). New artifacts carry milestone
+// prompt packs natively in the ```json synapse-plan fence; legacy artifacts
+// are adapted at render time with no migration.
 //
-// See docs/backlog/BACKLOG.md (Implementation Plan section) for deferred features.
+// Content with no fence and no `### Milestone N:` headings falls through to
+// the original milestone-regex timeline / plain-markdown rendering so older
+// projects in localStorage always stay readable.
 
 interface Props {
     content: string;
+    /**
+     * Content of the project's legacy standalone `prompt_pack` artifact, when
+     * one exists. Its prompts are adapted into prompt packs inside the
+     * consolidated view. Omitted for new projects (packs are native).
+     */
+    promptPackContent?: string;
 }
-
-const STRUCTURED_FENCE = /```json\s+synapse-plan\s*\n([\s\S]*?)\n```/;
-
-function extractStructuredPlan(markdown: string): StructuredImplementationPlan | null {
-    const match = markdown.match(STRUCTURED_FENCE);
-    if (!match) return null;
-    try {
-        const parsed = JSON.parse(match[1]) as StructuredImplementationPlan;
-        if (!Array.isArray(parsed?.milestones)) return null;
-        return parsed;
-    } catch {
-        return null;
-    }
-}
-
-// Legacy markdown parsing now lives in `src/lib/services/implementationPlanParser.ts`
-// so the task extractor can share the same regexes.
 
 function inlineMd(text: string) {
     return (
@@ -177,282 +167,21 @@ function LegacyTimeline({ content }: { content: string }) {
     );
 }
 
-// --- Structured (new) rendering ---
-
-type TopTabId = 'tasks' | 'architecture' | 'risks' | 'definition_of_done';
-
-const TASK_STATUS_STYLE: Record<TaskStatus, { label: string; cls: string }> = {
-    todo: { label: 'Todo', cls: 'bg-neutral-100 text-neutral-700 border-neutral-200' },
-    in_progress: { label: 'In Progress', cls: 'bg-amber-50 text-amber-700 border-amber-200' },
-    done: { label: 'Done', cls: 'bg-green-50 text-green-700 border-green-200' },
-    blocked: { label: 'Blocked', cls: 'bg-red-50 text-red-700 border-red-200' },
-};
-
-type MilestoneStatus = 'not_started' | 'in_progress' | 'complete';
-
-const MILESTONE_STATUS_STYLE: Record<MilestoneStatus, { label: string; cls: string }> = {
-    not_started: { label: 'Not Started', cls: 'bg-neutral-100 text-neutral-700 border-neutral-200' },
-    in_progress: { label: 'In Progress', cls: 'bg-amber-50 text-amber-700 border-amber-200' },
-    complete: { label: 'Complete', cls: 'bg-green-50 text-green-700 border-green-200' },
-};
-
-function deriveMilestoneStatus(tasks: ImplementationPlanTask[]): MilestoneStatus {
-    if (tasks.length === 0) return 'not_started';
-    if (tasks.every(t => t.status === 'todo')) return 'not_started';
-    if (tasks.every(t => t.status === 'done')) return 'complete';
-    return 'in_progress';
-}
-
-function TaskRow({
-    task,
-    titleById,
-}: {
-    task: ImplementationPlanTask;
-    titleById: Map<string, string>;
-}) {
-    const style = TASK_STATUS_STYLE[task.status] ?? TASK_STATUS_STYLE.todo;
-    const deps = task.dependencies?.filter(Boolean) ?? [];
-    const links = task.linkedArtifacts;
-    const linkSegments: string[] = [];
-    if (links?.prd?.length) linkSegments.push(`PRD: ${links.prd.join(', ')}`);
-    if (links?.dataModel?.length) linkSegments.push(`Data: ${links.dataModel.join(', ')}`);
-    if (links?.mockups?.length) linkSegments.push(`Mockups: ${links.mockups.join(', ')}`);
-
-    return (
-        <li className="py-2 first:pt-0 last:pb-0 border-b border-neutral-100 last:border-b-0">
-            <div className="flex items-start gap-2">
-                <span
-                    className={`shrink-0 mt-0.5 text-[10px] px-1.5 py-0.5 rounded border font-medium ${style.cls}`}
-                >
-                    {style.label}
-                </span>
-                <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-neutral-900 leading-snug">{task.title}</p>
-                    {task.description && (
-                        <p className="text-xs text-neutral-600 mt-0.5">{task.description}</p>
-                    )}
-                    {deps.length > 0 && (
-                        <p className="text-[11px] text-neutral-500 mt-1">
-                            <span className="font-semibold">Depends on:</span>{' '}
-                            {deps.map(id => titleById.get(id) ?? id).join(', ')}
-                        </p>
-                    )}
-                    {linkSegments.length > 0 && (
-                        <p className="text-[11px] text-neutral-500 mt-0.5">
-                            <span className="font-semibold">Linked:</span> {linkSegments.join(' · ')}
-                        </p>
-                    )}
-                </div>
-            </div>
-        </li>
+export function ImplementationPlanRenderer({ content, promptPackContent }: Props) {
+    const consolidated = useMemo(
+        () => {
+            try {
+                return buildConsolidatedPlan({ planContent: content, promptPackContent });
+            } catch {
+                // Malformed/partial data must never break the page — fall back
+                // to the legacy renderer, which degrades to plain markdown.
+                return null;
+            }
+        },
+        [content, promptPackContent],
     );
-}
-
-function MilestoneTaskGroup({
-    milestone,
-    index,
-    titleById,
-}: {
-    milestone: ImplementationPlanMilestone;
-    index: number;
-    titleById: Map<string, string>;
-}) {
-    const completed = milestone.tasks.filter(t => t.status === 'done').length;
-    const total = milestone.tasks.length;
-    const status = deriveMilestoneStatus(milestone.tasks);
-    const statusStyle = MILESTONE_STATUS_STYLE[status];
-
-    return (
-        <article className="bg-white rounded-xl border border-neutral-200 p-5">
-            <header className="flex items-start gap-3 mb-3 pb-3 border-b border-neutral-100">
-                <div className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-lg bg-indigo-600 text-white text-sm font-bold">
-                    M{index + 1}
-                </div>
-                <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                        <h3 className="text-base font-bold text-neutral-900 leading-snug">{milestone.name}</h3>
-                        <span
-                            className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${statusStyle.cls}`}
-                        >
-                            {statusStyle.label}
-                        </span>
-                    </div>
-                    <div className="flex items-center gap-3 text-[11px] text-neutral-500 mt-0.5">
-                        {milestone.timeframe && (
-                            <span className="flex items-center gap-1">
-                                <Calendar size={11} />
-                                {milestone.timeframe}
-                            </span>
-                        )}
-                        <span>
-                            {completed}/{total} tasks
-                        </span>
-                    </div>
-                    {milestone.goal && (
-                        <p className="flex items-start gap-1.5 text-sm text-neutral-700 mt-2">
-                            <Target size={12} className="mt-1 shrink-0 text-neutral-500" />
-                            <span>{milestone.goal}</span>
-                        </p>
-                    )}
-                </div>
-            </header>
-            {milestone.tasks.length > 0 ? (
-                <ul>
-                    {milestone.tasks.map(t => (
-                        <TaskRow key={t.id} task={t} titleById={titleById} />
-                    ))}
-                </ul>
-            ) : (
-                <p className="text-xs text-neutral-500 italic">No tasks defined.</p>
-            )}
-        </article>
-    );
-}
-
-function StructuredPlanView({ plan }: { plan: StructuredImplementationPlan }) {
-    const [tab, setTab] = useState<TopTabId>('tasks');
-
-    const titleById = useMemo(() => {
-        const map = new Map<string, string>();
-        for (const m of plan.milestones) {
-            for (const t of m.tasks) map.set(t.id, t.title);
-        }
-        return map;
-    }, [plan]);
-
-    const tabs: { id: TopTabId; label: string; count?: number }[] = [
-        { id: 'tasks', label: 'Tasks', count: plan.milestones.reduce((n, m) => n + m.tasks.length, 0) },
-        { id: 'architecture', label: 'Architecture', count: plan.architecture?.length },
-        { id: 'risks', label: 'Risks', count: plan.risks?.length },
-        { id: 'definition_of_done', label: 'Definition of Done', count: plan.definitionOfDone?.length },
-    ];
-
-    return (
-        <div className="space-y-5">
-            {plan.overview?.summary && (
-                <div className="bg-neutral-50 rounded-xl border border-neutral-200 p-4">
-                    <p className="text-sm text-neutral-800">{plan.overview.summary}</p>
-                    {(plan.overview.criticalPath || plan.overview.teamSize) && (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3 text-xs text-neutral-700">
-                            {plan.overview.criticalPath && (
-                                <div>
-                                    <span className="font-semibold text-neutral-600">Critical Path: </span>
-                                    {plan.overview.criticalPath}
-                                </div>
-                            )}
-                            {plan.overview.teamSize && (
-                                <div>
-                                    <span className="font-semibold text-neutral-600">Team: </span>
-                                    {plan.overview.teamSize}
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
-            )}
-
-            <nav className="flex flex-wrap gap-1 border-b border-neutral-200">
-                {tabs.map(t => {
-                    const active = tab === t.id;
-                    return (
-                        <button
-                            key={t.id}
-                            type="button"
-                            onClick={() => setTab(t.id)}
-                            className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-                                active
-                                    ? 'border-indigo-600 text-indigo-700'
-                                    : 'border-transparent text-neutral-600 hover:text-neutral-900'
-                            }`}
-                        >
-                            {t.label}
-                            {typeof t.count === 'number' && t.count > 0 && (
-                                <span className="ml-1.5 text-[10px] text-neutral-500">({t.count})</span>
-                            )}
-                        </button>
-                    );
-                })}
-            </nav>
-
-            {tab === 'tasks' && (
-                <div className="space-y-4">
-                    {plan.milestones.map((m, i) => (
-                        <MilestoneTaskGroup key={m.id} milestone={m} index={i} titleById={titleById} />
-                    ))}
-                </div>
-            )}
-
-            {tab === 'architecture' && (
-                <div className="bg-white rounded-xl border border-neutral-200 p-5">
-                    {plan.architecture?.length ? (
-                        <ul className="space-y-2 text-sm text-neutral-800">
-                            {plan.architecture.map((a, i) => (
-                                <li key={i} className="flex items-start gap-2">
-                                    <Layers size={14} className="mt-0.5 shrink-0 text-neutral-500" />
-                                    <span>{inlineMd(a)}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    ) : (
-                        <p className="text-sm text-neutral-500 italic">No architecture decisions captured.</p>
-                    )}
-                </div>
-            )}
-
-            {tab === 'risks' && (
-                <div className="space-y-3">
-                    {plan.risks?.length ? (
-                        plan.risks.map((r, i) => (
-                            <article key={i} className="bg-white rounded-xl border border-neutral-200 p-4">
-                                <p className="flex items-start gap-2 text-sm font-semibold text-neutral-900">
-                                    <Flag size={14} className="mt-0.5 shrink-0 text-red-500" />
-                                    <span>{r.description}</span>
-                                </p>
-                                {r.mitigation && (
-                                    <p className="text-sm text-neutral-700 mt-2 ml-6">
-                                        <span className="font-semibold text-neutral-600">Mitigation: </span>
-                                        {r.mitigation}
-                                    </p>
-                                )}
-                            </article>
-                        ))
-                    ) : (
-                        <div className="bg-white rounded-xl border border-neutral-200 p-5">
-                            <p className="text-sm text-neutral-500 italic">No risks captured.</p>
-                        </div>
-                    )}
-                </div>
-            )}
-
-            {tab === 'definition_of_done' && (
-                <div className="bg-white rounded-xl border border-neutral-200 p-5">
-                    {plan.definitionOfDone?.length ? (
-                        <ul className="space-y-2">
-                            {plan.definitionOfDone.map((d, i) => (
-                                <li key={i} className="flex items-start gap-2 text-sm text-neutral-800">
-                                    <input
-                                        type="checkbox"
-                                        readOnly
-                                        aria-label={d}
-                                        className="mt-1 rounded border-neutral-300 cursor-default"
-                                    />
-                                    <span>{inlineMd(d)}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    ) : (
-                        <p className="text-sm text-neutral-500 italic">No definition of done captured.</p>
-                    )}
-                </div>
-            )}
-        </div>
-    );
-}
-
-export function ImplementationPlanRenderer({ content }: Props) {
-    const structured = useMemo(() => extractStructuredPlan(content), [content]);
-    if (structured) {
-        return <StructuredPlanView plan={structured} />;
+    if (consolidated) {
+        return <ConsolidatedPlanView plan={consolidated} />;
     }
     return <LegacyTimeline content={content} />;
 }

--- a/src/components/renderers/PromptPackRenderer.tsx
+++ b/src/components/renderers/PromptPackRenderer.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, Check, Copy, Pencil, RotateCcw, ShieldCheck } from 'luci
 import { ArtifactOutlineNav, type ArtifactOutlineItem } from '../ArtifactOutlineNav';
 import { useArtifactOutline } from '../../lib/useArtifactOutline';
 import { useIsMobile } from '../../lib/useIsMobile';
+import { parsePromptPack, type PromptCard } from '../../lib/services/promptPackParser';
 import type { Feature } from '../../types';
 
 // Render a `prompt_pack` artifact as a vertical document — one card per
@@ -31,82 +32,8 @@ interface Props {
     versionNumber?: number;
 }
 
-type PromptCard = {
-    index: number;
-    title: string;
-    category?: string;
-    promptBody: string;
-    expected?: string;
-};
-
-const PROMPT_HEADING = /^###\s+(\d+)\.?\s+(.+?)\s*$/;
-
-function parsePromptPack(markdown: string): { preamble: string; cards: PromptCard[] } {
-    const lines = markdown.split('\n');
-    const preambleLines: string[] = [];
-    const cards: PromptCard[] = [];
-    let active: { rawLines: string[]; index: number; title: string } | null = null;
-    let inMilestones = false;
-
-    for (const line of lines) {
-        const heading = line.match(PROMPT_HEADING);
-        if (heading) {
-            if (active) cards.push(buildCard(active));
-            active = { rawLines: [], index: Number(heading[1]), title: heading[2] };
-            inMilestones = true;
-            continue;
-        }
-        if (active) {
-            active.rawLines.push(line);
-        } else if (!inMilestones) {
-            preambleLines.push(line);
-        }
-    }
-    if (active) cards.push(buildCard(active));
-    return { preamble: preambleLines.join('\n').trim(), cards };
-}
-
-function buildCard(active: { rawLines: string[]; index: number; title: string }): PromptCard {
-    const card: PromptCard = {
-        index: active.index,
-        title: active.title,
-        promptBody: '',
-    };
-    let inFence = false;
-    const promptLines: string[] = [];
-    let collectExpected = false;
-    const expectedLines: string[] = [];
-
-    for (const line of active.rawLines) {
-        if (/^```/.test(line.trim())) {
-            inFence = !inFence;
-            continue;
-        }
-        if (inFence) {
-            promptLines.push(line);
-            continue;
-        }
-        const cat = line.match(/^\*\*Category:\*\*\s*(.+)$/i);
-        if (cat) {
-            card.category = cat[1].trim();
-            continue;
-        }
-        const exp = line.match(/^\*\*Expected Output:\*\*\s*(.*)$/i);
-        if (exp) {
-            collectExpected = true;
-            if (exp[1].trim()) expectedLines.push(exp[1].trim());
-            continue;
-        }
-        if (collectExpected) {
-            expectedLines.push(line);
-        }
-    }
-    card.promptBody = promptLines.join('\n').trim();
-    if (expectedLines.length > 0) {
-        card.expected = expectedLines.join('\n').trim();
-    }
-    return card;
-}
+// Prompt-card parsing now lives in `src/lib/services/promptPackParser.ts`
+// so the implementation-plan adapter can share the same rules.
 
 // Find feature IDs (e.g. f1, F-014) that appear OUTSIDE a "## Features In
 // Scope" section. Dangling IDs aren't usable when the prompt is copied

--- a/src/components/renderers/implementationPlan/ConsolidatedPlanView.tsx
+++ b/src/components/renderers/implementationPlan/ConsolidatedPlanView.tsx
@@ -341,6 +341,15 @@ function OverviewTab({ plan, onOpenMilestones }: { plan: ConsolidatedImplementat
                     </ul>
                 </div>
             )}
+
+            {/* Unrecognized legacy appendix prose — preserved so nothing is
+                lost when an old markdown plan renders through this view. */}
+            {plan.appendixNotes && (
+                <div className="bg-neutral-50 rounded-xl border border-neutral-200 p-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">Notes</p>
+                    <p className="text-sm text-neutral-700 whitespace-pre-wrap">{plan.appendixNotes}</p>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/renderers/implementationPlan/ConsolidatedPlanView.tsx
+++ b/src/components/renderers/implementationPlan/ConsolidatedPlanView.tsx
@@ -1,0 +1,470 @@
+import { useMemo, useState } from 'react';
+import {
+    AlertTriangle,
+    ArrowRight,
+    CheckCircle2,
+    ClipboardList,
+    Flag,
+    Layers,
+    ShieldCheck,
+    Sparkles,
+    XCircle,
+} from 'lucide-react';
+import type {
+    ConsolidatedImplementationPlan,
+    ImplementationQualityGate,
+    QualityGateCategory,
+} from '../../../types';
+import {
+    collectAllPromptPacks,
+    consolidatedPlanToMarkdown,
+    promptPackToClipboardText,
+} from '../../../lib/services/implementationPlanAdapter';
+import { CopyTextButton } from './CopyTextButton';
+import { MilestoneCard } from './MilestoneCard';
+import { PromptPackCard } from './PromptPackCard';
+import { QualityGateRow } from './QualityGateRow';
+import { GATE_CATEGORY_LABELS, GATE_CATEGORY_ORDER } from './gateCategories';
+
+type TabId = 'overview' | 'milestones' | 'prompt_packs' | 'quality_gates' | 'traceability';
+
+const READINESS_STYLE = {
+    ready: { icon: CheckCircle2, cls: 'bg-emerald-50 border-emerald-200 text-emerald-800', label: 'Ready to build' },
+    needs_review: { icon: AlertTriangle, cls: 'bg-amber-50 border-amber-200 text-amber-800', label: 'Needs review' },
+    blocked: { icon: XCircle, cls: 'bg-red-50 border-red-200 text-red-800', label: 'Blocked' },
+} as const;
+
+interface Props {
+    plan: ConsolidatedImplementationPlan;
+}
+
+/**
+ * The consolidated Implementation Plan view: one place that connects
+ * milestones, tasks, prompt packs, linked artifacts, quality gates,
+ * validation commands, and definitions of done.
+ *
+ * Tabs scroll horizontally on mobile; the traceability matrix renders as a
+ * table on desktop and stacked cards on small screens.
+ */
+export function ConsolidatedPlanView({ plan }: Props) {
+    const [tab, setTab] = useState<TabId>('overview');
+
+    const milestoneNameById = useMemo(() => {
+        const map = new Map<string, string>();
+        plan.milestones.forEach(m => map.set(m.id, m.name));
+        return map;
+    }, [plan]);
+
+    const allPacks = useMemo(() => collectAllPromptPacks(plan), [plan]);
+    const allGates = useMemo(() => {
+        const rows: Array<{ gate: ImplementationQualityGate; milestoneName?: string }> = [];
+        plan.globalQualityGates.forEach(gate => rows.push({ gate }));
+        plan.milestones.forEach(m => (m.qualityGates ?? []).forEach(gate => rows.push({ gate, milestoneName: m.name })));
+        return rows;
+    }, [plan]);
+
+    const tabs: Array<{ id: TabId; label: string; count?: number }> = [
+        { id: 'overview', label: 'Overview' },
+        { id: 'milestones', label: 'Milestones', count: plan.milestones.length },
+        { id: 'prompt_packs', label: 'Prompt Packs', count: allPacks.length },
+        { id: 'quality_gates', label: 'Quality Gates', count: allGates.length },
+        { id: 'traceability', label: 'Traceability' },
+    ];
+
+    return (
+        <div className="space-y-4 not-prose">
+            {/* --- Tab nav (scrolls horizontally on mobile) ------------------ */}
+            <nav aria-label="Implementation plan sections" className="border-b border-neutral-200 -mx-1 px-1 overflow-x-auto">
+                <div className="flex gap-1 whitespace-nowrap">
+                    {tabs.map(t => {
+                        const active = tab === t.id;
+                        return (
+                            <button
+                                key={t.id}
+                                type="button"
+                                onClick={() => setTab(t.id)}
+                                className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors min-h-[40px] ${
+                                    active
+                                        ? 'border-indigo-600 text-indigo-700'
+                                        : 'border-transparent text-neutral-600 hover:text-neutral-900'
+                                }`}
+                            >
+                                {t.label}
+                                {typeof t.count === 'number' && t.count > 0 && (
+                                    <span className="ml-1.5 text-[10px] text-neutral-500">({t.count})</span>
+                                )}
+                            </button>
+                        );
+                    })}
+                </div>
+            </nav>
+
+            {tab === 'overview' && <OverviewTab plan={plan} onOpenMilestones={() => setTab('milestones')} />}
+
+            {tab === 'milestones' && (
+                <div className="space-y-3">
+                    {plan.milestones.length === 0 ? (
+                        <EmptyNote text="No milestones yet. Generate the Implementation Plan to get a milestone roadmap." />
+                    ) : (
+                        plan.milestones.map((m, i) => (
+                            <MilestoneCard
+                                key={m.id}
+                                milestone={m}
+                                index={i}
+                                milestoneNameById={milestoneNameById}
+                                defaultExpanded={i === 0}
+                            />
+                        ))
+                    )}
+                </div>
+            )}
+
+            {tab === 'prompt_packs' && (
+                <div className="space-y-4">
+                    {allPacks.length === 0 ? (
+                        <EmptyNote text="No prompt packs yet. Regenerate the Implementation Plan to get copy-ready coding-agent prompts per milestone." />
+                    ) : (
+                        <>
+                            <div className="flex items-center justify-end">
+                                <CopyTextButton
+                                    text={allPacks.map(promptPackToClipboardText).join('\n\n---\n\n')}
+                                    label="Copy all prompt packs"
+                                    variant="secondary"
+                                />
+                            </div>
+                            {plan.milestones.map((m, i) =>
+                                (m.promptPacks?.length ?? 0) > 0 ? (
+                                    <section key={m.id}>
+                                        <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-2">
+                                            Milestone {i + 1} · {m.name}
+                                        </p>
+                                        <div className="space-y-3">
+                                            {m.promptPacks!.map(pack => (
+                                                <PromptPackCard key={pack.id} pack={pack} defaultCollapsed />
+                                            ))}
+                                        </div>
+                                    </section>
+                                ) : null,
+                            )}
+                            {plan.unassignedPromptPacks.length > 0 && (
+                                <section>
+                                    <p className="text-[11px] font-semibold uppercase tracking-wider text-amber-700 mb-2">
+                                        Unassigned Prompt Packs
+                                    </p>
+                                    <p className="text-xs text-neutral-500 mb-2">
+                                        These prompts couldn't be confidently matched to a milestone. They're
+                                        still ready to copy — run them where they fit in your build order.
+                                    </p>
+                                    <div className="space-y-3">
+                                        {plan.unassignedPromptPacks.map(pack => (
+                                            <PromptPackCard key={pack.id} pack={pack} defaultCollapsed />
+                                        ))}
+                                    </div>
+                                </section>
+                            )}
+                        </>
+                    )}
+                </div>
+            )}
+
+            {tab === 'quality_gates' && <QualityGatesTab plan={plan} />}
+
+            {tab === 'traceability' && <TraceabilityTab plan={plan} />}
+
+            {/* --- Export / copy actions ------------------------------------- */}
+            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2.5">
+                <ClipboardList size={15} className="text-neutral-400 shrink-0" aria-hidden="true" />
+                <p className="text-xs text-neutral-500 mr-auto">Take this plan to your coding agent:</p>
+                <CopyTextButton text={consolidatedPlanToMarkdown(plan)} label="Copy plan as markdown" variant="secondary" />
+                {allPacks.length > 0 && (
+                    <CopyTextButton
+                        text={allPacks.map(promptPackToClipboardText).join('\n\n---\n\n')}
+                        label="Copy all prompt packs"
+                        variant="secondary"
+                    />
+                )}
+            </div>
+        </div>
+    );
+}
+
+function EmptyNote({ text }: { text: string }) {
+    return (
+        <div className="bg-white rounded-xl border border-neutral-200 p-5">
+            <p className="text-sm text-neutral-500 italic">{text}</p>
+        </div>
+    );
+}
+
+// --- Overview -------------------------------------------------------------
+
+function OverviewTab({ plan, onOpenMilestones }: { plan: ConsolidatedImplementationPlan; onOpenMilestones: () => void }) {
+    const readiness = READINESS_STYLE[plan.readiness.status];
+    const ReadinessIcon = readiness.icon;
+    const packCount = collectAllPromptPacks(plan).length;
+
+    return (
+        <div className="space-y-4">
+            {/* Readiness */}
+            <div className={`rounded-xl border px-4 py-3 ${readiness.cls}`}>
+                <p className="flex items-center gap-2 text-sm font-semibold">
+                    <ReadinessIcon size={15} /> {readiness.label}
+                </p>
+                {plan.readiness.recommendedNextStep && (
+                    <p className="flex items-start gap-1.5 text-xs mt-1.5">
+                        <ArrowRight size={12} className="mt-0.5 shrink-0" />
+                        {plan.readiness.recommendedNextStep}
+                    </p>
+                )}
+                {plan.readiness.missingInputs.length > 0 && (
+                    <p className="text-xs mt-1.5">
+                        <span className="font-semibold">Missing inputs:</span>{' '}
+                        {plan.readiness.missingInputs.join(', ')}
+                    </p>
+                )}
+                {plan.readiness.warnings.length > 0 && (
+                    <ul className="mt-1.5 space-y-0.5 text-xs">
+                        {plan.readiness.warnings.map((w, i) => (
+                            <li key={i} className="flex items-start gap-1.5">
+                                <AlertTriangle size={11} className="mt-0.5 shrink-0" />
+                                {w}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            {/* Build strategy + stack */}
+            <div className="bg-white rounded-xl border border-neutral-200 p-4 space-y-3">
+                {plan.summary.buildStrategy && (
+                    <div>
+                        <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">
+                            <Sparkles size={11} /> Build Strategy
+                        </p>
+                        <p className="text-sm text-neutral-800">{plan.summary.buildStrategy}</p>
+                    </div>
+                )}
+                {(plan.summary.stackSummary?.length ?? 0) > 0 && (
+                    <div>
+                        <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
+                            <Layers size={11} /> Stack
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                            {plan.summary.stackSummary!.map((s, i) => (
+                                <span key={i} className="text-xs px-2 py-0.5 rounded-full bg-neutral-100 text-neutral-700 border border-neutral-200">
+                                    {s}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                )}
+                {(plan.summary.criticalPath?.length ?? 0) > 0 && (
+                    <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">Critical Path</p>
+                        <p className="text-sm text-neutral-800">
+                            {plan.summary.criticalPath!.join(' → ')}
+                        </p>
+                    </div>
+                )}
+                {(plan.summary.estimatedEffort || plan.summary.teamAssumption) && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs text-neutral-700">
+                        {plan.summary.estimatedEffort && (
+                            <div><span className="font-semibold text-neutral-600">Estimated Effort: </span>{plan.summary.estimatedEffort}</div>
+                        )}
+                        {plan.summary.teamAssumption && (
+                            <div><span className="font-semibold text-neutral-600">Team: </span>{plan.summary.teamAssumption}</div>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* Roadmap-at-a-glance */}
+            {plan.milestones.length > 0 && (
+                <div className="bg-white rounded-xl border border-neutral-200 p-4">
+                    <div className="flex items-center justify-between gap-2 mb-2">
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                            Roadmap · {plan.milestones.length} milestones · {packCount} prompt packs
+                        </p>
+                        <button
+                            type="button"
+                            onClick={onOpenMilestones}
+                            className="text-xs font-medium text-indigo-600 hover:text-indigo-800 transition"
+                        >
+                            Open milestones →
+                        </button>
+                    </div>
+                    <ol className="space-y-1.5">
+                        {plan.milestones.map((m, i) => (
+                            <li key={m.id} className="flex items-center gap-2 text-sm text-neutral-800 min-w-0">
+                                <span className="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-md bg-indigo-50 text-indigo-700 text-[11px] font-bold border border-indigo-100">
+                                    {i + 1}
+                                </span>
+                                <span className="truncate">{m.name}</span>
+                                <span className="ml-auto shrink-0 text-[11px] text-neutral-500">
+                                    {(m.promptPacks?.length ?? 0)} packs · {m.tasks.length} tasks
+                                </span>
+                            </li>
+                        ))}
+                    </ol>
+                </div>
+            )}
+
+            {/* Architecture + risks (legacy content preservation) */}
+            {plan.architecture.length > 0 && (
+                <div className="bg-white rounded-xl border border-neutral-200 p-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">Architecture Decisions</p>
+                    <ul className="space-y-1 text-sm text-neutral-800">
+                        {plan.architecture.map((a, i) => (
+                            <li key={i} className="flex items-start gap-2">
+                                <Layers size={13} className="mt-0.5 shrink-0 text-neutral-400" />
+                                <span>{a}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+            {plan.risks.length > 0 && (
+                <div className="bg-white rounded-xl border border-neutral-200 p-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">Risks</p>
+                    <ul className="space-y-1.5 text-sm text-neutral-800">
+                        {plan.risks.map((r, i) => (
+                            <li key={i} className="flex items-start gap-2">
+                                <Flag size={13} className="mt-0.5 shrink-0 text-red-500" />
+                                <span>
+                                    {r.description}
+                                    {r.mitigation && (
+                                        <span className="block text-xs text-neutral-500">Mitigation: {r.mitigation}</span>
+                                    )}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// --- Quality gates ----------------------------------------------------------
+
+function QualityGatesTab({ plan }: { plan: ConsolidatedImplementationPlan }) {
+    const byCategory = useMemo(() => {
+        const map = new Map<QualityGateCategory, Array<{ gate: ImplementationQualityGate; milestoneName?: string }>>();
+        const push = (gate: ImplementationQualityGate, milestoneName?: string) => {
+            const list = map.get(gate.category) ?? [];
+            list.push({ gate, milestoneName });
+            map.set(gate.category, list);
+        };
+        plan.globalQualityGates.forEach(g => push(g));
+        plan.milestones.forEach(m => (m.qualityGates ?? []).forEach(g => push(g, m.name)));
+        return map;
+    }, [plan]);
+
+    if (byCategory.size === 0) {
+        return <EmptyNote text="No quality gates yet. Regenerate the Implementation Plan to get per-milestone quality gates." />;
+    }
+
+    return (
+        <div className="space-y-4">
+            {GATE_CATEGORY_ORDER.filter(c => byCategory.has(c)).map(category => (
+                <div key={category} className="bg-white rounded-xl border border-neutral-200 p-4">
+                    <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-2">
+                        <ShieldCheck size={11} /> {GATE_CATEGORY_LABELS[category]}
+                    </p>
+                    <ul className="space-y-2">
+                        {byCategory.get(category)!.map(({ gate, milestoneName }, i) => (
+                            <li key={`${gate.id}-${i}`}>
+                                <ul><QualityGateRow gate={gate} /></ul>
+                                <p className="text-[10px] text-neutral-400 ml-6 mt-0.5">
+                                    {milestoneName ? `Milestone: ${milestoneName}` : 'Global gate'}
+                                </p>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+// --- Traceability -------------------------------------------------------------
+
+function TraceabilityTab({ plan }: { plan: ConsolidatedImplementationPlan }) {
+    const packTitleById = useMemo(() => {
+        const map = new Map<string, string>();
+        collectAllPromptPacks(plan).forEach(p => map.set(p.id, p.title));
+        return map;
+    }, [plan]);
+    const gateTitleById = useMemo(() => {
+        const map = new Map<string, string>();
+        plan.globalQualityGates.forEach(g => map.set(g.id, g.title));
+        plan.milestones.forEach(m => (m.qualityGates ?? []).forEach(g => map.set(g.id, g.title)));
+        return map;
+    }, [plan]);
+
+    const rows = plan.traceability;
+    const hasAnyLinks = rows.some(r =>
+        r.screens.length || r.dataModels.length || r.components.length || r.promptPackIds.length || r.qualityGateIds.length);
+
+    if (rows.length === 0 || !hasAnyLinks) {
+        return <EmptyNote text="No traceability links yet. Regenerate the Implementation Plan so milestones reference screens, data models, and components from your other assets." />;
+    }
+
+    const cell = (items: string[]) =>
+        items.length ? items.join(', ') : <span className="text-neutral-300">—</span>;
+
+    return (
+        <div>
+            {/* Desktop: matrix table */}
+            <div className="hidden md:block bg-white rounded-xl border border-neutral-200 overflow-x-auto">
+                <table className="w-full text-left text-xs">
+                    <thead>
+                        <tr className="border-b border-neutral-200 text-[10px] uppercase tracking-wider text-neutral-500">
+                            <th className="px-3 py-2 font-semibold">Milestone</th>
+                            <th className="px-3 py-2 font-semibold">Screens</th>
+                            <th className="px-3 py-2 font-semibold">Data Models</th>
+                            <th className="px-3 py-2 font-semibold">Components</th>
+                            <th className="px-3 py-2 font-semibold">Prompt Packs</th>
+                            <th className="px-3 py-2 font-semibold">Quality Gates</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map(row => (
+                            <tr key={row.milestoneId} className="border-b border-neutral-100 last:border-b-0 align-top">
+                                <td className="px-3 py-2.5 font-medium text-neutral-900">{row.milestoneTitle}</td>
+                                <td className="px-3 py-2.5 text-neutral-700">{cell(row.screens)}</td>
+                                <td className="px-3 py-2.5 text-neutral-700">{cell(row.dataModels)}</td>
+                                <td className="px-3 py-2.5 text-neutral-700">{cell(row.components)}</td>
+                                <td className="px-3 py-2.5 text-neutral-700">{cell(row.promptPackIds.map(id => packTitleById.get(id) ?? id))}</td>
+                                <td className="px-3 py-2.5 text-neutral-700">{cell(row.qualityGateIds.map(id => gateTitleById.get(id) ?? id))}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* Mobile: stacked cards */}
+            <div className="md:hidden space-y-3">
+                {rows.map(row => (
+                    <div key={row.milestoneId} className="bg-white rounded-xl border border-neutral-200 p-4 space-y-1.5">
+                        <p className="text-sm font-bold text-neutral-900">{row.milestoneTitle}</p>
+                        {([
+                            ['Screens', row.screens],
+                            ['Data Models', row.dataModels],
+                            ['Components', row.components],
+                            ['Prompt Packs', row.promptPackIds.map(id => packTitleById.get(id) ?? id)],
+                            ['Quality Gates', row.qualityGateIds.map(id => gateTitleById.get(id) ?? id)],
+                        ] as Array<[string, string[]]>).map(([label, items]) =>
+                            items.length > 0 ? (
+                                <p key={label} className="text-xs text-neutral-700">
+                                    <span className="font-semibold text-neutral-500">{label}: </span>
+                                    {items.join(', ')}
+                                </p>
+                            ) : null,
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/renderers/implementationPlan/CopyTextButton.tsx
+++ b/src/components/renderers/implementationPlan/CopyTextButton.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { copyToClipboard } from '../../../lib/utils/copyToClipboard';
+
+interface Props {
+    text: string;
+    label: string;
+    /** Compact indigo pill (primary) or bordered neutral (secondary). */
+    variant?: 'primary' | 'secondary';
+}
+
+/** Small copy-to-clipboard button with a transient "Copied" state. */
+export function CopyTextButton({ text, label, variant = 'primary' }: Props) {
+    const [copied, setCopied] = useState(false);
+    const cls = variant === 'primary'
+        ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+        : 'border border-neutral-200 text-neutral-700 hover:bg-neutral-50';
+    return (
+        <button
+            type="button"
+            onClick={async () => {
+                const ok = await copyToClipboard(text);
+                if (ok) {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1500);
+                }
+            }}
+            className={`inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md transition min-h-[32px] ${cls}`}
+        >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+            {copied ? 'Copied' : label}
+        </button>
+    );
+}

--- a/src/components/renderers/implementationPlan/MilestoneCard.tsx
+++ b/src/components/renderers/implementationPlan/MilestoneCard.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import {
+    AppWindow,
+    Calendar,
+    ChevronDown,
+    ChevronUp,
+    Database,
+    Flag,
+    GitBranch,
+    Link2,
+    Puzzle,
+    ShieldCheck,
+    Target,
+    TerminalSquare,
+} from 'lucide-react';
+import type { ImplementationPlanMilestone, ImplementationPromptPack } from '../../../types';
+import { promptPackToClipboardText } from '../../../lib/services/implementationPlanAdapter';
+import { PromptPackCard } from './PromptPackCard';
+import { CopyTextButton } from './CopyTextButton';
+import { QualityGateRow } from './QualityGateRow';
+
+const PRIORITY_STYLE: Record<NonNullable<ImplementationPlanMilestone['priority']>, string> = {
+    critical: 'bg-red-50 text-red-700 border-red-200',
+    high: 'bg-amber-50 text-amber-700 border-amber-200',
+    medium: 'bg-sky-50 text-sky-700 border-sky-200',
+    low: 'bg-neutral-100 text-neutral-600 border-neutral-200',
+};
+
+function LinkedChips({ icon: Icon, label, items }: { icon: typeof Database; label: string; items: string[] }) {
+    if (items.length === 0) return null;
+    return (
+        <div className="flex items-start gap-1.5 min-w-0">
+            <Icon size={12} className="mt-0.5 shrink-0 text-neutral-400" />
+            <p className="text-[11px] text-neutral-600 leading-relaxed">
+                <span className="font-semibold text-neutral-500">{label}:</span>{' '}
+                {items.join(', ')}
+            </p>
+        </div>
+    );
+}
+
+interface Props {
+    milestone: ImplementationPlanMilestone;
+    index: number;
+    /** Resolve a milestone id in `dependencies` to its display name. */
+    milestoneNameById: Map<string, string>;
+    defaultExpanded?: boolean;
+}
+
+/**
+ * Full milestone detail: objective, linked artifacts, tasks, prompt packs,
+ * quality gates, validation commands, and definition of done. Header shows
+ * the compact roadmap facts (priority, effort, dependencies, counts).
+ */
+export function MilestoneCard({ milestone: m, index, milestoneNameById, defaultExpanded = false }: Props) {
+    const [expanded, setExpanded] = useState(defaultExpanded);
+    const packs: ImplementationPromptPack[] = m.promptPacks ?? [];
+    const gates = m.qualityGates ?? [];
+    const links = m.linkedArtifacts ?? {};
+    const objective = m.objective ?? m.goal;
+    const deps = (m.dependencies ?? []).map(d => milestoneNameById.get(d) ?? d);
+    const counts = [
+        `${m.tasks.length} task${m.tasks.length === 1 ? '' : 's'}`,
+        `${packs.length} prompt pack${packs.length === 1 ? '' : 's'}`,
+        `${gates.length} quality gate${gates.length === 1 ? '' : 's'}`,
+    ];
+    const allPromptsText = packs.map(promptPackToClipboardText).join('\n\n---\n\n');
+
+    return (
+        <article id={`impl-milestone-${m.id}`} className="bg-white rounded-xl border border-neutral-200 scroll-mt-24">
+            {/* --- Roadmap header (always visible) --------------------------- */}
+            <button
+                type="button"
+                onClick={() => setExpanded(prev => !prev)}
+                aria-expanded={expanded}
+                className="w-full text-left px-4 py-3.5 flex items-start gap-3"
+            >
+                <div className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-lg bg-indigo-600 text-white text-sm font-bold">
+                    M{index + 1}
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="text-base font-bold text-neutral-900 leading-snug">{m.name}</h3>
+                        {m.priority && (
+                            <span className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${PRIORITY_STYLE[m.priority]}`}>
+                                {m.priority}
+                            </span>
+                        )}
+                    </div>
+                    <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-[11px] text-neutral-500 mt-1">
+                        {(m.estimatedEffort ?? m.timeframe) && (
+                            <span className="flex items-center gap-1">
+                                <Calendar size={11} />
+                                {m.estimatedEffort ?? m.timeframe}
+                            </span>
+                        )}
+                        {counts.map((c, i) => <span key={i}>{c}</span>)}
+                    </div>
+                    {deps.length > 0 && (
+                        <p className="flex items-center gap-1 text-[11px] text-neutral-500 mt-1">
+                            <GitBranch size={11} className="shrink-0" />
+                            <span className="truncate">Depends on: {deps.join(', ')}</span>
+                        </p>
+                    )}
+                </div>
+                <span className="shrink-0 mt-1 text-neutral-400">
+                    {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                </span>
+            </button>
+
+            {/* --- Detail ----------------------------------------------------- */}
+            {expanded && (
+                <div className="px-4 pb-4 space-y-4 border-t border-neutral-100 pt-3">
+                    {objective && (
+                        <p className="flex items-start gap-1.5 text-sm text-neutral-800">
+                            <Target size={13} className="mt-0.5 shrink-0 text-indigo-500" />
+                            <span>{objective}</span>
+                        </p>
+                    )}
+
+                    {(links.screens?.length || links.dataModels?.length || links.components?.length
+                        || links.userFlows?.length || links.apis?.length || links.risks?.length) ? (
+                        <div className="rounded-lg bg-neutral-50 border border-neutral-200 px-3 py-2.5 space-y-1.5">
+                            <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                                <Link2 size={11} /> Linked Synapse Artifacts
+                            </p>
+                            <LinkedChips icon={AppWindow} label="Screens" items={links.screens ?? []} />
+                            <LinkedChips icon={Database} label="Data Models" items={links.dataModels ?? []} />
+                            <LinkedChips icon={Puzzle} label="Components" items={links.components ?? []} />
+                            <LinkedChips icon={GitBranch} label="User Flows" items={links.userFlows ?? []} />
+                            <LinkedChips icon={TerminalSquare} label="APIs" items={links.apis ?? []} />
+                            <LinkedChips icon={Flag} label="Risks" items={links.risks ?? []} />
+                        </div>
+                    ) : null}
+
+                    {m.tasks.length > 0 && (
+                        <div>
+                            <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
+                                Implementation Tasks
+                            </p>
+                            <ul className="space-y-1">
+                                {m.tasks.map(t => (
+                                    <li key={t.id} className="flex items-start gap-2 text-sm text-neutral-800">
+                                        <input
+                                            type="checkbox"
+                                            checked={t.status === 'done'}
+                                            readOnly
+                                            aria-label={t.title}
+                                            className="mt-1 rounded border-neutral-300 cursor-default"
+                                        />
+                                        <span>
+                                            {t.title}
+                                            {t.description && (
+                                                <span className="block text-xs text-neutral-500">{t.description}</span>
+                                            )}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {packs.length > 0 && (
+                        <div>
+                            <div className="flex items-center justify-between gap-2 mb-1.5">
+                                <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+                                    Prompt Packs
+                                </p>
+                                {packs.length > 1 && (
+                                    <CopyTextButton text={allPromptsText} label="Copy milestone prompts" variant="secondary" />
+                                )}
+                            </div>
+                            <div className="space-y-3">
+                                {packs.map(pack => (
+                                    <PromptPackCard key={pack.id} pack={pack} defaultCollapsed={packs.length > 1} />
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {gates.length > 0 && (
+                        <div>
+                            <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
+                                <ShieldCheck size={11} /> Quality Gates
+                            </p>
+                            <ul className="space-y-1">
+                                {gates.map(g => <QualityGateRow key={g.id} gate={g} />)}
+                            </ul>
+                        </div>
+                    )}
+
+                    {(m.validationCommands?.length ?? 0) > 0 && (
+                        <div>
+                            <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
+                                <TerminalSquare size={11} /> Validation Commands
+                            </p>
+                            <div className="bg-neutral-900 text-neutral-100 rounded-lg px-3 py-2 text-xs font-mono space-y-0.5 overflow-x-auto">
+                                {m.validationCommands!.map((c, i) => <p key={i}>$ {c}</p>)}
+                            </div>
+                        </div>
+                    )}
+
+                    {(m.definitionOfDone?.length ?? 0) > 0 && (
+                        <div>
+                            <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5">
+                                Definition of Done
+                            </p>
+                            <ul className="space-y-1">
+                                {m.definitionOfDone!.map((d, i) => (
+                                    <li key={i} className="flex items-start gap-2 text-sm text-neutral-800">
+                                        <input type="checkbox" readOnly aria-label={d} className="mt-1 rounded border-neutral-300 cursor-default" />
+                                        <span>{d}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </article>
+    );
+}

--- a/src/components/renderers/implementationPlan/PromptPackCard.tsx
+++ b/src/components/renderers/implementationPlan/PromptPackCard.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp, GitCommitHorizontal, Target } from 'lucide-react';
+import type { ImplementationPromptPack } from '../../../types';
+import { promptPackToClipboardText } from '../../../lib/services/implementationPlanAdapter';
+import { CopyTextButton } from './CopyTextButton';
+
+interface Props {
+    pack: ImplementationPromptPack;
+    /** Name of the milestone this pack belongs to; shown as a chip. */
+    milestoneName?: string;
+    /** Collapse the prompt body by default (used in dense lists). */
+    defaultCollapsed?: boolean;
+}
+
+/**
+ * One copy-ready coding-agent prompt: purpose, scope, acceptance criteria,
+ * commit guidance, and the prompt body itself. Copy always uses
+ * `promptPackToClipboardText` so criteria/commit guidance travel with the
+ * prompt when they aren't already part of it.
+ */
+export function PromptPackCard({ pack, milestoneName, defaultCollapsed = false }: Props) {
+    const [expanded, setExpanded] = useState(!defaultCollapsed);
+    return (
+        <article className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
+            <header className="px-4 py-3 border-b border-neutral-100">
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <div className="min-w-0">
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-indigo-600">
+                            Prompt Pack
+                        </p>
+                        <h4 className="text-sm font-bold text-neutral-900 leading-snug mt-0.5">{pack.title}</h4>
+                        <p className="text-xs text-neutral-600 mt-0.5">{pack.purpose}</p>
+                        <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+                            {milestoneName && (
+                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-700 border border-indigo-100 font-medium">
+                                    {milestoneName}
+                                </span>
+                            )}
+                            {pack.category && (
+                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600 border border-neutral-200">
+                                    {pack.category}
+                                </span>
+                            )}
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                        <CopyTextButton text={promptPackToClipboardText(pack)} label="Copy Prompt" />
+                        <button
+                            type="button"
+                            onClick={() => setExpanded(prev => !prev)}
+                            aria-label={expanded ? 'Collapse prompt' : 'Expand prompt'}
+                            className="inline-flex items-center justify-center w-8 h-8 rounded-md border border-neutral-200 text-neutral-500 hover:bg-neutral-50 transition"
+                        >
+                            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                        </button>
+                    </div>
+                </div>
+            </header>
+
+            {expanded && (
+                <>
+                    <div className="bg-neutral-900 text-neutral-100 px-4 py-3 text-xs font-mono whitespace-pre-wrap leading-relaxed max-h-72 overflow-y-auto">
+                        {pack.prompt}
+                    </div>
+
+                    {(pack.scope?.include.length || pack.scope?.exclude.length) ? (
+                        <div className="px-4 py-3 border-t border-neutral-100 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            {pack.scope.include.length > 0 && (
+                                <div>
+                                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">In Scope</p>
+                                    <ul className="space-y-0.5 text-xs text-neutral-700">
+                                        {pack.scope.include.map((s, i) => <li key={i}>• {s}</li>)}
+                                    </ul>
+                                </div>
+                            )}
+                            {pack.scope.exclude.length > 0 && (
+                                <div>
+                                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">Out of Scope</p>
+                                    <ul className="space-y-0.5 text-xs text-neutral-700">
+                                        {pack.scope.exclude.map((s, i) => <li key={i}>• {s}</li>)}
+                                    </ul>
+                                </div>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {pack.acceptanceCriteria.length > 0 && (
+                        <div className="px-4 py-3 border-t border-neutral-100">
+                            <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-emerald-700 mb-1">
+                                <Target size={11} /> Acceptance Criteria
+                            </p>
+                            <ul className="space-y-0.5 text-xs text-neutral-700">
+                                {pack.acceptanceCriteria.map((c, i) => <li key={i}>• {c}</li>)}
+                            </ul>
+                        </div>
+                    )}
+
+                    {pack.recommendedCommitMessage && (
+                        <div className="px-4 py-2.5 border-t border-neutral-100 flex items-center gap-2">
+                            <GitCommitHorizontal size={13} className="text-neutral-400 shrink-0" />
+                            <code className="text-[11px] text-neutral-600 truncate">{pack.recommendedCommitMessage}</code>
+                        </div>
+                    )}
+                </>
+            )}
+        </article>
+    );
+}

--- a/src/components/renderers/implementationPlan/PromptPackCard.tsx
+++ b/src/components/renderers/implementationPlan/PromptPackCard.tsx
@@ -63,28 +63,30 @@ export function PromptPackCard({ pack, milestoneName, defaultCollapsed = false }
                         {pack.prompt}
                     </div>
 
-                    {(pack.scope?.include.length || pack.scope?.exclude.length) ? (
+                    {/* The adapter normalizes scope arrays, but stay defensive:
+                        partial model output may omit include/exclude. */}
+                    {(pack.scope?.include?.length || pack.scope?.exclude?.length) ? (
                         <div className="px-4 py-3 border-t border-neutral-100 grid grid-cols-1 sm:grid-cols-2 gap-3">
-                            {pack.scope.include.length > 0 && (
+                            {(pack.scope.include?.length ?? 0) > 0 && (
                                 <div>
                                     <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">In Scope</p>
                                     <ul className="space-y-0.5 text-xs text-neutral-700">
-                                        {pack.scope.include.map((s, i) => <li key={i}>• {s}</li>)}
+                                        {pack.scope.include!.map((s, i) => <li key={i}>• {s}</li>)}
                                     </ul>
                                 </div>
                             )}
-                            {pack.scope.exclude.length > 0 && (
+                            {(pack.scope.exclude?.length ?? 0) > 0 && (
                                 <div>
                                     <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">Out of Scope</p>
                                     <ul className="space-y-0.5 text-xs text-neutral-700">
-                                        {pack.scope.exclude.map((s, i) => <li key={i}>• {s}</li>)}
+                                        {pack.scope.exclude!.map((s, i) => <li key={i}>• {s}</li>)}
                                     </ul>
                                 </div>
                             )}
                         </div>
                     ) : null}
 
-                    {pack.acceptanceCriteria.length > 0 && (
+                    {(pack.acceptanceCriteria?.length ?? 0) > 0 && (
                         <div className="px-4 py-3 border-t border-neutral-100">
                             <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-emerald-700 mb-1">
                                 <Target size={11} /> Acceptance Criteria

--- a/src/components/renderers/implementationPlan/QualityGateRow.tsx
+++ b/src/components/renderers/implementationPlan/QualityGateRow.tsx
@@ -1,0 +1,25 @@
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+import type { ImplementationQualityGate } from '../../../types';
+import { GATE_CATEGORY_LABELS } from './gateCategories';
+
+/** One quality gate line: required marker, title, category chip. */
+export function QualityGateRow({ gate }: { gate: ImplementationQualityGate }) {
+    const Icon = gate.required ? ShieldCheck : ShieldAlert;
+    return (
+        <li className="flex items-start gap-2 text-sm text-neutral-800">
+            <Icon size={14} className={`mt-0.5 shrink-0 ${gate.required ? 'text-emerald-600' : 'text-neutral-400'}`} />
+            <div className="min-w-0">
+                <span>{gate.title}</span>
+                {gate.description && (
+                    <span className="block text-xs text-neutral-500">{gate.description}</span>
+                )}
+                <span className="inline-flex items-center gap-1.5 mt-0.5">
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600 border border-neutral-200">
+                        {GATE_CATEGORY_LABELS[gate.category] ?? gate.category}
+                    </span>
+                    <span className="text-[10px] text-neutral-400">{gate.required ? 'Required' : 'Optional'}</span>
+                </span>
+            </div>
+        </li>
+    );
+}

--- a/src/components/renderers/implementationPlan/gateCategories.ts
+++ b/src/components/renderers/implementationPlan/gateCategories.ts
@@ -1,0 +1,25 @@
+import type { QualityGateCategory } from '../../../types';
+
+// Own module (not a component file) — the react-refresh/only-export-components
+// rule forbids constant exports from component files.
+export const GATE_CATEGORY_LABELS: Record<QualityGateCategory, string> = {
+    design_fidelity: 'Design fidelity',
+    functional: 'Functional',
+    data_integrity: 'Data integrity',
+    integration: 'Integration',
+    accessibility: 'Accessibility',
+    performance: 'Performance',
+    testing: 'Testing',
+    regression: 'Regression',
+};
+
+export const GATE_CATEGORY_ORDER: QualityGateCategory[] = [
+    'design_fidelity',
+    'functional',
+    'data_integrity',
+    'integration',
+    'accessibility',
+    'performance',
+    'testing',
+    'regression',
+];

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -40,6 +40,9 @@ interface DispatchProps {
      * journey nodes can open the matching Screen Detail view. */
     onNavigateToScreen?: (screenSlug: string) => void;
     availableScreenSlugs?: ReadonlySet<string>;
+    /** Only consumed by `implementation_plan`: content of the project's legacy
+     * standalone prompt_pack artifact, adapted into the consolidated view. */
+    promptPackContent?: string;
     /** Only consumed by `prompt_pack`; per-prompt user edit overlay keyed by index. */
     promptEdits?: Record<number, string>;
     /** Only consumed by `prompt_pack`; persists the new edit overlay. */
@@ -88,6 +91,7 @@ export function ArtifactContentRenderer({
     implementationPlan,
     onNavigateToScreen,
     availableScreenSlugs,
+    promptPackContent,
     promptEdits,
     onUpdatePromptEdits,
     generatedAt,
@@ -120,7 +124,7 @@ export function ArtifactContentRenderer({
         );
     }
     if (subtype === 'implementation_plan') {
-        return <ImplementationPlanRenderer content={content} />;
+        return <ImplementationPlanRenderer content={content} promptPackContent={promptPackContent} />;
     }
     if (subtype === 'prompt_pack') {
         return (

--- a/src/components/settings/ArtifactModelsSection.tsx
+++ b/src/components/settings/ArtifactModelsSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Box, FileText, Image as ImageIcon, ChevronDown, Sparkles } from 'lucide-react';
 import { MODEL_CATALOG, modelDisplayName } from '../../lib/modelCatalog';
-import { CORE_ARTIFACT_DISPLAY_ORDER } from '../../lib/coreArtifactPipeline';
+import { CORE_ARTIFACT_DISPLAY_ORDER, isRetiredArtifactSubtype } from '../../lib/coreArtifactPipeline';
 import { CORE_ARTIFACT_COMPLEXITY } from '../../lib/artifactModelSettings';
 import type { MockupImageMode } from '../../lib/artifactModelSettings';
 import { DEFAULT_PRD_SECTIONS, selectModelTier } from '../../lib/services/progressivePrdGeneration';
@@ -136,8 +136,10 @@ export function ArtifactModelsSection({
                     )}
                 </ArtifactRow>
 
-                {/* Text artifacts — one model selector each. */}
-                {CORE_ARTIFACT_DISPLAY_ORDER.map((meta) => {
+                {/* Text artifacts — one model selector each. Retired subtypes
+                    (prompt_pack, folded into the Implementation Plan) no longer
+                    generate, so they get no model row. */}
+                {CORE_ARTIFACT_DISPLAY_ORDER.filter((meta) => !isRetiredArtifactSubtype(meta.subtype)).map((meta) => {
                     const value = overrides[meta.subtype] ?? recommendedModel(meta.subtype);
                     return (
                         <ArtifactRow

--- a/src/components/tour/tourData.ts
+++ b/src/components/tour/tourData.ts
@@ -5,7 +5,6 @@ import {
     Boxes,
     Terminal,
     Palette,
-    MessageSquare,
     type LucideIcon,
 } from 'lucide-react';
 
@@ -233,13 +232,21 @@ export const TOUR_ASSETS: TourAsset[] = [
         preview: ['Button', 'Waveform', 'TrackRow', 'Transport bar', 'Mixer fader'],
     },
     {
+        // Consolidated Development artifact: milestones now carry their own
+        // prompt packs and quality gates (the old standalone Prompt Pack card
+        // folded into this one).
         id: 'implementation_plan',
         name: 'Implementation Plan',
-        tagline: 'Tech stack & architecture',
+        tagline: 'Milestones, prompt packs & quality gates',
         icon: Terminal,
         accent: 'text-amber-300 bg-amber-500/10',
         previewKind: 'roadmap',
-        preview: ['Phase 1 — Capture & projects', 'Phase 2 — Arrangement', 'Phase 3 — Collaboration', 'Phase 4 — Export'],
+        preview: [
+            'M1 — Capture & projects · 2 prompt packs',
+            'M2 — Arrangement · 2 prompt packs',
+            'M3 — Collaboration · 1 prompt pack',
+            'M4 — Export & launch · quality gates',
+        ],
     },
     {
         id: 'design_system',
@@ -249,19 +256,6 @@ export const TOUR_ASSETS: TourAsset[] = [
         accent: 'text-pink-300 bg-pink-500/10',
         previewKind: 'palette',
         preview: ['Indigo / primary', 'Neutral / surface', 'Emerald / success', 'Display / heading', 'Body / text'],
-    },
-    {
-        id: 'prompt_pack',
-        name: 'Prompt Pack',
-        tagline: 'AI prompts for future updates',
-        icon: MessageSquare,
-        accent: 'text-teal-300 bg-teal-500/10',
-        previewKind: 'prompt',
-        preview: [
-            'Add a metronome to the song editor.',
-            'Generate onboarding copy for first-time creators.',
-            'Draft release notes for v2.',
-        ],
     },
 ];
 

--- a/src/lib/__tests__/coreArtifactPipeline.test.ts
+++ b/src/lib/__tests__/coreArtifactPipeline.test.ts
@@ -2,10 +2,16 @@ import { describe, it, expect } from 'vitest';
 import {
     CORE_ARTIFACT_PIPELINE,
     HIDDEN_ARTIFACT_SUBTYPES,
+    RETIRED_ARTIFACT_SUBTYPES,
     buildDependencyLayers,
     getArtifactMeta,
     isHiddenArtifactSubtype,
+    isRetiredArtifactSubtype,
 } from '../coreArtifactPipeline';
+
+// Retired subtypes never generate, so the parallelism/depth UX properties
+// below are asserted over the pipeline that actually runs.
+const ACTIVE_PIPELINE = CORE_ARTIFACT_PIPELINE.filter(m => !isRetiredArtifactSubtype(m.subtype));
 
 describe('coreArtifactPipeline', () => {
     it('every dependency references a real subtype', () => {
@@ -30,17 +36,19 @@ describe('coreArtifactPipeline', () => {
         }
     });
 
-    it('parallelism: layer 1 fans out to >= 4 artifacts so generation feels parallel', () => {
-        const layers = buildDependencyLayers();
+    it('parallelism: layer 1 fans out to >= 3 artifacts so generation feels parallel', () => {
+        const layers = buildDependencyLayers(ACTIVE_PIPELINE);
         // The first layer dictates the initial concurrency the user sees in
-        // the right rail. Anything less than 4 means the UI shows a single
-        // spinner at start, which feels sequential. This is intentionally a
-        // stronger floor than the topological-validity check.
-        expect(layers[0].length).toBeGreaterThanOrEqual(4);
+        // the right rail. Too few means the UI shows a single spinner at
+        // start, which feels sequential. This is intentionally a stronger
+        // floor than the topological-validity check. (The floor moved from 4
+        // to 3 when implementation_plan gained true data deps on
+        // screen_inventory + data_model for milestone prompt packs.)
+        expect(layers[0].length).toBeGreaterThanOrEqual(3);
     });
 
     it('depth: <= 2 sequential layers so the worst-case waiter is one hop deep', () => {
-        const layers = buildDependencyLayers();
+        const layers = buildDependencyLayers(ACTIVE_PIPELINE);
         expect(layers.length).toBeLessThanOrEqual(2);
     });
 
@@ -59,6 +67,32 @@ describe('coreArtifactPipeline', () => {
         expect(isHiddenArtifactSubtype('component_inventory')).toBe(true);
         expect(isHiddenArtifactSubtype('screen_inventory')).toBe(false);
         expect(isHiddenArtifactSubtype('design_system')).toBe(false);
+    });
+
+    it('retired artifacts stay in the pipeline so legacy data keeps its meta', () => {
+        // Retired subtypes (prompt_pack) never generate, but persisted legacy
+        // artifacts still resolve titles/renderers through getArtifactMeta —
+        // removing one from the pipeline would make that throw.
+        const subtypes = new Set(CORE_ARTIFACT_PIPELINE.map(m => m.subtype));
+        for (const retired of RETIRED_ARTIFACT_SUBTYPES) {
+            expect(subtypes.has(retired)).toBe(true);
+        }
+    });
+
+    it('isRetiredArtifactSubtype retires prompt_pack and nothing that generates', () => {
+        expect(isRetiredArtifactSubtype('prompt_pack')).toBe(true);
+        expect(isRetiredArtifactSubtype('implementation_plan')).toBe(false);
+        expect(isRetiredArtifactSubtype('component_inventory')).toBe(false);
+    });
+
+    it('no retired artifact is a dependency of an active one', () => {
+        // An active artifact whose dep never generates would wait forever in
+        // buildDependencyLayers-driven runs (the layer filter would starve it).
+        for (const meta of ACTIVE_PIPELINE) {
+            for (const dep of meta.dependsOn) {
+                expect(isRetiredArtifactSubtype(dep)).toBe(false);
+            }
+        }
     });
 
     it('no hidden artifact is a hard dependency of a visible one', () => {

--- a/src/lib/__tests__/implementationPlanAdapter.test.ts
+++ b/src/lib/__tests__/implementationPlanAdapter.test.ts
@@ -220,6 +220,86 @@ Foundation then core.`;
         expect(plan!.readiness.missingInputs).toContain('Prompt packs');
     });
 
+    it('preserves the legacy markdown appendix (architecture, risks, DoD, critical path, notes)', () => {
+        const markdown = `# Implementation Plan
+
+Overall approach: ship a thin vertical slice first.
+
+### Milestone 1: Foundation (Week 1)
+**Goal:** Set up the project.
+**Key Deliverables:**
+- [ ] Initialize repository
+
+---
+
+## Architecture
+- Next.js frontend
+- Postgres database
+
+## Risks
+- **Vendor lock-in** — Mitigation: Abstract the storage layer
+
+## Definition of Done
+- [ ] All tests pass
+- [ ] Accessibility audit complete
+
+**Critical Path:** Foundation then launch
+**Team Size:** 2 devs
+
+Some extra hand-written appendix prose.`;
+        const plan = buildConsolidatedPlan({ planContent: markdown })!;
+        expect(plan.sources.plan).toBe('legacy_markdown');
+        // Preamble prose becomes the build strategy.
+        expect(plan.summary.buildStrategy).toContain('thin vertical slice');
+        // Appendix sections survive the consolidated view.
+        expect(plan.architecture).toEqual(['Next.js frontend', 'Postgres database']);
+        expect(plan.summary.stackSummary).toEqual(['Next.js frontend', 'Postgres database']);
+        expect(plan.summary.criticalPath).toEqual(['Foundation then launch']);
+        expect(plan.summary.teamAssumption).toBe('2 devs');
+        expect(plan.risks).toEqual([
+            { description: 'Vendor lock-in', mitigation: 'Abstract the storage layer' },
+        ]);
+        expect(plan.globalQualityGates.map(g => g.title)).toEqual([
+            'All tests pass',
+            'Accessibility audit complete',
+        ]);
+        expect(plan.appendixNotes).toContain('extra hand-written appendix prose');
+        // And it round-trips into the markdown export.
+        const md = consolidatedPlanToMarkdown(plan);
+        expect(md).toContain('Next.js frontend');
+        expect(md).toContain('extra hand-written appendix prose');
+    });
+
+    it('normalizes partial prompt-pack scope from native plans (schema-optional fields)', () => {
+        const partial: StructuredImplementationPlan = {
+            milestones: [
+                {
+                    id: 'm1',
+                    name: 'Setup',
+                    tasks: [],
+                    promptPacks: [
+                        {
+                            id: 'pp1',
+                            title: 'Partial scope pack',
+                            purpose: 'Test partial output.',
+                            prompt: '# Prompt',
+                            // scope.exclude / acceptanceCriteria omitted, as the
+                            // Gemini schema allows.
+                            scope: { include: ['Thing A'] } as never,
+                            acceptanceCriteria: undefined as never,
+                        },
+                    ],
+                },
+            ],
+        };
+        const plan = buildConsolidatedPlan({ planContent: fencePlan(partial) })!;
+        const pack = plan.milestones[0].promptPacks![0];
+        expect(pack.scope).toEqual({ include: ['Thing A'], exclude: [] });
+        expect(pack.acceptanceCriteria).toEqual([]);
+        // Copy helper must not throw on the normalized pack.
+        expect(promptPackToClipboardText(pack)).toContain('# Prompt');
+    });
+
     it('renders prompt packs alone when no plan exists', () => {
         const plan = buildConsolidatedPlan({ promptPackContent: LEGACY_PROMPT_PACK });
         expect(plan).not.toBeNull();

--- a/src/lib/__tests__/implementationPlanAdapter.test.ts
+++ b/src/lib/__tests__/implementationPlanAdapter.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildConsolidatedPlan,
+    collectAllPromptPacks,
+    consolidatedPlanToMarkdown,
+    promptPackToClipboardText,
+} from '../services/implementationPlanAdapter';
+import type { StructuredImplementationPlan } from '../../types';
+
+function fencePlan(plan: StructuredImplementationPlan): string {
+    return `# Implementation Plan\n\nSome preamble.\n\n\`\`\`json synapse-plan\n${JSON.stringify(plan, null, 2)}\n\`\`\``;
+}
+
+const NATIVE_PLAN: StructuredImplementationPlan = {
+    overview: { summary: 'Build in thin slices.', criticalPath: 'Setup → Core loop', teamSize: 'Solo dev' },
+    summary: {
+        buildStrategy: 'Ship a walking skeleton first, then layer features.',
+        stackSummary: ['React + Vite', 'Supabase'],
+        criticalPath: ['m_setup', 'm_core'],
+        estimatedEffort: '4 weeks',
+    },
+    milestones: [
+        {
+            id: 'm_setup',
+            name: 'Project Setup',
+            goal: 'Scaffold the app.',
+            objective: 'Stand up a deployable skeleton with CI.',
+            priority: 'critical',
+            estimatedEffort: '2 days',
+            dependencies: [],
+            linkedArtifacts: { screens: ['Landing'], dataModels: ['User'] },
+            tasks: [{ id: 't1', title: 'Initialize Vite app', status: 'todo' }],
+            promptPacks: [
+                {
+                    id: 'pp_setup',
+                    title: 'Scaffold the project',
+                    purpose: 'Create the initial repo structure.',
+                    prompt: '# Prompt: Scaffold\n## Goal\nSet up Vite.',
+                    acceptanceCriteria: ['App boots locally'],
+                    recommendedCommitMessage: 'chore: scaffold project',
+                },
+            ],
+            qualityGates: [
+                { id: 'qg1', title: 'Lint passes', category: 'testing', required: true },
+            ],
+            validationCommands: ['npm run lint'],
+            definitionOfDone: ['CI green on main'],
+        },
+        {
+            id: 'm_core',
+            name: 'Core Loop',
+            goal: 'Deliver the main flow.',
+            dependencies: ['m_setup'],
+            tasks: [{ id: 't2', title: 'Build capture screen', status: 'todo' }],
+            promptPacks: [
+                {
+                    id: 'pp_core',
+                    title: 'Implement capture flow',
+                    purpose: 'Build the capture screen.',
+                    prompt: '# Prompt: Capture\n## Goal\nBuild it.',
+                    acceptanceCriteria: ['Capture works'],
+                },
+            ],
+        },
+    ],
+    globalQualityGates: [
+        { id: 'g1', title: 'All P0 screens implemented', category: 'functional', required: true },
+    ],
+    architecture: ['SPA with serverless API'],
+    risks: [{ description: 'Third-party API rate limits', mitigation: 'Cache responses' }],
+    definitionOfDone: ['App deployed'],
+};
+
+const LEGACY_STRUCTURED: StructuredImplementationPlan = {
+    overview: { summary: 'Legacy overview.', criticalPath: 'M1 → M2', teamSize: '2 devs' },
+    milestones: [
+        {
+            id: 'm_auth',
+            name: 'Authentication and Accounts',
+            goal: 'Users can sign up and log in.',
+            tasks: [
+                { id: 't1', title: 'Build login screen', status: 'todo', linkedArtifacts: { mockups: ['Login'], dataModel: ['User'] } },
+                { id: 't2', title: 'Add session management', status: 'todo' },
+            ],
+        },
+        {
+            id: 'm_dash',
+            name: 'Dashboard Experience',
+            goal: 'Users see their data at a glance.',
+            tasks: [{ id: 't3', title: 'Build dashboard screen', status: 'todo' }],
+        },
+    ],
+    architecture: ['Next.js frontend', 'Postgres database'],
+    risks: [{ description: 'OAuth provider outages' }],
+    definitionOfDone: ['All tests pass', 'Accessibility audit complete'],
+};
+
+const LEGACY_PROMPT_PACK = `# Prompt Pack
+
+Ready-to-use prompts.
+
+### 1. Implement the authentication login screen
+**Category:** UI Implementation
+**Prompt:**
+\`\`\`
+# Task
+Build the login screen.
+
+## Features In Scope
+- f1 — Login
+  - Purpose: Let users authenticate.
+
+## Requirements
+- Email/password form validates input
+- Errors render inline
+\`\`\`
+**Expected Output:** A working login screen.
+
+### 2. Write haiku poetry about databases
+**Category:** Content
+**Prompt:**
+\`\`\`
+# Task
+Write copy.
+\`\`\`
+**Expected Output:** Marketing copy.
+`;
+
+describe('buildConsolidatedPlan', () => {
+    it('returns null when there is nothing to consolidate', () => {
+        expect(buildConsolidatedPlan({})).toBeNull();
+        expect(buildConsolidatedPlan({ planContent: '', promptPackContent: '  ' })).toBeNull();
+    });
+
+    it('passes a native consolidated plan through', () => {
+        const plan = buildConsolidatedPlan({ planContent: fencePlan(NATIVE_PLAN) });
+        expect(plan).not.toBeNull();
+        expect(plan!.sources).toEqual({ plan: 'structured', promptPacks: 'native' });
+        expect(plan!.readiness.status).toBe('ready');
+        expect(plan!.milestones).toHaveLength(2);
+        expect(plan!.milestones[0].promptPacks?.[0].id).toBe('pp_setup');
+        expect(plan!.summary.buildStrategy).toBe('Ship a walking skeleton first, then layer features.');
+        expect(plan!.globalQualityGates.map(g => g.id)).toEqual(['g1']);
+        // Traceability derives from milestone + task links.
+        expect(plan!.traceability[0]).toMatchObject({
+            milestoneId: 'm_setup',
+            screens: ['Landing'],
+            dataModels: ['User'],
+            promptPackIds: ['pp_setup'],
+            qualityGateIds: ['qg1'],
+        });
+        // Risks surface as readiness warnings.
+        expect(plan!.readiness.warnings.some(w => w.includes('rate limits'))).toBe(true);
+    });
+
+    it('adapts legacy structured plan + prompt_pack, attaching by best-effort match', () => {
+        const plan = buildConsolidatedPlan({
+            planContent: fencePlan(LEGACY_STRUCTURED),
+            promptPackContent: LEGACY_PROMPT_PACK,
+        });
+        expect(plan).not.toBeNull();
+        expect(plan!.sources).toEqual({ plan: 'structured', promptPacks: 'legacy_prompt_pack' });
+        expect(plan!.readiness.status).toBe('needs_review');
+
+        // The auth-themed prompt attaches to the auth milestone…
+        const auth = plan!.milestones.find(m => m.id === 'm_auth')!;
+        expect(auth.promptPacks).toHaveLength(1);
+        expect(auth.promptPacks![0].title).toContain('authentication');
+        // …its Requirements become acceptance criteria and scope carries features.
+        expect(auth.promptPacks![0].acceptanceCriteria).toContain('Email/password form validates input');
+        expect(auth.promptPacks![0].scope?.include.length).toBeGreaterThan(0);
+
+        // The unrelated prompt lands in Unassigned.
+        expect(plan!.unassignedPromptPacks).toHaveLength(1);
+        expect(plan!.unassignedPromptPacks[0].title).toContain('haiku');
+
+        // Legacy plan-wide DoD becomes global quality gates with categories.
+        expect(plan!.globalQualityGates).toHaveLength(2);
+        expect(plan!.globalQualityGates[0].category).toBe('testing');
+        expect(plan!.globalQualityGates[1].category).toBe('accessibility');
+
+        // Legacy architecture feeds the stack summary; overview feeds strategy.
+        expect(plan!.summary.stackSummary).toEqual(['Next.js frontend', 'Postgres database']);
+        expect(plan!.summary.buildStrategy).toBe('Legacy overview.');
+        expect(plan!.summary.criticalPath).toEqual(['M1 → M2']);
+
+        // Task-level links roll up into traceability.
+        expect(plan!.traceability[0].screens).toEqual(['Login']);
+        expect(plan!.traceability[0].dataModels).toEqual(['User']);
+    });
+
+    it('handles a legacy markdown-only plan (no JSON fence)', () => {
+        const markdown = `# Implementation Plan
+
+### Milestone 1: Foundation (Week 1)
+**Goal:** Set up the project.
+**Key Deliverables:**
+- [ ] Initialize repository
+- [x] Choose hosting
+**Dependencies:** None
+**Definition of Done:** CI runs on every push
+
+### Milestone 2: Core Features (Week 2-3)
+**Goal:** Build the main flow.
+**Key Deliverables:**
+- [ ] Build home screen
+**Risks:** Scope creep
+
+---
+## Critical Path Summary
+Foundation then core.`;
+        const plan = buildConsolidatedPlan({ planContent: markdown });
+        expect(plan).not.toBeNull();
+        expect(plan!.sources.plan).toBe('legacy_markdown');
+        expect(plan!.milestones).toHaveLength(2);
+        expect(plan!.milestones[0].tasks).toHaveLength(2);
+        expect(plan!.milestones[0].tasks[1].status).toBe('done');
+        expect(plan!.milestones[0].definitionOfDone).toEqual(['CI runs on every push']);
+        expect(plan!.readiness.warnings.some(w => w.includes('Scope creep'))).toBe(true);
+        expect(plan!.readiness.missingInputs).toContain('Prompt packs');
+    });
+
+    it('renders prompt packs alone when no plan exists', () => {
+        const plan = buildConsolidatedPlan({ promptPackContent: LEGACY_PROMPT_PACK });
+        expect(plan).not.toBeNull();
+        expect(plan!.sources).toEqual({ plan: 'none', promptPacks: 'legacy_prompt_pack' });
+        expect(plan!.readiness.status).toBe('blocked');
+        expect(plan!.milestones).toHaveLength(0);
+        expect(plan!.unassignedPromptPacks).toHaveLength(2);
+    });
+
+    it('tolerates malformed plan content without throwing', () => {
+        const plan = buildConsolidatedPlan({ planContent: 'just some prose\nno milestones here' });
+        expect(plan).toBeNull();
+    });
+});
+
+describe('copy/export helpers', () => {
+    it('collects all prompt packs in milestone order then unassigned', () => {
+        const plan = buildConsolidatedPlan({
+            planContent: fencePlan(LEGACY_STRUCTURED),
+            promptPackContent: LEGACY_PROMPT_PACK,
+        })!;
+        const packs = collectAllPromptPacks(plan);
+        expect(packs.map(p => p.id)).toEqual(['legacy-prompt-1', 'legacy-prompt-2']);
+    });
+
+    it('appends acceptance criteria and commit guidance to clipboard text when missing from the prompt', () => {
+        const text = promptPackToClipboardText({
+            id: 'p1',
+            title: 'T',
+            purpose: 'P',
+            prompt: '# Task\nDo the thing.',
+            acceptanceCriteria: ['Thing done'],
+            recommendedCommitMessage: 'feat: do the thing',
+        });
+        expect(text).toContain('## Acceptance Criteria');
+        expect(text).toContain('- Thing done');
+        expect(text).toContain('feat: do the thing');
+    });
+
+    it('renders the consolidated plan as markdown with milestones, packs, and gates', () => {
+        const plan = buildConsolidatedPlan({ planContent: fencePlan(NATIVE_PLAN) })!;
+        const md = consolidatedPlanToMarkdown(plan);
+        expect(md).toContain('## Milestone 1: Project Setup');
+        expect(md).toContain('### Prompt Pack: Scaffold the project');
+        expect(md).toContain('npm run lint');
+        expect(md).toContain('## Global Quality Gates');
+        expect(md).toContain('## Risks');
+    });
+});

--- a/src/lib/coreArtifactPipeline.ts
+++ b/src/lib/coreArtifactPipeline.ts
@@ -61,6 +61,11 @@ export const CORE_ARTIFACT_PIPELINE: CoreArtifactMeta[] = [
         displayOrder: 5,
     },
     {
+        // RETIRED (see RETIRED_ARTIFACT_SUBTYPES): standalone Developer
+        // Prompts no longer generate — the implementation_plan artifact now
+        // carries milestone-centered prompt packs. The meta stays so legacy
+        // persisted prompt_pack artifacts keep their title, renderer, and
+        // export path, and getArtifactMeta never throws for them.
         subtype: 'prompt_pack',
         title: 'Developer Prompts',
         description: 'AI prompts for downstream tasks',
@@ -69,8 +74,8 @@ export const CORE_ARTIFACT_PIPELINE: CoreArtifactMeta[] = [
     },
     {
         subtype: 'implementation_plan',
-        title: 'Build Plan',
-        description: 'High-level build sequence and milestones',
+        title: 'Implementation Plan',
+        description: 'Milestones, prompt packs, and quality gates',
         dependsOn: [],
         displayOrder: 7,
     },
@@ -95,6 +100,20 @@ export const HIDDEN_ARTIFACT_SUBTYPES: ReadonlySet<CoreArtifactSubtype> = new Se
 
 export const isHiddenArtifactSubtype = (subtype: CoreArtifactSubtype): boolean =>
     HIDDEN_ARTIFACT_SUBTYPES.has(subtype);
+
+// Subtypes that are fully retired from **new generation**: no sidebar row, no
+// slot in new runs, no Settings model row — stronger than HIDDEN (which still
+// generates). The subtype stays in the type union and CORE_ARTIFACT_PIPELINE
+// so legacy persisted artifacts keep rendering/exporting, and their content is
+// consumed by newer views (the Implementation Plan adapter reads legacy
+// prompt_pack artifacts). Retired subtypes must never gate readiness, never
+// appear in pendingSlotsForSpine, and never surface a generation-config row.
+export const RETIRED_ARTIFACT_SUBTYPES: ReadonlySet<CoreArtifactSubtype> = new Set<CoreArtifactSubtype>([
+    'prompt_pack',
+]);
+
+export const isRetiredArtifactSubtype = (subtype: CoreArtifactSubtype): boolean =>
+    RETIRED_ARTIFACT_SUBTYPES.has(subtype);
 
 /**
  * Group the pipeline into dependency layers. Items in the same layer have no

--- a/src/lib/coreArtifactPipeline.ts
+++ b/src/lib/coreArtifactPipeline.ts
@@ -76,7 +76,13 @@ export const CORE_ARTIFACT_PIPELINE: CoreArtifactMeta[] = [
         subtype: 'implementation_plan',
         title: 'Implementation Plan',
         description: 'Milestones, prompt packs, and quality gates',
-        dependsOn: [],
+        // True data deps: the consolidated plan links milestones to screen and
+        // entity names and writes prompt packs that reference them, so it
+        // needs those artifacts' output as prompt context. user_flows is
+        // deliberately NOT a dep — flow links are nice-to-have and adding the
+        // edge would make the active pipeline 3 layers deep (see the depth
+        // test in coreArtifactPipeline.test.ts).
+        dependsOn: ['screen_inventory', 'data_model'],
         displayOrder: 7,
     },
 ];

--- a/src/lib/schemas/artifactSchemas.ts
+++ b/src/lib/schemas/artifactSchemas.ts
@@ -346,6 +346,53 @@ export const designSystemTokensSchema = {
     required: ["colors", "typography", "spacing", "radius", "components", "rules"],
 };
 
+// Consolidated Implementation Plan sub-schemas. Prompt packs and quality
+// gates are milestone-centered; the plan drives the Development section of
+// the assets workspace directly.
+const implementationQualityGateSchema = {
+    type: "OBJECT",
+    properties: {
+        id: { type: "STRING" },
+        title: { type: "STRING" },
+        description: { type: "STRING" },
+        category: {
+            type: "STRING",
+            enum: [
+                "design_fidelity",
+                "functional",
+                "data_integrity",
+                "integration",
+                "accessibility",
+                "performance",
+                "testing",
+                "regression",
+            ],
+        },
+        required: { type: "BOOLEAN" },
+    },
+    required: ["id", "title", "category", "required"],
+};
+
+const implementationPromptPackSchema = {
+    type: "OBJECT",
+    properties: {
+        id: { type: "STRING" },
+        title: { type: "STRING" },
+        purpose: { type: "STRING" },
+        prompt: { type: "STRING" },
+        scope: {
+            type: "OBJECT",
+            properties: {
+                include: { type: "ARRAY", items: { type: "STRING" } },
+                exclude: { type: "ARRAY", items: { type: "STRING" } },
+            },
+        },
+        acceptanceCriteria: { type: "ARRAY", items: { type: "STRING" } },
+        recommendedCommitMessage: { type: "STRING" },
+    },
+    required: ["id", "title", "purpose", "prompt", "acceptanceCriteria"],
+};
+
 export const implementationPlanSchema = {
     type: "OBJECT",
     properties: {
@@ -357,6 +404,16 @@ export const implementationPlanSchema = {
                 teamSize: { type: "STRING" },
             },
         },
+        summary: {
+            type: "OBJECT",
+            properties: {
+                buildStrategy: { type: "STRING" },
+                stackSummary: { type: "ARRAY", items: { type: "STRING" } },
+                criticalPath: { type: "ARRAY", items: { type: "STRING" } },
+                estimatedEffort: { type: "STRING" },
+                teamAssumption: { type: "STRING" },
+            },
+        },
         milestones: {
             type: "ARRAY",
             items: {
@@ -366,6 +423,28 @@ export const implementationPlanSchema = {
                     name: { type: "STRING" },
                     timeframe: { type: "STRING" },
                     goal: { type: "STRING" },
+                    objective: { type: "STRING" },
+                    priority: {
+                        type: "STRING",
+                        enum: ["critical", "high", "medium", "low"],
+                    },
+                    estimatedEffort: { type: "STRING" },
+                    dependencies: { type: "ARRAY", items: { type: "STRING" } },
+                    linkedArtifacts: {
+                        type: "OBJECT",
+                        properties: {
+                            screens: { type: "ARRAY", items: { type: "STRING" } },
+                            dataModels: { type: "ARRAY", items: { type: "STRING" } },
+                            components: { type: "ARRAY", items: { type: "STRING" } },
+                            userFlows: { type: "ARRAY", items: { type: "STRING" } },
+                            risks: { type: "ARRAY", items: { type: "STRING" } },
+                            apis: { type: "ARRAY", items: { type: "STRING" } },
+                        },
+                    },
+                    promptPacks: { type: "ARRAY", items: implementationPromptPackSchema },
+                    qualityGates: { type: "ARRAY", items: implementationQualityGateSchema },
+                    validationCommands: { type: "ARRAY", items: { type: "STRING" } },
+                    definitionOfDone: { type: "ARRAY", items: { type: "STRING" } },
                     tasks: {
                         type: "ARRAY",
                         items: {
@@ -395,6 +474,7 @@ export const implementationPlanSchema = {
                 required: ["id", "name", "tasks"],
             },
         },
+        globalQualityGates: { type: "ARRAY", items: implementationQualityGateSchema },
         architecture: { type: "ARRAY", items: { type: "STRING" } },
         risks: {
             type: "ARRAY",

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -14,6 +14,7 @@ import { validateArtifactContent } from '../artifactValidation';
 import { validateCrossArtifactConsistency } from '../artifactOrchestration';
 import {
     CORE_ARTIFACT_PIPELINE,
+    isRetiredArtifactSubtype,
     buildDependencyLayers,
     getArtifactMeta,
     isHiddenArtifactSubtype,
@@ -520,7 +521,12 @@ async function executeJob(args: StartArgs, controller: AbortController, slotKeys
 }
 
 function pendingSlotsForSpine(args: StartArgs): ArtifactSlotKey[] {
-    return ALL_SLOT_KEYS.filter(k => !isSlotDoneForSpine(args.projectId, k, args.spineVersionId));
+    // Retired subtypes (e.g. prompt_pack, folded into the consolidated
+    // implementation_plan) never generate in new runs — they're excluded
+    // here so startAll/resume/regenerate can't schedule them.
+    return ALL_SLOT_KEYS.filter(k =>
+        (k === 'mockup' || !isRetiredArtifactSubtype(k))
+        && !isSlotDoneForSpine(args.projectId, k, args.spineVersionId));
 }
 
 // A slot is "hidden" when its subtype is hidden from the assets list. 'mockup'

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -118,14 +118,21 @@ Categories to cover: Navigation, Forms & Inputs, Data Display, Feedback & Status
         userPrefix: 'Create a Component Inventory from this PRD:',
     },
     implementation_plan: {
-        system: `You are a senior software architect producing production-grade artifacts for engineering teams. Produce a structured Implementation Plan as a task-driven execution system, not a narrative document. The JSON you return drives the rendered UI directly. Every task must be atomic and actionable — concrete engineering work a developer can execute — never an abstract theme. Dependencies must be explicit and accurate so the execution order is unambiguous.
+        system: `You are a senior software architect producing production-grade artifacts for engineering teams. Produce a consolidated Implementation Plan — a milestone-driven execution system that takes a developer from this product design to working software with a coding agent. The JSON you return drives the rendered UI directly. Every task must be atomic and actionable — concrete engineering work a developer can execute — never an abstract theme. Dependencies must be explicit and accurate so the execution order is unambiguous.
 
 Top-level shape:
 - overview: { summary, criticalPath, teamSize }
   - summary: 2-3 sentences describing the build approach.
   - criticalPath: one sentence naming the milestones on the critical path.
   - teamSize: short recommendation (e.g. "1 frontend + 1 backend" or "Solo dev, ~6 weeks").
-- milestones: 4-6 entries. First is infrastructure/setup. Last covers testing and launch prep.
+- summary: { buildStrategy, stackSummary, criticalPath, estimatedEffort, teamAssumption }
+  - buildStrategy: 2-3 sentences on the overall approach (walking skeleton, thin vertical slices, etc.).
+  - stackSummary: 3-6 short entries naming the concrete stack (e.g. "React + Vite SPA", "Postgres via Supabase").
+  - criticalPath: ordered array of the milestone NAMES on the critical path.
+  - estimatedEffort: total effort estimate (e.g. "~4 weeks solo").
+  - teamAssumption: who this plan assumes is building (e.g. "One developer pairing with a coding agent").
+- milestones: 4-6 entries. First is infrastructure/setup. Last covers testing and launch prep. Keep milestones SMALL — each should be independently shippable and verifiable.
+- globalQualityGates: 3-6 project-wide quality gates (shape below) that apply to every milestone.
 - architecture: top-level array of cross-cutting technical decisions (tech stack picks, key architectural calls). Hoisted out of per-milestone bodies.
 - risks: top-level array of { description, mitigation } items spanning the project.
 - definitionOfDone: top-level array of project-wide acceptance criteria.
@@ -135,7 +142,16 @@ Per milestone:
 - name: human-readable milestone name.
 - timeframe: "Week 1-2" style range.
 - goal: one-sentence objective.
+- objective: 1-2 sentence richer statement of what the milestone delivers and why it's next.
+- priority: "critical" | "high" | "medium" | "low" — by position on the critical path.
+- estimatedEffort: short effort estimate (e.g. "2-3 days").
+- dependencies: array of OTHER milestone ids that must complete first. Empty array if none.
+- linkedArtifacts: { screens, dataModels, components, userFlows, apis } — EXACT names drawn from the dependency artifacts and PRD. Link only what this milestone directly implements; do not invent names.
 - tasks: 3-8 atomic, executable tasks.
+- promptPacks: 1-3 copy-ready coding-agent prompts (shape below) that implement this milestone. Every milestone MUST have at least one.
+- qualityGates: 2-4 milestone-specific quality gates.
+- validationCommands: shell commands to verify the milestone (e.g. "npm run build", "npm test"), consistent with the chosen stack.
+- definitionOfDone: 2-5 observable acceptance criteria for the milestone.
 
 Per task:
 - id: stable lower-snake-case identifier (e.g. "task_initialize_nextjs"). Unique across the whole plan.
@@ -149,12 +165,34 @@ Per task:
   - mockups: screen names from the screen_inventory dependency context that this task implements.
   - Link an artifact only when the task directly implements or modifies it. Omit (or use empty arrays) otherwise. Don't invent artifact references.
 
+Per prompt pack:
+- id: stable lower-snake-case identifier, unique across the plan (e.g. "pp_setup_scaffold").
+- title: short imperative name.
+- purpose: one sentence on what running this prompt accomplishes.
+- prompt: the FULL copy-ready prompt body, structured with exactly these markdown headings:
+  # Prompt: [Title]
+  ## Goal
+  ## Relevant Synapse Artifacts
+  ## Scope
+  ## Out of Scope
+  ## Implementation Steps
+  ## Acceptance Criteria
+  ## Quality Gates
+  ## Validation Commands
+  ## Commit Guidance
+  The body must be fully self-contained (the recipient sees ONLY this text — no PRD, no other artifact): restate the relevant product context, feature behavior, screen/entity names, and constraints inline. Refer to features by human name, never bare IDs. Never use triple backticks inside the prompt body. The prompts MUST be agent-agnostic — never name, recommend, or assume a specific tool (e.g. Cursor, Claude Code, ChatGPT, Copilot).
+- scope: { include, exclude } — bulleted scope boundaries; exclude MUST list explicit non-goals.
+- acceptanceCriteria: 3-6 specific, testable criteria.
+- recommendedCommitMessage: a conventional, imperative commit message for the resulting change.
+
 Rules:
-- Task ids must be unique across the entire plan.
-- All ids in dependencies must reference other task ids in the same plan.
+- Task, milestone, prompt-pack, and quality-gate ids must be unique across the entire plan.
+- All ids in dependencies must reference ids in the same plan.
+- Quality gate shape: { id, title, description?, category, required } with category one of design_fidelity | functional | data_integrity | integration | accessibility | performance | testing | regression.
 - Hoist cross-cutting architecture, risks, and definition-of-done into the top-level arrays — do NOT duplicate them per milestone.
-- Tasks should read as atomic engineering work, not as themes.`,
-        userPrefix: 'Create an Implementation Plan from this PRD:',
+- Tasks should read as atomic engineering work, not as themes.
+- Favor safe implementation: small milestones, frequent commits, explicit non-goals, validation after every milestone, no broad rewrites.`,
+        userPrefix: 'Create a consolidated Implementation Plan (milestones + prompt packs + quality gates) from this PRD:',
     },
     data_model: {
         system: `You are a senior backend architect producing production-grade artifacts for engineering teams. Produce a Data Model that reads as a clear product/engineering explanation, not a raw schema dump. The artifact must remain structurally parseable: use the same heading and table conventions on every regeneration, and every field must appear in exactly one fieldGroup. Define every field at field level — name, type, requiredness, and a precise description. Model only entities and fields that the PRD's features and entities require; do not introduce speculative fields. Keep entity and field names consistent with the PRD's defined entities.
@@ -341,18 +379,48 @@ function implementationPlanToMarkdown(plan: StructuredImplementationPlan): strin
     plan.milestones.forEach((m, i) => {
         const heading = `### Milestone ${i + 1}: ${m.name}${m.timeframe ? ` (${m.timeframe})` : ''}`;
         lines.push(heading);
-        if (m.goal) lines.push(`**Goal:** ${m.goal}`);
+        if (m.goal) lines.push(`**Goal:** ${m.objective ?? m.goal}`);
         if (m.tasks.length) {
             lines.push('**Key Deliverables:**');
             for (const t of m.tasks) {
                 lines.push(`- [${t.status === 'done' ? 'x' : ' '}] **${t.title}** — _${t.status}_`);
             }
         }
-        const deps = Array.from(new Set(m.tasks.flatMap(t => t.dependencies ?? []))).filter(Boolean);
+        // Milestone-level dependencies (consolidated plans) win over the
+        // task-id rollup (legacy plans) — same header either way, which is
+        // what artifactValidation and the legacy parser expect.
+        const deps = m.dependencies?.length
+            ? m.dependencies
+            : Array.from(new Set(m.tasks.flatMap(t => t.dependencies ?? []))).filter(Boolean);
         if (deps.length) lines.push(`**Dependencies:** ${deps.join(', ')}`);
+        // Consolidated-plan sections. Prompt bodies live only in the JSON
+        // fence below (they can be long and may collide with markdown
+        // formatting); the readable body carries title + purpose.
+        if (m.promptPacks?.length) {
+            lines.push('**Prompt Packs:**');
+            m.promptPacks.forEach(p => lines.push(`- **${p.title}** — ${p.purpose}`));
+        }
+        if (m.qualityGates?.length) {
+            lines.push('**Quality Gates:**');
+            m.qualityGates.forEach(g => lines.push(`- [${g.required ? 'required' : 'optional'} · ${g.category}] ${g.title}`));
+        }
+        if (m.validationCommands?.length) {
+            lines.push(`**Validation Commands:** ${m.validationCommands.map(c => `\`${c}\``).join(' · ')}`);
+        }
+        if (m.definitionOfDone?.length) {
+            lines.push('**Definition of Done:**');
+            m.definitionOfDone.forEach(d => lines.push(`- [ ] ${d}`));
+        }
         lines.push('');
     });
 
+    if (plan.globalQualityGates?.length) {
+        lines.push('---', '', '## Global Quality Gates');
+        plan.globalQualityGates.forEach(g => {
+            lines.push(`- [${g.required ? 'required' : 'optional'} · ${g.category}] ${g.title}`);
+        });
+        lines.push('');
+    }
     if (plan.architecture?.length) {
         lines.push('---', '', '## Architecture');
         plan.architecture.forEach(a => lines.push(`- ${a}`));

--- a/src/lib/services/implementationPlanAdapter.ts
+++ b/src/lib/services/implementationPlanAdapter.ts
@@ -1,0 +1,501 @@
+/**
+ * Backwards-compatible adapter that builds the consolidated
+ * `ConsolidatedImplementationPlan` view model the Implementation Plan
+ * renderer consumes. Pure — no store, LLM, or React access.
+ *
+ * Sources, in preference order:
+ *
+ * 1. A native structured plan (```json synapse-plan fence) that already
+ *    carries milestone prompt packs / quality gates — passed through.
+ * 2. A legacy structured plan (fence without the consolidated fields) plus,
+ *    when present, a legacy `prompt_pack` artifact whose prompts are adapted
+ *    into prompt packs and attached to milestones by best-effort
+ *    title/category matching (unmatched ones land in a clearly labeled
+ *    "Unassigned" group).
+ * 3. A legacy markdown-only plan (### Milestone N: headings).
+ * 4. Only a legacy `prompt_pack` artifact (no plan) — prompts render as
+ *    unassigned packs with a readiness warning.
+ *
+ * Everything here is derived at render time; legacy artifacts are never
+ * rewritten or migrated. Data is preserved: legacy Definition of Done items
+ * become quality gates, Architecture feeds the summary, Risks become
+ * readiness warnings.
+ */
+
+import type {
+    ConsolidatedImplementationPlan,
+    ImplementationPlanMilestone,
+    ImplementationPlanSummary,
+    ImplementationPromptPack,
+    ImplementationQualityGate,
+    ImplementationReadiness,
+    ImplementationTraceabilityItem,
+    QualityGateCategory,
+    StructuredImplementationPlan,
+} from '../../types';
+import {
+    extractStructuredPlan,
+    findSection,
+    parseImplementationPlan,
+    parseMilestoneBody,
+} from './implementationPlanParser';
+import { parsePromptPack, type PromptCard } from './promptPackParser';
+
+export interface ConsolidatedPlanInput {
+    /** Preferred implementation_plan artifact content (markdown), if any. */
+    planContent?: string | null;
+    /** Preferred legacy prompt_pack artifact content (markdown), if any. */
+    promptPackContent?: string | null;
+    /** Display title for the consolidated view. */
+    title?: string;
+}
+
+// --- Quality-gate derivation -------------------------------------------------
+
+// Stem tokens (accessib, integrat, regress, …) deliberately have no trailing
+// \b so they match their inflections ("Accessibility", "integrated").
+const GATE_CATEGORY_KEYWORDS: Array<{ category: QualityGateCategory; pattern: RegExp }> = [
+    { category: 'testing', pattern: /\b(test|tests|tested|testing|coverage|e2e|unit|vitest|jest|playwright)\b/i },
+    { category: 'accessibility', pattern: /accessib|a11y|\baria\b|screen reader|keyboard|contrast|wcag/i },
+    { category: 'performance', pattern: /performan|\bperf\b|latency|load time|lighthouse|\bfps\b|bundle size/i },
+    { category: 'data_integrity', pattern: /data integrity|schema|migration|database|persist|constraint/i },
+    { category: 'integration', pattern: /integrat|\bapi\b|endpoint|webhook|third-party|oauth|\bsync\b/i },
+    { category: 'design_fidelity', pattern: /design|visual|style|pixel|mockup|token|brand|responsive|layout/i },
+    { category: 'regression', pattern: /regress|doesn't break|does not break|backwards/i },
+];
+
+function categorizeGate(text: string): QualityGateCategory {
+    for (const { category, pattern } of GATE_CATEGORY_KEYWORDS) {
+        if (pattern.test(text)) return category;
+    }
+    return 'functional';
+}
+
+/** Turn a Definition-of-Done line into a derived quality gate. */
+function gateFromDoD(text: string, id: string): ImplementationQualityGate {
+    return {
+        id,
+        title: text,
+        category: categorizeGate(text),
+        required: true,
+    };
+}
+
+// --- Legacy prompt_pack → prompt packs ---------------------------------------
+
+function splitBullets(section: string | undefined): string[] {
+    if (!section) return [];
+    return section
+        .split('\n')
+        .map(line => line.replace(/^\s*[-*]\s*/, '').trim())
+        .filter(Boolean);
+}
+
+/** Extract the lines of a `## Heading` section from a prompt body. */
+function extractPromptSection(body: string, heading: RegExp): string | undefined {
+    const lines = body.split('\n');
+    const collected: string[] = [];
+    let inSection = false;
+    for (const line of lines) {
+        const h = line.match(/^##\s+(.+?)\s*$/);
+        if (h) {
+            inSection = heading.test(h[1]);
+            continue;
+        }
+        if (inSection) collected.push(line);
+    }
+    const joined = collected.join('\n').trim();
+    return joined || undefined;
+}
+
+export function promptPackFromLegacyCard(card: PromptCard): ImplementationPromptPack {
+    const requirements = splitBullets(extractPromptSection(card.promptBody, /^requirements$/i));
+    const expected = splitBullets(extractPromptSection(card.promptBody, /^expected output$/i));
+    const inScope = splitBullets(extractPromptSection(card.promptBody, /^features? in scope$/i))
+        // Keep only the top-level feature lines ("<id> — <name>"), not the
+        // indented purpose/behavior/constraint sub-bullets.
+        .filter(line => /—|--|-\s/.test(line) || /^\S+\s+—/.test(line))
+        .map(line => line.replace(/^`?([^`]+)`?\s*—\s*/, '$1 — '));
+
+    return {
+        id: `legacy-prompt-${card.index}`,
+        title: card.title,
+        purpose: card.expected ?? `Ready-to-run prompt: ${card.title}`,
+        prompt: card.promptBody,
+        scope: inScope.length ? { include: inScope, exclude: [] } : undefined,
+        acceptanceCriteria: requirements.length ? requirements : expected,
+        category: card.category,
+    };
+}
+
+// --- Best-effort prompt ↔ milestone matching ---------------------------------
+
+const STOPWORDS = new Set([
+    'the', 'a', 'an', 'and', 'or', 'is', 'are', 'be', 'with', 'for', 'of',
+    'to', 'in', 'on', 'at', 'by', 'from', 'as', 'this', 'that', 'implement',
+    'implementation', 'build', 'create', 'setup', 'set', 'core', 'basic',
+]);
+
+function tokenize(text: string): string[] {
+    return text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(token => token.length > 3 && !STOPWORDS.has(token));
+}
+
+/**
+ * Score how well a legacy prompt matches a milestone: shared meaningful
+ * tokens between the prompt's title/category and the milestone's
+ * name/goal/task titles. Conservative — an ambiguous prompt is better
+ * surfaced as "Unassigned" than attached to the wrong milestone.
+ */
+function matchScore(pack: ImplementationPromptPack, milestone: ImplementationPlanMilestone): number {
+    const packTokens = new Set(tokenize(`${pack.title} ${pack.category ?? ''}`));
+    const milestoneText = [
+        milestone.name,
+        milestone.goal ?? '',
+        milestone.objective ?? '',
+        ...milestone.tasks.map(t => t.title),
+    ].join(' ');
+    let score = 0;
+    for (const token of tokenize(milestoneText)) {
+        if (packTokens.has(token)) score++;
+    }
+    return score;
+}
+
+function attachLegacyPacks(
+    milestones: ImplementationPlanMilestone[],
+    packs: ImplementationPromptPack[],
+): { attached: Map<string, ImplementationPromptPack[]>; unassigned: ImplementationPromptPack[] } {
+    const attached = new Map<string, ImplementationPromptPack[]>();
+    const unassigned: ImplementationPromptPack[] = [];
+    for (const pack of packs) {
+        let best: ImplementationPlanMilestone | null = null;
+        let bestScore = 0;
+        for (const milestone of milestones) {
+            const score = matchScore(pack, milestone);
+            if (score > bestScore) {
+                bestScore = score;
+                best = milestone;
+            }
+        }
+        // Require at least two shared meaningful tokens to claim a match.
+        if (best && bestScore >= 2) {
+            const list = attached.get(best.id) ?? [];
+            list.push(pack);
+            attached.set(best.id, list);
+        } else {
+            unassigned.push(pack);
+        }
+    }
+    return { attached, unassigned };
+}
+
+// --- Legacy markdown plan → milestones ---------------------------------------
+
+function milestonesFromLegacyMarkdown(planContent: string): {
+    milestones: ImplementationPlanMilestone[];
+    globalDoD: string[];
+    architecture: string[];
+    riskTexts: string[];
+} {
+    const parsed = parseImplementationPlan(planContent);
+    const riskTexts: string[] = [];
+
+    const milestones = parsed.milestones.map(m => {
+        const details = parseMilestoneBody(m.body);
+        const goal = findSection(details, 'Goal');
+        const dod = splitBullets(findSection(details, 'Definition of Done'));
+        const deps = splitBullets(findSection(details, 'Dependencies'));
+        const risks = splitBullets(findSection(details, 'Risks'));
+        riskTexts.push(...risks);
+        const milestone: ImplementationPlanMilestone = {
+            id: `m${m.id}`,
+            name: m.title,
+            timeframe: m.timeframe,
+            goal,
+            tasks: details.deliverables.map((d, i) => ({
+                id: `m${m.id}-d${i + 1}`,
+                title: d.text,
+                status: d.checked ? 'done' : 'todo',
+            })),
+            dependencies: deps.length ? deps : undefined,
+            definitionOfDone: dod.length ? dod : undefined,
+            linkedArtifacts: risks.length ? { risks } : undefined,
+        };
+        return milestone;
+    });
+
+    return { milestones, globalDoD: [], architecture: [], riskTexts };
+}
+
+// --- Summary / readiness derivation ------------------------------------------
+
+function deriveSummary(plan: StructuredImplementationPlan | null): ImplementationPlanSummary {
+    if (!plan) return {};
+    const summary: ImplementationPlanSummary = { ...(plan.summary ?? {}) };
+    if (!summary.buildStrategy && plan.overview?.summary) {
+        summary.buildStrategy = plan.overview.summary;
+    }
+    if ((!summary.criticalPath || summary.criticalPath.length === 0) && plan.overview?.criticalPath) {
+        summary.criticalPath = [plan.overview.criticalPath];
+    }
+    if (!summary.teamAssumption && plan.overview?.teamSize) {
+        summary.teamAssumption = plan.overview.teamSize;
+    }
+    if ((!summary.stackSummary || summary.stackSummary.length === 0) && plan.architecture?.length) {
+        // Legacy plans hold stack decisions in `architecture`; surface the
+        // first few as the stack summary rather than losing them.
+        summary.stackSummary = plan.architecture.slice(0, 6);
+    }
+    return summary;
+}
+
+function deriveReadiness(args: {
+    planSource: ConsolidatedImplementationPlan['sources']['plan'];
+    packSource: ConsolidatedImplementationPlan['sources']['promptPacks'];
+    milestones: ImplementationPlanMilestone[];
+    unassignedCount: number;
+    riskTexts: string[];
+}): ImplementationReadiness {
+    const { planSource, packSource, milestones, unassignedCount, riskTexts } = args;
+    const warnings: string[] = [];
+    const missingInputs: string[] = [];
+
+    if (planSource === 'none') {
+        missingInputs.push('Build plan (milestones)');
+        warnings.push('No build plan was found — showing prompt packs only. Generate the Implementation Plan to get a milestone roadmap.');
+    }
+    if (packSource === 'none') {
+        missingInputs.push('Prompt packs');
+        warnings.push('No prompt packs yet — regenerate the Implementation Plan to get copy-ready coding-agent prompts per milestone.');
+    }
+    if (packSource === 'legacy_prompt_pack') {
+        warnings.push('Prompt packs were adapted from a previously generated Developer Prompts artifact; matches to milestones are best-effort.');
+    }
+    if (unassignedCount > 0) {
+        warnings.push(`${unassignedCount} prompt pack${unassignedCount === 1 ? '' : 's'} could not be confidently matched to a milestone — see Unassigned Prompt Packs.`);
+    }
+    const withoutValidation = milestones.filter(m => !m.validationCommands?.length).length;
+    if (milestones.length > 0 && withoutValidation === milestones.length && planSource !== 'none') {
+        warnings.push('Milestones have no validation commands — regenerate the Implementation Plan to get per-milestone validation guidance.');
+    }
+    for (const risk of riskTexts.slice(0, 5)) {
+        warnings.push(`Risk: ${risk}`);
+    }
+
+    const status: ImplementationReadiness['status'] =
+        planSource === 'none' ? 'blocked'
+            : missingInputs.length > 0 || packSource === 'legacy_prompt_pack' ? 'needs_review'
+                : 'ready';
+
+    const first = milestones[0];
+    const recommendedNextStep = first
+        ? `Start with "${first.name}"${(first.promptPacks?.length ?? 0) > 0 ? ' — copy its first prompt pack into your coding agent.' : '.'}`
+        : 'Generate the Implementation Plan to get a milestone roadmap.';
+
+    return { status, warnings, missingInputs, recommendedNextStep };
+}
+
+// --- Traceability derivation --------------------------------------------------
+
+function deriveTraceability(milestones: ImplementationPlanMilestone[]): ImplementationTraceabilityItem[] {
+    return milestones.map(m => {
+        const links = m.linkedArtifacts ?? {};
+        // Task-level links (legacy structured plans) roll up into the
+        // milestone row so old plans still get a traceability view.
+        const taskScreens = m.tasks.flatMap(t => t.linkedArtifacts?.mockups ?? []);
+        const taskData = m.tasks.flatMap(t => t.linkedArtifacts?.dataModel ?? []);
+        return {
+            milestoneId: m.id,
+            milestoneTitle: m.name,
+            screens: dedupe([...(links.screens ?? []), ...taskScreens]),
+            dataModels: dedupe([...(links.dataModels ?? []), ...taskData]),
+            components: dedupe(links.components ?? []),
+            promptPackIds: (m.promptPacks ?? []).map(p => p.id),
+            qualityGateIds: (m.qualityGates ?? []).map(g => g.id),
+        };
+    });
+}
+
+function dedupe(items: string[]): string[] {
+    return Array.from(new Set(items.map(i => i.trim()).filter(Boolean)));
+}
+
+// --- Main entry ----------------------------------------------------------------
+
+export function buildConsolidatedPlan(input: ConsolidatedPlanInput): ConsolidatedImplementationPlan | null {
+    const planContent = input.planContent?.trim() || '';
+    const promptPackContent = input.promptPackContent?.trim() || '';
+    if (!planContent && !promptPackContent) return null;
+
+    // 1. Resolve the plan source.
+    let structured: StructuredImplementationPlan | null = null;
+    let planSource: ConsolidatedImplementationPlan['sources']['plan'] = 'none';
+    let milestones: ImplementationPlanMilestone[] = [];
+    const riskTexts: string[] = [];
+
+    if (planContent) {
+        structured = extractStructuredPlan(planContent);
+        if (structured) {
+            planSource = 'structured';
+            milestones = structured.milestones.map(m => ({ ...m }));
+            riskTexts.push(...(structured.risks ?? []).map(r => r.description));
+        } else {
+            const legacy = milestonesFromLegacyMarkdown(planContent);
+            if (legacy.milestones.length > 0) {
+                planSource = 'legacy_markdown';
+                milestones = legacy.milestones;
+                riskTexts.push(...legacy.riskTexts);
+            }
+        }
+    }
+
+    // 2. Resolve prompt packs.
+    const nativePackCount = milestones.reduce((n, m) => n + (m.promptPacks?.length ?? 0), 0);
+    let packSource: ConsolidatedImplementationPlan['sources']['promptPacks'] = 'none';
+    let unassignedPromptPacks: ImplementationPromptPack[] = [];
+
+    if (nativePackCount > 0) {
+        packSource = 'native';
+    } else if (promptPackContent) {
+        const { cards } = parsePromptPack(promptPackContent);
+        if (cards.length > 0) {
+            packSource = 'legacy_prompt_pack';
+            const packs = cards.map(promptPackFromLegacyCard);
+            const { attached, unassigned } = attachLegacyPacks(milestones, packs);
+            milestones = milestones.map(m => {
+                const extra = attached.get(m.id);
+                return extra ? { ...m, promptPacks: [...(m.promptPacks ?? []), ...extra] } : m;
+            });
+            unassignedPromptPacks = unassigned;
+        }
+    }
+
+    if (planSource === 'none' && packSource === 'none') return null;
+
+    // 3. Quality gates: native global gates, plus gates derived from the
+    //    plan-wide Definition of Done so legacy plans keep that content.
+    const globalQualityGates: ImplementationQualityGate[] = [
+        ...(structured?.globalQualityGates ?? []),
+    ];
+    if (globalQualityGates.length === 0 && structured?.definitionOfDone?.length) {
+        structured.definitionOfDone.forEach((d, i) => {
+            globalQualityGates.push(gateFromDoD(d, `gate-dod-${i + 1}`));
+        });
+    }
+
+    const summary = deriveSummary(structured);
+    const readiness = deriveReadiness({
+        planSource,
+        packSource,
+        milestones,
+        unassignedCount: unassignedPromptPacks.length,
+        riskTexts,
+    });
+
+    return {
+        title: input.title ?? 'Implementation Plan',
+        summary,
+        readiness,
+        milestones,
+        unassignedPromptPacks,
+        globalQualityGates,
+        traceability: deriveTraceability(milestones),
+        risks: structured?.risks ?? riskTexts.map(description => ({ description })),
+        architecture: structured?.architecture ?? [],
+        sources: { plan: planSource, promptPacks: packSource },
+    };
+}
+
+// --- Copy / export helpers -----------------------------------------------------
+
+/** Compose the clipboard text for one prompt pack (prompt + context). */
+export function promptPackToClipboardText(pack: ImplementationPromptPack): string {
+    const parts: string[] = [pack.prompt.trim()];
+    const extras: string[] = [];
+    if (pack.acceptanceCriteria.length && !/acceptance criteria/i.test(pack.prompt)) {
+        extras.push(`## Acceptance Criteria\n${pack.acceptanceCriteria.map(c => `- ${c}`).join('\n')}`);
+    }
+    if (pack.recommendedCommitMessage && !/commit/i.test(pack.prompt)) {
+        extras.push(`## Commit Guidance\nSuggested commit message: ${pack.recommendedCommitMessage}`);
+    }
+    if (extras.length) parts.push('', ...extras);
+    return parts.join('\n');
+}
+
+/** Render the consolidated plan back to a shareable markdown document. */
+export function consolidatedPlanToMarkdown(plan: ConsolidatedImplementationPlan): string {
+    const lines: string[] = [`# ${plan.title}`, ''];
+
+    if (plan.summary.buildStrategy) lines.push(plan.summary.buildStrategy, '');
+    if (plan.summary.stackSummary?.length) {
+        lines.push('**Stack:**');
+        plan.summary.stackSummary.forEach(s => lines.push(`- ${s}`));
+        lines.push('');
+    }
+    if (plan.summary.criticalPath?.length) {
+        lines.push(`**Critical Path:** ${plan.summary.criticalPath.join(' → ')}`, '');
+    }
+    if (plan.summary.estimatedEffort) lines.push(`**Estimated Effort:** ${plan.summary.estimatedEffort}`, '');
+    if (plan.summary.teamAssumption) lines.push(`**Team Assumption:** ${plan.summary.teamAssumption}`, '');
+
+    plan.milestones.forEach((m, i) => {
+        lines.push(`## Milestone ${i + 1}: ${m.name}`);
+        const meta: string[] = [];
+        if (m.priority) meta.push(`Priority: ${m.priority}`);
+        if (m.estimatedEffort ?? m.timeframe) meta.push(`Effort: ${m.estimatedEffort ?? m.timeframe}`);
+        if (m.dependencies?.length) meta.push(`Depends on: ${m.dependencies.join(', ')}`);
+        if (meta.length) lines.push(`_${meta.join(' · ')}_`);
+        const objective = m.objective ?? m.goal;
+        if (objective) lines.push('', `**Objective:** ${objective}`);
+        if (m.tasks.length) {
+            lines.push('', '**Tasks:**');
+            m.tasks.forEach(t => lines.push(`- [${t.status === 'done' ? 'x' : ' '}] ${t.title}`));
+        }
+        for (const pack of m.promptPacks ?? []) {
+            lines.push('', `### Prompt Pack: ${pack.title}`, '', '```', pack.prompt.trim(), '```');
+        }
+        if (m.qualityGates?.length) {
+            lines.push('', '**Quality Gates:**');
+            m.qualityGates.forEach(g => lines.push(`- [${g.required ? 'required' : 'optional'} · ${g.category}] ${g.title}`));
+        }
+        if (m.validationCommands?.length) {
+            lines.push('', '**Validation Commands:**');
+            m.validationCommands.forEach(c => lines.push(`- \`${c}\``));
+        }
+        if (m.definitionOfDone?.length) {
+            lines.push('', '**Definition of Done:**');
+            m.definitionOfDone.forEach(d => lines.push(`- [ ] ${d}`));
+        }
+        lines.push('');
+    });
+
+    if (plan.unassignedPromptPacks.length) {
+        lines.push('## Unassigned Prompt Packs', '');
+        for (const pack of plan.unassignedPromptPacks) {
+            lines.push(`### ${pack.title}`, '', '```', pack.prompt.trim(), '```', '');
+        }
+    }
+    if (plan.globalQualityGates.length) {
+        lines.push('## Global Quality Gates', '');
+        plan.globalQualityGates.forEach(g => lines.push(`- [${g.required ? 'required' : 'optional'} · ${g.category}] ${g.title}`));
+        lines.push('');
+    }
+    if (plan.risks.length) {
+        lines.push('## Risks', '');
+        plan.risks.forEach(r => lines.push(`- ${r.description}${r.mitigation ? ` — Mitigation: ${r.mitigation}` : ''}`));
+        lines.push('');
+    }
+
+    return lines.join('\n').trim() + '\n';
+}
+
+/** All prompt packs in build order (milestone order, then unassigned). */
+export function collectAllPromptPacks(plan: ConsolidatedImplementationPlan): ImplementationPromptPack[] {
+    return [
+        ...plan.milestones.flatMap(m => m.promptPacks ?? []),
+        ...plan.unassignedPromptPacks,
+    ];
+}

--- a/src/lib/services/implementationPlanAdapter.ts
+++ b/src/lib/services/implementationPlanAdapter.ts
@@ -31,6 +31,7 @@ import type {
     ImplementationReadiness,
     ImplementationTraceabilityItem,
     QualityGateCategory,
+    RiskItem,
     StructuredImplementationPlan,
 } from '../../types';
 import {
@@ -194,11 +195,74 @@ function attachLegacyPacks(
 
 // --- Legacy markdown plan → milestones ---------------------------------------
 
+interface LegacyAppendix {
+    architecture: string[];
+    risks: RiskItem[];
+    definitionOfDone: string[];
+    criticalPath?: string;
+    teamSize?: string;
+    /** Appendix prose that didn't match a known section — kept, never dropped. */
+    notes?: string;
+}
+
+/**
+ * Parse the post-`---` appendix of a legacy markdown plan. The serializer
+ * (and hand-written legacy plans) put Architecture / Risks / Definition of
+ * Done sections and Critical Path / Team Size labels there; anything
+ * unrecognized is preserved as free-form notes so no content is lost when
+ * the plan renders through the consolidated view.
+ */
+function parseLegacyAppendix(appendix: string): LegacyAppendix {
+    const out: LegacyAppendix = { architecture: [], risks: [], definitionOfDone: [] };
+    if (!appendix.trim()) return out;
+
+    type Section = 'architecture' | 'risks' | 'dod' | 'other';
+    let section: Section = 'other';
+    const notes: string[] = [];
+
+    for (const raw of appendix.split('\n')) {
+        const line = raw.trim();
+        const heading = line.match(/^#{2,3}\s+(.+?)\s*$/);
+        if (heading) {
+            const name = heading[1].toLowerCase();
+            section = name.includes('architecture') ? 'architecture'
+                : name.includes('risk') ? 'risks'
+                    : name.includes('definition of done') ? 'dod'
+                        : 'other';
+            if (section === 'other') notes.push(raw);
+            continue;
+        }
+        const cp = line.match(/^\*\*Critical Path:\*\*\s*(.+)$/i);
+        if (cp) { out.criticalPath = cp[1].trim(); continue; }
+        const ts = line.match(/^\*\*Team Size:\*\*\s*(.+)$/i);
+        if (ts) { out.teamSize = ts[1].trim(); continue; }
+
+        const bullet = line.match(/^[-*]\s*(?:\[\s*[ xX]\s*\]\s*)?(.+)$/);
+        if (bullet && section !== 'other') {
+            const text = bullet[1].trim();
+            if (section === 'architecture') out.architecture.push(text);
+            else if (section === 'dod') out.definitionOfDone.push(text);
+            else {
+                // Risks serialize as "- **desc** — Mitigation: …".
+                const m = text.match(/^\*\*(.+?)\*\*\s*(?:—|-)?\s*(?:Mitigation:\s*(.+))?$/);
+                out.risks.push(m ? { description: m[1].trim(), mitigation: m[2]?.trim() } : { description: text });
+            }
+            continue;
+        }
+        if (line) notes.push(raw);
+    }
+
+    const joined = notes.join('\n').trim();
+    if (joined) out.notes = joined;
+    return out;
+}
+
 function milestonesFromLegacyMarkdown(planContent: string): {
     milestones: ImplementationPlanMilestone[];
-    globalDoD: string[];
-    architecture: string[];
     riskTexts: string[];
+    appendix: LegacyAppendix;
+    /** Pre-milestone prose — used as the build-strategy fallback. */
+    preamble: string;
 } {
     const parsed = parseImplementationPlan(planContent);
     const riskTexts: string[] = [];
@@ -227,7 +291,12 @@ function milestonesFromLegacyMarkdown(planContent: string): {
         return milestone;
     });
 
-    return { milestones, globalDoD: [], architecture: [], riskTexts };
+    return {
+        milestones,
+        riskTexts,
+        appendix: parseLegacyAppendix(parsed.appendix),
+        preamble: parsed.preamble.replace(/^#{1,3}\s+.+$/gm, '').trim(),
+    };
 }
 
 // --- Summary / readiness derivation ------------------------------------------
@@ -325,6 +394,22 @@ function dedupe(items: string[]): string[] {
 
 // --- Main entry ----------------------------------------------------------------
 
+/**
+ * Fill schema-optional nested fields with safe defaults. The Gemini response
+ * schema doesn't require `scope.include`/`scope.exclude` (or reject a missing
+ * `acceptanceCriteria` on hand-edited data), so partial model output like
+ * `scope: { include: [...] }` must not crash the renderer.
+ */
+function normalizePromptPack(pack: ImplementationPromptPack): ImplementationPromptPack {
+    return {
+        ...pack,
+        acceptanceCriteria: pack.acceptanceCriteria ?? [],
+        scope: pack.scope
+            ? { include: pack.scope.include ?? [], exclude: pack.scope.exclude ?? [] }
+            : undefined,
+    };
+}
+
 export function buildConsolidatedPlan(input: ConsolidatedPlanInput): ConsolidatedImplementationPlan | null {
     const planContent = input.planContent?.trim() || '';
     const promptPackContent = input.promptPackContent?.trim() || '';
@@ -335,19 +420,27 @@ export function buildConsolidatedPlan(input: ConsolidatedPlanInput): Consolidate
     let planSource: ConsolidatedImplementationPlan['sources']['plan'] = 'none';
     let milestones: ImplementationPlanMilestone[] = [];
     const riskTexts: string[] = [];
+    let legacyAppendix: LegacyAppendix | null = null;
+    let legacyPreamble = '';
 
     if (planContent) {
         structured = extractStructuredPlan(planContent);
         if (structured) {
             planSource = 'structured';
-            milestones = structured.milestones.map(m => ({ ...m }));
+            milestones = structured.milestones.map(m => ({
+                ...m,
+                promptPacks: m.promptPacks?.map(normalizePromptPack),
+            }));
             riskTexts.push(...(structured.risks ?? []).map(r => r.description));
         } else {
             const legacy = milestonesFromLegacyMarkdown(planContent);
             if (legacy.milestones.length > 0) {
                 planSource = 'legacy_markdown';
                 milestones = legacy.milestones;
+                legacyAppendix = legacy.appendix;
+                legacyPreamble = legacy.preamble;
                 riskTexts.push(...legacy.riskTexts);
+                riskTexts.push(...legacy.appendix.risks.map(r => r.description));
             }
         }
     }
@@ -376,17 +469,34 @@ export function buildConsolidatedPlan(input: ConsolidatedPlanInput): Consolidate
     if (planSource === 'none' && packSource === 'none') return null;
 
     // 3. Quality gates: native global gates, plus gates derived from the
-    //    plan-wide Definition of Done so legacy plans keep that content.
+    //    plan-wide Definition of Done (fenced or legacy-markdown appendix) so
+    //    legacy plans keep that content.
     const globalQualityGates: ImplementationQualityGate[] = [
         ...(structured?.globalQualityGates ?? []),
     ];
-    if (globalQualityGates.length === 0 && structured?.definitionOfDone?.length) {
-        structured.definitionOfDone.forEach((d, i) => {
+    const dodSource = structured?.definitionOfDone?.length
+        ? structured.definitionOfDone
+        : legacyAppendix?.definitionOfDone ?? [];
+    if (globalQualityGates.length === 0 && dodSource.length) {
+        dodSource.forEach((d, i) => {
             globalQualityGates.push(gateFromDoD(d, `gate-dod-${i + 1}`));
         });
     }
 
     const summary = deriveSummary(structured);
+    // Legacy markdown-only plans carry their summary/architecture content in
+    // the preamble + appendix — surface it instead of dropping it.
+    if (legacyAppendix) {
+        if (!summary.buildStrategy && legacyPreamble) summary.buildStrategy = legacyPreamble;
+        if ((!summary.criticalPath || summary.criticalPath.length === 0) && legacyAppendix.criticalPath) {
+            summary.criticalPath = [legacyAppendix.criticalPath];
+        }
+        if (!summary.teamAssumption && legacyAppendix.teamSize) summary.teamAssumption = legacyAppendix.teamSize;
+        if ((!summary.stackSummary || summary.stackSummary.length === 0) && legacyAppendix.architecture.length) {
+            summary.stackSummary = legacyAppendix.architecture.slice(0, 6);
+        }
+    }
+
     const readiness = deriveReadiness({
         planSource,
         packSource,
@@ -394,6 +504,11 @@ export function buildConsolidatedPlan(input: ConsolidatedPlanInput): Consolidate
         unassignedCount: unassignedPromptPacks.length,
         riskTexts,
     });
+
+    const risks: RiskItem[] = structured?.risks
+        ?? (legacyAppendix?.risks.length
+            ? legacyAppendix.risks
+            : riskTexts.map(description => ({ description })));
 
     return {
         title: input.title ?? 'Implementation Plan',
@@ -403,8 +518,9 @@ export function buildConsolidatedPlan(input: ConsolidatedPlanInput): Consolidate
         unassignedPromptPacks,
         globalQualityGates,
         traceability: deriveTraceability(milestones),
-        risks: structured?.risks ?? riskTexts.map(description => ({ description })),
-        architecture: structured?.architecture ?? [],
+        risks,
+        architecture: structured?.architecture ?? legacyAppendix?.architecture ?? [],
+        appendixNotes: legacyAppendix?.notes,
         sources: { plan: planSource, promptPacks: packSource },
     };
 }
@@ -487,6 +603,9 @@ export function consolidatedPlanToMarkdown(plan: ConsolidatedImplementationPlan)
         lines.push('## Risks', '');
         plan.risks.forEach(r => lines.push(`- ${r.description}${r.mitigation ? ` — Mitigation: ${r.mitigation}` : ''}`));
         lines.push('');
+    }
+    if (plan.appendixNotes) {
+        lines.push('## Notes', '', plan.appendixNotes, '');
     }
 
     return lines.join('\n').trim() + '\n';

--- a/src/lib/services/promptPackParser.ts
+++ b/src/lib/services/promptPackParser.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure parser for legacy `prompt_pack` artifact markdown.
+ *
+ * Extracted from `PromptPackRenderer` (which still renders legacy artifacts
+ * with it) so the implementation-plan adapter can turn old Developer Prompts
+ * into consolidated prompt packs without duplicating the parsing rules.
+ *
+ * The conventional shape (from `coreArtifactService.ts`):
+ *
+ *   ### N. Prompt Title
+ *   **Category:** UI Implementation | Testing | ...
+ *   **Prompt:**
+ *   ```
+ *   <the copyable prompt body>
+ *   ```
+ *   **Expected Output:** one-line summary
+ */
+
+export type PromptCard = {
+    index: number;
+    title: string;
+    category?: string;
+    promptBody: string;
+    expected?: string;
+};
+
+const PROMPT_HEADING = /^###\s+(\d+)\.?\s+(.+?)\s*$/;
+
+export function parsePromptPack(markdown: string): { preamble: string; cards: PromptCard[] } {
+    const lines = markdown.split('\n');
+    const preambleLines: string[] = [];
+    const cards: PromptCard[] = [];
+    let active: { rawLines: string[]; index: number; title: string } | null = null;
+    let inMilestones = false;
+
+    for (const line of lines) {
+        const heading = line.match(PROMPT_HEADING);
+        if (heading) {
+            if (active) cards.push(buildCard(active));
+            active = { rawLines: [], index: Number(heading[1]), title: heading[2] };
+            inMilestones = true;
+            continue;
+        }
+        if (active) {
+            active.rawLines.push(line);
+        } else if (!inMilestones) {
+            preambleLines.push(line);
+        }
+    }
+    if (active) cards.push(buildCard(active));
+    return { preamble: preambleLines.join('\n').trim(), cards };
+}
+
+function buildCard(active: { rawLines: string[]; index: number; title: string }): PromptCard {
+    const card: PromptCard = {
+        index: active.index,
+        title: active.title,
+        promptBody: '',
+    };
+    let inFence = false;
+    const promptLines: string[] = [];
+    let collectExpected = false;
+    const expectedLines: string[] = [];
+
+    for (const line of active.rawLines) {
+        if (/^```/.test(line.trim())) {
+            inFence = !inFence;
+            continue;
+        }
+        if (inFence) {
+            promptLines.push(line);
+            continue;
+        }
+        const cat = line.match(/^\*\*Category:\*\*\s*(.+)$/i);
+        if (cat) {
+            card.category = cat[1].trim();
+            continue;
+        }
+        const exp = line.match(/^\*\*Expected Output:\*\*\s*(.*)$/i);
+        if (exp) {
+            collectExpected = true;
+            if (exp[1].trim()) expectedLines.push(exp[1].trim());
+            continue;
+        }
+        if (collectExpected) {
+            expectedLines.push(line);
+        }
+    }
+    card.promptBody = promptLines.join('\n').trim();
+    if (expectedLines.length > 0) {
+        card.expected = expectedLines.join('\n').trim();
+    }
+    return card;
+}

--- a/src/lib/services/taskExtractor.ts
+++ b/src/lib/services/taskExtractor.ts
@@ -284,6 +284,9 @@ export function extractTasksFromStructuredPlan(
 
     plan.milestones.forEach((milestone: ImplementationPlanMilestone, milestoneIndex) => {
         const milestoneNumericId = milestoneIndex + 1;
+        // Consolidated plans carry a per-milestone Definition of Done — the
+        // tighter criteria source; fall back to the plan-wide list.
+        const dodSource = milestone.definitionOfDone?.length ? milestone.definitionOfDone : planDoD;
         milestone.tasks.forEach(task => {
             const haystack = `${task.title} ${task.description ?? ''} ${milestone.goal ?? ''}`;
             const taskType = inferTaskType(haystack);
@@ -292,7 +295,7 @@ export function extractTasksFromStructuredPlan(
 
             const acceptanceCriteria = buildAcceptanceCriteria(
                 task.title,
-                planDoD.length ? planDoD.join('\n') : undefined,
+                dodSource.length ? dodSource.join('\n') : undefined,
                 milestone.tasks.map(t => t.title),
             );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -692,17 +692,93 @@ export interface ImplementationPlanTask {
     linkedArtifacts?: LinkedArtifacts;
 }
 
+// A ready-to-copy coding-agent prompt attached to a milestone. Legacy
+// `prompt_pack` artifacts are adapted into this shape at render time
+// (see lib/services/implementationPlanAdapter.ts).
+export interface ImplementationPromptPack {
+    id: string;
+    title: string;
+    /** What running this prompt accomplishes, in one sentence. */
+    purpose: string;
+    /** The full coding-agent-ready prompt body. */
+    prompt: string;
+    scope?: {
+        include: string[];
+        exclude: string[];
+    };
+    acceptanceCriteria: string[];
+    recommendedCommitMessage?: string;
+    /** Legacy prompt_pack category label (e.g. "UI Implementation"). */
+    category?: string;
+}
+
+export type QualityGateCategory =
+    | 'design_fidelity'
+    | 'functional'
+    | 'data_integrity'
+    | 'integration'
+    | 'accessibility'
+    | 'performance'
+    | 'testing'
+    | 'regression';
+
+export interface ImplementationQualityGate {
+    id: string;
+    title: string;
+    description?: string;
+    category: QualityGateCategory;
+    required: boolean;
+}
+
+/** Milestone-level references to other Synapse artifacts, by display name. */
+export interface MilestoneLinkedArtifacts {
+    screens?: string[];
+    dataModels?: string[];
+    components?: string[];
+    userFlows?: string[];
+    risks?: string[];
+    apis?: string[];
+}
+
 export interface ImplementationPlanMilestone {
     id: string;
     name: string;
     timeframe?: string;
     goal?: string;
     tasks: ImplementationPlanTask[];
+    // --- Consolidated-plan fields (all optional; legacy plans lack them) ---
+    /** Richer objective statement; falls back to `goal` when absent. */
+    objective?: string;
+    phase?: string;
+    priority?: 'critical' | 'high' | 'medium' | 'low';
+    estimatedEffort?: string;
+    /** Ids of other milestones that must complete first. */
+    dependencies?: string[];
+    linkedArtifacts?: MilestoneLinkedArtifacts;
+    promptPacks?: ImplementationPromptPack[];
+    qualityGates?: ImplementationQualityGate[];
+    validationCommands?: string[];
+    definitionOfDone?: string[];
 }
 
 export interface RiskItem {
     description: string;
     mitigation?: string;
+}
+
+export interface ImplementationPlanSummary {
+    buildStrategy?: string;
+    stackSummary?: string[];
+    criticalPath?: string[];
+    estimatedEffort?: string;
+    teamAssumption?: string;
+}
+
+export interface ImplementationReadiness {
+    status: 'ready' | 'needs_review' | 'blocked';
+    warnings: string[];
+    missingInputs: string[];
+    recommendedNextStep?: string;
 }
 
 export interface StructuredImplementationPlan {
@@ -715,6 +791,43 @@ export interface StructuredImplementationPlan {
     architecture?: string[];
     risks?: RiskItem[];
     definitionOfDone?: string[];
+    // --- Consolidated-plan fields (all optional; legacy plans lack them) ---
+    summary?: ImplementationPlanSummary;
+    globalQualityGates?: ImplementationQualityGate[];
+}
+
+// --- Consolidated Implementation Plan (render-time view model) ---
+//
+// Built by `implementationPlanAdapter.ts` from a native structured plan
+// and/or a legacy prompt_pack artifact. Never persisted — derived on read so
+// legacy projects need no migration.
+
+export interface ImplementationTraceabilityItem {
+    milestoneId: string;
+    milestoneTitle: string;
+    screens: string[];
+    dataModels: string[];
+    components: string[];
+    promptPackIds: string[];
+    qualityGateIds: string[];
+}
+
+export interface ConsolidatedImplementationPlan {
+    title: string;
+    summary: ImplementationPlanSummary;
+    readiness: ImplementationReadiness;
+    milestones: ImplementationPlanMilestone[];
+    /** Prompt packs that couldn't be attached to any milestone. */
+    unassignedPromptPacks: ImplementationPromptPack[];
+    globalQualityGates: ImplementationQualityGate[];
+    traceability: ImplementationTraceabilityItem[];
+    risks: RiskItem[];
+    architecture: string[];
+    /** Where the data came from — drives legacy explainer copy in the UI. */
+    sources: {
+        plan: 'structured' | 'legacy_markdown' | 'none';
+        promptPacks: 'native' | 'legacy_prompt_pack' | 'none';
+    };
 }
 
 // --- Artifact System ---

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -823,6 +823,9 @@ export interface ConsolidatedImplementationPlan {
     traceability: ImplementationTraceabilityItem[];
     risks: RiskItem[];
     architecture: string[];
+    /** Unrecognized appendix prose from a legacy markdown plan — preserved
+     * verbatim so switching to the consolidated view never loses content. */
+    appendixNotes?: string;
     /** Where the data came from — drives legacy explainer copy in the UI. */
     sources: {
         plan: 'structured' | 'legacy_markdown' | 'none';


### PR DESCRIPTION
## Summary

- Consolidated the Development section's two disconnected artifacts — **Developer Prompts** (`prompt_pack`) and **Build Plan** (`implementation_plan`) — into a single, higher-value **Implementation Plan** artifact that connects milestones, tasks, prompt packs, linked Synapse artifacts, dependencies, quality gates, validation commands, and definitions of done.
- **Milestone-centered prompt packs**: new generation emits 1–3 copy-ready, agent-agnostic coding-agent prompts per milestone (Goal / Relevant Synapse Artifacts / Scope / Out of Scope / Implementation Steps / Acceptance Criteria / Quality Gates / Validation Commands / Commit Guidance), plus per-milestone quality gates, validation commands, and a definition of done.
- New consolidated renderer with **Overview** (readiness banner, build strategy, stack, critical path, roadmap-at-a-glance), **Milestones** (expandable detail cards), **Prompt Packs** (grouped by milestone + a labeled Unassigned section), **Quality Gates** (grouped by category, global vs milestone), **Traceability** (milestone → screens → data models → prompt packs → gates; table on desktop, stacked cards on mobile), and copy actions (per prompt, per milestone, all packs, whole plan as markdown).
- **Backwards compatibility preserved** via a render-time adapter — no data migration, no schema break, no new subtype (the consolidated artifact reuses the `implementation_plan` subtype id, so version history, snapshots, sync, model routing, and Convert-to-Tasks keep working).
- Cloud/demo snapshot note: **the demo snapshot should be regenerated because prompt packs are now nested under Implementation Plan milestones.** The demo is a cloud snapshot (not a repo fixture); until the owner re-pins a regenerated one, the adapter renders the existing legacy snapshot consolidated (legacy prompts appear as prompt packs), so the demo does not present disconnected artifacts either way.

## Compatibility Notes

How old `developer_prompts` / `build_plan` artifacts are handled:

- `prompt_pack` becomes the first **retired** subtype (`RETIRED_ARTIFACT_SUBTYPES` in `coreArtifactPipeline.ts` — stronger than the existing "hidden" concept): excluded from new generation runs, finalize readiness, the sidebar, and the Settings model list, while its pipeline meta, renderer, and export path remain for legacy persisted artifacts.
- `implementationPlanAdapter.buildConsolidatedPlan` (pure, unit-tested) derives the consolidated view from any combination of: a native new-shape plan, a legacy structured plan (fence without the new fields), a legacy markdown-only plan, and/or a legacy `prompt_pack` artifact — either artifact may be missing.
- Legacy Developer Prompts are parsed with the same rules as before (parser extracted to `promptPackParser.ts`, shared with the old renderer) and attached to milestones by conservative title/category token matching; unmatched prompts land in a clearly labeled **Unassigned Prompt Packs** group. Legacy plan-wide Definition of Done items become categorized global quality gates; Architecture feeds the stack summary; Risks surface as readiness warnings. Nothing is dropped.
- `StructuredImplementationPlan` was extended **additively** (all new fields optional); the storage format is unchanged (markdown + `json synapse-plan` fence) and the readable markdown keeps the legacy `Milestone/Goal/Deliverables/Dependencies` headings that `artifactValidation` and older parsers expect.
- Readiness and traceability are always **derived at render time**, never persisted.
- Fence-less, milestone-less content still falls back to the original timeline / plain-markdown rendering, and malformed fence JSON degrades gracefully (regression-tested).

## Validation

- `npm run build` (`tsc -b && vite build`) — ✅ passes
- `npm run lint` — ✅ passes
- `npm test` — ✅ 817 tests / 112 files pass (was 806/111 before this branch; adds adapter unit tests, pipeline retired-subtype tests, and renderer component tests)

## Manual Verification

Verified end-to-end in the running app (Playwright against `npm run dev`, seeding a legacy project with a structured Build Plan fence + a standalone Developer Prompts artifact into localStorage):

- **Development section**: shows a single "Implementation Plan" row (no Developer Prompts / Build Plan rows); status dot, version chip, and Version History still work.
- **Overview**: readiness banner ("Needs review" for adapted legacy data, with adaptation/unassigned/risk warnings), build strategy, stack chips, critical path, roadmap-at-a-glance with per-milestone pack/task counts.
- **Milestone detail**: objective, tasks, linked artifacts, and (for legacy data) per-milestone DoD render; first milestone expanded by default.
- **Prompt pack copy**: the song-editor-themed legacy prompt attached to the "Song Editor Core" milestone; the unrelated content prompt landed in Unassigned; Copy Prompt / Copy all prompt packs / Copy plan as markdown wired (clipboard path also covered by component test).
- **Quality gates**: legacy DoD items appear as categorized global gates (testing / accessibility / functional).
- **Traceability**: task-level links roll up into milestone rows (screens + data models + prompt packs).
- **Mobile (390×844)**: tabs scroll horizontally, milestone cards don't overflow, prompt text readable, copy buttons ≥32px, traceability renders as stacked cards.
- **Convert to Tasks** button and `TaskChecklist` remain on the artifact; extraction now prefers milestone-level DoD for acceptance criteria when present.

## Follow-up Recommendations (not implemented)

- Owner re-pins a freshly generated demo snapshot so the demo carries native milestone prompt packs (adapter covers the interim).
- "Convert milestone to tasks" (per-milestone scope) on top of the existing whole-plan conversion.
- Wire `onUsage` token capture into artifact generation (pre-existing TODO) so the richer implementation_plan runs report cost.
- Consider retiring the now-unreferenced prompt_pack progress-stage labels in `generationStages.ts` once legacy retry paths are confirmed dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146CSmSzdxPFo3fftqt6aP7

---
_Generated by [Claude Code](https://claude.ai/code/session_0146CSmSzdxPFo3fftqt6aP7)_