### PR TITLE
Design System under Project Foundation + locked assets + setup-style change-direction screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,12 +501,27 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       `DesignDirectionControl` (`src/components/DesignDirectionControl.tsx`,
       presentational) above its content in `ArtifactWorkspace`: it shows the
       current direction (or an "AI decides" fallback) and offers **Change
-      direction** (re-opens `DesignSystemPresetChoice`, now accepting
-      `currentPresetId`/`title`/`description` props so it doubles as a change
-      dialog) and **Regenerate**. Choosing a new direction persists it via
-      `setProjectDesignSystemPreset` then opens a regenerate-confirm that calls
-      `artifactJobController.retrySlot('design_system')` — which re-reads the
-      preset off the project, so the new direction actually reaches generation.
+      direction** and **Regenerate**. **Change direction opens
+      `ChangeDirectionModal` (`src/components/setup/ChangeDirectionModal.tsx`),
+      which deliberately mirrors the setup-stage `DesignSetupStep`** — same light
+      surface and large `DesignPresetGrid` preview cards (the card grid is
+      extracted into the shared `src/components/setup/DesignPresetGrid.tsx` so the
+      two screens are visually identical) — with the active preset marked
+      **Current** and a prominent amber warning that the change flows through to
+      downstream artifacts (mockups + copied screen prompts). Choosing a new
+      direction persists it via `setProjectDesignSystemPreset` then opens a
+      regenerate-confirm (itself carrying the downstream-impact warning) that
+      calls `artifactJobController.retrySlot('design_system')` — which re-reads
+      the preset off the project, so the new direction actually reaches
+      generation. (The old compact `DesignSystemPresetChoice` sheet now serves
+      only the Mark-as-Final fallback gate in `ProjectWorkspace`.)
+    - **Generated-asset lock affordance.** Every *downstream* asset in the
+      sidebar/mobile-header — anything except the PRD and the Design System
+      itself (`isLockableAsset` / `LOCK_EXEMPT_SELECTIONS` in `ArtifactWorkspace`)
+      — shows a small `Lock` icon once its slot status is `done`, signalling it's
+      anchored ("locked") to the current design system. It's a passive indicator
+      only; changing the visual direction + regenerating the design system is what
+      updates those assets.
     - **Mockup-drift prompt.** Regenerating the design system produces a new
       `tokensHash`, which `stalenessSlice` already uses to flip dependent mockups
       to `possibly_outdated` (the auto-flag). On top of that, the Mockups view in
@@ -922,12 +937,14 @@ User prompt → HomePage.handleCreateProject() → PreflightModeChoice
 
 ### Post-finalization transition (Mark Final → Assets)
 
-The artifact sidebar is organized into five workflow-named sections —
-**Project Foundation** (PRD), **Experience** (User Flows, Screens — see "The
-Experience workspace" below), **Design** (Design System), **Architecture**
-(Data Model), and **Development** (Implementation Plan — see "Consolidated
-Implementation Plan" below) — driven by `ARTIFACT_GROUPS` in
-`ArtifactWorkspace.tsx`. Grouping is purely visual; `CoreArtifactSubtype` ids
+The artifact sidebar is organized into four workflow-named sections —
+**Project Foundation** (PRD **and** Design System — the design system sits
+directly below the PRD as the shared visual foundation every downstream asset is
+generated against), **Experience** (User Flows, Screens — see "The Experience
+workspace" below), **Architecture** (Data Model), and **Development**
+(Implementation Plan — see "Consolidated Implementation Plan" below) — driven by
+`ARTIFACT_GROUPS` in `ArtifactWorkspace.tsx`. Grouping is purely visual;
+`CoreArtifactSubtype` ids
 (`'data_model'`, `'component_inventory'`, `'design_system'`, `'prompt_pack'`,
 `'implementation_plan'`) are unchanged so persisted artifacts, generation, and
 per-artifact model overrides keep working. **`component_inventory` (UI Components)
@@ -973,7 +990,7 @@ switching stage. Its
 `ArtifactWorkspace` as `autoOpenIntent`. `ArtifactWorkspace` consumes it once
 (via `onAutoOpenConsumed`): it auto-selects the first **non-PRD** artifact —
 preferring `done`, then `generating`, then `queued`, else the first slot in
-`ARTIFACT_GROUPS` order (user_flows → screens → design_system → … →
+`ARTIFACT_GROUPS` order (design_system → user_flows → screens → … →
 implementation_plan) — and opens the mobile drawer (`useIsMobile`-gated, so it
 never reopens after the user closes it; desktop keeps the persistent side rail). While the overall run is in
 flight, an idle slot renders a centered `BuildAssetsLoading` ("Creating your

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
-    RefreshCcw, Menu, X, ListChecks, History,
-    Layers, Database, Code2, AppWindow, Palette,
+    RefreshCcw, Menu, X, ListChecks, History, Lock,
+    Layers, Database, Code2, AppWindow,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -21,7 +21,7 @@ import { ConvertToTasksModal } from './ConvertToTasksModal';
 import { TaskChecklist } from './tasks/TaskChecklist';
 import { StalenessBadge } from './StalenessBadge';
 import { VersionHistoryPanel, type VersionEntry } from './versions';
-import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
+import { ChangeDirectionModal } from './setup/ChangeDirectionModal';
 import { DesignDirectionControl } from './DesignDirectionControl';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -91,10 +91,12 @@ interface ArtifactGroup {
 
 // Sidebar grouping is purely visual — subtype IDs are unchanged. Order within
 // a group is the order rows render in. The "Project Foundation → Experience →
-// Design → Architecture → Development" sequence tells the product-build story;
-// keep it in sync with the README/tour if either changes.
+// Architecture → Development" sequence tells the product-build story; keep it in
+// sync with the README/tour if either changes. The Design System sits under
+// Project Foundation, directly below the PRD — it's the visual foundation every
+// downstream asset is generated against.
 const ARTIFACT_GROUPS: ArtifactGroup[] = [
-    { id: 'foundation', title: 'Project Foundation', icon: FileText, items: ['prd'] },
+    { id: 'foundation', title: 'Project Foundation', icon: FileText, items: ['prd', 'design_system'] },
     {
         id: 'experience',
         title: 'Experience',
@@ -108,7 +110,6 @@ const ARTIFACT_GROUPS: ArtifactGroup[] = [
         // a hidden subtype — see HIDDEN_ARTIFACT_SUBTYPES / docs/backlog §6.
         items: ['user_flows', 'screens'],
     },
-    { id: 'design', title: 'Design', icon: Palette, items: ['design_system'] },
     { id: 'architecture', title: 'Architecture', icon: Database, items: ['data_model'] },
     // Development consolidates the old Developer Prompts + Build Plan rows
     // into one Implementation Plan artifact (milestones + prompt packs +
@@ -153,6 +154,25 @@ function StatusDot({ status }: { status: GenerationStatus }) {
     if (status === 'error') return <AlertTriangle size={14} className="text-red-500 shrink-0" />;
     if (status === 'interrupted') return <AlertTriangle size={14} className="text-amber-500 shrink-0" />;
     return <Circle size={14} className="text-neutral-300 shrink-0" />;
+}
+
+// The PRD and the Design System itself are the foundation — every other asset is
+// generated *against* the design system, so once produced it's "locked" to that
+// visual direction (changing direction + regenerating the design system is what
+// updates it). These two are exempt from the lock affordance.
+const LOCK_EXEMPT_SELECTIONS = new Set<WorkspaceSelection>(['prd', 'design_system']);
+function isLockableAsset(key: WorkspaceSelection): boolean {
+    return !LOCK_EXEMPT_SELECTIONS.has(key);
+}
+
+// Small lock shown on a generated downstream asset, signalling it's anchored to
+// the current design system. Rendered only for `done` lockable assets.
+function AssetLock() {
+    return (
+        <span title="Locked to your design system" className="inline-flex shrink-0">
+            <Lock size={11} className="text-neutral-400" aria-label="Locked to your design system" />
+        </span>
+    );
 }
 
 export function ArtifactWorkspace({
@@ -1102,6 +1122,9 @@ export function ArtifactWorkspace({
                                                                 {slot.title}
                                                             </span>
                                                             <StatusDot status={status} />
+                                                            {status === 'done' && isLockableAsset(slot.key) && (
+                                                                <AssetLock />
+                                                            )}
                                                         </div>
                                                         <div className="text-[11px] text-neutral-500 leading-tight truncate">
                                                             {slot.description}
@@ -1134,8 +1157,11 @@ export function ArtifactWorkspace({
                         {selectedMeta?.title ?? 'Artifacts'}
                     </span>
                     {activeSelection !== 'prd' && (
-                        <span className="ml-auto shrink-0">
+                        <span className="ml-auto shrink-0 flex items-center gap-1.5">
                             <StatusDot status={slotStatusFor(activeSelection)} />
+                            {slotStatusFor(activeSelection) === 'done' && isLockableAsset(activeSelection) && (
+                                <AssetLock />
+                            )}
                         </span>
                     )}
                 </div>
@@ -1260,10 +1286,8 @@ export function ArtifactWorkspace({
             )}
 
             {showDirectionPicker && (
-                <DesignSystemPresetChoice
+                <ChangeDirectionModal
                     currentPresetId={designSystemPreset}
-                    title="Change your visual direction"
-                    description="Pick a new direction for this project's design system. Internal mockups and the prompts you copy for external image tools both follow it, so everything stays consistent."
                     onChoose={handleChooseDirection}
                     onClose={() => setShowDirectionPicker(false)}
                 />
@@ -1289,10 +1313,15 @@ export function ArtifactWorkspace({
                             <p className="text-sm text-neutral-700 mt-1">
                                 Creates Version {designRegenConfirm.nextVersion} using your chosen direction.
                             </p>
-                            <p className="text-xs text-neutral-500 mt-1">
-                                This may make your existing mockups out of date — you can regenerate them
-                                afterward. The current version remains in version history.
-                            </p>
+                            <div className="mt-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+                                <AlertTriangle size={14} className="shrink-0 mt-0.5 text-amber-500" />
+                                <p className="text-xs text-amber-800">
+                                    This changes the visual foundation, so your downstream assets —
+                                    mockups and the screen-level prompts you copy for external image
+                                    tools — may become out of date. You can regenerate them afterward.
+                                    The current version stays in version history.
+                                </p>
+                            </div>
                         </div>
                         <div className="px-5 pb-4 flex items-center justify-end gap-2">
                             <button

--- a/src/components/setup/ChangeDirectionModal.tsx
+++ b/src/components/setup/ChangeDirectionModal.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { AlertTriangle, Sparkles, X } from 'lucide-react';
+import { DESIGN_SYSTEM_PRESETS } from '../../lib/designSystemPresets';
+import { getDefaultDesignPreset, setDefaultDesignPreset } from '../../lib/designPresetPreference';
+import { DesignPresetGrid } from './DesignPresetGrid';
+
+interface ChangeDirectionModalProps {
+    /** The direction currently stored on the project (marked "Current"). */
+    currentPresetId?: string;
+    /**
+     * Commit a newly-chosen direction. The caller persists it and leads into a
+     * regenerate confirmation — the change only takes effect on regeneration.
+     */
+    onChoose: (presetId: string) => void;
+    onClose: () => void;
+}
+
+/**
+ * Post-finalization "Change your visual direction" screen. Deliberately mirrors
+ * the setup-stage `DesignSetupStep` a user sees right after their initial prompt
+ * — same light surface and large preview cards — so switching direction feels
+ * like the original choice, not a different control. A prominent warning makes
+ * clear the change flows through to downstream artifacts (mockups, screens, and
+ * copied image prompts) before the user commits; the caller then requires an
+ * explicit regenerate confirmation.
+ */
+export function ChangeDirectionModal({
+    currentPresetId,
+    onChoose,
+    onClose,
+}: ChangeDirectionModalProps) {
+    // Preselect the current direction so the screen opens on what's active.
+    const [selectedId, setSelectedId] = useState<string>(
+        currentPresetId ?? DESIGN_SYSTEM_PRESETS[0].id,
+    );
+    const [defaultPresetId] = useState<string | null>(() => getDefaultDesignPreset());
+    const [saveAsDefault, setSaveAsDefault] = useState(false);
+
+    const selectedPreset = DESIGN_SYSTEM_PRESETS.find((p) => p.id === selectedId);
+    const isUnchanged = selectedId === currentPresetId;
+
+    const handleContinue = () => {
+        if (!selectedPreset) return;
+        if (saveAsDefault) setDefaultDesignPreset(selectedPreset.id);
+        onChoose(selectedPreset.id);
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-end sm:items-center justify-center sm:p-4"
+            onClick={onClose}
+            role="presentation"
+        >
+            <div
+                className="bg-white w-full sm:max-w-3xl max-h-[92vh] rounded-t-3xl sm:rounded-2xl shadow-xl border border-neutral-200/80 overflow-y-auto"
+                style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 0.25rem)' }}
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="change-direction-title"
+            >
+                <div className="p-6 md:p-8">
+                    <div className="flex items-start justify-between gap-3">
+                        <h2
+                            id="change-direction-title"
+                            className="text-xl md:text-2xl font-semibold text-neutral-900"
+                        >
+                            Change your visual direction
+                        </h2>
+                        <button
+                            onClick={onClose}
+                            className="p-2 -mr-2 -mt-1 text-neutral-400 hover:text-neutral-700 rounded-lg transition shrink-0"
+                            aria-label="Cancel"
+                        >
+                            <X size={18} />
+                        </button>
+                    </div>
+                    <p className="mt-2 text-sm text-neutral-500 max-w-2xl">
+                        Pick a new direction for this project&apos;s design system. Internal mockups and
+                        the prompts you copy for external image tools both follow it, so everything
+                        stays visually consistent.
+                    </p>
+
+                    {/* Downstream-impact warning — shown before the user commits. */}
+                    <div className="mt-4 flex items-start gap-2.5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                        <AlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-500" />
+                        <span>
+                            Changing direction regenerates the design system, which may make your
+                            existing <span className="font-medium">mockups and screen-level prompts</span>{' '}
+                            out of date. You&apos;ll confirm before anything regenerates, and the current
+                            version stays in version history.
+                        </span>
+                    </div>
+
+                    <div className="mt-6">
+                        <DesignPresetGrid
+                            selectedId={selectedId}
+                            onSelect={setSelectedId}
+                            defaultPresetId={defaultPresetId}
+                            currentId={currentPresetId}
+                        />
+                    </div>
+
+                    {/* Action bar */}
+                    <div
+                        className="sticky bottom-0 mt-6 flex flex-wrap items-center gap-3 bg-white/95 backdrop-blur pt-4 border-t border-neutral-100"
+                    >
+                        <label className="flex items-center gap-2 text-sm text-neutral-600 cursor-pointer select-none min-h-[44px]">
+                            <input
+                                type="checkbox"
+                                checked={saveAsDefault}
+                                onChange={(e) => setSaveAsDefault(e.target.checked)}
+                                className="h-4 w-4 rounded border-neutral-300 text-indigo-600 focus:ring-indigo-500"
+                            />
+                            Use this as my default for future projects
+                        </label>
+                        <div className="flex-1" />
+                        <button
+                            onClick={onClose}
+                            className="px-4 py-3 min-h-[44px] rounded-xl text-sm font-medium text-neutral-500 hover:bg-neutral-100 transition"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleContinue}
+                            disabled={!selectedPreset || isUnchanged}
+                            className="inline-flex items-center gap-1.5 px-6 py-3 min-h-[44px] rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 transition disabled:opacity-60"
+                        >
+                            <Sparkles size={16} />
+                            {isUnchanged
+                                ? 'Current direction'
+                                : `Continue with ${selectedPreset?.label ?? 'selection'}`}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/setup/DesignPresetGrid.tsx
+++ b/src/components/setup/DesignPresetGrid.tsx
@@ -1,0 +1,226 @@
+import { Check, CheckCircle2, Wand2 } from 'lucide-react';
+import {
+    DESIGN_SYSTEM_PRESETS,
+    type DesignSystemPreset,
+    type PresetPreviewTokens,
+} from '../../lib/designSystemPresets';
+
+interface DesignPresetGridProps {
+    /** Currently highlighted preset id. */
+    selectedId: string;
+    onSelect: (presetId: string) => void;
+    /** Rule-based recommendation → "Recommended" badge (optional). */
+    recommendedId?: string;
+    /** The user's saved default → "Your default" badge (optional). */
+    defaultPresetId?: string | null;
+    /**
+     * The direction currently stored on the project → "Current" badge. Used by
+     * the post-finalization "change your visual direction" flow so the user can
+     * see what's active while they pick a new one.
+     */
+    currentId?: string;
+}
+
+/**
+ * The shared visual-direction picker grid — the large static preview cards used
+ * both by the setup-stage `DesignSetupStep` (right after the initial prompt) and
+ * the post-finalization "Change your visual direction" flow, so the two screens
+ * look identical. Presentational only; the caller owns the selection + actions.
+ */
+export function DesignPresetGrid({
+    selectedId,
+    onSelect,
+    recommendedId,
+    defaultPresetId,
+    currentId,
+}: DesignPresetGridProps) {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {DESIGN_SYSTEM_PRESETS.map((preset) => (
+                <PresetCard
+                    key={preset.id}
+                    preset={preset}
+                    selected={preset.id === selectedId}
+                    recommended={preset.id === recommendedId}
+                    isDefault={preset.id === defaultPresetId}
+                    isCurrent={preset.id === currentId}
+                    onSelect={() => onSelect(preset.id)}
+                />
+            ))}
+        </div>
+    );
+}
+
+// --- Cards ------------------------------------------------------------------
+
+interface PresetCardProps {
+    preset: DesignSystemPreset;
+    selected: boolean;
+    recommended: boolean;
+    isDefault: boolean;
+    isCurrent?: boolean;
+    onSelect: () => void;
+}
+
+export function PresetCard({
+    preset,
+    selected,
+    recommended,
+    isDefault,
+    isCurrent,
+    onSelect,
+}: PresetCardProps) {
+    return (
+        <button
+            onClick={onSelect}
+            aria-pressed={selected}
+            className={`text-left rounded-2xl border p-3 transition group ${
+                selected
+                    ? 'border-indigo-500 ring-2 ring-indigo-200 bg-indigo-50/40'
+                    : 'border-neutral-200 hover:border-indigo-300 bg-white'
+            }`}
+        >
+            {preset.previewTokens ? (
+                <PresetPreview tokens={preset.previewTokens} />
+            ) : (
+                <CustomPreviewPlaceholder />
+            )}
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-neutral-900 text-sm">{preset.label}</span>
+                {isCurrent && (
+                    <span className="inline-flex items-center gap-1 text-[11px] font-medium text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">
+                        <Check size={11} /> Current
+                    </span>
+                )}
+                {recommended && (
+                    <span className="text-[11px] font-medium text-indigo-700 bg-indigo-100 px-2 py-0.5 rounded-full">
+                        Recommended
+                    </span>
+                )}
+                {isDefault && (
+                    <span className="text-[11px] font-medium text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">
+                        Your default
+                    </span>
+                )}
+                {selected && (
+                    <span className="ml-auto inline-flex items-center justify-center w-5 h-5 rounded-full bg-indigo-600 text-white shrink-0">
+                        <CheckCircle2 size={12} />
+                    </span>
+                )}
+            </div>
+            {preset.tone && (
+                <p className="mt-0.5 text-xs font-medium text-neutral-500">{preset.tone}</p>
+            )}
+            <p className="mt-1 text-xs text-neutral-500 leading-relaxed">{preset.detail}</p>
+            {preset.recommendedUseCases && preset.recommendedUseCases.length > 0 && (
+                <p className="mt-1.5 text-[11px] text-neutral-400">
+                    Great for: {preset.recommendedUseCases.join(' · ')}
+                </p>
+            )}
+        </button>
+    );
+}
+
+/**
+ * Static mini-layout rendered purely from the preset's preview tokens — no AI
+ * call, no images. Top bar + sidebar + heading/body type sample + primary
+ * button + mock content card + color swatches.
+ */
+export function PresetPreview({ tokens }: { tokens: PresetPreviewTokens }) {
+    const cardRadius = Math.min(tokens.radius, 12);
+    return (
+        <div
+            aria-hidden
+            className="pointer-events-none select-none overflow-hidden rounded-xl border"
+            style={{ background: tokens.background, borderColor: tokens.border, fontFamily: tokens.fontFamily }}
+        >
+            {/* Header shape */}
+            <div
+                className="flex items-center gap-1.5 px-2.5 py-1.5 border-b"
+                style={{ background: tokens.surface, borderColor: tokens.border }}
+            >
+                <span className="w-2 h-2 rounded-full" style={{ background: tokens.primary }} />
+                <span className="h-1.5 w-10 rounded-full" style={{ background: tokens.border }} />
+                <span className="ml-auto h-1.5 w-5 rounded-full" style={{ background: tokens.border }} />
+            </div>
+            <div className="flex gap-2 p-2.5">
+                {/* Sidebar shape */}
+                <div
+                    className="w-9 shrink-0 p-1.5 space-y-1.5 border"
+                    style={{ background: tokens.surface, borderColor: tokens.border, borderRadius: cardRadius }}
+                >
+                    <span className="block h-1 rounded-full" style={{ background: tokens.primary }} />
+                    <span className="block h-1 rounded-full" style={{ background: tokens.border }} />
+                    <span className="block h-1 rounded-full" style={{ background: tokens.border }} />
+                </div>
+                <div className="flex-1 min-w-0">
+                    {/* Typography sample */}
+                    <div
+                        className="text-[11px] leading-tight truncate"
+                        style={{ color: tokens.text, fontWeight: tokens.headingWeight }}
+                    >
+                        Aa — Heading
+                    </div>
+                    <div className="text-[9px] truncate" style={{ color: tokens.mutedText }}>
+                        Body copy sample text
+                    </div>
+                    {/* Sample button */}
+                    <div className="mt-1.5 flex items-center gap-1.5">
+                        <span
+                            className="px-2 py-0.5 text-[9px] font-medium"
+                            style={{
+                                background: tokens.primary,
+                                color: tokens.primaryText,
+                                borderRadius: cardRadius,
+                            }}
+                        >
+                            Button
+                        </span>
+                        <span
+                            className="px-2 py-0.5 text-[9px] border"
+                            style={{
+                                color: tokens.mutedText,
+                                borderColor: tokens.border,
+                                borderRadius: cardRadius,
+                            }}
+                        >
+                            Action
+                        </span>
+                    </div>
+                    {/* Mock content card */}
+                    <div
+                        className="mt-1.5 p-1.5 space-y-1 border"
+                        style={{ background: tokens.surface, borderColor: tokens.border, borderRadius: cardRadius }}
+                    >
+                        <span className="block h-1 w-3/4 rounded-full" style={{ background: tokens.mutedText, opacity: 0.5 }} />
+                        <span className="block h-1 w-1/2 rounded-full" style={{ background: tokens.mutedText, opacity: 0.3 }} />
+                    </div>
+                </div>
+            </div>
+            {/* Color swatches */}
+            <div className="flex items-center gap-1 px-2.5 pb-2">
+                {[tokens.primary, tokens.text, tokens.mutedText, tokens.surface].map((c, i) => (
+                    <span
+                        key={i}
+                        className="w-3.5 h-3.5 rounded-full border"
+                        style={{ background: c, borderColor: tokens.border }}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export function CustomPreviewPlaceholder() {
+    return (
+        <div
+            aria-hidden
+            className="pointer-events-none select-none rounded-xl border border-dashed border-neutral-300 bg-neutral-50 flex flex-col items-center justify-center gap-1.5 py-8"
+        >
+            <Wand2 size={18} className="text-neutral-400" />
+            <span className="text-[10px] text-neutral-500">
+                Synapse designs it from your PRD
+            </span>
+        </div>
+    );
+}

--- a/src/components/setup/DesignSetupStep.tsx
+++ b/src/components/setup/DesignSetupStep.tsx
@@ -1,13 +1,10 @@
 import { useMemo, useState } from 'react';
-import { Check, CheckCircle2, Loader2, Sparkles, Wand2 } from 'lucide-react';
+import { CheckCircle2, Loader2, Sparkles } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
-import {
-    DESIGN_SYSTEM_PRESETS,
-    type DesignSystemPreset,
-    type PresetPreviewTokens,
-} from '../../lib/designSystemPresets';
+import { DESIGN_SYSTEM_PRESETS } from '../../lib/designSystemPresets';
 import { recommendDesignSystemPresetId } from '../../lib/designPresetRecommendation';
 import { getDefaultDesignPreset, setDefaultDesignPreset } from '../../lib/designPresetPreference';
+import { DesignPresetGrid } from './DesignPresetGrid';
 
 interface DesignSetupStepProps {
     projectId: string;
@@ -92,17 +89,13 @@ export function DesignSetupStep({ projectId, recommendationText, prdGenerating }
                 consistent. You can change it later from the Design System artifact.
             </p>
 
-            <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {DESIGN_SYSTEM_PRESETS.map((preset) => (
-                    <PresetCard
-                        key={preset.id}
-                        preset={preset}
-                        selected={preset.id === selectedId}
-                        recommended={preset.id === recommendedId}
-                        isDefault={preset.id === defaultPresetId}
-                        onSelect={() => setSelectedId(preset.id)}
-                    />
-                ))}
+            <div className="mt-6">
+                <DesignPresetGrid
+                    selectedId={selectedId}
+                    onSelect={setSelectedId}
+                    recommendedId={recommendedId}
+                    defaultPresetId={defaultPresetId}
+                />
             </div>
 
             {/* Action bar — pinned near the bottom with safe-area inset,
@@ -136,167 +129,6 @@ export function DesignSetupStep({ projectId, recommendationText, prdGenerating }
                     Continue with {selectedPreset?.label ?? 'selection'}
                 </button>
             </div>
-        </div>
-    );
-}
-
-// --- Cards ------------------------------------------------------------------
-
-interface PresetCardProps {
-    preset: DesignSystemPreset;
-    selected: boolean;
-    recommended: boolean;
-    isDefault: boolean;
-    onSelect: () => void;
-}
-
-function PresetCard({ preset, selected, recommended, isDefault, onSelect }: PresetCardProps) {
-    return (
-        <button
-            onClick={onSelect}
-            aria-pressed={selected}
-            className={`text-left rounded-2xl border p-3 transition group ${
-                selected
-                    ? 'border-indigo-500 ring-2 ring-indigo-200 bg-indigo-50/40'
-                    : 'border-neutral-200 hover:border-indigo-300 bg-white'
-            }`}
-        >
-            {preset.previewTokens ? (
-                <PresetPreview tokens={preset.previewTokens} />
-            ) : (
-                <CustomPreviewPlaceholder />
-            )}
-            <div className="mt-3 flex items-center gap-2 flex-wrap">
-                <span className="font-semibold text-neutral-900 text-sm">{preset.label}</span>
-                {recommended && (
-                    <span className="text-[11px] font-medium text-indigo-700 bg-indigo-100 px-2 py-0.5 rounded-full">
-                        Recommended
-                    </span>
-                )}
-                {isDefault && (
-                    <span className="text-[11px] font-medium text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">
-                        Your default
-                    </span>
-                )}
-                {selected && (
-                    <span className="ml-auto inline-flex items-center justify-center w-5 h-5 rounded-full bg-indigo-600 text-white shrink-0">
-                        <Check size={12} />
-                    </span>
-                )}
-            </div>
-            {preset.tone && (
-                <p className="mt-0.5 text-xs font-medium text-neutral-500">{preset.tone}</p>
-            )}
-            <p className="mt-1 text-xs text-neutral-500 leading-relaxed">{preset.detail}</p>
-            {preset.recommendedUseCases && preset.recommendedUseCases.length > 0 && (
-                <p className="mt-1.5 text-[11px] text-neutral-400">
-                    Great for: {preset.recommendedUseCases.join(' · ')}
-                </p>
-            )}
-        </button>
-    );
-}
-
-/**
- * Static mini-layout rendered purely from the preset's preview tokens — no AI
- * call, no images. Top bar + sidebar + heading/body type sample + primary
- * button + mock content card + color swatches.
- */
-function PresetPreview({ tokens }: { tokens: PresetPreviewTokens }) {
-    const cardRadius = Math.min(tokens.radius, 12);
-    return (
-        <div
-            aria-hidden
-            className="pointer-events-none select-none overflow-hidden rounded-xl border"
-            style={{ background: tokens.background, borderColor: tokens.border, fontFamily: tokens.fontFamily }}
-        >
-            {/* Header shape */}
-            <div
-                className="flex items-center gap-1.5 px-2.5 py-1.5 border-b"
-                style={{ background: tokens.surface, borderColor: tokens.border }}
-            >
-                <span className="w-2 h-2 rounded-full" style={{ background: tokens.primary }} />
-                <span className="h-1.5 w-10 rounded-full" style={{ background: tokens.border }} />
-                <span className="ml-auto h-1.5 w-5 rounded-full" style={{ background: tokens.border }} />
-            </div>
-            <div className="flex gap-2 p-2.5">
-                {/* Sidebar shape */}
-                <div
-                    className="w-9 shrink-0 p-1.5 space-y-1.5 border"
-                    style={{ background: tokens.surface, borderColor: tokens.border, borderRadius: cardRadius }}
-                >
-                    <span className="block h-1 rounded-full" style={{ background: tokens.primary }} />
-                    <span className="block h-1 rounded-full" style={{ background: tokens.border }} />
-                    <span className="block h-1 rounded-full" style={{ background: tokens.border }} />
-                </div>
-                <div className="flex-1 min-w-0">
-                    {/* Typography sample */}
-                    <div
-                        className="text-[11px] leading-tight truncate"
-                        style={{ color: tokens.text, fontWeight: tokens.headingWeight }}
-                    >
-                        Aa — Heading
-                    </div>
-                    <div className="text-[9px] truncate" style={{ color: tokens.mutedText }}>
-                        Body copy sample text
-                    </div>
-                    {/* Sample button */}
-                    <div className="mt-1.5 flex items-center gap-1.5">
-                        <span
-                            className="px-2 py-0.5 text-[9px] font-medium"
-                            style={{
-                                background: tokens.primary,
-                                color: tokens.primaryText,
-                                borderRadius: cardRadius,
-                            }}
-                        >
-                            Button
-                        </span>
-                        <span
-                            className="px-2 py-0.5 text-[9px] border"
-                            style={{
-                                color: tokens.mutedText,
-                                borderColor: tokens.border,
-                                borderRadius: cardRadius,
-                            }}
-                        >
-                            Action
-                        </span>
-                    </div>
-                    {/* Mock content card */}
-                    <div
-                        className="mt-1.5 p-1.5 space-y-1 border"
-                        style={{ background: tokens.surface, borderColor: tokens.border, borderRadius: cardRadius }}
-                    >
-                        <span className="block h-1 w-3/4 rounded-full" style={{ background: tokens.mutedText, opacity: 0.5 }} />
-                        <span className="block h-1 w-1/2 rounded-full" style={{ background: tokens.mutedText, opacity: 0.3 }} />
-                    </div>
-                </div>
-            </div>
-            {/* Color swatches */}
-            <div className="flex items-center gap-1 px-2.5 pb-2">
-                {[tokens.primary, tokens.text, tokens.mutedText, tokens.surface].map((c, i) => (
-                    <span
-                        key={i}
-                        className="w-3.5 h-3.5 rounded-full border"
-                        style={{ background: c, borderColor: tokens.border }}
-                    />
-                ))}
-            </div>
-        </div>
-    );
-}
-
-function CustomPreviewPlaceholder() {
-    return (
-        <div
-            aria-hidden
-            className="pointer-events-none select-none rounded-xl border border-dashed border-neutral-300 bg-neutral-50 flex flex-col items-center justify-center gap-1.5 py-8"
-        >
-            <Wand2 size={18} className="text-neutral-400" />
-            <span className="text-[10px] text-neutral-500">
-                Synapse designs it from your PRD
-            </span>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Three design-system UX changes to the artifact workspace, driven by the attached mockups:

1. **Design System moves under "Project Foundation", directly below the PRD.** The standalone "Design" sidebar group is removed; the Design System now sits with the PRD as the shared visual foundation every downstream asset is generated against. Grouping is purely visual — `CoreArtifactSubtype` ids are unchanged, so persisted artifacts, generation, model routing, and sync all keep working.

2. **Generated downstream assets show a small lock icon.** Once a slot is `done`, every asset except the PRD and the Design System itself (`isLockableAsset` / `LOCK_EXEMPT_SELECTIONS`) renders a small `Lock` next to its status dot in the sidebar and mobile header, signalling it's anchored ("locked") to the current design system. Passive indicator only.

3. **"Change your visual direction" now matches the setup screen and warns before executing.** The Design System artifact's *Change direction* action opens a new `ChangeDirectionModal` that mirrors the setup-stage `DesignSetupStep` a user sees right after their initial prompt — same light surface and large preview cards (the card grid is extracted into a shared `DesignPresetGrid` used by both screens) — instead of the old compact dark preset sheet. The active preset is marked **Current**, and a prominent amber warning makes clear the change flows through to downstream artifacts (mockups + copied screen prompts) before the user commits. The follow-up regenerate confirmation carries the same downstream-impact warning. The compact `DesignSystemPresetChoice` sheet now serves only the Mark-as-Final fallback gate.

## Changes

- `src/components/ArtifactWorkspace.tsx` — reorganize `ARTIFACT_GROUPS`, add the lock affordance, swap the change-direction picker to `ChangeDirectionModal`, strengthen the regenerate-confirm warning.
- `src/components/setup/DesignPresetGrid.tsx` *(new)* — shared visual-direction preview-card grid.
- `src/components/setup/ChangeDirectionModal.tsx` *(new)* — setup-styled change-direction screen with downstream warning.
- `src/components/setup/DesignSetupStep.tsx` — reuse the shared `DesignPresetGrid`.
- `CLAUDE.md` — docs updated for the new foundation grouping, the lock affordance, and the change-direction flow.

## Testing

- `npm run build` ✓ (tsc -b + vite build)
- `npm run lint` ✓
- `npm test` ✓ (819 tests, 112 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMEmz3cH8VbMNYuJntaJ4w

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMEmz3cH8VbMNYuJntaJ4w)_