### PR TITLE
Align the product tour assets with the real Assets page

### DIFF
--- a/src/components/tour/screens/ScreenAssets.tsx
+++ b/src/components/tour/screens/ScreenAssets.tsx
@@ -4,16 +4,18 @@ import { Check, ChevronRight, FileText, Sparkles, Zap } from 'lucide-react';
 import { ScreenShell } from '../components/ScreenShell';
 import { StatusIcon, type StepStatus } from '../components/GenerationStep';
 import { ArtifactDrawer } from '../components/ArtifactDrawer';
-import { TOUR_ASSETS, type TourAsset } from '../tourData';
+import { TOUR_ASSETS, TOUR_ASSET_GROUPS, type TourAsset } from '../tourData';
 import type { ScreenProps } from '../tourTypes';
 
 const ASSET_GEN_MS = 650;
 const allDone = () => TOUR_ASSETS.map(() => 'done' as StepStatus);
 
 /**
- * Screen 5 (hero) — "Mark as Final" finalizes the PRD and the seven workspace
- * assets generate one at a time. Each finished asset is clickable and opens a
- * lightweight preview drawer. This is the key onboarding moment.
+ * Screen 5 (hero) — "Mark as Final" finalizes the PRD and the downstream
+ * workspace assets generate one at a time, grouped exactly as the real Assets
+ * page groups them (Project Foundation → Experience → Architecture →
+ * Development). Each finished asset is clickable and opens a lightweight preview
+ * drawer. This is the key onboarding moment.
  */
 export default function ScreenAssets({ reducedMotion }: ScreenProps) {
     // The screen remounts fresh each time it becomes active, so the hero moment
@@ -92,40 +94,62 @@ export default function ScreenAssets({ reducedMotion }: ScreenProps) {
                     </motion.span>
                 </div>
 
-                {/* Assets grid */}
-                <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-                    {TOUR_ASSETS.map((asset, i) => {
-                        const status = statuses[i];
-                        const isDone = status === 'done';
+                {/* Assets — grouped exactly like the workspace Assets page
+                    sidebar (Project Foundation → Experience → Architecture →
+                    Development). The generation status array is keyed by the
+                    flat TOUR_ASSETS order, so each button looks up its own
+                    index. */}
+                <div className="space-y-4">
+                    {TOUR_ASSET_GROUPS.map((group) => {
+                        const groupAssets = TOUR_ASSETS.map((asset, i) => ({ asset, i })).filter(
+                            ({ asset }) => asset.group === group.id,
+                        );
+                        if (groupAssets.length === 0) return null;
                         return (
-                            <button
-                                key={asset.id}
-                                type="button"
-                                disabled={!isDone}
-                                onClick={() => setOpenAsset(asset)}
-                                aria-label={isDone ? `Preview ${asset.name}` : `${asset.name} (not generated yet)`}
-                                className={`flex items-center gap-3 rounded-xl border p-3 text-left transition ${
-                                    isDone
-                                        ? 'border-neutral-700 bg-neutral-800/50 hover:border-indigo-500/50 hover:bg-neutral-800'
-                                        : 'border-neutral-800 bg-neutral-800/20'
-                                }`}
-                            >
-                                <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${asset.accent}`}>
-                                    <asset.icon size={18} aria-hidden="true" />
-                                </span>
-                                <span className="min-w-0 flex-1">
-                                    <span className="block truncate text-sm font-medium text-neutral-100">{asset.name}</span>
-                                    <span className="block truncate text-xs text-neutral-500">{asset.tagline}</span>
-                                </span>
-                                {status === 'queued' ? (
-                                    <span className="text-[11px] text-neutral-600">Queued</span>
-                                ) : (
-                                    <span className="flex items-center gap-1">
-                                        <StatusIcon status={status} reducedMotion={reducedMotion} size="sm" />
-                                        {isDone && <ChevronRight size={15} className="text-neutral-500" />}
+                            <div key={group.id}>
+                                <div className="mb-2 flex items-center gap-2">
+                                    <group.icon size={13} className="text-neutral-500" aria-hidden="true" />
+                                    <span className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                                        {group.title}
                                     </span>
-                                )}
-                            </button>
+                                </div>
+                                <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+                                    {groupAssets.map(({ asset, i }) => {
+                                        const status = statuses[i];
+                                        const isDone = status === 'done';
+                                        return (
+                                            <button
+                                                key={asset.id}
+                                                type="button"
+                                                disabled={!isDone}
+                                                onClick={() => setOpenAsset(asset)}
+                                                aria-label={isDone ? `Preview ${asset.name}` : `${asset.name} (not generated yet)`}
+                                                className={`flex items-center gap-3 rounded-xl border p-3 text-left transition ${
+                                                    isDone
+                                                        ? 'border-neutral-700 bg-neutral-800/50 hover:border-indigo-500/50 hover:bg-neutral-800'
+                                                        : 'border-neutral-800 bg-neutral-800/20'
+                                                }`}
+                                            >
+                                                <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${asset.accent}`}>
+                                                    <asset.icon size={18} aria-hidden="true" />
+                                                </span>
+                                                <span className="min-w-0 flex-1">
+                                                    <span className="block truncate text-sm font-medium text-neutral-100">{asset.name}</span>
+                                                    <span className="block truncate text-xs text-neutral-500">{asset.tagline}</span>
+                                                </span>
+                                                {status === 'queued' ? (
+                                                    <span className="text-[11px] text-neutral-600">Queued</span>
+                                                ) : (
+                                                    <span className="flex items-center gap-1">
+                                                        <StatusIcon status={status} reducedMotion={reducedMotion} size="sm" />
+                                                        {isDone && <ChevronRight size={15} className="text-neutral-500" />}
+                                                    </span>
+                                                )}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
                         );
                     })}
                 </div>

--- a/src/components/tour/screens/ScreenConnections.tsx
+++ b/src/components/tour/screens/ScreenConnections.tsx
@@ -45,7 +45,7 @@ function PrdHubCard() {
 
 /**
  * Screen 6 — the connected workspace. A project rail, the finalized PRD wired
- * to its seven generated artifacts (tap any node to trace dependencies), and a
+ * to its generated artifacts (tap any node to trace dependencies), and a
  * tappable recent-activity timeline. Teaches that Synapse keeps the whole
  * project consistent.
  */
@@ -97,7 +97,7 @@ export default function ScreenConnections({ reducedMotion }: ScreenProps) {
                         <div className="mb-4 flex items-center justify-between">
                             <h3 className="text-sm font-semibold text-white">Generated Artifacts</h3>
                             <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
-                                <Check size={13} /> 7 of 7 up to date
+                                <Check size={13} /> {TOUR_ASSETS.length} of {TOUR_ASSETS.length} up to date
                             </span>
                         </div>
                         <NodeGraph

--- a/src/components/tour/tourData.ts
+++ b/src/components/tour/tourData.ts
@@ -1,10 +1,12 @@
 import {
     Workflow,
-    Smartphone,
+    AppWindow,
     Database,
-    Boxes,
     Terminal,
     Palette,
+    FileText,
+    Layers,
+    Code2,
     type LucideIcon,
 } from 'lucide-react';
 
@@ -182,8 +184,31 @@ export const VERSIONS: VersionEntry[] = [
 
 export type AssetPreviewKind = 'flow' | 'screens' | 'table' | 'grid' | 'roadmap' | 'palette' | 'prompt';
 
+/**
+ * Sidebar groups shown on the workspace Assets page. These mirror
+ * `ARTIFACT_GROUPS` in `ArtifactWorkspace.tsx` (minus the PRD row, which is the
+ * hub these assets are generated *from*, not a generated asset itself). Keep the
+ * ids, titles, order, and icons in sync if the workspace grouping changes.
+ */
+export type AssetGroupId = 'foundation' | 'experience' | 'architecture' | 'development';
+
+export interface AssetGroup {
+    id: AssetGroupId;
+    title: string;
+    icon: LucideIcon;
+}
+
+export const TOUR_ASSET_GROUPS: AssetGroup[] = [
+    { id: 'foundation', title: 'Project Foundation', icon: FileText },
+    { id: 'experience', title: 'Experience', icon: Layers },
+    { id: 'architecture', title: 'Architecture', icon: Database },
+    { id: 'development', title: 'Development', icon: Code2 },
+];
+
 export interface TourAsset {
     id: string;
+    /** Which Assets-page sidebar group this artifact lives under. */
+    group: AssetGroupId;
     name: string;
     tagline: string;
     icon: LucideIcon;
@@ -194,9 +219,30 @@ export interface TourAsset {
     preview: string[];
 }
 
+/**
+ * The assets Synapse generates from a finalized PRD, in the same order and
+ * grouping the workspace Assets page shows them. This list is deliberately
+ * limited to artifacts that are actually surfaced to the user — the hidden
+ * `component_inventory` (mockups consume it but it has no sidebar row) and the
+ * retired standalone `prompt_pack` (folded into the Implementation Plan) are
+ * intentionally omitted so the tour matches the real product. Mockups aren't a
+ * standalone row either: they live inside the consolidated **Screens** view
+ * under Experience, alongside **User Flows**.
+ */
 export const TOUR_ASSETS: TourAsset[] = [
     {
+        id: 'design_system',
+        group: 'foundation',
+        name: 'Design System',
+        tagline: 'Colors, typography & components',
+        icon: Palette,
+        accent: 'text-pink-300 bg-pink-500/10',
+        previewKind: 'palette',
+        preview: ['Indigo / primary', 'Neutral / surface', 'Emerald / success', 'Display / heading', 'Body / text'],
+    },
+    {
         id: 'user_flows',
+        group: 'experience',
         name: 'User Flows',
         tagline: 'Flow diagrams & journeys',
         icon: Workflow,
@@ -205,16 +251,21 @@ export const TOUR_ASSETS: TourAsset[] = [
         preview: ['Open app', 'Start a song idea', 'Record / import', 'Arrange sections', 'Export & release'],
     },
     {
-        id: 'ui_mockups',
-        name: 'UI Mockups',
-        tagline: 'Screens & wireframes',
-        icon: Smartphone,
+        // The consolidated, screen-centric Experience view: each screen gets an
+        // Overview / Flow / Mockups tab. This is where UI mockups live in the
+        // real product — there's no standalone "UI Mockups" sidebar row.
+        id: 'screens',
+        group: 'experience',
+        name: 'Screens',
+        tagline: 'Screen-by-screen: overview, flow & mockups',
+        icon: AppWindow,
         accent: 'text-indigo-300 bg-indigo-500/10',
         previewKind: 'screens',
         preview: ['Home', 'Song editor', 'Arrangement view', 'Collaboration', 'Library'],
     },
     {
         id: 'data_model',
+        group: 'architecture',
         name: 'Data Model',
         tagline: 'Entities & relationships',
         icon: Database,
@@ -223,19 +274,11 @@ export const TOUR_ASSETS: TourAsset[] = [
         preview: ['User', 'Song', 'Track', 'Section', 'Collaborator'],
     },
     {
-        id: 'component_library',
-        name: 'Component Library',
-        tagline: 'Reusable UI components',
-        icon: Boxes,
-        accent: 'text-orange-300 bg-orange-500/10',
-        previewKind: 'grid',
-        preview: ['Button', 'Waveform', 'TrackRow', 'Transport bar', 'Mixer fader'],
-    },
-    {
         // Consolidated Development artifact: milestones now carry their own
         // prompt packs and quality gates (the old standalone Prompt Pack card
         // folded into this one).
         id: 'implementation_plan',
+        group: 'development',
         name: 'Implementation Plan',
         tagline: 'Milestones, prompt packs & quality gates',
         icon: Terminal,
@@ -247,15 +290,6 @@ export const TOUR_ASSETS: TourAsset[] = [
             'M3 — Collaboration · 1 prompt pack',
             'M4 — Export & launch · quality gates',
         ],
-    },
-    {
-        id: 'design_system',
-        name: 'Design System',
-        tagline: 'Colors, typography & components',
-        icon: Palette,
-        accent: 'text-pink-300 bg-pink-500/10',
-        previewKind: 'palette',
-        preview: ['Indigo / primary', 'Neutral / surface', 'Emerald / success', 'Display / heading', 'Body / text'],
     },
 ];
 
@@ -284,7 +318,7 @@ export interface ActivityEntry {
     when: string;
     title: string;
     detail: string;
-    /** e.g. "7 artifacts updated"; empty for the initial version. */
+    /** e.g. "5 artifacts updated"; empty for the initial version. */
     impact: string;
 }
 
@@ -295,7 +329,7 @@ export const RECENT_ACTIVITY: ActivityEntry[] = [
         when: '2h ago',
         title: 'Consolidated Strategy',
         detail: 'Added pricing strategy and refined user personas',
-        impact: '7 artifacts updated',
+        impact: '5 artifacts updated',
     },
     {
         id: 'a3',
@@ -303,7 +337,7 @@ export const RECENT_ACTIVITY: ActivityEntry[] = [
         when: 'Yesterday',
         title: 'New Monetization Strategy',
         detail: 'Updated subscription tiers and pricing approach',
-        impact: '5 artifacts updated',
+        impact: '3 artifacts updated',
     },
     {
         id: 'a2',
@@ -311,7 +345,7 @@ export const RECENT_ACTIVITY: ActivityEntry[] = [
         when: 'May 14',
         title: 'Expanded User Personas',
         detail: 'Added detailed user segments and workflows',
-        impact: '6 artifacts updated',
+        impact: '4 artifacts updated',
     },
     {
         id: 'a1',


### PR DESCRIPTION
## What & why

The interactive product tour ("take a tour" / `/tour`) had drifted from the actual workspace **Assets** page. It advertised an artifact that users never see, listed mockups as a standalone asset when the product consolidated them into the Screens view, and showed a flat, ungrouped list. This restores parity so the tour tells the same story as the real product.

## Changes

- **Only surface artifacts that are actually generated *and* shown to the user.** Dropped the **Component Library** card — `component_inventory` is a *hidden* artifact (mockups consume it, but it has no sidebar row). The retired standalone `prompt_pack` was already folded into the Implementation Plan, so it stays out too.
- **Mockups are no longer a standalone row.** Renamed the **UI Mockups** card to **Screens**, matching the consolidated screen-centric Experience view (Overview / Flow / Mockups tabs) the real product ships. Icon updated to `AppWindow` to match the workspace.
- **Grouped the tour assets like the Assets page sidebar** — Project Foundation → Experience → Architecture → Development — with group headers on the hero Assets screen. New `TOUR_ASSET_GROUPS` in `tourData.ts` mirrors `ARTIFACT_GROUPS` in `ArtifactWorkspace.tsx` (minus the PRD, which is the hub these assets are generated *from*).
- **Fixed now-wrong hardcoded counts.** The Connections screen's "7 of 7 up to date" is derived from the asset list, and the recent-activity impact numbers are capped to the 5 real assets.

### Resulting asset list (in Assets-page order)

| Group | Asset |
|---|---|
| Project Foundation | Design System |
| Experience | User Flows, Screens |
| Architecture | Data Model |
| Development | Implementation Plan |

## Files touched

- `src/components/tour/tourData.ts` — asset groups, remapped/trimmed asset list, activity counts
- `src/components/tour/screens/ScreenAssets.tsx` — grouped rendering with section headers
- `src/components/tour/screens/ScreenConnections.tsx` — derived count, comment fix

## Testing

- `npm run build` ✓ (tour screens remain separately chunked)
- `npm run lint` ✓
- `npm test` ✓ (819 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MC91aNJ9ZKhEQRD5L2nhB

---
_Generated by [Claude Code](https://claude.ai/code/session_013MC91aNJ9ZKhEQRD5L2nhB)_