### PR TITLE
Show the lock icon only on the Design System artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,13 +515,16 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       the preset off the project, so the new direction actually reaches
       generation. (The old compact `DesignSystemPresetChoice` sheet now serves
       only the Mark-as-Final fallback gate in `ProjectWorkspace`.)
-    - **Generated-asset lock affordance.** Every *downstream* asset in the
-      sidebar/mobile-header — anything except the PRD and the Design System
-      itself (`isLockableAsset` / `LOCK_EXEMPT_SELECTIONS` in `ArtifactWorkspace`)
-      — shows a small `Lock` icon once its slot status is `done`, signalling it's
-      anchored ("locked") to the current design system. It's a passive indicator
-      only; changing the visual direction + regenerating the design system is what
-      updates those assets.
+    - **Design-system lock affordance.** The **Design System row only**
+      (`isLockedAsset` in `ArtifactWorkspace`) shows a small `Lock` icon in the
+      sidebar/mobile-header once its slot status is `done`, signalling the
+      project's visual direction is locked in — one committed aesthetic every
+      downstream asset is generated against. It's a passive nudge, not a hard
+      lock: the user can still change direction via `ChangeDirectionModal`
+      (which carries the downstream-regression warning), but the lock
+      encourages staying with one aesthetic to avoid costly regeneration of
+      screens/mockups. Do **not** re-add per-asset lock icons to downstream
+      rows.
     - **Mockup-drift prompt.** Regenerating the design system produces a new
       `tokensHash`, which `stalenessSlice` already uses to flip dependent mockups
       to `possibly_outdated` (the auto-flag). On top of that, the Mockups view in

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -156,21 +156,22 @@ function StatusDot({ status }: { status: GenerationStatus }) {
     return <Circle size={14} className="text-neutral-300 shrink-0" />;
 }
 
-// The PRD and the Design System itself are the foundation — every other asset is
-// generated *against* the design system, so once produced it's "locked" to that
-// visual direction (changing direction + regenerating the design system is what
-// updates it). These two are exempt from the lock affordance.
-const LOCK_EXEMPT_SELECTIONS = new Set<WorkspaceSelection>(['prd', 'design_system']);
-function isLockableAsset(key: WorkspaceSelection): boolean {
-    return !LOCK_EXEMPT_SELECTIONS.has(key);
+// The lock lives on the Design System row only. Every downstream asset is
+// generated *against* the design system, so the lock signals "your visual
+// direction is locked in" — one aesthetic, committed — rather than tagging
+// each asset. Changing direction later is still possible (ChangeDirectionModal,
+// with its downstream-regression warning), but the lock nudges against it.
+function isLockedAsset(key: WorkspaceSelection): boolean {
+    return key === 'design_system';
 }
 
-// Small lock shown on a generated downstream asset, signalling it's anchored to
-// the current design system. Rendered only for `done` lockable assets.
+// Small lock shown on the generated Design System, signalling the project's
+// visual direction is locked in. Rendered only once its slot is `done`.
 function AssetLock() {
+    const label = 'Visual direction locked in — changing it can require regenerating downstream screens';
     return (
-        <span title="Locked to your design system" className="inline-flex shrink-0">
-            <Lock size={11} className="text-neutral-400" aria-label="Locked to your design system" />
+        <span title={label} className="inline-flex shrink-0">
+            <Lock size={11} className="text-neutral-400" aria-label={label} />
         </span>
     );
 }
@@ -1122,7 +1123,7 @@ export function ArtifactWorkspace({
                                                                 {slot.title}
                                                             </span>
                                                             <StatusDot status={status} />
-                                                            {status === 'done' && isLockableAsset(slot.key) && (
+                                                            {status === 'done' && isLockedAsset(slot.key) && (
                                                                 <AssetLock />
                                                             )}
                                                         </div>
@@ -1159,7 +1160,7 @@ export function ArtifactWorkspace({
                     {activeSelection !== 'prd' && (
                         <span className="ml-auto shrink-0 flex items-center gap-1.5">
                             <StatusDot status={slotStatusFor(activeSelection)} />
-                            {slotStatusFor(activeSelection) === 'done' && isLockableAsset(activeSelection) && (
+                            {slotStatusFor(activeSelection) === 'done' && isLockedAsset(activeSelection) && (
                                 <AssetLock />
                             )}
                         </span>


### PR DESCRIPTION
## What changed

The recently added lock affordance rendered on **every** generated downstream asset (everything except the PRD and the Design System itself). This inverts it: the small `Lock` icon now appears **only on the Design System row** in the sidebar and mobile header, once its slot is `done`.

## Why

The lock is meant to communicate commitment — the project's visual direction is "locked in" to one aesthetic that every downstream asset is generated against. Scattering it across all assets diluted that message. Placing it on the Design System alone encourages the user to stay with one visual direction and avoid the costly regeneration of screens/mockups a direction change triggers.

Changing direction is still fully supported: `ChangeDirectionModal` (with its existing amber downstream-impact warning) is untouched — the lock is a passive nudge, not a hard lock.

## Details

- `ArtifactWorkspace.tsx`: replaced `isLockableAsset` / `LOCK_EXEMPT_SELECTIONS` (exempt PRD + design system, lock everything else) with `isLockedAsset` (`key === 'design_system'`); updated the `AssetLock` tooltip/aria-label to "Visual direction locked in — changing it can require regenerating downstream screens".
- `CLAUDE.md`: updated the lock-affordance section to match, with a note not to re-add per-asset locks.

## Verification

- `npm run build` (tsc -b + vite) — passes
- `npm run lint` — passes
- `npm test` — 819 tests, 112 files, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAYqzQceqsyVu2DfhgZVCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAYqzQceqsyVu2DfhgZVCr)_