### PR TITLE
Leaner, decision-focused generated PRD: retire embedded artifact sections, slim prompts, add handoff appendix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,7 +420,12 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     **PRD reading order ≠ generation (DAG) order.** The human/agent-facing
     section order is a fixed logical flow (Product Overview → Target Users →
     MVP Scope → Core Features → UX → Success Metrics → Risks → Technical
-    Architecture → Data Model → State Machines → NFRs → reference appendix)
+    Architecture → Data Model → State Machines → NFRs → reference appendix →
+    **"Where the Detail Lives"**, a static deterministic handoff appendix
+    pointing to the downstream artifacts, rendered unconditionally by both
+    renderers — legacy spines' persisted `responseText` picks it up on the
+    next re-render (edit / section retry / regenerate), while the in-app
+    Structured view shows it immediately for every PRD)
     defined in **two mirrored renderers that must stay in sync**:
     `prdMarkdownRenderer.renderPremiumMarkdown` (export/`responseText`) and
     `StructuredPRDView`/`PremiumSections` (in-app). Reordering is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,19 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     `DEFAULT_PRD_SECTIONS ∪ RETIRED_PRD_SECTIONS`). Never re-add retired
     sections to `DEFAULT_PRD_SECTIONS`, and never feed them to `runDag`.
     Legacy PRDs with `richDataModel`/`stateMachines`/`implementationPlan` keep
-    rendering — the renderer blocks and optional `StructuredPRD` fields stay. `runDag()` runs every section whose
+    rendering — the renderer blocks and optional `StructuredPRD` fields stay.
+    The remaining sections are prompted (and, where it matters,
+    **schema-enforced** via lean slice schemas in `prdSchemas.ts` —
+    `leanUxPageItemSchema`/`leanFeatureItemSchema`/`leanSuccessMetricSchema`,
+    since Gemini JSON mode can't emit properties absent from the schema) to
+    stay at decision level: `uxPages` is a lean screen list (name/purpose/key
+    content — no per-screen interaction/empty/loading/error specs), features
+    drop `uiAcceptanceCriteria`/`analyticsEvents`, success metrics drop
+    `instrumentation`, and the architecture narrative is a short decision
+    story grounded on `domainEntities`. `RUBRIC_DEFINITION` (`prdPrompts.ts`)
+    encodes this split — decisions live in the PRD, detail lives in the
+    artifacts — so don't re-add "full schemas / state machines / per-page
+    component specs" demands to prompts or rubric. `runDag()` runs every section whose
     deps are satisfied concurrently, under separate per-tier concurrency caps
     (`maxFastConcurrency` / `maxStrongConcurrency`); low-risk sections use the
     fast (Flash) model, high-risk the strong (Pro) model. `validateGraph()` runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,10 +379,23 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
   `llmProvider.ts` barrel keeps legacy call sites stable.
   - `prdService.ts` → `progressivePrdPipeline.ts` → `progressivePrdGeneration.ts`
     — PRD generation runs as a **dependency-graph (DAG) pipeline**, not in
-    document order. `DEFAULT_PRD_SECTIONS` (10 schema-aligned sections in
+    document order. `DEFAULT_PRD_SECTIONS` (8 schema-aligned sections in
     `progressivePrdGeneration.ts`) each declare `dependencies` that are **true
     data dependencies only** — a section lists another solely when it consumes
-    that section's output as prompt context. `runDag()` runs every section whose
+    that section's output as prompt context. **The PRD is the product decision
+    document, not a container for downstream artifacts:** the former
+    `data_model` and `implementation_plan` PRD sections are **retired** from the
+    default graph (`RETIRED_PRD_SECTIONS` / `RETIRED_SECTION_IDS`) — the
+    dedicated data_model / implementation_plan *artifacts* own that detail, and
+    the PRD-embedded copies duplicated them (two entity lists was a standing
+    inconsistency source; `implementationPlan` was never rendered). Their
+    `SectionId`, prompt builder, slice schema, and title all survive solely so
+    single-section retry of legacy `generationMeta.failedSections` keeps
+    working (`prdSectionRetry.ts` looks sections up across
+    `DEFAULT_PRD_SECTIONS ∪ RETIRED_PRD_SECTIONS`). Never re-add retired
+    sections to `DEFAULT_PRD_SECTIONS`, and never feed them to `runDag`.
+    Legacy PRDs with `richDataModel`/`stateMachines`/`implementationPlan` keep
+    rendering — the renderer blocks and optional `StructuredPRD` fields stay. `runDag()` runs every section whose
     deps are satisfied concurrently, under separate per-tier concurrency caps
     (`maxFastConcurrency` / `maxStrongConcurrency`); low-risk sections use the
     fast (Flash) model, high-risk the strong (Pro) model. `validateGraph()` runs
@@ -1283,7 +1296,7 @@ component). It is driven directly by the live `prdSectionStatus` store slice
 (not by parsing the `prdProgress` message log):
 
 - **`buildGenerationSteps.ts`** — pure adapter. `computeWaves()` groups the
-  10 pipeline sections (`DEFAULT_PRD_SECTIONS`) into **dependency waves**
+  pipeline sections (`DEFAULT_PRD_SECTIONS`) into **dependency waves**
   (topological levels): a single-section wave is a sequential row, a
   multi-section wave is a "Running concurrently" group whose children are the
   parallel sections (labeled `2A`, `2B`, …). This is purely graph-derived, so

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ touching the rest of the document.
 
 You get back a structured PRD with vision, target users, core problems,
 features (with priority, acceptance criteria, and dependencies), architecture,
-metrics, risks, and non-functional requirements.
+metrics, risks, and non-functional requirements. The PRD deliberately stays at
+the product-decision level — deep specification (data model, screens, flows,
+implementation plan) is generated as the dedicated downstream assets, and the
+PRD ends with a "Where the Detail Lives" appendix pointing to them.
 
 That concurrency is **measured, not just claimed**. An **Orchestration
 Metrics** dashboard (`/metrics`, linked from Settings and the workspace menu)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can also skip and decide later, at the latest when marking the PRD final.
 <img width="100%" alt="PRD generation progress timeline — sections generated wave by wave" src="public/screenshots/tour-spec.png" />
 
 The PRD is generated as structured JSON by a **dependency-graph pipeline**:
-the ten sections run concurrently the moment their inputs are ready — they are
+the sections run concurrently the moment their inputs are ready — they are
 never sequenced just because they appear later in the document. A live
 **progress timeline** shows exactly what's happening: sections are grouped into
 dependency *waves*, with independent sections rendered as "running

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -35,6 +35,7 @@ import {
     MvpScopeSection,
     MetricsSection,
     AssumptionsSection,
+    HandoffAppendixSection,
 } from './prd/PremiumSections';
 
 interface StructuredPRDViewProps {
@@ -559,7 +560,8 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                 {/* Section order is a logical reading flow (mirrors
                     prdMarkdownRenderer): Product Overview → Target Users → MVP
                     Scope → Features → UX → Metrics → Risks → Technical
-                    Architecture → Data Model → State Machines → reference. */}
+                    Architecture → Data Model → State Machines → reference →
+                    Where the Detail Lives (static handoff appendix). */}
 
                 {/* Product Overview: Vision → Problem → Thesis → Principles */}
                 {renderTextSection('Vision', 'vision', structuredPRD.vision)}
@@ -675,6 +677,8 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                 {structuredPRD.assumptions && structuredPRD.assumptions.length > 0 && (
                     <AssumptionsSection assumptions={structuredPRD.assumptions} />
                 )}
+
+                <HandoffAppendixSection />
             </div>
 
             {selection && (

--- a/src/components/prd/PremiumSections.tsx
+++ b/src/components/prd/PremiumSections.tsx
@@ -571,3 +571,32 @@ export function AssumptionsSection({ assumptions }: { assumptions: Assumption[] 
         </Section>
     );
 }
+
+// Static handoff appendix — always rendered, for legacy PRDs too. Wording must
+// stay bullet-for-bullet identical to the `## Where the Detail Lives` block in
+// prdMarkdownRenderer.ts (mirrored-renderer rule).
+const HANDOFF_ARTIFACTS: Array<{ name: string; detail: string }> = [
+    { name: 'Data Model', detail: 'entities, fields, relationships, and state machines' },
+    { name: 'Screens (Screen Inventory)', detail: 'per-screen components, states, and interactions' },
+    { name: 'User Flows', detail: 'step-by-step journeys and decision points' },
+    { name: 'Design System', detail: 'visual tokens and component conventions' },
+    { name: 'Implementation Plan', detail: 'phased milestones, tasks, and quality gates' },
+];
+
+export function HandoffAppendixSection() {
+    return (
+        <Section title="Where the Detail Lives" id="prd-handoff-appendix">
+            <p className="text-sm text-neutral-600 mb-3">
+                This PRD stays at the product-decision level. The deep specification is generated as dedicated downstream artifacts:
+            </p>
+            <ul className="space-y-1.5">
+                {HANDOFF_ARTIFACTS.map(a => (
+                    <li key={a.name} className="text-sm text-neutral-700">
+                        <span className="font-semibold text-neutral-900">{a.name}</span>
+                        {' — '}{a.detail}
+                    </li>
+                ))}
+            </ul>
+        </Section>
+    );
+}

--- a/src/components/progress/__tests__/buildGenerationSteps.test.ts
+++ b/src/components/progress/__tests__/buildGenerationSteps.test.ts
@@ -29,13 +29,12 @@ describe('formatModelName', () => {
 });
 
 describe('computeWaves (default DAG)', () => {
-    it('groups the 10 sections into dependency waves', () => {
+    it('groups the 8 sections into dependency waves', () => {
         const waves = computeWaves();
-        expect(waves.map((w) => w.length)).toEqual([1, 3, 4, 1, 1]);
+        expect(waves.map((w) => w.length)).toEqual([1, 3, 4]);
         expect(waves[0][0].id).toBe('product_basics');
         expect(waves[1].map((s) => s.id)).toEqual(['product_thesis', 'grounding', 'features']);
-        expect(waves[2].map((s) => s.id)).toEqual(['data_model', 'ux_loops', 'quality_risks', 'metrics_scope']);
-        expect(waves[4].map((s) => s.id)).toEqual(['implementation_plan']);
+        expect(waves[2].map((s) => s.id)).toEqual(['ux_loops', 'architecture', 'quality_risks', 'metrics_scope']);
     });
 });
 
@@ -56,7 +55,7 @@ describe('computeWaves (arbitrary graph — future-proofing)', () => {
 describe('buildGenerationSteps', () => {
     it('builds sequential rows and concurrent groups with labels', () => {
         const steps = buildGenerationSteps({}, MODELS);
-        expect(steps).toHaveLength(5);
+        expect(steps).toHaveLength(3);
         expect(steps[0].sectionId).toBe('product_basics');
         expect(steps[0].label).toBe('1');
         expect(steps[0].executionMode).toBe('sequential');
@@ -134,9 +133,9 @@ describe('summarizeSteps', () => {
         };
         const steps = buildGenerationSteps(status, MODELS);
         const summary = summarizeSteps(steps);
-        expect(summary.total).toBe(10);
+        expect(summary.total).toBe(8);
         expect(summary.completed).toBe(2);
-        expect(summary.percent).toBe(20);
+        expect(summary.percent).toBe(25);
         expect(summary.status).toBe('in_progress');
     });
 
@@ -148,8 +147,8 @@ describe('summarizeSteps', () => {
         expect(summarizeSteps(steps).status).toBe('failed');
     });
 
-    it('flattenLeaves returns all 10 leaf sections', () => {
+    it('flattenLeaves returns all 8 leaf sections', () => {
         const steps = buildGenerationSteps({}, MODELS);
-        expect(flattenLeaves(steps)).toHaveLength(10);
+        expect(flattenLeaves(steps)).toHaveLength(8);
     });
 });

--- a/src/lib/__tests__/prdMarkdownRenderer.test.ts
+++ b/src/lib/__tests__/prdMarkdownRenderer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { renderPremiumMarkdown } from '../services/prdMarkdownRenderer';
+import type { StructuredPRD } from '../../types';
+
+const minimalPrd: StructuredPRD = {
+    vision: 'A calmer inbox',
+    targetUsers: ['Support agents'],
+    coreProblem: 'Ticket triage is manual',
+    features: [],
+    architecture: 'SPA + serverless',
+    risks: ['Adoption'],
+};
+
+describe('renderPremiumMarkdown handoff appendix', () => {
+    it('renders "Where the Detail Lives" as the last section for a minimal legacy PRD', () => {
+        const md = renderPremiumMarkdown(minimalPrd);
+        const headings = md.split('\n').filter((l) => l.startsWith('## '));
+        expect(headings[headings.length - 1]).toBe('## Where the Detail Lives');
+        expect(md).toContain('**Data Model** — entities, fields, relationships, and state machines');
+        expect(md).toContain('**Implementation Plan** — phased milestones, tasks, and quality gates');
+    });
+});
+
+describe('renderPremiumMarkdown legacy-field back-compat', () => {
+    it('still renders retired-section content stored on legacy PRDs', () => {
+        const legacyPrd: StructuredPRD = {
+            ...minimalPrd,
+            richDataModel: {
+                entities: [
+                    { name: 'Ticket', description: 'A support request', fields: [{ name: 'id', type: 'string' }] },
+                ],
+            },
+            stateMachines: [
+                { entity: 'Ticket', states: [{ name: 'open', nextStates: ['closed'] }] },
+            ],
+            uxPages: [
+                {
+                    id: 'pg1',
+                    name: 'Inbox',
+                    purpose: 'Triage tickets',
+                    components: ['Ticket list'],
+                    interactions: ['Click a ticket to open it'],
+                    emptyState: 'No tickets yet',
+                },
+            ],
+        };
+        const md = renderPremiumMarkdown(legacyPrd);
+        expect(md).toContain('## Data Model');
+        expect(md).toContain('## State Machines');
+        expect(md).toContain('Ticket');
+        expect(md).toContain('No tickets yet');
+    });
+
+    it('omits retired sections entirely when the fields are absent (lean PRDs)', () => {
+        const md = renderPremiumMarkdown(minimalPrd);
+        expect(md).not.toContain('## Data Model');
+        expect(md).not.toContain('## State Machines');
+    });
+});

--- a/src/lib/__tests__/prdSectionPrompts.test.ts
+++ b/src/lib/__tests__/prdSectionPrompts.test.ts
@@ -77,6 +77,39 @@ describe('buildSectionPrompt', () => {
     });
 });
 
+describe('lean decision-level prompts (detail deferred to artifacts)', () => {
+    it('ux_loops asks for a lean screen list, not per-screen UI specs', () => {
+        const { user } = buildSectionPrompt('ux_loops', { idea: 'Test app', upstream: {} });
+        expect(user).toContain('key content');
+        expect(user).not.toContain('emptyState');
+        expect(user).not.toContain('loadingState');
+        expect(user).not.toContain('errorState');
+        expect(user).not.toContain('interactions (array)');
+    });
+
+    it('architecture grounds on domainEntities instead of the retired richDataModel', () => {
+        const { user } = buildSectionPrompt('architecture', {
+            idea: 'Test app',
+            upstream: { domainEntities: [{ name: 'UniqueEntity99', description: 'x' }] },
+        });
+        expect(user).toContain('UniqueEntity99');
+        expect(user).not.toContain('richDataModel');
+    });
+
+    it('features omits UI-acceptance and analytics-event asks', () => {
+        const { user } = buildSectionPrompt('features', { idea: 'Test app', upstream: {} });
+        expect(user).not.toContain('uiAcceptanceCriteria');
+        expect(user).not.toContain('analyticsEvents');
+        expect(user).toContain('failureModes');
+    });
+
+    it('metrics_scope asks for decision-level metrics without instrumentation fields', () => {
+        const { user } = buildSectionPrompt('metrics_scope', { idea: 'Test app', upstream: {} });
+        expect(user).toContain('{ name, target? }');
+        expect(user).not.toContain('instrumentation?');
+    });
+});
+
 describe('SECTION_TITLES', () => {
     it('covers every active and retired section id', () => {
         for (const section of [...DEFAULT_PRD_SECTIONS, ...RETIRED_PRD_SECTIONS]) {

--- a/src/lib/__tests__/prdSectionPrompts.test.ts
+++ b/src/lib/__tests__/prdSectionPrompts.test.ts
@@ -108,6 +108,19 @@ describe('lean decision-level prompts (detail deferred to artifacts)', () => {
         expect(user).toContain('{ name, target? }');
         expect(user).not.toContain('instrumentation?');
     });
+
+    it('retired-section retry prompts omit the lean rubric that would contradict their asks', () => {
+        // The rubric says schemas/state machines "do NOT belong in the PRD" —
+        // a legacy data_model/implementation_plan retry must not receive it.
+        for (const retired of RETIRED_PRD_SECTIONS) {
+            const { system } = buildSectionPrompt(retired.id as SectionId, { idea: 'Test app', upstream: {} });
+            expect(system).not.toContain('QUALITY BAR');
+            expect(system).not.toContain('do NOT belong in the PRD');
+        }
+        // Active sections keep the rubric.
+        const { system } = buildSectionPrompt('ux_loops', { idea: 'Test app', upstream: {} });
+        expect(system).toContain('QUALITY BAR');
+    });
 });
 
 describe('SECTION_TITLES', () => {

--- a/src/lib/__tests__/prdSectionPrompts.test.ts
+++ b/src/lib/__tests__/prdSectionPrompts.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { buildSectionPrompt, SECTION_TITLES } from '../prompts/prdSectionPrompts';
-import { DEFAULT_PRD_SECTIONS } from '../services/progressivePrdGeneration';
+import { DEFAULT_PRD_SECTIONS, RETIRED_PRD_SECTIONS } from '../services/progressivePrdGeneration';
 import type { SectionId } from '../schemas/prdSchemas';
 
 describe('buildSectionPrompt', () => {
-    it('returns non-empty system and user strings for all 10 sections', () => {
-        for (const section of DEFAULT_PRD_SECTIONS) {
+    it('returns non-empty system and user strings for all pipeline sections', () => {
+        for (const section of [...DEFAULT_PRD_SECTIONS, ...RETIRED_PRD_SECTIONS]) {
             const { system, user } = buildSectionPrompt(section.id as SectionId, {
                 idea: 'A task management app for remote teams',
                 upstream: {},
@@ -78,14 +78,17 @@ describe('buildSectionPrompt', () => {
 });
 
 describe('SECTION_TITLES', () => {
-    it('has an entry for all 10 sections', () => {
-        expect(Object.keys(SECTION_TITLES).length).toBe(DEFAULT_PRD_SECTIONS.length);
-    });
-
-    it('every DEFAULT_PRD_SECTIONS entry has a non-empty title', () => {
-        for (const section of DEFAULT_PRD_SECTIONS) {
+    it('covers every active and retired section id', () => {
+        for (const section of [...DEFAULT_PRD_SECTIONS, ...RETIRED_PRD_SECTIONS]) {
             const title = SECTION_TITLES[section.id as SectionId];
             expect(title).toBeTruthy();
+        }
+    });
+
+    it('retired sections are not in the default generation graph', () => {
+        const activeIds = new Set(DEFAULT_PRD_SECTIONS.map((s) => s.id));
+        for (const retired of RETIRED_PRD_SECTIONS) {
+            expect(activeIds.has(retired.id)).toBe(false);
         }
     });
 });

--- a/src/lib/__tests__/prdSectionRetry.test.ts
+++ b/src/lib/__tests__/prdSectionRetry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StructuredPRD } from '../../types';
+
+// Mock the Gemini transport so retries run offline. The data_model prompt
+// returns a rich data model slice; everything else returns an empty slice.
+vi.mock('../geminiClient', () => ({
+    callGemini: vi.fn(async (_system: string, prompt: string) => {
+        if (prompt.includes('richDataModel')) {
+            return JSON.stringify({
+                richDataModel: {
+                    entities: [{ name: 'Invoice', fields: [{ name: 'id', type: 'string' }] }],
+                },
+            });
+        }
+        return '{}';
+    }),
+    getFastModel: () => 'fast-model',
+    getStrongModel: () => 'strong-model',
+}));
+
+import { regeneratePrdSection } from '../services/prdSectionRetry';
+
+const legacyPrd: StructuredPRD = {
+    vision: 'Invoicing for freelancers',
+    targetUsers: ['Freelancers'],
+    coreProblem: 'Manual invoicing is slow',
+    features: [],
+    architecture: 'SPA + serverless',
+    risks: ['Adoption'],
+};
+
+describe('regeneratePrdSection retired-section back-compat', () => {
+    it('retries the retired data_model section for legacy failedSections without throwing', async () => {
+        const result = await regeneratePrdSection('data_model', 'An invoicing app', legacyPrd);
+        // The regenerated slice is overlaid; every other section's fields survive.
+        expect(result.structuredPRD.richDataModel?.entities?.[0]?.name).toBe('Invoice');
+        expect(result.structuredPRD.vision).toBe('Invoicing for freelancers');
+        expect(result.markdown).toContain('Invoice');
+    });
+
+    it('retries the retired implementation_plan section without throwing', async () => {
+        const result = await regeneratePrdSection('implementation_plan', 'An invoicing app', legacyPrd);
+        expect(result.structuredPRD.vision).toBe('Invoicing for freelancers');
+    });
+
+    it('still retries an active section', async () => {
+        const result = await regeneratePrdSection('quality_risks', 'An invoicing app', legacyPrd);
+        expect(result.structuredPRD.coreProblem).toBe('Manual invoicing is slow');
+    });
+});

--- a/src/lib/prompts/prdPrompts.ts
+++ b/src/lib/prompts/prdPrompts.ts
@@ -43,15 +43,19 @@ export const PROMPT_CONTRACT = `OPERATING CONTRACT — these principles are bind
 
 // Quality bar appended to the strategy system instruction. Phrased as
 // targets the model should aim for in its first (and only) output.
+// The PRD is the product DECISION document: it must make every product
+// decision crisp and unambiguous, and must NOT contain the detailed
+// specifications (schemas, state machines, per-screen UI specs, tracking
+// plans) that the dedicated downstream artifacts own.
 export const RUBRIC_DEFINITION = `QUALITY BAR — this is a hard requirement, not guidance. Your output is judged on these dimensions and must reach 5/5 on each:
 
 - specificity: 1=generic template; 3=some product-specific detail; 5=deeply tailored, opinionated, no filler.
-- uxUsefulness: 1=no page-level detail; 3=basic page list; 5=clear screen architecture with empty/loading/error states and interactions per page.
-- engineeringUsefulness: 1=feature list only; 3=some tech notes; 5=concrete data model, state machines, roles, request flows, NFRs.
+- uxUsefulness: 1=no screen-level signal; 3=basic page list; 5=every screen's name, purpose, and key content are unambiguous enough for the dedicated Screen Inventory and Design System artifacts to specify the full UI without guessing. Per-screen component architecture, interaction specs, and state matrices do NOT belong in the PRD.
+- engineeringUsefulness: 1=feature list only; 3=some tech notes; 5=architecture direction, roles, NFRs, and constraints decided crisply enough for the dedicated Data Model and Implementation Plan artifacts to be derived with no rework. Database schemas, state machines, and request-flow specifications do NOT belong in the PRD.
 - strategicClarity: 1=vague vision; 3=some differentiation; 5=strong product thesis, intentional non-goals, explicit tradeoffs.
 - formatting: handled deterministically by the client renderer — focus on populating the structured fields richly.
-- acceptanceCriteria: 1=basic checkboxes; 3=some details; 5=success, edge, failure, and UI behavior all enumerated per major feature.
-- downstreamReadiness: 1=weak source artifact; 3=usable with edits; 5=strong enough to drive mockups, screen inventory, data model, implementation plan with no rework.`;
+- acceptanceCriteria: 1=basic checkboxes; 3=some details; 5=success, edge, and failure behavior enumerated per major feature.
+- downstreamReadiness: 1=weak source artifact; 3=usable with edits; 5=every product decision is stated and unambiguous, so the dedicated downstream artifacts (screen inventory, user flows, data model, design system, implementation plan) can be generated with no rework — decisions live in the PRD, detail lives in those artifacts.`;
 
 // NOTE: currently unused at runtime. The live PRD path is the progressive
 // section pipeline (prdSectionPrompts.ts); this single-pass instruction is

--- a/src/lib/prompts/prdSectionPrompts.ts
+++ b/src/lib/prompts/prdSectionPrompts.ts
@@ -137,10 +137,10 @@ Product basics: ${basics}
 ${hasThesis ? `Product thesis: ${thesis}` : ''}
 
 Return JSON with:
-- features: array of 8–14 features, each: { id (f1, f2…), name, description, userValue, complexity (low/medium/high), priority (must/should/could), acceptanceCriteria (≥2 success-path checks), system?, successCriteria?, edgeCases?, failureModes?, uiAcceptanceCriteria?, analyticsEvents?, tier? (mvp/v1/later), dependencies? }
+- features: array of 8–14 features, each: { id (f1, f2…), name, description, userValue, complexity (low/medium/high), priority (must/should/could), acceptanceCriteria (≥2 success-path checks), system?, successCriteria?, edgeCases?, failureModes?, tier? (mvp/v1/later), dependencies? }
 - featureSystems: array of 2–4 system groups, each: { id (s1…), name, purpose, featureIds, endToEndBehavior, dependencies?, edgeCases?, mvpVsLater? }
 
-For every must- and should-priority feature, populate successCriteria, edgeCases, failureModes, and uiAcceptanceCriteria — treat these as expected, not optional.`,
+For every must- and should-priority feature, populate successCriteria, edgeCases, and failureModes — treat these as expected, not optional. Stay at the product-requirement level: do NOT specify UI acceptance details or analytics/tracking events — the dedicated Screen Inventory and downstream artifacts own that detail.`,
         };
     },
 
@@ -185,29 +185,29 @@ ${thesis !== UNAVAILABLE ? `Product thesis: ${thesis}` : ''}
 
 Return JSON with:
 - userLoops: array of 2–4 retention loops, each: { name, trigger, action, systemResponse, reward, retentionMechanic }
-- uxPages: array of 5–10 screens, each: { id (pg1…), name, purpose, primaryUser?, components (array), interactions (array), emptyState?, loadingState?, errorState?, responsiveNotes? }. Specify emptyState, loadingState, and errorState for every screen.
+- uxPages: array of 5–10 screens, each: { id (pg1…), name, purpose, primaryUser?, components (3–6 short items — the key content and primary actions the user sees on this screen) }. Stay at the decision level: do NOT write component-by-component UI specs, interaction lists, or empty/loading/error state definitions — the dedicated Screen Inventory artifact owns that detail.
 - roles: array of user roles, each: { role, allowed (array), restricted?, dataVisibility?, notes? }`,
         };
     },
 
     architecture: (ctx) => {
         const features = pick(ctx.upstream, 'features', 'featureSystems');
-        const dataModel = pick(ctx.upstream, 'richDataModel');
+        const grounding = pick(ctx.upstream, 'domainEntities');
         const hasFeatures = features !== UNAVAILABLE;
         const note = !hasFeatures ? missingNote('features') : '';
         return {
             system: `${SHARED_PREAMBLE}
 
-You are generating the architecture slice: architecture (narrative), architectureFlows, nonFunctionalRequirements, constraints. Every technology and architectural decision must include reasoning grounded in scalability, maintainability, ecosystem maturity, or performance — never stylistic descriptors. Prefer widely adopted, stable technologies unless the product requires otherwise.
+You are generating the architecture slice: architecture (narrative), architectureFlows, nonFunctionalRequirements, constraints. Every technology and architectural decision must include reasoning grounded in scalability, maintainability, ecosystem maturity, or performance — never stylistic descriptors. Prefer widely adopted, stable technologies unless the product requires otherwise. State decisions, not designs — detailed schemas, entity models, and step-by-step request specifications belong to the dedicated Data Model and Implementation Plan artifacts.
 ${ctx.platform ? PLATFORM_NOTE[ctx.platform] : ''}`,
             user: `${note}Product idea:\n${ctx.idea}
 
 ${hasFeatures ? `Features: ${features}` : ''}
-${dataModel !== UNAVAILABLE ? `Data model: ${dataModel}` : ''}
+${grounding !== UNAVAILABLE ? `Domain entities: ${grounding}` : ''}
 
 Return JSON with:
-- architecture: string — 2–4 paragraph technical architecture narrative covering tech stack, key components, integration points
-- architectureFlows: array of { name, steps (array of strings) } — 3–5 key system flows (auth, data write, notification, etc.). Express each flow's steps as an ordered, numbered sequence.
+- architecture: string — 2–3 paragraph decision narrative: the chosen stack and why, the major components and their responsibilities, key integration points, and significant build-vs-buy decisions
+- architectureFlows: array of { name, steps (array of strings) } — the 2–3 highest-risk system flows only (e.g. auth, the core data write), each an ordered numbered sequence of at most 7 decision-level steps
 - nonFunctionalRequirements: array of strings — testable requirements spanning performance, accessibility, security, privacy, reliability, scalability, observability, and cost
 - constraints: array of strings — budget, timeline, technical, regulatory, or integration constraints`,
         };
@@ -249,7 +249,7 @@ ${features !== UNAVAILABLE ? `Features: ${features}` : ''}
 
 Return JSON with:
 - mvpScope: { mvp (array of feature names/descriptions), v1 (array), later (array), rationale? } — the MVP must be opinionated, coherent, and shippable; defer aggressively rather than listing every feature.
-- successMetrics: array of { name, target?, instrumentation? } — 5–8 measurable product success criteria spanning activation, engagement, conversion, quality, and operational metrics`,
+- successMetrics: array of { name, target? } — 5–8 measurable product success criteria spanning activation, engagement, conversion, quality, and operational metrics. State the decision-level target; do NOT specify instrumentation, event names, or tracking implementation — analytics detail belongs to downstream artifacts.`,
         };
     },
 

--- a/src/lib/prompts/prdSectionPrompts.ts
+++ b/src/lib/prompts/prdSectionPrompts.ts
@@ -144,6 +144,9 @@ For every must- and should-priority feature, populate successCriteria, edgeCases
         };
     },
 
+    // Retired from default generation (see RETIRED_PRD_SECTIONS) — the
+    // data_model artifact owns this detail now. Retained so single-section
+    // retry of legacy PRDs' failedSections keeps working.
     data_model: (ctx) => {
         const features = pick(ctx.upstream, 'features', 'featureSystems');
         const grounding = pick(ctx.upstream, 'domainEntities', 'primaryActions');
@@ -250,6 +253,9 @@ Return JSON with:
         };
     },
 
+    // Retired from default generation (see RETIRED_PRD_SECTIONS) — the
+    // implementation_plan artifact owns this detail now. Retained so
+    // single-section retry of legacy PRDs' failedSections keeps working.
     implementation_plan: (ctx) => {
         const features = pick(ctx.upstream, 'features', 'featureSystems');
         const dataModel = pick(ctx.upstream, 'richDataModel');
@@ -288,6 +294,9 @@ export const buildSectionPrompt = (
     return builder(ctx);
 };
 
+// Keyed by the FULL SectionId union — retired sections (data_model,
+// implementation_plan) keep their entries so legacy failed-section banners
+// and retries still resolve a title.
 export const SECTION_TITLES: Record<SectionId, string> = {
     product_basics: 'Product Basics',
     product_thesis: 'Product Thesis',

--- a/src/lib/prompts/prdSectionPrompts.ts
+++ b/src/lib/prompts/prdSectionPrompts.ts
@@ -45,6 +45,17 @@ ${PROMPT_CONTRACT}
 
 ${RUBRIC_DEFINITION}`;
 
+// Preamble for RETIRED sections (legacy single-section retry only). Omits
+// RUBRIC_DEFINITION: its lean-PRD rules ("database schemas, state machines …
+// do NOT belong in the PRD") would directly contradict these sections' own
+// asks (richDataModel / stateMachines / implementationPlan) and could thin or
+// empty the regenerated slice. A legacy retry must reproduce full detail.
+const RETIRED_SECTION_PREAMBLE = `${SAFETY_OVERRIDE}
+
+You are a senior product strategist and tech lead regenerating one section of an existing full-detail structured PRD as JSON. Output ONLY the JSON object matching the provided schema — no markdown, no commentary, no preamble, no extra fields, and no conversational language. Every string value must be specific, definitive, and implementation-ready; write as a practitioner who has shipped this product. Produce the complete level of detail this section's schema asks for.
+
+${PROMPT_CONTRACT}`;
+
 const UNAVAILABLE = '<unavailable — infer conservatively and flag uncertainties as assumptions>';
 
 // Serialize a subset of the upstream PRD as compact JSON. Returns the
@@ -153,7 +164,7 @@ For every must- and should-priority feature, populate successCriteria, edgeCases
         const hasFeatures = features !== UNAVAILABLE;
         const note = !hasFeatures ? missingNote('features') : '';
         return {
-            system: `${SHARED_PREAMBLE}
+            system: `${RETIRED_SECTION_PREAMBLE}
 
 You are generating the data_model slice: richDataModel, stateMachines.
 ${ctx.platform ? PLATFORM_NOTE[ctx.platform] : ''}`,
@@ -265,7 +276,7 @@ Return JSON with:
         const note = (!hasFeatures ? missingNote('features') : '') +
             (!hasArch ? missingNote('architecture') : '');
         return {
-            system: `${SHARED_PREAMBLE}
+            system: `${RETIRED_SECTION_PREAMBLE}
 
 You are generating the implementation_plan slice: a phased development roadmap. Phases and their goals must be concrete and actionable, not abstract; each phase must state the reasoning or dependency that determines its ordering.
 ${ctx.platform ? PLATFORM_NOTE[ctx.platform] : ''}`,

--- a/src/lib/schemas/prdSchemas.ts
+++ b/src/lib/schemas/prdSchemas.ts
@@ -29,6 +29,30 @@ const featureItemSchema = {
     required: ["id", "name", "description", "userValue", "complexity", "priority", "acceptanceCriteria"],
 };
 
+// Lean feature shape for NEW generation (features slice): drops the
+// uiAcceptanceCriteria / analyticsEvents properties — UI acceptance detail
+// belongs to the Screen Inventory artifact and analytics/tracking detail to
+// downstream artifacts. Legacy PRDs keep the full shape via featureItemSchema.
+const leanFeatureItemSchema = {
+    type: "OBJECT",
+    properties: {
+        id: { type: "STRING" },
+        name: { type: "STRING" },
+        description: { type: "STRING" },
+        userValue: { type: "STRING" },
+        complexity: { type: "STRING", enum: ["low", "medium", "high"] },
+        priority: { type: "STRING", enum: ["must", "should", "could"] },
+        acceptanceCriteria: { type: "ARRAY", items: { type: "STRING" } },
+        dependencies: { type: "ARRAY", items: { type: "STRING" } },
+        system: { type: "STRING" },
+        successCriteria: { type: "ARRAY", items: { type: "STRING" } },
+        edgeCases: { type: "ARRAY", items: { type: "STRING" } },
+        failureModes: { type: "ARRAY", items: { type: "STRING" } },
+        tier: { type: "STRING", enum: ["mvp", "v1", "later"] },
+    },
+    required: ["id", "name", "description", "userValue", "complexity", "priority", "acceptanceCriteria"],
+};
+
 const productThesisSchema = {
     type: "OBJECT",
     properties: {
@@ -89,7 +113,29 @@ const uxPageItemSchema = {
         errorState: { type: "STRING" },
         responsiveNotes: { type: "STRING" },
     },
-    required: ["id", "name", "purpose", "components", "interactions"],
+    // `components`/`interactions` are no longer required: new PRDs are lean
+    // (screen list only — the Screen Inventory artifact owns UI detail), and
+    // the consistency-review pass validates against structuredPRDSchema, so a
+    // stricter list would force the model to fabricate UI specs for lean PRDs.
+    required: ["id", "name", "purpose"],
+};
+
+// Lean uxPages shape for NEW generation (ux_loops slice): the PRD carries a
+// decision-level screen list (name/purpose/key content) only. Detailed
+// component/interaction/state specs belong to the Screen Inventory artifact.
+// Gemini JSON mode cannot emit properties absent from the schema, so omitting
+// them here is what actually enforces the slimming. Legacy PRDs keep the full
+// shape via uxPageItemSchema above.
+const leanUxPageItemSchema = {
+    type: "OBJECT",
+    properties: {
+        id: { type: "STRING" },
+        name: { type: "STRING" },
+        purpose: { type: "STRING" },
+        primaryUser: { type: "STRING" },
+        components: { type: "ARRAY", items: { type: "STRING" } },
+    },
+    required: ["id", "name", "purpose"],
 };
 
 const featureSystemItemSchema = {
@@ -214,6 +260,17 @@ const successMetricSchema = {
         name: { type: "STRING" },
         target: { type: "STRING" },
         instrumentation: { type: "STRING" },
+    },
+    required: ["name"],
+};
+
+// Lean metric shape for NEW generation (metrics_scope slice): decision-level
+// name + target only — instrumentation/tracking detail belongs downstream.
+const leanSuccessMetricSchema = {
+    type: "OBJECT",
+    properties: {
+        name: { type: "STRING" },
+        target: { type: "STRING" },
     },
     required: ["name"],
 };
@@ -349,7 +406,7 @@ export const groundingSliceSchema = {
 export const featuresSliceSchema = {
     type: "OBJECT",
     properties: {
-        features: { type: "ARRAY", items: featureItemSchema },
+        features: { type: "ARRAY", items: leanFeatureItemSchema },
         featureSystems: { type: "ARRAY", items: featureSystemItemSchema },
     },
     required: ["features"],
@@ -368,7 +425,7 @@ export const uxSliceSchema = {
     type: "OBJECT",
     properties: {
         userLoops: { type: "ARRAY", items: userLoopItemSchema },
-        uxPages: { type: "ARRAY", items: uxPageItemSchema },
+        uxPages: { type: "ARRAY", items: leanUxPageItemSchema },
         roles: { type: "ARRAY", items: rolePermissionSchema },
     },
     required: ["userLoops"],
@@ -399,7 +456,7 @@ export const metricsScopeSliceSchema = {
     type: "OBJECT",
     properties: {
         mvpScope: mvpScopeSchema,
-        successMetrics: { type: "ARRAY", items: successMetricSchema },
+        successMetrics: { type: "ARRAY", items: leanSuccessMetricSchema },
     },
     required: ["successMetrics"],
 };

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -307,9 +307,10 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
     // ── Section order is a logical reading flow (see StructuredPRDView, which
     // mirrors it): Product Overview → Target Users → MVP Scope → Features →
     // UX → Metrics → Risks → Technical Architecture → Data Model → State
-    // Machines → NFRs → reference appendix. This ordering is presentation-only;
-    // downstream artifacts consume the StructuredPRD object by field, not this
-    // markdown, so blocks may be reordered freely without affecting generation.
+    // Machines → NFRs → reference appendix → Where the Detail Lives (static
+    // handoff appendix). This ordering is presentation-only; downstream
+    // artifacts consume the StructuredPRD object by field, not this markdown,
+    // so blocks may be reordered freely without affecting generation.
 
     // ── Product Overview ────────────────────────────────────────────────
     // Vision (always present in legacy spec)
@@ -506,6 +507,18 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
             lines.push('');
         });
     }
+
+    // Static handoff appendix — always rendered (legacy PRDs included).
+    // Wording must stay bullet-for-bullet identical to HandoffAppendixSection
+    // in src/components/prd/PremiumSections.tsx (mirrored-renderer rule).
+    lines.push('## Where the Detail Lives');
+    lines.push('This PRD stays at the product-decision level. The deep specification is generated as dedicated downstream artifacts:');
+    lines.push('- **Data Model** — entities, fields, relationships, and state machines');
+    lines.push('- **Screens (Screen Inventory)** — per-screen components, states, and interactions');
+    lines.push('- **User Flows** — step-by-step journeys and decision points');
+    lines.push('- **Design System** — visual tokens and component conventions');
+    lines.push('- **Implementation Plan** — phased milestones, tasks, and quality gates');
+    lines.push('');
 
     return lines.join('\n').trimEnd() + '\n';
 };

--- a/src/lib/services/prdSectionRetry.ts
+++ b/src/lib/services/prdSectionRetry.ts
@@ -11,6 +11,7 @@ import { buildSectionPrompt } from '../prompts/prdSectionPrompts';
 import { renderPremiumMarkdown } from './prdMarkdownRenderer';
 import {
     DEFAULT_PRD_SECTIONS,
+    RETIRED_PRD_SECTIONS,
     selectModelTier,
     parseSectionJson,
 } from './progressivePrdGeneration';
@@ -46,7 +47,9 @@ export const regeneratePrdSection = async (
 ): Promise<RetrySectionResult> => {
     const { platform, signal, onSectionStatus } = options;
 
-    const template = DEFAULT_PRD_SECTIONS.find((s) => s.id === sectionId);
+    // RETIRED_PRD_SECTIONS keeps retry working for legacy spines whose
+    // failedSections reference a section no longer in the default graph.
+    const template = [...DEFAULT_PRD_SECTIONS, ...RETIRED_PRD_SECTIONS].find((s) => s.id === sectionId);
     if (!template) {
         throw new Error(`Unknown PRD section: ${sectionId}`);
     }

--- a/src/lib/services/progressivePrdGeneration.ts
+++ b/src/lib/services/progressivePrdGeneration.ts
@@ -94,9 +94,17 @@ export type ProgressiveEvent =
     | { type: 'session_completed' };
 
 // ─── Section topology ────────────────────────────────────────────────────────
-// 10 schema-aligned sections. Each emits a typed slice of StructuredPRD that
+// 8 schema-aligned sections. Each emits a typed slice of StructuredPRD that
 // is merged client-side into the final document. Fast (Flash) sections run
 // independently; strong (Pro) sections depend on earlier results.
+//
+// The PRD is the product DECISION document — detailed specification belongs to
+// the dedicated downstream artifacts. The former `data_model` and
+// `implementation_plan` sections are retired from the default graph (see
+// RETIRED_PRD_SECTIONS below): the data_model and implementation_plan
+// artifacts own that detail, the PRD-embedded copies duplicated them (two
+// entity lists — domainEntities vs richDataModel.entities — was a standing
+// internal-inconsistency source), and implementationPlan was never rendered.
 
 // Dependencies are TRUE data dependencies only — a section lists another only
 // when it actually consumes that section's output as prompt context. Sections
@@ -115,16 +123,31 @@ export const DEFAULT_PRD_SECTIONS: PrdSectionTemplate[] = [
     // features depends on product_basics only — it runs in parallel with the
     // slow product_thesis call instead of waiting behind it.
     { id: 'features',             title: SECTION_TITLES.features,             order: 4,  risk: 'high', estimatedSeconds: 35, dependencies: ['product_basics'] },
-    { id: 'data_model',           title: SECTION_TITLES.data_model,           order: 5,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'grounding'] },
     // ux_loops only truly needs the feature set; thesis is incidental context.
     { id: 'ux_loops',             title: SECTION_TITLES.ux_loops,             order: 6,  risk: 'high', estimatedSeconds: 25, dependencies: ['features'] },
-    { id: 'architecture',         title: SECTION_TITLES.architecture,         order: 7,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'data_model'] },
+    // architecture grounds its entity reasoning in the grounding section's
+    // domainEntities (the retired data_model section previously played this role).
+    { id: 'architecture',         title: SECTION_TITLES.architecture,         order: 7,  risk: 'high', estimatedSeconds: 25, dependencies: ['features', 'grounding'] },
     // quality_risks is derivable from the feature set; it no longer waits on the
     // long architecture chain.
     { id: 'quality_risks',        title: SECTION_TITLES.quality_risks,        order: 8,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features'] },
     { id: 'metrics_scope',        title: SECTION_TITLES.metrics_scope,        order: 9,  risk: 'low',  estimatedSeconds: 10, dependencies: ['features'] },
-    { id: 'implementation_plan',  title: SECTION_TITLES.implementation_plan,  order: 10, risk: 'high', estimatedSeconds: 30, dependencies: ['features', 'data_model', 'architecture'] },
 ];
+
+// Sections retired from the DEFAULT generation graph. Kept ONLY so the
+// single-section retry path (prdSectionRetry.ts) can re-run them for legacy
+// PRDs whose generationMeta.failedSections still reference them — their
+// SectionId, prompt builder, slice schema, and title all survive. Never feed
+// these to runDag, and never re-add them to DEFAULT_PRD_SECTIONS: the
+// dedicated data_model / implementation_plan artifacts own that detail now.
+export const RETIRED_PRD_SECTIONS: PrdSectionTemplate[] = [
+    { id: 'data_model',          title: SECTION_TITLES.data_model,          order: 98, risk: 'high', estimatedSeconds: 25 },
+    { id: 'implementation_plan', title: SECTION_TITLES.implementation_plan, order: 99, risk: 'high', estimatedSeconds: 30 },
+];
+
+export const RETIRED_SECTION_IDS: ReadonlySet<string> = new Set(
+    RETIRED_PRD_SECTIONS.map(s => s.id),
+);
 
 /** Lookup of estimated wall-clock seconds per section, derived from DEFAULT_PRD_SECTIONS. */
 export const SECTION_ESTIMATES_S: Record<string, number> = Object.fromEntries(

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -139,3 +139,28 @@ see CLAUDE.md "Cross-device mockup image sync"). Follow-ups:
 - [ ] Consider switching to signed/expiring read URLs if mockups ever carry
       sensitive content (current decision: public + unguessable content-addressed
       path, for direct browser downloads).
+
+## Lean PRD follow-ups (data_model / implementation_plan sections retired)
+
+Deferred from the lean-PRD change (PRD = decision document; detail lives in
+the dedicated artifacts).
+
+- [ ] **Renderer-parity test** for the two mirrored PRD renderers
+      (`prdMarkdownRenderer.renderPremiumMarkdown` vs
+      `StructuredPRDView`/`PremiumSections`): CLAUDE.md mandates their section
+      order stays in sync, but nothing asserts it. Consider extracting a shared
+      SECTION_ORDER constant both consume, then asserting against it.
+- [ ] **User Flows "Related Artifacts" phase chips**: new PRDs no longer carry
+      `structuredPRD.implementationPlan`, so `RelatedArtifactsPanel` loses its
+      implementation-phase cross-links (graceful — optional prop). If the chips
+      are worth keeping, source them from the implementation_plan *artifact*'s
+      structured JSON instead of the retired PRD field.
+- [ ] **Artifact prompt hints**: data_model / screen_inventory artifact
+      generation lost the PRD-embedded schema/page-spec hints from the markdown
+      body (intended — single source of truth per concern). If artifact quality
+      regresses, thread `domainEntities`/lean `uxPages` into those artifacts'
+      structured `prdSummary` context in `coreArtifactService.ts` rather than
+      re-fattening the PRD.
+- [ ] **Dead `PRD_GENERATION_STAGES` labels** in `src/components/generationStages.ts`
+      still mention "Defining data model…" but have no consumers — remove the
+      dead exports in a cleanup pass.


### PR DESCRIPTION
# Leaner, decision-focused generated PRD

The generated PRD tried to contain every downstream artifact inside itself — a full data model with per-field schemas, state machines, deep technical architecture with request flows, per-page UX component specs, analytics/instrumentation plans, and a phased implementation plan (generated with a strong-model call but **never rendered anywhere**). This cluttered the PRD, duplicated the dedicated artifacts, and created internal-inconsistency surfaces — most notably **two overlapping entity lists** (`domainEntities` vs `richDataModel.entities`).

This change makes the PRD the product **decision** document (intent, scope, features, risks, assumptions, handoff) while the dedicated artifacts carry the detail. Based on a full audit of PRD generation, rendering, and downstream artifact consumption.

## What changed (one commit each)

1. **Retire `data_model` & `implementation_plan` PRD sections** from `DEFAULT_PRD_SECTIONS` (10 → 8 sections, two fewer strong-model calls per run). `architecture` now depends on `grounding` (domainEntities) instead of the retired `richDataModel`. `RETIRED_PRD_SECTIONS` keeps the retired defs — with their prompt builders, slice schemas, and titles — solely so single-section retry of legacy `failedSections` keeps working (covered by a new test).
2. **Slim the remaining prompts to decision level**, schema-enforced via lean slice-item schemas (Gemini JSON mode can't emit properties absent from the schema): `uxPages` becomes a lean screen list (no per-screen interaction/empty/loading/error specs — Screen Inventory owns those); features drop `uiAcceptanceCriteria`/`analyticsEvents`; success metrics drop `instrumentation`; architecture becomes a short decision narrative with 2–3 highest-risk flows. `RUBRIC_DEFINITION` no longer demands schemas/state machines/request flows inside the PRD.
3. **Static "Where the Detail Lives" handoff appendix** rendered unconditionally by both mirrored renderers (markdown + in-app), pointing to the Data Model, Screens, User Flows, Design System, and Implementation Plan artifacts.

## Downstream-breakage assessment (audit findings)

- Every core-artifact prompt embeds a **structured** summary reading `vision, coreProblem, targetUsers, features(+acceptanceCriteria), architecture, nonFunctionalRequirements, constraints` — **all untouched and still generated**. All other PRD fields reached artifact prompts only via the rendered markdown body (context hints, not structure).
- `implementationPlan` never entered `responseText`, so it never reached any artifact prompt. Its only consumer (`RelatedArtifactsPanel` phase chips in User Flows) takes it as an optional prop and degrades cleanly.
- `versionDiff`, `implementationSummary`, `groundingService`, `prdConsistencyReview` (comparative guard), mockup fidelity/title logic: verified unaffected.
- Settings → "PRD (Multi)" model list is data-driven and now shows 8 rows.

## Back-compat

- No type removals: `SectionId` union, slice schemas, and `StructuredPRD.richDataModel/stateMachines/implementationPlan` stay (optional, legacy localStorage data).
- Legacy PRDs keep rendering their Data Model / State Machines / detailed UX sections — both renderers' blocks are untouched and skip missing fields (regression-tested).
- Legacy failed-section retries of `data_model`/`implementation_plan` still work via `RETIRED_PRD_SECTIONS` (regression-tested).
- Legacy spines' persisted `responseText` picks up the handoff appendix on the next re-render; the in-app view shows it immediately.

## Known trade-offs / follow-ups (documented in `tasks/TODO.md`)

- data_model / screen_inventory artifact generation loses the PRD-embedded schema/page hints from the markdown body (intended: single source of truth per concern). If quality regresses, thread `domainEntities`/lean `uxPages` into their structured prompt context instead of re-fattening the PRD.
- New PRDs lose the User Flows implementation-phase cross-link chips (optional, graceful); could be re-sourced from the implementation_plan artifact.
- Renderer-parity test for the two mirrored renderers remains a gap (pre-existing).

## Testing

- `npm test` — 829 tests / 114 files pass, including new `prdSectionRetry.test.ts` (retired-section retry back-compat), new `prdMarkdownRenderer.test.ts` (appendix position + legacy-field rendering), updated wave/prompt assertions.
- `npm run build` (`tsc -b`) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rs9AMsno5nifjn2SiFqbT

---
_Generated by [Claude Code](https://claude.ai/code/session_011rs9AMsno5nifjn2SiFqbT)_