### PR TITLE
Make PRD consistency review default and silent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,14 +448,35 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       still free to coin one. `runPrdGeneration` reads the name from the store by
       `projectId`; pass it explicitly from any new direct `generateStructuredPRD`
       call site.
-    - **Optional final consistency review** (`prdConsistencyReview.ts`): off by
-      default (one extra fast-model call). When enabled (localStorage
-      `synapse-prd-consistency-review === 'true'`, threaded through as
-      `enableConsistencyReview`), it reconciles terminology / names /
-      contradictions across the merged PRD. It **merges over the original**
-      (omitted fields preserved) and a **detail-loss guard** discards any
-      revision that would shrink/empty a key content array; on apply it sets
-      `generationMeta.revised` and adds a `consistency_review` pass record.
+    - **Automatic final consistency review** (`prdConsistencyReview.ts`): runs
+      **by default and silently** as the last step of normal PRD generation
+      (one extra fast-model call, after DAG merge, before markdown is rendered
+      for display/storage). It reconciles terminology / names / feature ids /
+      duplicates / cross-section contradictions across the merged PRD. The user
+      is **never** asked to approve ordinary repairs. The reviewed PRD replaces
+      the merged one **only** when it clears conservative acceptance guards; a
+      failed/unsafe review is discarded and the merged PRD is kept, so a review
+      failure never blocks a usable PRD:
+      - **merge-over-original** (omitted fields preserved — safety-restriction
+        `constraints` survive even if the model omits them),
+      - **detail-loss guard** (discards any revision shrinking/emptying a key
+        content array below 70%),
+      - **required-field guard** (vision/coreProblem/architecture must stay
+        non-empty; targetUsers/features/risks must stay non-empty),
+      - **feature-id stability** (every original `Feature.id` must survive —
+        downstream artifacts/tasks reference them),
+      - **product-identity guard** (a present `productName` may be canonicalized
+        but never blanked).
+      On apply it sets `generationMeta.revised` and adds a `consistency_review`
+      pass record. The outcome (`ran`/`applied`/`status`/`rejectionReason`) is
+      recorded in `generationMeta.consistencyReview` (`ConsistencyReviewMeta`)
+      for diagnostics — never surfaced in the UI. It is **skipped** for a
+      partial run (a section failed → PRD already surfaced as incomplete). The
+      localStorage `synapse-prd-consistency-review` key is now only a
+      **developer/debug opt-out** (`'false'` → skip via `enableConsistencyReview:
+      false`); default and any other value leave the review on. `runPrdGeneration`
+      resolves that override; `ProjectWorkspace.handleRegenerate` leaves it
+      default-on. Do **not** re-add a user-facing "repair PRD?" prompt.
     - **Observability** (`prdGenerationLog.ts`): structured, debug-gated logs
       (`synapse-prd-debug` / `?prddebug`) for queued/started/completed/failed,
       retry, run summary, model, est-vs-actual, and `surface` (mobile/web).

--- a/src/lib/__tests__/prdConsistencyReview.test.ts
+++ b/src/lib/__tests__/prdConsistencyReview.test.ts
@@ -68,5 +68,54 @@ describe('reviewPrdConsistency', () => {
     const result = await reviewPrdConsistency(original, { transport });
     expect(result.applied).toBe(false);
     expect(result.prd).toEqual(original);
+    expect(result.rejectionReason).toBe('unparseable');
+  });
+
+  it('rejects a revision that empties a required field', async () => {
+    const original = basePrd();
+    // Model blanks out the vision — the PRD would be unusable.
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, vision: '' }, changeLog: 'tightened' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('missing-required');
+    expect(result.prd.vision).toBe('A vision');
+  });
+
+  it('rejects a revision that renames/drops a feature id', async () => {
+    const original = basePrd();
+    // Same feature count (passes detail-loss) but the ids are all different.
+    const renamed = original.features.map((f, i) => ({ ...f, id: `renamed-${i}` }));
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, features: renamed }, changeLog: 'renamed ids' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('feature-ids-changed');
+    expect(result.prd.features.map(f => f.id)).toEqual(original.features.map(f => f.id));
+  });
+
+  it('rejects a revision that blanks the product name', async () => {
+    const original = basePrd();
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, productName: '' }, changeLog: 'dropped name' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('product-identity-lost');
+    expect(result.prd.productName).toBe('MyApp');
+  });
+
+  it('preserves safety-restriction constraints the model omits (merge)', async () => {
+    const original: StructuredPRD = { ...basePrd(), constraints: ['No collection of medical data'] };
+    // Model returns a revision that omits constraints entirely.
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, constraints: undefined }, changeLog: 'reconciled' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(true);
+    // The restriction survives via merge-over-original.
+    expect(result.prd.constraints).toEqual(['No collection of medical data']);
   });
 });

--- a/src/lib/__tests__/progressivePrdConsistency.test.ts
+++ b/src/lib/__tests__/progressivePrdConsistency.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Controls what the mocked consistency-review model call returns per test.
+let consistencyResponse = '{}';
+
+// Mock the Gemini transport so the pipeline runs offline. Section calls return
+// empty JSON (so every section succeeds and no section-failure skips the
+// review); the final consistency-review call is detected by its system prompt
+// and returns `consistencyResponse`.
+vi.mock('../geminiClient', () => ({
+    callGemini: vi.fn(async (_system: string, prompt: string) => {
+        if (prompt.includes('final consistency pass')) return consistencyResponse;
+        return '{}';
+    }),
+    getFastModel: () => 'fast-model',
+    getStrongModel: () => 'strong-model',
+}));
+
+import { callGemini } from '../geminiClient';
+import { runProgressivePrdPipeline } from '../services/progressivePrdPipeline';
+
+const consistencyCalls = () =>
+    (callGemini as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(
+        (c) => typeof c[1] === 'string' && (c[1] as string).includes('final consistency pass'),
+    );
+
+describe('progressive pipeline consistency review (default-on)', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        consistencyResponse = '{}';
+        vi.clearAllMocks();
+    });
+
+    it('runs the consistency review automatically after the DAG merge', async () => {
+        consistencyResponse = JSON.stringify({
+            prd: { productName: 'Canonical', vision: 'v' },
+            changeLog: 'normalized terminology',
+        });
+        const result = await runProgressivePrdPipeline('Build a project management app');
+        expect(consistencyCalls()).toHaveLength(1);
+        expect(result.generationMeta.consistencyReview?.ran).toBe(true);
+    });
+
+    it('replaces the merged PRD with the accepted reviewed PRD and renders its markdown', async () => {
+        consistencyResponse = JSON.stringify({
+            prd: { productName: 'Canonical Name', vision: 'reviewed vision' },
+            changeLog: 'normalized product name',
+        });
+        const result = await runProgressivePrdPipeline('Build a project management app');
+        expect(result.generationMeta.consistencyReview?.status).toBe('applied');
+        expect(result.generationMeta.revised).toBe(true);
+        expect(result.structuredPRD.productName).toBe('Canonical Name');
+        // Markdown must be rendered from the reviewed PRD, not the pre-review one.
+        expect(result.markdown).toContain('Canonical Name');
+    });
+
+    it('falls back to the merged PRD when the review is unparseable', async () => {
+        consistencyResponse = 'not json at all';
+        const result = await runProgressivePrdPipeline('Build a project management app');
+        expect(result.generationMeta.consistencyReview?.status).toBe('rejected');
+        expect(result.generationMeta.consistencyReview?.rejectionReason).toBe('unparseable');
+        expect(result.generationMeta.revised).toBe(false);
+        // A usable (merged) PRD is still returned — the failure does not block.
+        expect(result.structuredPRD).toBeTruthy();
+    });
+
+    it('skips the review when disabled by the developer override', async () => {
+        const result = await runProgressivePrdPipeline('Build a project management app', {
+            enableConsistencyReview: false,
+        });
+        expect(consistencyCalls()).toHaveLength(0);
+        expect(result.generationMeta.consistencyReview?.status).toBe('skipped');
+        expect(result.generationMeta.consistencyReview?.ran).toBe(false);
+    });
+});

--- a/src/lib/__tests__/progressivePrdPipeline.test.ts
+++ b/src/lib/__tests__/progressivePrdPipeline.test.ts
@@ -23,5 +23,9 @@ describe('runProgressivePrdPipeline partial failure', () => {
         expect(result.generationMeta.failedSections).toEqual(['product_thesis']);
         // The run still settles with a merged (partial) PRD.
         expect(result.structuredPRD).toBeTruthy();
+        // A partial run skips the consistency review (the PRD is already
+        // surfaced as incomplete) — no review runs, so the merged PRD stands.
+        expect(result.generationMeta.consistencyReview?.status).toBe('skipped');
+        expect(result.generationMeta.revised).toBe(false);
     });
 });

--- a/src/lib/runPrdGeneration.ts
+++ b/src/lib/runPrdGeneration.ts
@@ -16,16 +16,25 @@ import type { PreflightContext } from './llmProvider';
 import { detectSurface } from './services/prdGenerationLog';
 
 /**
- * Read the opt-in consistency-review flag from localStorage. Default OFF —
- * enabling adds a final reconciliation model call. Wrapped in try/catch for
- * non-browser contexts.
+ * Resolve the consistency-review override from localStorage.
+ *
+ * The final consistency-review pass now runs by DEFAULT and silently as part of
+ * normal PRD generation (see prdConsistencyReview.ts / progressivePrdPipeline).
+ * The `synapse-prd-consistency-review` key is retained only as a
+ * developer/debug override: `'false'` skips the pass (saving one model call),
+ * anything else (including absent) leaves the default-on behavior. Returns
+ * `undefined` when there is no override, so the pipeline default applies.
+ * Wrapped in try/catch for non-browser contexts.
  */
-const consistencyReviewEnabled = (): boolean => {
+const consistencyReviewOverride = (): boolean | undefined => {
     try {
-        return typeof localStorage !== 'undefined'
-            && localStorage.getItem('synapse-prd-consistency-review') === 'true';
+        if (typeof localStorage === 'undefined') return undefined;
+        const value = localStorage.getItem('synapse-prd-consistency-review');
+        if (value === 'false') return false;
+        if (value === 'true') return true;
+        return undefined;
     } catch {
-        return false;
+        return undefined;
     }
 };
 
@@ -84,7 +93,7 @@ export async function runPrdGeneration({
             {
                 preflight,
                 projectName,
-                enableConsistencyReview: consistencyReviewEnabled(),
+                enableConsistencyReview: consistencyReviewOverride(),
                 surface: detectSurface(),
                 onWorkflowRun: (run) => {
                     // The pipeline doesn't know the project — stamp identity here

--- a/src/lib/services/prdConsistencyReview.ts
+++ b/src/lib/services/prdConsistencyReview.ts
@@ -1,4 +1,4 @@
-// Optional final consistency-review pass for the parallel PRD pipeline.
+// Automatic final consistency-review pass for the parallel PRD pipeline.
 //
 // Because sections are generated concurrently (and some without seeing each
 // other's output), the merged document can carry small inconsistencies:
@@ -7,13 +7,18 @@
 // fully-merged PRD and asks the model to reconcile those issues WITHOUT
 // removing substantive detail.
 //
-// It is OFF by default in the pipeline (it adds a model call). Two safety
-// properties make it safe to enable:
+// It runs by DEFAULT in the pipeline and silently — the user is never asked to
+// approve ordinary repairs. Several conservative acceptance guards make the
+// reviewed PRD safe to substitute for the merged one, and a failed/unsafe
+// review is discarded (the merged PRD is kept):
 //   1. It MERGES the revision over the original, so any field the model omits
 //      is preserved (never dropped).
 //   2. A detail-loss guard discards the entire revision if it would shrink or
 //      empty any key content array — a defensive backstop against a model that
 //      "summarizes" instead of reconciling.
+//   3. Required top-level fields must survive, feature IDs must stay stable
+//      (downstream artifacts reference them), and product identity must be
+//      preserved — any violation discards the revision.
 
 import { callGemini, getFastModel } from '../geminiClient';
 import type { StructuredPRD } from '../../types';
@@ -43,6 +48,18 @@ export interface ReviewOptions {
     signal?: AbortSignal;
 }
 
+/**
+ * Why a review revision was discarded (merged PRD kept). Recorded in
+ * generation metadata for diagnostics; never surfaced to the user.
+ */
+export type ReviewRejectionReason =
+    | 'no-prd'                // model response carried no `prd` object
+    | 'unparseable'           // model response was not valid JSON
+    | 'detail-loss'           // a key content array materially shrank
+    | 'missing-required'      // a required top-level field was emptied/dropped
+    | 'feature-ids-changed'   // one or more original feature IDs disappeared
+    | 'product-identity-lost'; // productName was present originally, now empty
+
 export interface ReviewResult {
     /** The PRD to use downstream (revised when `applied`, else the original). */
     prd: StructuredPRD;
@@ -50,6 +67,8 @@ export interface ReviewResult {
     applied: boolean;
     /** Short human-readable note about what changed (model-provided, optional). */
     changeLog?: string;
+    /** Present only when `applied` is false: why the revision was discarded. */
+    rejectionReason?: ReviewRejectionReason;
 }
 
 const SYSTEM = `You are a meticulous product editor performing a final consistency pass on a Product Requirements Document. The PRD was assembled from independently-generated sections, so it may contain inconsistencies.
@@ -108,6 +127,52 @@ const losesDetail = (original: StructuredPRD, revised: StructuredPRD): boolean =
     return false;
 };
 
+/**
+ * Required top-level fields the reviewed PRD must still carry. Emptying any of
+ * these (string blanked, array emptied) makes the PRD unusable, so the revision
+ * is discarded. Only enforced when the original actually had the field.
+ */
+const dropsRequiredField = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const strings: Array<keyof StructuredPRD> = ['vision', 'coreProblem', 'architecture'];
+    for (const key of strings) {
+        const before = original[key];
+        if (typeof before === 'string' && before.trim().length > 0) {
+            const after = revised[key];
+            if (typeof after !== 'string' || after.trim().length === 0) return true;
+        }
+    }
+    const arrays: Array<keyof StructuredPRD> = ['targetUsers', 'features', 'risks'];
+    for (const key of arrays) {
+        if (len(original[key]) > 0 && len(revised[key]) === 0) return true;
+    }
+    return false;
+};
+
+/**
+ * Feature IDs must stay stable: downstream artifacts, tasks, and cross-feature
+ * dependency references key off `Feature.id`. A revision that renames or drops
+ * any original id (even while keeping the count high enough to pass the
+ * detail-loss guard) would silently break those references, so it is discarded.
+ */
+const changesFeatureIds = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const originalIds = (original.features ?? []).map(f => f.id).filter(Boolean);
+    if (originalIds.length === 0) return false;
+    const revisedIds = new Set((revised.features ?? []).map(f => f.id).filter(Boolean));
+    return originalIds.some(id => !revisedIds.has(id));
+};
+
+/**
+ * Product identity guard: if the merged PRD named the product, the reviewed one
+ * must still name it. The review may canonicalize the name (that is its job),
+ * but it must never blank it out.
+ */
+const losesProductIdentity = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const before = original.productName;
+    if (typeof before !== 'string' || before.trim().length === 0) return false;
+    const after = revised.productName;
+    return typeof after !== 'string' || after.trim().length === 0;
+};
+
 const parse = (raw: string): { prd?: Partial<StructuredPRD>; changeLog?: string } | null => {
     const tryParse = (s: string) => {
         try {
@@ -132,15 +197,29 @@ export const reviewPrdConsistency = async (
     const raw = await transport({ prompt: buildPrompt(prd), model: getFastModel() });
 
     const parsed = parse(raw);
-    if (!parsed?.prd) {
-        return { prd, applied: false };
+    if (parsed === null) {
+        return { prd, applied: false, rejectionReason: 'unparseable' };
+    }
+    if (!parsed.prd) {
+        return { prd, applied: false, rejectionReason: 'no-prd' };
     }
 
     // Merge over the original so any omitted field is preserved.
     const revised: StructuredPRD = { ...prd, ...parsed.prd };
 
+    // Conservative acceptance guards — any violation discards the whole
+    // revision and keeps the deterministically-merged PRD.
     if (losesDetail(prd, revised)) {
-        return { prd, applied: false, changeLog: 'discarded: detail-loss guard tripped' };
+        return { prd, applied: false, rejectionReason: 'detail-loss' };
+    }
+    if (dropsRequiredField(prd, revised)) {
+        return { prd, applied: false, rejectionReason: 'missing-required' };
+    }
+    if (changesFeatureIds(prd, revised)) {
+        return { prd, applied: false, rejectionReason: 'feature-ids-changed' };
+    }
+    if (losesProductIdentity(prd, revised)) {
+        return { prd, applied: false, rejectionReason: 'product-identity-lost' };
     }
 
     return { prd: revised, applied: true, changeLog: parsed.changeLog };

--- a/src/lib/services/prdService.ts
+++ b/src/lib/services/prdService.ts
@@ -64,7 +64,11 @@ export const generateStructuredPRD = async (
          * questions as open unknowns.
          */
         preflight?: PreflightContext;
-        /** Run the optional final consistency-review pass (default false). */
+        /**
+         * Consistency-review override. The final review runs by default and
+         * silently; pass `false` only as a developer/debug override to skip it.
+         * Undefined leaves the default-on behavior. See prdConsistencyReview.ts.
+         */
         enableConsistencyReview?: ProgressivePrdPipelineOptions['enableConsistencyReview'];
         /** Rendering surface for observability logs. */
         surface?: ProgressivePrdPipelineOptions['surface'];

--- a/src/lib/services/progressivePrdPipeline.ts
+++ b/src/lib/services/progressivePrdPipeline.ts
@@ -10,7 +10,7 @@ import { renderPremiumMarkdown } from './prdMarkdownRenderer';
 import { reviewPrdConsistency } from './prdConsistencyReview';
 import { logPrd, type PrdLogSurface } from './prdGenerationLog';
 import type { PrdPipelineOptions, PrdPipelineResult } from './prdPipeline';
-import type { StructuredPRD, GenerationPassRecord, WorkflowRun } from '../../types';
+import type { StructuredPRD, GenerationPassRecord, WorkflowRun, ConsistencyReviewMeta } from '../../types';
 import type { SectionId } from '../schemas/prdSchemas';
 import type { ProjectPlatform } from '../../types';
 import { buildWorkflowRun, type NodeObservation } from '../metrics/buildWorkflowRun';
@@ -36,9 +36,13 @@ export interface ProgressivePrdPipelineOptions extends PrdPipelineOptions {
      */
     onSectionStatus?: (sectionId: SectionId, update: SectionStatusUpdate) => void;
     /**
-     * When true, run a final cross-section consistency-review pass after the
-     * DAG completes. Default false — the deterministic merge is the fast path;
-     * the review adds one extra model call. See prdConsistencyReview.ts.
+     * Controls the final cross-section consistency-review pass that runs after
+     * the DAG completes and reconciles terminology/name/reference drift left by
+     * parallel generation. **Default ON** — the review runs automatically and
+     * silently as part of normal generation (its output is only used when it
+     * passes conservative acceptance guards; otherwise the merged PRD is kept).
+     * Pass `false` only as a developer/debug override to skip the extra model
+     * call. See prdConsistencyReview.ts.
      */
     enableConsistencyReview?: boolean;
     /** Rendering surface, attached to structured logs for observability. */
@@ -240,14 +244,20 @@ export const runProgressivePrdPipeline = async (
     const allJobs = Object.values(jobs);
     const failedSections = allJobs.filter(j => j.status === 'error');
 
-    // Optional final consistency-review pass. Reconciles terminology, names,
-    // duplicates, and contradictions introduced by parallel generation. Skipped
-    // by default (extra model call) and never runs when every section failed
-    // (handled below) or on a heavily-degraded partial. Guarded against detail
-    // loss inside reviewPrdConsistency — a lossy revision is discarded.
+    // Automatic final consistency-review pass. Reconciles terminology, names,
+    // feature ids, duplicates, and cross-section contradictions introduced by
+    // parallel generation. Runs by DEFAULT and silently — the user is never
+    // asked to approve ordinary repairs. Pass `enableConsistencyReview: false`
+    // only as a developer/debug override. It is skipped when a section failed
+    // (the PRD is already surfaced as incomplete) or when every section failed
+    // (handled below). Its output is used only when it clears the conservative
+    // acceptance guards inside reviewPrdConsistency; otherwise the
+    // deterministically-merged PRD is kept and the reason is recorded in meta.
+    const runConsistencyReview = enableConsistencyReview !== false;
     let reviewed = false;
     let consistencyMs: number | undefined;
-    if (enableConsistencyReview && failedSections.length === 0) {
+    let consistencyReviewMeta: ConsistencyReviewMeta = { ran: false, applied: false, status: 'skipped' };
+    if (runConsistencyReview && failedSections.length === 0) {
         onProgress?.('Reviewing for consistency…');
         const reviewStart = performance.now();
         const reviewStartEpoch = nowEpoch();
@@ -256,6 +266,12 @@ export const runProgressivePrdPipeline = async (
             const reviewMs = performance.now() - reviewStart;
             consistencyMs = reviewMs;
             reviewed = review.applied;
+            consistencyReviewMeta = {
+                ran: true,
+                applied: review.applied,
+                status: review.applied ? 'applied' : 'rejected',
+                rejectionReason: review.applied ? undefined : review.rejectionReason,
+            };
             if (review.applied) structuredPRD = review.prd;
             // Record the consistency pass as a final, all-sections-dependent
             // node so the Gantt shows it sequentially after the parallel wave.
@@ -274,12 +290,15 @@ export const runProgressivePrdPipeline = async (
             logPrd({
                 event: 'consistency_review',
                 actualSeconds: reviewMs / 1000,
-                detail: review.applied ? (review.changeLog || 'applied') : 'discarded (no-op or detail-loss guard)',
+                detail: review.applied
+                    ? (review.changeLog || 'applied')
+                    : `discarded (${review.rejectionReason ?? 'no-op'})`,
                 surface,
             });
         } catch (e) {
             // A review failure must never fail the whole generation — keep the
             // deterministically-merged PRD.
+            consistencyReviewMeta = { ran: true, applied: false, status: 'error', rejectionReason: 'error' };
             console.warn('[prd] consistency review failed; keeping merged PRD.', e);
         }
     }
@@ -345,6 +364,7 @@ export const runProgressivePrdPipeline = async (
             revised: reviewed,
             schemaVersion: PRD_SCHEMA_VERSION,
             failedSections: failedSections.map(j => j.id),
+            consistencyReview: consistencyReviewMeta,
         },
         model: `${fastModel} / ${strongModel}`,
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -284,6 +284,21 @@ export type GenerationPassRecord = {
     ok: boolean;
 };
 
+// Outcome of the automatic final consistency-review pass. Records — for
+// debugging/diagnostics, never the UI — whether the review ran, whether its
+// output was accepted over the deterministically-merged PRD, and (on
+// rejection) why the merged PRD was kept instead. Optional/back-compat:
+// legacy generation meta lacks it.
+export type ConsistencyReviewMeta = {
+    /** The review model call was attempted (false = skipped, e.g. partial run). */
+    ran: boolean;
+    /** The reviewed PRD passed every guard and was used as the generated PRD. */
+    applied: boolean;
+    status: 'applied' | 'rejected' | 'skipped' | 'error';
+    /** Present only when status is 'rejected' or 'error'. */
+    rejectionReason?: string;
+};
+
 export type GenerationMeta = {
     passes: GenerationPassRecord[];
     totalMs: number;
@@ -294,6 +309,10 @@ export type GenerationMeta = {
     // workspace surfaces an incomplete-PRD banner with per-section retry, and
     // a successful single-section retry removes its id from this list.
     failedSections?: string[];
+    // Result of the automatic consistency-review pass (default-on). See
+    // ConsistencyReviewMeta. Absent on legacy meta / when the pass was skipped
+    // for a partial run.
+    consistencyReview?: ConsistencyReviewMeta;
 };
 
 // --- Workflow orchestration metrics domain types ---

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -10,9 +10,9 @@ dashboard) is implemented; the items below are deferred follow-ups.
       an "advanced" control with sane defaults.
 - [ ] Auto-tune concurrency caps based on observed 429/rate-limit responses
       (back off the per-tier cap on `RESOURCE_EXHAUSTED`, recover on success).
-- [ ] Consider overlapping the optional consistency-review pass with
-      independent downstream work where it's safe (today it's strictly after the
-      DAG).
+- [ ] Consider overlapping the automatic consistency-review pass (now default-on)
+      with independent downstream work where it's safe (today it's strictly after
+      the DAG).
 - [ ] Expose the artifact dependency layers' concurrency utilization the same
       way the PRD waves are shown.
 


### PR DESCRIPTION
## Summary

The generated PRD is now internally consistent **by default** before the user ever sees or finalizes it. The final cross-section consistency-review pass (`prdConsistencyReview.ts`) — previously opt-in and off by default — now runs automatically and **silently** as the last step of normal PRD generation. The user is never asked to approve ordinary model-created repairs (terminology drift, duplicate concepts, feature naming/ID inconsistencies, cross-section contradictions, inconsistent references).

The review runs after the 8-section DAG merges and **before** the markdown is rendered for display/storage. Its output is used only when it clears conservative acceptance guards; otherwise the deterministically-merged PRD is kept, so a review failure can never block a usable PRD.

## Changes

- **Default-on, silent review** (`progressivePrdPipeline.ts`): the review runs unless explicitly disabled (`enableConsistencyReview !== false`). Skipped for a partial run (a section failed → PRD already surfaced as incomplete). Both PRD entry points get default-on behavior (`runPrdGeneration` for HomePage/Preflight, `ProjectWorkspace.handleRegenerate`).
- **Conservative acceptance guards** (`prdConsistencyReview.ts`): the existing merge-over-original and detail-loss guard, plus new guards — required top-level fields preserved, **feature IDs stable** (downstream artifacts/tasks reference them), and **product identity** preserved (name may be canonicalized, never blanked). Any violation discards the revision (with a typed `rejectionReason`) and keeps the merged PRD. Safety-restriction `constraints` survive via merge even when the model omits them.
- **Diagnostics, not UI** (`ConsistencyReviewMeta` in `src/types`): `generationMeta.consistencyReview` records `ran`/`applied`/`status`/`rejectionReason`. No new user-facing prompt or UI.
- **Reinterpreted the localStorage toggle**: `synapse-prd-consistency-review` is now a developer/debug **opt-out** (`'false'` skips the pass) rather than an opt-in. `runPrdGeneration` resolves the override; default and any other value leave the review on.

## Preserved behavior

- Disallowed safety classifications still hard-stop before any PRD content is generated; `allowed_with_restrictions` directives still propagate into prompts (they run before the review, which only reconciles the merged PRD and never touches the spine's safety review). Fail-closed classification unchanged.
- Existing single-section retry behavior unchanged. The detail-loss guard is intact and unchanged in threshold.

## Tests

- `prdConsistencyReview.test.ts`: new guard coverage (required-field, feature-id, product-identity, unparseable `rejectionReason`, merge-preservation of omitted safety constraints).
- `progressivePrdConsistency.test.ts` (new): review runs automatically after DAG merge; accepted revision replaces the merged PRD and its markdown is rendered from the reviewed PRD; unparseable review falls back; developer override skips it; metadata records accepted/rejected/skipped.
- `progressivePrdPipeline.test.ts`: partial run skips the review.

Full suite (838 tests), `npm run build`, and `npm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfbo1x6QbNBMnH4fLE9Wus

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfbo1x6QbNBMnH4fLE9Wus)_