### PR TITLE
Introduce a stricter Canonical PRD Spine as the primary artifact-generation context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,6 +585,35 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       design system (`selectPreferredDesignSystem`), wired to the existing mockup
       regenerate-confirm. Mockup *images* are keyed by the new mockup version id,
       so the user must regenerate to pull the new visual direction through.
+  - **Canonical PRD Spine (`src/lib/canonicalPrdSpine.ts`) — the primary,
+    authoritative context for artifact generation.** `buildCanonicalPrdSpine(prd,
+    options)` is a **pure, deterministic** builder (NEVER an LLM call) that
+    distills the finalized `StructuredPRD` into a compact structured contract
+    (`CanonicalPrdSpine` in `src/types`): product identity, users/JTBD, a
+    canonical feature glossary (**PRD `Feature.id`s preserved verbatim**),
+    conservative **screen seeds** (deterministic `scr-<slug>` ids) and **entity
+    seeds** (deterministic `ent-<slug>` ids — isolated in `slugId`, an interim
+    stable-id source), constraints (privacy/security auto-extracted), safety
+    restrictions (reconstructed from the persisted `SpineSafetyReview` via
+    `buildRestrictionDirective`), architecture direction, and design direction
+    (from the selected preset). Seeds are **seeds, not full artifacts** — derived
+    only from existing structured fields (`uxPages`/`userLoops`;
+    `domainEntities`/`richDataModel`), never invented. `validateCanonicalPrdSpine`
+    records non-invasive warnings in `spine.meta.validation` (never a silently
+    empty/misleading spine). The spine is **attached to `SpineVersion.canonicalSpine`**
+    on final settle (`updateSpineStructuredPRD`, only when `generationMeta` is
+    present — a diagnostic/diffing copy; artifact generation always **rebuilds it
+    lazily** from `structuredPRD` so old projects and post-edit PRDs stay
+    consistent). In `generateCoreArtifact` the prompt hierarchy is **persona →
+    guardrails → Canonical PRD Spine (authoritative) → dependency artifacts →
+    full PRD markdown (SECONDARY fallback only)**; the spine subsumes and
+    **replaces** the old standalone feature glossary + inline PRD summary (they
+    are dropped when a spine is present). A spine with **no features** yields a
+    null prompt section → the legacy summary prompt. Each artifact version stamps
+    `metadata.spineContextUsed` / `spineSchemaVersion`. Do **not** re-add the
+    duplicate glossary/summary blocks alongside the spine, and do **not** feed
+    long markdown into the spine (it must stay compact/structured). See
+    `docs/CANONICAL_PRD_SPINE.md`.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
     implementation_plan, prompt_pack, design_system). **`prompt_pack` is

--- a/docs/CANONICAL_PRD_SPINE.md
+++ b/docs/CANONICAL_PRD_SPINE.md
@@ -1,0 +1,78 @@
+# Canonical PRD Spine
+
+Status: Phase 1 (introduce + prioritize; full PRD markdown kept as fallback).
+
+## Problem
+
+Downstream core-artifact generation historically received several overlapping
+views of the same PRD, concatenated into one prompt (`generateCoreArtifact` in
+`src/lib/services/coreArtifactService.ts`):
+
+1. Narrative guardrails (`buildNarrativeGuardrails`)
+2. **Canonical Feature Glossary** (`buildFeatureGlossary`)
+3. An inline **structured PRD summary** (`prdSummary`, built ad-hoc from a
+   subset of `StructuredPRD`)
+4. **Dependency artifacts** (`buildDependencyContext`)
+5. **Full PRD markdown** (`spine.responseText`, injected verbatim)
+6. Subtype-specific steering (e.g. the design-system preset directive)
+
+The feature glossary and the inline PRD summary duplicated each other (both
+listed feature ids/names/descriptions) and neither captured the premium
+`StructuredPRD` fields (jtbd, uxPages, domainEntities, successMetrics,
+architecture flows, safety restrictions, design direction). Artifacts had to
+re-interpret and re-summarize the PRD, which is a standing source of drift and
+inconsistent terminology across artifacts.
+
+## Current flow (audit)
+
+- **Entry:** `artifactJobController.startAll(StartArgs)` where
+  `StartArgs = { projectId, spineVersionId, prdContent, structuredPRD, projectPlatform? }`.
+  `prdContent` is `SpineVersion.responseText` (rendered markdown);
+  `structuredPRD` is `SpineVersion.structuredPRD`.
+- **Per-slot:** `executeJob` → `runCoreArtifactSlot` reads the project's
+  `designSystemPreset` off the store and calls
+  `generateCoreArtifact(subtype, prdContent, structuredPRD, { designSystemPreset, generatedArtifacts, ... })`.
+- **Prompt assembly** (`coreArtifactService.ts`): the user prompt was
+  `userPrefix + guardrails + "Canonical Feature Glossary" + "Dependency Artifacts" + prdSummary + presetSection + "Full PRD" + mockupSection`.
+- **Persistence:** each artifact version stores a single `sourceRef` of
+  `sourceType: 'spine'` pointing at the spine version id; `metadata` carries
+  `{ subtype, dependencyTrace, validationWarnings }` (+ design tokens for
+  design_system).
+- **Safety:** `SpineVersion.safetyReview` (`SpineSafetyReview`). A `blocked`
+  status gates all downstream generation (`startAll` early-returns). A
+  `restricted` status means the PRD was generated under a restriction directive
+  (`buildRestrictionDirective`).
+- **Design direction:** `Project.designSystemPreset` → concrete
+  `DesignSystemPreset` (`getDesignSystemPreset`) carrying `directive`, `tone`,
+  `visualTraits`.
+
+## Design
+
+A **Canonical PRD Spine** (`src/lib/canonicalPrdSpine.ts`) is a compact,
+structured, deterministic contract built from the finalized `StructuredPRD`
+(after the silent consistency review). It becomes the **primary** source of
+truth for artifact generation; full PRD markdown stays as a lower-priority
+fallback during this first migration.
+
+- **Type:** `CanonicalPrdSpine` in `src/types/index.ts` — product identity,
+  target users / JTBD, canonical feature glossary (PRD feature ids preserved),
+  screen seeds (deterministic `scr-<slug>` ids), entity seeds (deterministic
+  `ent-<slug>` ids), constraints, safety restrictions, architecture direction,
+  design direction, plus a `meta` block (schema version, source spine id,
+  validation result).
+- **Builder:** `buildCanonicalPrdSpine(prd, options)` — pure, deterministic, no
+  LLM call. Screen/entity seeds are conservatively derived from existing
+  structured fields (uxPages / userLoops for screens; domainEntities /
+  richDataModel for entities); it does not invent a full inventory.
+- **Validation:** `validateCanonicalPrdSpine` — deterministic, non-invasive;
+  warnings are recorded in the spine `meta`, never silently dropped.
+- **Persistence:** `SpineVersion.canonicalSpine` is attached on final settle
+  (in `updateSpineStructuredPRD` when `generationMeta` is present). Old
+  projects have none; artifact generation rebuilds the spine lazily from the
+  stored `structuredPRD`, so backwards compatibility is automatic.
+- **Prompt order:** persona/system → guardrails → **Canonical PRD Spine
+  (authoritative)** → dependency artifacts → **Full PRD (secondary fallback)**.
+  The separate feature glossary and inline PRD summary are removed when a spine
+  is present (the spine subsumes both).
+- **Diagnostics:** each artifact version records `spineContextUsed` and
+  `spineSchemaVersion` in `metadata`.

--- a/src/lib/__tests__/canonicalPrdSpine.test.ts
+++ b/src/lib/__tests__/canonicalPrdSpine.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildCanonicalPrdSpine,
+    validateCanonicalPrdSpine,
+    canonicalSpineToPromptJson,
+    buildCanonicalSpinePromptSection,
+} from '../canonicalPrdSpine';
+import type { StructuredPRD, SpineSafetyReview } from '../../types';
+import { CANONICAL_SPINE_SCHEMA_VERSION } from '../../types';
+
+const FIXED_NOW = () => 1_700_000_000_000;
+
+const BASE_PRD: StructuredPRD = {
+    productName: 'MoodTune',
+    executiveSummary: 'MoodTune turns a quick emotional check-in into a personalized playlist. It adapts over time.',
+    vision: 'Help people find music that matches how they feel in seconds.',
+    coreProblem: 'Choosing music for a mood is slow and manual.',
+    targetUsers: ['Casual listeners', 'Commuters'],
+    architecture: 'Local-first React SPA with a lightweight recommendation service. Storage in IndexedDB.',
+    features: [
+        {
+            id: 'f1',
+            name: 'Mood Capture',
+            description: 'Capture a mood in under five seconds.',
+            userValue: 'Fast emotional input',
+            complexity: 'medium',
+            priority: 'must',
+            tier: 'mvp',
+            acceptanceCriteria: ['Mood recorded in <5s'],
+            successCriteria: ['Playlist seeded from mood'],
+        },
+        {
+            id: 'f2',
+            name: 'Resonance Playlist',
+            description: 'Generate a playlist from the captured mood.',
+            userValue: 'Instant fitting music',
+            complexity: 'high',
+            priority: 'should',
+        },
+    ],
+    risks: ['Recommendation quality'],
+    constraints: ['Must work offline', 'All PII must be encrypted at rest'],
+    nonFunctionalRequirements: ['P95 latency under 200ms', 'GDPR compliant data handling'],
+    domainEntities: [
+        { name: 'MoodSnapshot', description: 'A captured emotional state.' },
+        { name: 'ResonancePlaylist', description: 'A generated playlist.' },
+    ],
+    jtbd: [
+        {
+            segment: 'Commuter',
+            motivation: 'Wants a soundtrack for the drive',
+            painPoints: ['Too many taps to build a playlist'],
+            job: 'Get fitting music instantly',
+            successMoment: 'Playlist starts before the light turns green',
+        },
+    ],
+    uxPages: [
+        { id: 'p1', name: 'Mood Capture', purpose: 'Capture the mood', components: [], interactions: [], primaryUser: 'Commuter', emptyState: 'No mood yet' },
+        { id: 'p2', name: 'Player', purpose: 'Play the resonance playlist', components: [], interactions: [] },
+    ],
+    productThesis: {
+        whyExist: 'Music selection should match emotion, not genre.',
+        differentiation: 'Emotion-first.',
+        nonGoals: ['Not a social network'],
+    },
+};
+
+describe('buildCanonicalPrdSpine', () => {
+    it('builds a spine from a normal structured PRD', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.identity.productName).toBe('MoodTune');
+        expect(spine.identity.description).toBe('MoodTune turns a quick emotional check-in into a personalized playlist.');
+        expect(spine.identity.primaryGoal).toBe(BASE_PRD.vision);
+        expect(spine.features).toHaveLength(2);
+        expect(spine.users[0].segment).toBe('Commuter');
+        expect(spine.meta.schemaVersion).toBe(CANONICAL_SPINE_SCHEMA_VERSION);
+        expect(spine.meta.generatedAt).toBe(FIXED_NOW());
+    });
+
+    it('preserves PRD feature ids exactly and keeps them unique', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.features.map(f => f.id)).toEqual(['f1', 'f2']);
+        const ids = spine.features.map(f => f.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('merges successCriteria into acceptance criteria', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.features[0].acceptanceCriteria).toEqual(['Mood recorded in <5s', 'Playlist seeded from mood']);
+    });
+
+    it('uses the user-chosen project name when the PRD has none (product identity preserved)', () => {
+        const prd: StructuredPRD = { ...BASE_PRD, productName: undefined };
+        const spine = buildCanonicalPrdSpine(prd, { projectName: 'My Chosen Name', now: FIXED_NOW });
+        expect(spine.identity.productName).toBe('My Chosen Name');
+    });
+
+    it('maps platform to a human label', () => {
+        expect(buildCanonicalPrdSpine(BASE_PRD, { platform: 'app', now: FIXED_NOW }).identity.platform).toBe('Mobile app');
+        expect(buildCanonicalPrdSpine(BASE_PRD, { platform: 'web', now: FIXED_NOW }).identity.platform).toBe('Web app');
+    });
+
+    it('derives screen seeds from uxPages with deterministic scr- ids', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.screenSeeds.map(s => s.id)).toEqual(['scr-mood-capture', 'scr-player']);
+        const again = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(again.screenSeeds.map(s => s.id)).toEqual(spine.screenSeeds.map(s => s.id));
+        // The Mood Capture screen matches feature f1 by name.
+        expect(spine.screenSeeds[0].relatedFeatureIds).toContain('f1');
+        expect(spine.screenSeeds[0].userIntent).toBe('Commuter');
+    });
+
+    it('suffixes duplicate screen names deterministically', () => {
+        const prd: StructuredPRD = {
+            ...BASE_PRD,
+            uxPages: [
+                { id: 'a', name: 'Settings', purpose: 'x', components: [], interactions: [] },
+                { id: 'b', name: 'Settings', purpose: 'y', components: [], interactions: [] },
+            ],
+        };
+        const spine = buildCanonicalPrdSpine(prd, { now: FIXED_NOW });
+        expect(spine.screenSeeds.map(s => s.id)).toEqual(['scr-settings', 'scr-settings-2']);
+    });
+
+    it('derives entity seeds from domainEntities with deterministic ent- ids', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.entitySeeds.map(e => e.id)).toEqual(['ent-moodsnapshot', 'ent-resonanceplaylist']);
+        const again = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(again.entitySeeds.map(e => e.id)).toEqual(spine.entitySeeds.map(e => e.id));
+    });
+
+    it('extracts privacy/security constraints out of the general lists', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.constraints.privacySecurityCompliance).toEqual(
+            expect.arrayContaining(['All PII must be encrypted at rest', 'GDPR compliant data handling']),
+        );
+        expect(spine.constraints.product).toEqual(['Must work offline']);
+        expect(spine.constraints.nonFunctional).toEqual(['P95 latency under 200ms']);
+        expect(spine.constraints.outOfScope).toEqual(['Not a social network']);
+    });
+
+    it('preserves architecture direction when present in the PRD', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.architecture.summary).toBe(BASE_PRD.architecture);
+    });
+
+    it('includes design direction when a concrete preset is selected', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { designSystemPreset: 'saas_minimal', now: FIXED_NOW });
+        expect(spine.design?.presetId).toBe('saas_minimal');
+        expect(spine.design?.presetLabel).toBeTruthy();
+    });
+
+    it('omits design direction for a custom/unknown preset', () => {
+        expect(buildCanonicalPrdSpine(BASE_PRD, { designSystemPreset: 'custom', now: FIXED_NOW }).design).toBeUndefined();
+        expect(buildCanonicalPrdSpine(BASE_PRD, { designSystemPreset: 'nope', now: FIXED_NOW }).design).toBeUndefined();
+        expect(buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW }).design).toBeUndefined();
+    });
+
+    it('propagates safety restrictions for an allowed_with_restrictions run', () => {
+        const review: SpineSafetyReview = {
+            classification: 'allowed_with_restrictions',
+            status: 'restricted',
+            detectedConcerns: ['covert collection', 'surveillance'],
+            userFacingReason: 'Touches monitoring.',
+            safeAlternatives: ['Add consent'],
+            reviewedAt: 1,
+        };
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { safetyReview: review, now: FIXED_NOW });
+        expect(spine.safety?.classification).toBe('allowed_with_restrictions');
+        expect(spine.safety?.status).toBe('restricted');
+        expect(spine.safety?.boundaries).toEqual(['covert collection', 'surveillance']);
+        expect(spine.safety?.restrictionDirectives?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it('falls back to targetUsers and richDataModel when premium fields are absent', () => {
+        const prd: StructuredPRD = {
+            ...BASE_PRD,
+            jtbd: undefined,
+            uxPages: undefined,
+            domainEntities: undefined,
+            userLoops: [
+                { name: 'Capture loop', trigger: 't', action: 'Capture mood', systemResponse: 'r', reward: 'w', retentionMechanic: 'm' },
+            ],
+            richDataModel: { entities: [{ name: 'Track', description: 'A song', fields: [] }] },
+        };
+        const spine = buildCanonicalPrdSpine(prd, { now: FIXED_NOW });
+        expect(spine.users.map(u => u.segment)).toEqual(['Casual listeners', 'Commuters']);
+        expect(spine.screenSeeds.map(s => s.id)).toEqual(['scr-capture-loop']);
+        expect(spine.entitySeeds.map(e => e.id)).toEqual(['ent-track']);
+    });
+});
+
+describe('validateCanonicalPrdSpine', () => {
+    it('passes for a normal spine', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        expect(spine.meta.validation.valid).toBe(true);
+        expect(spine.meta.validation.warnings).toEqual([]);
+    });
+
+    it('warns when the feature glossary is empty', () => {
+        const prd: StructuredPRD = { ...BASE_PRD, features: [] };
+        const spine = buildCanonicalPrdSpine(prd, { now: FIXED_NOW });
+        expect(spine.meta.validation.valid).toBe(false);
+        expect(spine.meta.validation.warnings.some(w => /Feature glossary is empty/.test(w))).toBe(true);
+    });
+
+    it('warns when feature ids are not unique', () => {
+        const prd: StructuredPRD = {
+            ...BASE_PRD,
+            features: [BASE_PRD.features[0], { ...BASE_PRD.features[1], id: 'f1' }],
+        };
+        const spine = buildCanonicalPrdSpine(prd, { now: FIXED_NOW });
+        expect(spine.meta.validation.warnings.some(w => /not unique/.test(w))).toBe(true);
+    });
+
+    it('warns when safety restrictions were present but dropped', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        // Simulate a spine that lost its safety block.
+        const stripped = { ...spine, safety: undefined };
+        const review: SpineSafetyReview = {
+            classification: 'allowed_with_restrictions',
+            status: 'restricted',
+            detectedConcerns: [],
+            userFacingReason: '',
+            safeAlternatives: [],
+            reviewedAt: 1,
+        };
+        const result = validateCanonicalPrdSpine(stripped, { prd: BASE_PRD, options: { safetyReview: review } });
+        expect(result.warnings.some(w => /Safety restrictions/.test(w))).toBe(true);
+    });
+});
+
+describe('canonicalSpineToPromptJson / buildCanonicalSpinePromptSection', () => {
+    it('omits the meta block and empty containers from the prompt JSON', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        const json = canonicalSpineToPromptJson(spine);
+        const parsed = JSON.parse(json);
+        expect(parsed.meta).toBeUndefined();
+        expect(parsed.identity.productName).toBe('MoodTune');
+        // safety/design were not provided → pruned out entirely.
+        expect(parsed.safety).toBeUndefined();
+        expect(parsed.design).toBeUndefined();
+    });
+
+    it('produces an authoritative prompt section for a spine with features', () => {
+        const spine = buildCanonicalPrdSpine(BASE_PRD, { now: FIXED_NOW });
+        const section = buildCanonicalSpinePromptSection(spine);
+        expect(section).not.toBeNull();
+        expect(section).toMatch(/AUTHORITATIVE/);
+        expect(section).toMatch(/Reuse feature ids exactly/);
+        expect(section).toMatch(/"id": "f1"/);
+    });
+
+    it('returns null (fallback signal) for a spine with no features', () => {
+        const spine = buildCanonicalPrdSpine({ ...BASE_PRD, features: [] }, { now: FIXED_NOW });
+        expect(buildCanonicalSpinePromptSection(spine)).toBeNull();
+    });
+});

--- a/src/lib/canonicalPrdSpine.ts
+++ b/src/lib/canonicalPrdSpine.ts
@@ -1,0 +1,443 @@
+// Canonical PRD Spine — deterministic builder, validator, and prompt renderer.
+//
+// The spine is a compact, structured contract derived from the finalized
+// StructuredPRD. It is built with pure deterministic code (NEVER an LLM call)
+// so it is stable, testable, and cheap to rebuild. It becomes the primary
+// source of truth for downstream artifact generation; full PRD markdown is
+// retained only as a secondary fallback (see coreArtifactService).
+//
+// Design rules:
+// - Feature ids stay canonical: they are copied verbatim from PRD Feature.id.
+// - Screen/entity seed ids are deterministic slug-based ids (scr-/ent- prefix)
+//   with numeric dedup suffixes — an interim stable id until a real inventory
+//   exists. The slug logic is isolated in `slugId` so it is easy to swap for a
+//   true id source later.
+// - Seeds are conservative. We derive them only from structured fields already
+//   in the PRD (uxPages / userLoops for screens; domainEntities / richDataModel
+//   for entities). We never invent a large detailed inventory or data model.
+// - The spine is compact: no embedded markdown, only short structured values.
+
+import type {
+    CanonicalPrdSpine,
+    CanonicalSpineValidation,
+    SafetyClassificationResult,
+    SpineArchitectureDirection,
+    SpineConstraints,
+    SpineDesignDirection,
+    SpineEntitySeed,
+    SpineFeature,
+    SpineProductIdentity,
+    SpineSafetyRestrictions,
+    SpineSafetyReview,
+    SpineScreenSeed,
+    SpineUserSegment,
+    StructuredPRD,
+} from '../types';
+import { CANONICAL_SPINE_SCHEMA_VERSION } from '../types';
+import { getDesignSystemPreset, getDesignSystemPresetLabel } from './designSystemPresets';
+import { buildRestrictionDirective } from './safety/safetyReviewArtifact';
+
+export interface BuildCanonicalSpineOptions {
+    /** Authoritative product name (the user-chosen project name). */
+    projectName?: string;
+    /** Project platform ('app' | 'web') for the identity/platform line. */
+    platform?: string;
+    /** Selected design-system preset id (Project.designSystemPreset). */
+    designSystemPreset?: string;
+    /** Persisted safety verdict for the source spine, if any. */
+    safetyReview?: SpineSafetyReview;
+    /** Source spine version id (recorded in meta for diffing/debugging). */
+    sourceSpineVersionId?: string;
+    /** StructuredPRD schema version at build time (recorded in meta). */
+    sourcePrdVersion?: number;
+    /**
+     * Injected clock. Defaults to Date.now(); overridable so tests can build a
+     * deterministic spine.
+     */
+    now?: () => number;
+}
+
+// --- small pure helpers -----------------------------------------------------
+
+const firstSentence = (text: string | undefined): string | undefined => {
+    if (!text) return undefined;
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+    const match = trimmed.match(/^.*?[.!?](\s|$)/);
+    return (match ? match[0] : trimmed).trim();
+};
+
+const nonEmpty = (values: (string | undefined)[] | undefined): string[] =>
+    (values ?? []).map(v => (v ?? '').trim()).filter(Boolean);
+
+const dedupe = (values: string[]): string[] => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const v of values) {
+        const key = v.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(v);
+    }
+    return out;
+};
+
+const slug = (name: string): string =>
+    name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'item';
+
+/**
+ * Deterministic slug-based id with a numeric dedup suffix. Isolated so the
+ * interim slug id logic is easy to replace with a real stable id source later.
+ * Given the same ordered inputs it always produces the same ids.
+ */
+const slugId = (prefix: string, name: string, used: Set<string>): string => {
+    const base = `${prefix}-${slug(name)}`;
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+    let n = 2;
+    while (used.has(`${base}-${n}`)) n += 1;
+    const id = `${base}-${n}`;
+    used.add(id);
+    return id;
+};
+
+const PRIVACY_RE = /privacy|security|compliance|gdpr|hipaa|ccpa|pii|encrypt|consent|audit|retention|data protection|soc\s?2/i;
+
+/** Match canonical feature ids for entities/screens by conservative name mention. */
+const relatedFeatureIds = (prd: StructuredPRD, ...needles: (string | undefined)[]): string[] => {
+    const terms = nonEmpty(needles).map(t => t.toLowerCase());
+    if (terms.length === 0) return [];
+    const hits = prd.features
+        .filter(f => {
+            const hay = `${f.name} ${f.description}`.toLowerCase();
+            return terms.some(term => term.length >= 3 && hay.includes(term));
+        })
+        .map(f => f.id);
+    return dedupe(hits);
+};
+
+// --- section builders -------------------------------------------------------
+
+const buildIdentity = (
+    prd: StructuredPRD,
+    options: BuildCanonicalSpineOptions,
+): SpineProductIdentity => {
+    const platformLabel =
+        options.platform === 'app'
+            ? 'Mobile app'
+            : options.platform === 'web'
+                ? 'Web app'
+                : options.platform || undefined;
+    return {
+        productName: (prd.productName || options.projectName || '').trim() || undefined,
+        description: firstSentence(prd.executiveSummary) ?? firstSentence(prd.vision),
+        platform: platformLabel,
+        primaryGoal: (prd.vision || prd.productThesis?.whyExist || prd.coreProblem || '').trim() || undefined,
+    };
+};
+
+const buildUsers = (prd: StructuredPRD): SpineUserSegment[] => {
+    if (prd.jtbd && prd.jtbd.length > 0) {
+        return prd.jtbd.map(j => ({
+            segment: j.segment,
+            jobsToBeDone: dedupe(nonEmpty([j.job, j.motivation])),
+            pains: dedupe(nonEmpty(j.painPoints)),
+        }));
+    }
+    return dedupe(nonEmpty(prd.targetUsers)).map(segment => ({ segment }));
+};
+
+const buildFeatures = (prd: StructuredPRD): SpineFeature[] =>
+    prd.features.map(f => {
+        const acceptance = dedupe(nonEmpty([...(f.acceptanceCriteria ?? []), ...(f.successCriteria ?? [])]));
+        const entry: SpineFeature = {
+            id: f.id,
+            name: f.name,
+            description: f.description,
+        };
+        if (acceptance.length > 0) entry.acceptanceCriteria = acceptance;
+        if (f.priority) entry.priority = f.priority;
+        if (f.tier) entry.tier = f.tier;
+        return entry;
+    });
+
+const buildScreenSeeds = (prd: StructuredPRD): SpineScreenSeed[] => {
+    const used = new Set<string>();
+    // Prefer the PRD's declared UX pages; fall back to user loops (each loop
+    // implies a screen). Never invent a full inventory beyond these.
+    if (prd.uxPages && prd.uxPages.length > 0) {
+        return prd.uxPages.map(p => {
+            const seed: SpineScreenSeed = { id: slugId('scr', p.name, used), name: p.name };
+            if (p.purpose) seed.purpose = p.purpose;
+            const related = relatedFeatureIds(prd, p.name, p.purpose);
+            if (related.length > 0) seed.relatedFeatureIds = related;
+            if (p.primaryUser) seed.userIntent = p.primaryUser;
+            const states = dedupe(nonEmpty([p.emptyState, p.loadingState, p.errorState]));
+            if (states.length > 0) seed.states = states;
+            return seed;
+        });
+    }
+    if (prd.userLoops && prd.userLoops.length > 0) {
+        return prd.userLoops.map(loop => {
+            const seed: SpineScreenSeed = { id: slugId('scr', loop.name, used), name: loop.name };
+            if (loop.action) seed.purpose = loop.action;
+            const related = relatedFeatureIds(prd, loop.name, loop.action);
+            if (related.length > 0) seed.relatedFeatureIds = related;
+            return seed;
+        });
+    }
+    return [];
+};
+
+const buildEntitySeeds = (prd: StructuredPRD): SpineEntitySeed[] => {
+    const used = new Set<string>();
+    if (prd.domainEntities && prd.domainEntities.length > 0) {
+        return prd.domainEntities.map(e => {
+            const seed: SpineEntitySeed = { id: slugId('ent', e.name, used), name: e.name };
+            if (e.description) seed.description = e.description;
+            const related = relatedFeatureIds(prd, e.name);
+            if (related.length > 0) seed.relatedFeatureIds = related;
+            return seed;
+        });
+    }
+    if (prd.richDataModel && prd.richDataModel.entities.length > 0) {
+        return prd.richDataModel.entities.map(e => {
+            const seed: SpineEntitySeed = { id: slugId('ent', e.name, used), name: e.name };
+            if (e.description) seed.description = e.description;
+            const related = relatedFeatureIds(prd, e.name);
+            if (related.length > 0) seed.relatedFeatureIds = related;
+            const relationships = dedupe(nonEmpty(e.relationships));
+            if (relationships.length > 0) seed.relationships = relationships;
+            return seed;
+        });
+    }
+    return [];
+};
+
+const buildConstraints = (prd: StructuredPRD): SpineConstraints => {
+    const product: string[] = [];
+    const nonFunctional: string[] = [];
+    const privacy: string[] = [];
+
+    for (const c of dedupe(nonEmpty(prd.constraints))) {
+        (PRIVACY_RE.test(c) ? privacy : product).push(c);
+    }
+    for (const nfr of dedupe(nonEmpty(prd.nonFunctionalRequirements))) {
+        (PRIVACY_RE.test(nfr) ? privacy : nonFunctional).push(nfr);
+    }
+
+    const outOfScope = dedupe(nonEmpty(prd.productThesis?.nonGoals));
+
+    const constraints: SpineConstraints = {};
+    if (product.length > 0) constraints.product = product;
+    if (nonFunctional.length > 0) constraints.nonFunctional = nonFunctional;
+    if (privacy.length > 0) constraints.privacySecurityCompliance = dedupe(privacy);
+    if (outOfScope.length > 0) constraints.outOfScope = outOfScope;
+    return constraints;
+};
+
+const buildSafety = (review: SpineSafetyReview | undefined): SpineSafetyRestrictions | undefined => {
+    if (!review) return undefined;
+    const safety: SpineSafetyRestrictions = {
+        classification: review.classification,
+        status: review.status,
+    };
+    const boundaries = dedupe(nonEmpty(review.detectedConcerns));
+    if (boundaries.length > 0) safety.boundaries = boundaries;
+    if (review.status === 'restricted' || review.classification === 'allowed_with_restrictions') {
+        // Reconstruct the binding restriction directive from the persisted
+        // review so downstream artifacts inherit the same constraints the PRD
+        // was generated under. SpineSafetyReview lacks `confidence`; the
+        // directive builder does not use it, so a placeholder is safe.
+        const asResult: SafetyClassificationResult = {
+            classification: review.classification,
+            confidence: 'medium',
+            detectedConcerns: review.detectedConcerns,
+            userFacingReason: review.userFacingReason,
+            safeAlternatives: review.safeAlternatives,
+        };
+        const directive = buildRestrictionDirective(asResult)
+            .split('\n')
+            .map(l => l.replace(/^-\s*/, '').trim())
+            .filter(l => l && !/^SAFETY CONSTRAINTS/i.test(l));
+        if (directive.length > 0) safety.restrictionDirectives = directive;
+    }
+    return safety;
+};
+
+const buildArchitecture = (prd: StructuredPRD): SpineArchitectureDirection => {
+    const architecture: SpineArchitectureDirection = {};
+    const summary = (prd.architecture || '').trim();
+    if (summary) architecture.summary = summary;
+    const integration = dedupe(nonEmpty(prd.architectureFlows?.map(f => f.name)));
+    if (integration.length > 0) architecture.integrationAssumptions = integration;
+    return architecture;
+};
+
+const buildDesign = (presetId: string | undefined): SpineDesignDirection | undefined => {
+    const preset = getDesignSystemPreset(presetId);
+    // Only concrete presets carry a design direction. 'custom'/unknown/missing
+    // → no design direction (the model decides), mirroring the prompt behavior.
+    if (!preset || !preset.directive) return undefined;
+    const design: SpineDesignDirection = {
+        presetId: preset.id,
+        presetLabel: getDesignSystemPresetLabel(preset.id),
+    };
+    if (preset.tone) design.tone = preset.tone;
+    const visual = dedupe(nonEmpty(preset.visualTraits));
+    if (visual.length > 0) design.visualDirection = visual.join(', ');
+    return design;
+};
+
+// --- public API -------------------------------------------------------------
+
+/**
+ * Deterministically build the Canonical PRD Spine from a finalized structured
+ * PRD. Pure — no LLM call, no store access, no I/O beyond the injected clock.
+ * The result always carries a `meta.validation` block (see
+ * `validateCanonicalPrdSpine`); the spine is never silently empty.
+ */
+export function buildCanonicalPrdSpine(
+    prd: StructuredPRD,
+    options: BuildCanonicalSpineOptions = {},
+): CanonicalPrdSpine {
+    const now = options.now ?? Date.now;
+    const spine: CanonicalPrdSpine = {
+        identity: buildIdentity(prd, options),
+        users: buildUsers(prd),
+        features: buildFeatures(prd),
+        screenSeeds: buildScreenSeeds(prd),
+        entitySeeds: buildEntitySeeds(prd),
+        constraints: buildConstraints(prd),
+        safety: buildSafety(options.safetyReview),
+        architecture: buildArchitecture(prd),
+        design: buildDesign(options.designSystemPreset),
+        meta: {
+            schemaVersion: CANONICAL_SPINE_SCHEMA_VERSION,
+            generatedAt: now(),
+            sourceSpineVersionId: options.sourceSpineVersionId,
+            sourcePrdVersion: options.sourcePrdVersion,
+            validation: { valid: true, warnings: [] },
+        },
+    };
+    spine.meta.validation = validateCanonicalPrdSpine(spine, { prd, options });
+    return spine;
+}
+
+/**
+ * Lightweight deterministic validation. Non-invasive — it never mutates the
+ * spine — but failures are surfaced as warnings and recorded in
+ * `meta.validation` so a misleading/empty spine is never produced silently.
+ */
+export function validateCanonicalPrdSpine(
+    spine: CanonicalPrdSpine,
+    context?: { prd?: StructuredPRD; options?: BuildCanonicalSpineOptions },
+): CanonicalSpineValidation {
+    const warnings: string[] = [];
+    const prd = context?.prd;
+    const options = context?.options;
+
+    // Product identity present.
+    const { identity } = spine;
+    if (!identity.productName && !identity.description && !identity.primaryGoal) {
+        warnings.push('Product identity is empty (no product name, description, or primary goal).');
+    }
+
+    // Features present, ids unique, names present.
+    if (spine.features.length === 0) {
+        warnings.push('Feature glossary is empty.');
+    }
+    const featureIds = spine.features.map(f => f.id);
+    if (featureIds.some(id => !id || !id.trim())) {
+        warnings.push('One or more features have a missing id.');
+    }
+    if (new Set(featureIds).size !== featureIds.length) {
+        warnings.push('Feature ids are not unique.');
+    }
+    if (spine.features.some(f => !f.name || !f.name.trim())) {
+        warnings.push('One or more features have a missing name.');
+    }
+
+    // Screen/entity seed ids unique when present.
+    const screenIds = spine.screenSeeds.map(s => s.id);
+    if (new Set(screenIds).size !== screenIds.length) {
+        warnings.push('Screen seed ids are not unique.');
+    }
+    const entityIds = spine.entitySeeds.map(e => e.id);
+    if (new Set(entityIds).size !== entityIds.length) {
+        warnings.push('Entity seed ids are not unique.');
+    }
+
+    // Safety restrictions preserved when applicable.
+    const review = options?.safetyReview;
+    if (review && (review.status === 'restricted' || review.status === 'blocked') && !spine.safety) {
+        warnings.push('Safety restrictions were present on the spine but are missing from the canonical spine.');
+    }
+
+    // Architecture direction must survive when the PRD had one.
+    if (prd && (prd.architecture || '').trim() && !spine.architecture.summary) {
+        warnings.push('Architecture direction is present in the PRD but missing from the canonical spine.');
+    }
+
+    // Design direction included when a concrete preset was selected.
+    if (options?.designSystemPreset) {
+        const preset = getDesignSystemPreset(options.designSystemPreset);
+        if (preset && preset.directive && !spine.design) {
+            warnings.push('A design preset was selected but design direction is missing from the canonical spine.');
+        }
+    }
+
+    return { valid: warnings.length === 0, warnings };
+}
+
+/**
+ * Compact JSON projection of the spine for prompt injection. Strips the `meta`
+ * block and empty containers so the prompt carries only the product contract.
+ */
+export function canonicalSpineToPromptJson(spine: CanonicalPrdSpine): string {
+    const prune = (value: unknown): unknown => {
+        if (Array.isArray(value)) {
+            const arr = value.map(prune).filter(v => v !== undefined);
+            return arr.length > 0 ? arr : undefined;
+        }
+        if (value && typeof value === 'object') {
+            const out: Record<string, unknown> = {};
+            for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+                const pruned = prune(v);
+                if (pruned !== undefined) out[k] = pruned;
+            }
+            return Object.keys(out).length > 0 ? out : undefined;
+        }
+        if (typeof value === 'string') return value.trim() ? value : undefined;
+        return value;
+    };
+    const { meta: _meta, ...rest } = spine;
+    void _meta;
+    return JSON.stringify(prune(rest) ?? {}, null, 2);
+}
+
+/**
+ * Render the authoritative "Canonical PRD Spine" prompt section. Returns null
+ * when the spine has no features (nothing reliable to anchor on) so callers can
+ * fall back to the legacy summary path.
+ */
+export function buildCanonicalSpinePromptSection(spine: CanonicalPrdSpine): string | null {
+    if (spine.features.length === 0) return null;
+    return [
+        'Canonical PRD Spine (AUTHORITATIVE — this compact structured contract is the primary',
+        'source of truth for this artifact). Rules:',
+        '- Treat the Canonical PRD Spine as authoritative. Where the full PRD markdown below',
+        '  conflicts with it, the spine wins.',
+        '- Reuse feature ids exactly as given. Do not rename features or invent new ids.',
+        '- Reuse screen seed ids and entity seed ids where relevant; do not introduce duplicate',
+        '  or alternate terminology for the same concept.',
+        '- Use the full PRD markdown only as secondary context for detail the spine omits.',
+        '',
+        canonicalSpineToPromptJson(spine),
+    ].join('\n');
+}

--- a/src/lib/services/__tests__/coreArtifactSpinePrompt.test.ts
+++ b/src/lib/services/__tests__/coreArtifactSpinePrompt.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { generateCoreArtifact } from '../coreArtifactService';
+import { buildCanonicalPrdSpine } from '../../canonicalPrdSpine';
+import { callGeminiStream } from '../../geminiClient';
+import type { StructuredPRD } from '../../../types';
+
+// Keep the real module (model resolution, retry helpers) but stub the two
+// transport functions so we can capture the assembled user prompt.
+vi.mock('../../geminiClient', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../geminiClient')>();
+    return {
+        ...actual,
+        callGemini: vi.fn(),
+        callGeminiStream: vi.fn(),
+    };
+});
+
+const streamMock = callGeminiStream as unknown as Mock;
+
+const PRD: StructuredPRD = {
+    productName: 'MoodTune',
+    vision: 'Match music to mood in seconds.',
+    coreProblem: 'Picking music for a mood is slow.',
+    targetUsers: ['Commuters'],
+    architecture: 'Local-first SPA.',
+    features: [
+        { id: 'f1', name: 'Mood Capture', description: 'Capture a mood fast.', userValue: 'Speed', complexity: 'medium', priority: 'must' },
+        { id: 'f2', name: 'Resonance Playlist', description: 'Playlist from mood.', userValue: 'Fit', complexity: 'high' },
+    ],
+    risks: ['Quality'],
+};
+
+const PRD_MARKDOWN = '# MoodTune PRD\n\nFull rendered PRD markdown body.';
+
+// user_flows has no JSON schema → plain markdown stream path (simplest to
+// assert against). The mock returns a heading so normalizeArtifactMarkdown keeps it.
+const lastUserPrompt = (): string => streamMock.mock.calls[0][1] as string;
+
+beforeEach(() => {
+    streamMock.mockReset();
+    streamMock.mockResolvedValue('### Flow: Onboarding\nStep one.');
+});
+
+describe('generateCoreArtifact — canonical spine prompt', () => {
+    it('leads with the authoritative Canonical PRD Spine and demotes full PRD to a fallback', async () => {
+        const spine = buildCanonicalPrdSpine(PRD, { now: () => 1 });
+        await generateCoreArtifact('user_flows', PRD_MARKDOWN, PRD, { canonicalSpine: spine });
+
+        const prompt = lastUserPrompt();
+        expect(prompt).toMatch(/Canonical PRD Spine \(AUTHORITATIVE/);
+        expect(prompt).toMatch(/"id": "f1"/);
+        // Full PRD present but explicitly marked secondary.
+        expect(prompt).toMatch(/Full PRD \(SECONDARY reference only/);
+        expect(prompt).toContain('Full rendered PRD markdown body.');
+        // The spine section must appear before the full PRD.
+        expect(prompt.indexOf('Canonical PRD Spine')).toBeLessThan(prompt.indexOf('Full PRD (SECONDARY'));
+        // The redundant standalone glossary/summary headers are gone.
+        expect(prompt).not.toContain('Canonical Feature Glossary:');
+        expect(prompt).not.toContain('Vision: Match music to mood');
+    });
+
+    it('records spineContextUsed + spineSchemaVersion in the returned metadata', async () => {
+        const spine = buildCanonicalPrdSpine(PRD, { now: () => 1 });
+        const result = await generateCoreArtifact('user_flows', PRD_MARKDOWN, PRD, { canonicalSpine: spine });
+        expect(result.metadata?.spineContextUsed).toBe(true);
+        expect(result.metadata?.spineSchemaVersion).toBe(spine.meta.schemaVersion);
+    });
+
+    it('rebuilds a spine when the caller passes none (old projects without a saved spine)', async () => {
+        const result = await generateCoreArtifact('user_flows', PRD_MARKDOWN, PRD);
+        expect(result.metadata?.spineContextUsed).toBe(true);
+        expect(lastUserPrompt()).toMatch(/Canonical PRD Spine \(AUTHORITATIVE/);
+    });
+
+    it('falls back to the legacy summary prompt when the PRD has no features', async () => {
+        const prdNoFeatures: StructuredPRD = { ...PRD, features: [] };
+        const result = await generateCoreArtifact('user_flows', PRD_MARKDOWN, prdNoFeatures);
+        const prompt = lastUserPrompt();
+        expect(result.metadata?.spineContextUsed).toBe(false);
+        expect(prompt).toContain('Canonical Feature Glossary:');
+        expect(prompt).toContain('Vision: Match music to mood');
+        expect(prompt).not.toMatch(/Canonical PRD Spine \(AUTHORITATIVE/);
+        // Legacy path still includes the full PRD.
+        expect(prompt).toContain('Full rendered PRD markdown body.');
+    });
+});

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -9,6 +9,7 @@ import type {
 import { MOCKUP_SPEC_V1 } from '../../types';
 import { useProjectStore } from '../../store/projectStore';
 import { generateCoreArtifact, selectArtifactModel } from './coreArtifactService';
+import { buildCanonicalPrdSpine } from '../canonicalPrdSpine';
 import { generateMockup } from './mockupService';
 import { validateArtifactContent } from '../artifactValidation';
 import { validateCrossArtifactConsistency } from '../artifactOrchestration';
@@ -167,11 +168,26 @@ async function runCoreArtifactSlot(
         // Read the chosen design-system preset off the project here (rather than
         // threading it through every startAll/regenerate/resume call site) so
         // ALL generation paths consistently honor it. Only design_system uses it.
-        const designSystemPreset = store.getProject(projectId)?.designSystemPreset;
+        const project = store.getProject(projectId);
+        const designSystemPreset = project?.designSystemPreset;
+        // Build the Canonical PRD Spine — the primary source of truth — freshly
+        // from THIS run's structuredPRD (rather than trusting a persisted copy,
+        // which could lag an edit). Deterministic and cheap. The persisted
+        // spine on the SpineVersion is a diagnostic/diffing convenience only.
+        const spineVersion = (store.spineVersions[projectId] || []).find(s => s.id === spineVersionId);
+        const canonicalSpine = buildCanonicalPrdSpine(structuredPRD, {
+            projectName: project?.productName || project?.name,
+            platform: project?.platform,
+            designSystemPreset,
+            safetyReview: spineVersion?.safetyReview,
+            sourceSpineVersionId: spineVersionId,
+            sourcePrdVersion: spineVersion?.prdVersion,
+        });
         const result = await generateCoreArtifact(subtype, prdContent, structuredPRD, {
             generatedArtifacts,
             signal,
             designSystemPreset,
+            canonicalSpine,
             onProgress: (msg) => useProjectStore.getState().appendSlotProgress(projectId, subtype, msg),
         });
         content = result.content;

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -1,10 +1,11 @@
-import type { StructuredPRD, CoreArtifactSubtype, DataModelContent, ComponentInventoryContent, DesignTokens, StructuredImplementationPlan } from '../../types';
+import type { StructuredPRD, CoreArtifactSubtype, DataModelContent, ComponentInventoryContent, DesignTokens, StructuredImplementationPlan, CanonicalPrdSpine } from '../../types';
 import { callGemini, callGeminiStream } from '../geminiClient';
 import type { ProviderOptions } from '../geminiClient';
 import { getArtifactModel, CORE_ARTIFACT_COMPLEXITY } from '../artifactModelSettings';
 import type { ArtifactComplexity } from '../artifactModelSettings';
 import { screenInventorySchema, dataModelSchema, componentInventorySchema, designSystemTokensSchema, implementationPlanSchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
+import { buildCanonicalPrdSpine, buildCanonicalSpinePromptSection } from '../canonicalPrdSpine';
 import { normalizeScreenInventory, screenInventoryToMarkdown } from '../screenInventoryNormalize';
 import { dataModelToMarkdown } from './dataModelMarkdown';
 import {
@@ -467,6 +468,14 @@ export const generateCoreArtifact = async (
          * other subtypes ignore it. Absent/unknown/'custom' → no steering.
          */
         designSystemPreset?: string;
+        /**
+         * The Canonical PRD Spine — the primary, authoritative source of truth
+         * for artifact generation. When present (and non-empty), the prompt
+         * leads with it and demotes full PRD markdown to a secondary fallback.
+         * When absent, one is rebuilt deterministically from `structuredPRD`;
+         * an empty spine (no features) falls back to the legacy summary prompt.
+         */
+        canonicalSpine?: CanonicalPrdSpine;
     },
 ): Promise<CoreArtifactGenerationResult> => {
     const config = CORE_ARTIFACT_PROMPTS[subtype];
@@ -475,34 +484,6 @@ export const generateCoreArtifact = async (
     // Fast (Flash). Mirrors the PRD pipeline's per-section tiering.
     const model = selectArtifactModel(subtype);
 
-    const featureList = structuredPRD.features.map(f => {
-        let line = `- [${f.id}] ${f.name} (${f.complexity}${f.priority ? `, ${f.priority}` : ''}): ${f.description}`;
-        if (f.acceptanceCriteria && f.acceptanceCriteria.length > 0) {
-            line += `\n  Acceptance Criteria: ${f.acceptanceCriteria.join('; ')}`;
-        }
-        if (f.dependencies && f.dependencies.length > 0) {
-            line += `\n  Dependencies: ${f.dependencies.join(', ')}`;
-        }
-        return line;
-    }).join('\n');
-
-const prdSummary = `Vision: ${structuredPRD.vision}
-Core Problem: ${structuredPRD.coreProblem}
-Target Users: ${structuredPRD.targetUsers.join(', ')}
-
-Features:
-${featureList}
-
-Architecture: ${structuredPRD.architecture}${
-    structuredPRD.nonFunctionalRequirements?.length
-        ? `\n\nNon-Functional Requirements:\n${structuredPRD.nonFunctionalRequirements.map(r => `- ${r}`).join('\n')}`
-        : ''
-}${
-    structuredPRD.constraints?.length
-        ? `\n\nConstraints:\n${structuredPRD.constraints.map(c => `- ${c}`).join('\n')}`
-        : ''
-}`;
-    const featureGlossary = buildFeatureGlossary(structuredPRD);
     const dependencyContext = buildDependencyContext(subtype, options?.generatedArtifacts ?? {});
     const guardrails = buildNarrativeGuardrails(structuredPRD);
 
@@ -529,7 +510,61 @@ Architecture: ${structuredPRD.architecture}${
         implementation_plan: implementationPlanSchema,
     };
 
-    const userPrompt = `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}${presetSection}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`;
+    // Canonical PRD Spine — the primary, authoritative source of truth. Rebuild
+    // deterministically when the caller didn't pass one (e.g. legacy projects
+    // with no saved spine). A spine with no features yields a null section; we
+    // then fall back to the legacy feature-glossary + inline-summary prompt.
+    const canonicalSpine = options?.canonicalSpine
+        ?? buildCanonicalPrdSpine(structuredPRD, { designSystemPreset: options?.designSystemPreset });
+    const spineSection = buildCanonicalSpinePromptSection(canonicalSpine);
+    const spineContextUsed = spineSection !== null;
+
+    // Prompt hierarchy: persona/system → guardrails → Canonical PRD Spine
+    // (authoritative) → dependency artifacts → full PRD markdown (secondary
+    // fallback only). The spine subsumes the old feature glossary + inline PRD
+    // summary, so those are dropped when the spine is used to avoid feeding
+    // several differently-worded views of the same product facts.
+    let userPrompt: string;
+    if (spineSection) {
+        userPrompt = `${config.userPrefix}\n\n${guardrails}\n\n${spineSection}\n\nDependency Artifacts:\n${dependencyContext}${presetSection}\n\n---\n\nFull PRD (SECONDARY reference only — defer to the Canonical PRD Spine above on any conflict; use this solely for detail the spine omits):\n${prdContent}${mockupSection}`;
+    } else {
+        // Legacy fallback: no reliable spine (e.g. a PRD with no features).
+        const featureList = structuredPRD.features.map(f => {
+            let line = `- [${f.id}] ${f.name} (${f.complexity}${f.priority ? `, ${f.priority}` : ''}): ${f.description}`;
+            if (f.acceptanceCriteria && f.acceptanceCriteria.length > 0) {
+                line += `\n  Acceptance Criteria: ${f.acceptanceCriteria.join('; ')}`;
+            }
+            if (f.dependencies && f.dependencies.length > 0) {
+                line += `\n  Dependencies: ${f.dependencies.join(', ')}`;
+            }
+            return line;
+        }).join('\n');
+        const prdSummary = `Vision: ${structuredPRD.vision}
+Core Problem: ${structuredPRD.coreProblem}
+Target Users: ${structuredPRD.targetUsers.join(', ')}
+
+Features:
+${featureList}
+
+Architecture: ${structuredPRD.architecture}${
+            structuredPRD.nonFunctionalRequirements?.length
+                ? `\n\nNon-Functional Requirements:\n${structuredPRD.nonFunctionalRequirements.map(r => `- ${r}`).join('\n')}`
+                : ''
+        }${
+            structuredPRD.constraints?.length
+                ? `\n\nConstraints:\n${structuredPRD.constraints.map(c => `- ${c}`).join('\n')}`
+                : ''
+        }`;
+        const featureGlossary = buildFeatureGlossary(structuredPRD);
+        userPrompt = `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}${presetSection}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`;
+    }
+
+    // Diagnostics stamped onto every artifact version — records whether the
+    // canonical spine drove generation or the legacy summary path was used.
+    const spineMeta: Record<string, unknown> = {
+        spineContextUsed,
+        spineSchemaVersion: canonicalSpine.meta.schemaVersion,
+    };
 
     // Cap progress messages at ~3/s; emit every 250 chars OR 350ms to keep the
     // UI feeling alive without thrashing the store.
@@ -586,7 +621,7 @@ Architecture: ${structuredPRD.architecture}${
             // markdown for storage to avoid cross-cutting changes.
             if (subtype === 'screen_inventory') {
                 const normalized = normalizeScreenInventory(parsed) ?? parsed;
-                return { content: JSON.stringify(normalized, null, 2) };
+                return { content: JSON.stringify(normalized, null, 2), metadata: spineMeta };
             }
             const content = normalizeArtifactMarkdown(structuredArtifactToMarkdown(subtype, parsed));
             // For design_system specifically, the parsed JSON IS the token
@@ -597,15 +632,15 @@ Architecture: ${structuredPRD.architecture}${
                 const tokens = normalizeDesignTokens(parsed);
                 return {
                     content,
-                    metadata: { tokens, tokensHash: hashDesignTokens(tokens) },
+                    metadata: { ...spineMeta, tokens, tokensHash: hashDesignTokens(tokens) },
                 };
             }
-            return { content };
+            return { content, metadata: spineMeta };
         } catch {
             // JSON-mode failure: fall back to the raw text body. For
             // design_system this means we won't have structured tokens —
             // legacy markdown rendering still works in the UI.
-            return { content: normalizeArtifactMarkdown(result) };
+            return { content: normalizeArtifactMarkdown(result), metadata: spineMeta };
         }
     }
 
@@ -622,7 +657,7 @@ Architecture: ${structuredPRD.architecture}${
         { model },
     );
     onProgress?.('Validating output…');
-    return { content: normalizeArtifactMarkdown(result) };
+    return { content: normalizeArtifactMarkdown(result), metadata: spineMeta };
 };
 
 export const refineCoreArtifact = async (

--- a/src/store/__tests__/spineSlice.canonicalSpine.test.ts
+++ b/src/store/__tests__/spineSlice.canonicalSpine.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import type { GenerationMeta, StructuredPRD } from '../../types';
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+    localStorage.clear();
+});
+
+const prd: StructuredPRD = {
+    vision: 'Match music to mood.',
+    targetUsers: ['Commuters'],
+    coreProblem: 'Slow music picking.',
+    features: [
+        { id: 'f1', name: 'Mood Capture', description: 'Capture a mood.', userValue: 'Speed', complexity: 'medium' },
+    ],
+    architecture: 'Local-first SPA.',
+    risks: ['Quality'],
+};
+
+const meta: GenerationMeta = {
+    passes: [],
+    totalMs: 10,
+    revised: false,
+    schemaVersion: 2,
+};
+
+describe('updateSpineStructuredPRD — canonical spine attachment', () => {
+    it('attaches a canonical spine on final settle (generationMeta present)', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('MoodTune', 'idea');
+        const v1 = useProjectStore.getState().spineVersions[projectId][0];
+
+        store.updateSpineStructuredPRD(projectId, v1.id, prd, 'md', { generationMeta: meta, prdVersion: 2 });
+
+        const spine = useProjectStore.getState().spineVersions[projectId][0];
+        expect(spine.canonicalSpine).toBeDefined();
+        expect(spine.canonicalSpine?.features.map(f => f.id)).toEqual(['f1']);
+        // Product name defaults to the user-chosen project name.
+        expect(spine.canonicalSpine?.identity.productName).toBe('MoodTune');
+        expect(spine.canonicalSpine?.meta.sourceSpineVersionId).toBe(v1.id);
+        expect(spine.canonicalSpine?.meta.sourcePrdVersion).toBe(2);
+        expect(spine.canonicalSpine?.meta.validation.valid).toBe(true);
+    });
+
+    it('does NOT attach a spine on a partial (streaming) update without generationMeta', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('MoodTune', 'idea');
+        const v1 = useProjectStore.getState().spineVersions[projectId][0];
+
+        store.updateSpineStructuredPRD(projectId, v1.id, prd, 'partial md');
+
+        const spine = useProjectStore.getState().spineVersions[projectId][0];
+        expect(spine.canonicalSpine).toBeUndefined();
+    });
+});

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -6,6 +6,7 @@ import type {
     PreflightSession,
 } from '../../types';
 import type { ProjectState, SpineGenerationMetaInput } from '../types';
+import { buildCanonicalPrdSpine } from '../../lib/canonicalPrdSpine';
 
 export type SpineSlice = {
     spineVersions: Record<string, SpineVersion[]>;
@@ -272,7 +273,27 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
                 if (meta?.prdVersion !== undefined) next.prdVersion = meta.prdVersion;
                 // generationMeta only arrives with the final onResult — partial
                 // (onPartial) updates leave the run marked as still running.
-                if (meta?.generationMeta !== undefined) next.generationPhase = 'complete';
+                if (meta?.generationMeta !== undefined) {
+                    next.generationPhase = 'complete';
+                    // Attach the canonical PRD spine on final settle only. It is
+                    // rebuilt deterministically at artifact-generation time too,
+                    // so this persisted copy is a diagnostic/diffing convenience
+                    // and never the sole source of truth. Best-effort — a build
+                    // failure must never block a usable PRD.
+                    try {
+                        const project = state.projects[projectId];
+                        next.canonicalSpine = buildCanonicalPrdSpine(structuredPRD, {
+                            projectName: project?.productName || project?.name,
+                            platform: project?.platform,
+                            designSystemPreset: project?.designSystemPreset,
+                            safetyReview: next.safetyReview,
+                            sourceSpineVersionId: next.id,
+                            sourcePrdVersion: meta.prdVersion ?? meta.generationMeta.schemaVersion,
+                        });
+                    } catch {
+                        // Leave canonicalSpine unset; lazy rebuild covers it.
+                    }
+                }
                 return next;
             });
             return { spineVersions: { ...state.spineVersions, [projectId]: updatedSpines } };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -426,6 +426,168 @@ export type SpineSafetyReview = {
     reviewedAt: number;
 };
 
+// --- Canonical PRD Spine ---------------------------------------------------
+//
+// A compact, structured, deterministic contract derived from the finalized
+// StructuredPRD (after the silent consistency review). It is the *primary*
+// source of truth for downstream artifact generation — a single, stable
+// product contract that replaces the several overlapping PRD summaries that
+// used to be concatenated into artifact prompts (feature glossary + inline
+// PRD summary). Full PRD markdown is retained only as a secondary fallback.
+//
+// The spine is built by `buildCanonicalPrdSpine` (deterministic code, never an
+// LLM call) and attached to `SpineVersion.canonicalSpine`. It is intentionally
+// compact — no embedded markdown — so it can be rendered into a prompt as
+// structured JSON without bloating context. Every field is conservative:
+// screen/entity seeds are *seeds*, not full downstream artifacts. All arrays
+// are optional-empty and the whole object is optional on SpineVersion so
+// legacy projects (which have no saved spine) keep working — artifact
+// generation rebuilds a spine lazily from the stored StructuredPRD.
+
+/** Schema version for the canonical spine shape — bump on breaking changes. */
+export const CANONICAL_SPINE_SCHEMA_VERSION = 1 as const;
+
+export type SpineProductIdentity = {
+    /** Authoritative product name (user-chosen name wins over model-invented). */
+    productName?: string;
+    /** One-sentence product description. */
+    description?: string;
+    /** Platform / delivery context, e.g. "Mobile app", "Web app". */
+    platform?: string;
+    /** The single primary product goal. */
+    primaryGoal?: string;
+};
+
+export type SpineUserSegment = {
+    /** Segment / persona name. */
+    segment: string;
+    /** Primary jobs-to-be-done for this segment. */
+    jobsToBeDone?: string[];
+    /** Key pains or needs. */
+    pains?: string[];
+};
+
+/**
+ * Canonical feature entry. `id` is the PRD `Feature.id` verbatim — feature ids
+ * stay canonical across the PRD and every downstream artifact.
+ */
+export type SpineFeature = {
+    id: string;
+    name: string;
+    description: string;
+    /** Acceptance criteria or success expectations, when available. */
+    acceptanceCriteria?: string[];
+    /** MoSCoW priority marker, when available. */
+    priority?: 'must' | 'should' | 'could';
+    /** MVP / post-MVP release tier, when available. */
+    tier?: 'mvp' | 'v1' | 'later';
+};
+
+/**
+ * A likely canonical screen implied by the PRD. `id` is a deterministic
+ * slug-based id (`scr-<slug>` with numeric dedup suffixes) — interim stable id
+ * until a real screen inventory exists. Seeds are conservative, not a full
+ * screen inventory.
+ */
+export type SpineScreenSeed = {
+    id: string;
+    name: string;
+    purpose?: string;
+    /** Canonical `Feature.id`s this screen relates to, when derivable. */
+    relatedFeatureIds?: string[];
+    /** Primary user intent for the screen, in the user's own words. */
+    userIntent?: string;
+    /** Known screen states, when available. */
+    states?: string[];
+};
+
+/**
+ * A likely canonical domain entity implied by the PRD. `id` is a deterministic
+ * slug-based id (`ent-<slug>` with numeric dedup suffixes). Seeds are
+ * conservative, not a full data model.
+ */
+export type SpineEntitySeed = {
+    id: string;
+    name: string;
+    description?: string;
+    /** Canonical `Feature.id`s this entity relates to, when derivable. */
+    relatedFeatureIds?: string[];
+    /** Obvious relationships, when available. */
+    relationships?: string[];
+};
+
+export type SpineConstraints = {
+    technical?: string[];
+    product?: string[];
+    nonFunctional?: string[];
+    /** Privacy / security / compliance constraints (extracted from the above). */
+    privacySecurityCompliance?: string[];
+    /** Explicit out-of-scope items. */
+    outOfScope?: string[];
+};
+
+/**
+ * Safety restrictions that must propagate downstream. Sourced from the spine's
+ * persisted `SpineSafetyReview`. `blocked` spines never reach artifact
+ * generation, so in practice this carries `generated` / `restricted`.
+ */
+export type SpineSafetyRestrictions = {
+    classification: SafetyClassification;
+    status: SpineSafetyReview['status'];
+    /** Binding restriction directives for `allowed_with_restrictions` runs. */
+    restrictionDirectives?: string[];
+    /** Content/implementation boundaries (detected concerns) to honor. */
+    boundaries?: string[];
+};
+
+export type SpineArchitectureDirection = {
+    /** High-level architecture guidance (short decision narrative). */
+    summary?: string;
+    integrationAssumptions?: string[];
+    dataStorageAssumptions?: string[];
+    aiToolingAssumptions?: string[];
+    /** Implementation constraints artifacts should respect. */
+    implementationConstraints?: string[];
+};
+
+export type SpineDesignDirection = {
+    /** Selected `DESIGN_SYSTEM_PRESETS` id. */
+    presetId?: string;
+    presetLabel?: string;
+    tone?: string;
+    visualDirection?: string;
+    accessibilityExpectations?: string[];
+    platformNotes?: string[];
+};
+
+export type CanonicalSpineValidation = {
+    valid: boolean;
+    warnings: string[];
+};
+
+export type CanonicalSpineMeta = {
+    schemaVersion: typeof CANONICAL_SPINE_SCHEMA_VERSION;
+    generatedAt: number;
+    /** Spine version the contract was built from (for diffing/staleness). */
+    sourceSpineVersionId?: string;
+    /** `StructuredPRD` schema version at build time, when known. */
+    sourcePrdVersion?: number;
+    validation: CanonicalSpineValidation;
+};
+
+export type CanonicalPrdSpine = {
+    identity: SpineProductIdentity;
+    users: SpineUserSegment[];
+    features: SpineFeature[];
+    screenSeeds: SpineScreenSeed[];
+    entitySeeds: SpineEntitySeed[];
+    constraints: SpineConstraints;
+    safety?: SpineSafetyRestrictions;
+    architecture: SpineArchitectureDirection;
+    design?: SpineDesignDirection;
+    meta: CanonicalSpineMeta;
+};
+
 // --- Preflight clarification (optional pre-PRD interview) ---
 // When the user opts into Quick (5) or Deep (10) clarification, Synapse
 // generates idea-specific questions, collects answers one at a time, shows a
@@ -502,6 +664,12 @@ export type SpineVersion = {
     // Change attribution for this version (user edit vs AI regen vs revert, …).
     // Optional & backward-compatible: legacy spines have none.
     provenance?: VersionProvenance;
+    // Compact structured contract derived deterministically from the finalized
+    // structuredPRD (after the consistency review). The primary source of truth
+    // for downstream artifact generation. Attached on final settle; optional &
+    // backward-compatible — legacy spines lack it and artifact generation
+    // rebuilds one lazily from `structuredPRD`.
+    canonicalSpine?: CanonicalPrdSpine;
 };
 
 // --- Structured Artifact Content Types ---


### PR DESCRIPTION
## Summary

Downstream core-artifact generation used to receive several overlapping views of the same PRD concatenated into one prompt — a narrative guardrails block, a **Canonical Feature Glossary**, an ad-hoc **inline PRD summary**, dependency artifacts, and the **full PRD markdown**. The glossary and inline summary duplicated each other and neither captured the richer `StructuredPRD` fields, so artifacts had to re-interpret and re-summarize the PRD — a standing source of drift and inconsistent terminology.

This PR introduces a **Canonical PRD Spine**: a compact, structured, deterministic contract derived from the finalized `StructuredPRD`. It becomes the **primary, authoritative** source of truth for artifact generation, while full PRD markdown is retained as a **secondary fallback** during this first migration.

This is a staged, low-risk change: it introduces the spine and prioritizes it, but does **not** redesign the PRD pipeline or artifact schemas, does not remove full PRD markdown, and preserves safety, versioning, and staleness behavior.

## What's included

- **`CanonicalPrdSpine` type** (`src/types`) — product identity, target users/JTBD, canonical feature glossary (**PRD `Feature.id`s preserved verbatim**), screen seeds (deterministic `scr-<slug>` ids), entity seeds (deterministic `ent-<slug>` ids), constraints (privacy/security auto-extracted), safety restrictions, architecture direction, design direction, plus a `meta` block (schema version, source spine id, validation result). All fields conservative/optional.
- **Deterministic builder** (`src/lib/canonicalPrdSpine.ts`) — `buildCanonicalPrdSpine(prd, options)` is pure (no LLM call). Screen/entity seeds are derived only from existing structured fields (`uxPages`/`userLoops`; `domainEntities`/`richDataModel`) — seeds, not a full inventory. Slug-id logic is isolated in `slugId` as an interim stable-id source. Includes `validateCanonicalPrdSpine` (non-invasive warnings recorded in `meta.validation`) and a compact prompt renderer.
- **Persistence** — the spine is attached to `SpineVersion.canonicalSpine` on final settle (`updateSpineStructuredPRD`, guarded on `generationMeta`). Best-effort and backward-compatible.
- **Prompt composition** — `generateCoreArtifact` now leads with the authoritative spine (persona → guardrails → **Canonical PRD Spine** → dependency artifacts → **full PRD (secondary fallback)**). The standalone feature glossary + inline summary are dropped when a spine is present. A featureless PRD falls back to the legacy summary prompt. The spine is rebuilt lazily from `structuredPRD`, so **old projects without a saved spine still generate**.
- **Diagnostics** — each artifact version records `metadata.spineContextUsed` and `spineSchemaVersion`.

## Testing

- `npm run build` (tsc -b && vite build) — passes.
- `npm run lint` — clean.
- `npm test` — **865 passed** (118 files), including new coverage:
  - `src/lib/__tests__/canonicalPrdSpine.test.ts` — build, stable/unique feature ids, deterministic screen/entity seed ids, product identity, safety propagation, constraint extraction, design direction, validation warnings, prompt-JSON pruning, fallback signal.
  - `src/lib/services/__tests__/coreArtifactSpinePrompt.test.ts` — prompt leads with the authoritative spine, full PRD demoted to secondary, `spineContextUsed` metadata, lazy rebuild for old projects, legacy fallback for featureless PRDs.
  - `src/store/__tests__/spineSlice.canonicalSpine.test.ts` — spine attached on final settle only, not on partial streaming updates.

## Safety / compatibility

- Safety behavior preserved — restriction directives for `allowed_with_restrictions` runs are reconstructed from the persisted `SpineSafetyReview` and propagate into the spine; `blocked` spines never reach artifact generation (unchanged gate).
- No schema/pipeline/staleness/mockup changes; PRD versioning untouched.
- Legacy projects (no saved spine) rebuild one lazily; a build failure or featureless PRD degrades gracefully to the previous prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTmdUiVPCcHLXKkrBGGqB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTmdUiVPCcHLXKkrBGGqB1)_