### PR TITLE
Declutter desktop User Flows artifact UI

### DIFF
--- a/src/components/renderers/userFlows/AssumptionsPanel.tsx
+++ b/src/components/renderers/userFlows/AssumptionsPanel.tsx
@@ -2,6 +2,7 @@ import { HelpCircle, Lightbulb } from 'lucide-react';
 import type { Feature } from '../../../types';
 import type { FeatureRef, ParsedFlow } from './types';
 import { inlineWithFeatures } from './inlineWithFeatures';
+import { CollapsibleSection } from './CollapsibleSection';
 
 interface Props {
     flow: ParsedFlow;
@@ -41,10 +42,11 @@ export function AssumptionsPanel({ flow, featuresById, onSelectFeature }: Props)
         inlineWithFeatures(text, { featuresById, onSelectFeature });
 
     return (
-        <section className="mb-4">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2 inline-flex items-center gap-1">
-                <Lightbulb size={11} /> Assumptions & open questions
-            </p>
+        <CollapsibleSection
+            title="Assumptions & open questions"
+            icon={<Lightbulb size={12} />}
+            count={assumptions.length + openQuestions.length}
+        >
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 {assumptions.length > 0 && (
                     <section className="rounded-xl border border-neutral-200 bg-white p-3.5">
@@ -79,6 +81,6 @@ export function AssumptionsPanel({ flow, featuresById, onSelectFeature }: Props)
                     </section>
                 )}
             </div>
-        </section>
+        </CollapsibleSection>
     );
 }

--- a/src/components/renderers/userFlows/CollapsibleSection.tsx
+++ b/src/components/renderers/userFlows/CollapsibleSection.tsx
@@ -1,0 +1,57 @@
+import { useState, type ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+interface Props {
+    /** Section label shown in the header button. */
+    title: string;
+    /** Small icon left of the title. */
+    icon?: ReactNode;
+    /** Optional count badge rendered after the title (e.g. "· 4"). */
+    count?: number;
+    /** Whether the section starts expanded. Defaults to collapsed. */
+    defaultOpen?: boolean;
+    /** Optional muted summary shown inline in the header while collapsed. */
+    collapsedSummary?: ReactNode;
+    children: ReactNode;
+}
+
+/**
+ * A lightweight progressive-disclosure section used by the User Flows
+ * renderer to demote secondary content (Related Artifacts, Edge Cases,
+ * Technical Dependencies) below the primary reading flow. Presentation
+ * only — no data is removed, just tucked behind a toggle.
+ */
+export function CollapsibleSection({
+    title, icon, count, defaultOpen = false, collapsedSummary, children,
+}: Props) {
+    const [open, setOpen] = useState(defaultOpen);
+    return (
+        <section className="mb-4 rounded-xl border border-neutral-200 bg-white overflow-hidden">
+            <button
+                type="button"
+                onClick={() => setOpen(o => !o)}
+                aria-expanded={open}
+                className="w-full flex items-center gap-2 px-3.5 py-2.5 text-left hover:bg-neutral-50 transition-colors"
+            >
+                <ChevronRight
+                    size={14}
+                    className={`shrink-0 text-neutral-400 transition-transform ${open ? 'rotate-90' : ''}`}
+                    aria-hidden="true"
+                />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-neutral-600 inline-flex items-center gap-1.5">
+                    {icon}
+                    <span>{title}</span>
+                    {typeof count === 'number' && count > 0 && (
+                        <span className="text-neutral-400 font-normal">· {count}</span>
+                    )}
+                </span>
+                {!open && collapsedSummary && (
+                    <span className="ml-auto text-[11px] text-neutral-400 truncate min-w-0">
+                        {collapsedSummary}
+                    </span>
+                )}
+            </button>
+            {open && <div className="px-3.5 pb-3.5 pt-1">{children}</div>}
+        </section>
+    );
+}

--- a/src/components/renderers/userFlows/FlowJourney.tsx
+++ b/src/components/renderers/userFlows/FlowJourney.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import {
-    AppWindow, Cog, GitBranch, Layers, MousePointerClick, Sparkles, Workflow,
+    AppWindow, ChevronRight, Cog, GitBranch, Layers, MousePointerClick,
+    Sparkles, Workflow,
 } from 'lucide-react';
 import type { FlowJourneyNode, ParsedStep, FlowJourneyNodeKind } from './types';
 import { buildJourneyNodes, NODE_KIND_LABEL, nodeKindStyle } from './journeyNode';
@@ -55,12 +57,6 @@ function Legend() {
                     </span>
                 );
             })}
-            <span className="inline-flex items-center gap-1 ml-1">
-                <span className="inline-block w-6 border-t-2 border-neutral-400" /> Primary path
-            </span>
-            <span className="inline-flex items-center gap-1">
-                <span className="inline-block w-6 border-t-2 border-dashed border-amber-500" /> Alternate path
-            </span>
         </div>
     );
 }
@@ -69,6 +65,7 @@ export function FlowJourney({
     flowIndex, steps, issuesByStep,
     onNavigateToScreen, availableScreenSlugs, highlightedStepIndices,
 }: Props) {
+    const [legendOpen, setLegendOpen] = useState(false);
     if (steps.length === 0) return null;
     const nodes = buildJourneyNodes(steps);
 
@@ -98,48 +95,47 @@ export function FlowJourney({
                 </span>
             </div>
 
-            <div className="overflow-x-auto -mx-1 px-1 pb-1">
-                <ol className="flex items-stretch gap-3 min-w-max">
-                    {nodes.map((node, i) => {
-                        const Icon = KIND_ICON[node.kind];
-                        const style = nodeKindStyle(node.kind);
-                        const altCount = issuesByStep.get(node.stepIndex) ?? 0;
-                        const isLast = i === nodes.length - 1;
-                        const highlighted = highlightedStepIndices?.has(node.stepIndex) ?? false;
-                        return (
-                            <li
-                                key={node.stepIndex}
-                                className="flex items-stretch gap-3"
+            {/* Vertical timeline — readable at any width, no horizontal scroll,
+                and each row lines up 1:1 with the Step-by-Step cards below. */}
+            <ol className="relative">
+                {nodes.map((node, i) => {
+                    const Icon = KIND_ICON[node.kind];
+                    const style = nodeKindStyle(node.kind);
+                    const altCount = issuesByStep.get(node.stepIndex) ?? 0;
+                    const isLast = i === nodes.length - 1;
+                    const highlighted = highlightedStepIndices?.has(node.stepIndex) ?? false;
+                    return (
+                        <li key={node.stepIndex} className="relative flex gap-3">
+                            {/* Rail: number marker + connector line */}
+                            <div className="relative flex flex-col items-center">
+                                <span className="z-10 inline-flex items-center justify-center w-7 h-7 rounded-full bg-white border border-neutral-300 text-[11px] font-bold text-neutral-700">
+                                    {node.stepIndex + 1}
+                                </span>
+                                {!isLast && (
+                                    <span
+                                        aria-hidden="true"
+                                        className="w-px flex-1 bg-neutral-200 my-0.5"
+                                    />
+                                )}
+                            </div>
+
+                            {/* Node card */}
+                            <button
+                                type="button"
+                                onClick={() => handleClick(node)}
+                                aria-current={highlighted ? 'true' : undefined}
+                                className={`group flex-1 min-w-0 text-left rounded-lg border ${style.border} ${style.bg} hover:ring-2 hover:ring-offset-1 hover:ring-indigo-300 transition px-3 py-2 mb-2 flex items-start gap-2.5 ${
+                                    highlighted ? 'ring-2 ring-offset-1 ring-indigo-500' : ''
+                                }`}
                             >
-                                <button
-                                    type="button"
-                                    onClick={() => handleClick(node)}
-                                    aria-current={highlighted ? 'true' : undefined}
-                                    className={`group relative w-40 text-left rounded-xl border ${style.border} ${style.bg} hover:ring-2 hover:ring-offset-1 hover:ring-indigo-300 transition px-3 py-2.5 flex flex-col ${
-                                        highlighted ? 'ring-2 ring-offset-1 ring-indigo-500' : ''
-                                    }`}
-                                >
-                                    <div className="flex items-center justify-between gap-1 mb-1">
-                                        <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-white/80 text-[10px] font-bold text-neutral-700 border border-neutral-200">
-                                            {node.stepIndex + 1}
-                                        </span>
-                                        <span className={`inline-flex items-center justify-center w-5 h-5 rounded ${style.badgeBg} ${style.badgeText}`}>
-                                            <Icon size={11} />
-                                        </span>
-                                    </div>
-                                    <p
-                                        className={`text-[12px] font-medium leading-snug ${style.text}`}
-                                        title={node.label}
-                                        style={{
-                                            display: '-webkit-box',
-                                            WebkitLineClamp: 2,
-                                            WebkitBoxOrient: 'vertical',
-                                            overflow: 'hidden',
-                                        }}
-                                    >
+                                <span className={`shrink-0 mt-0.5 inline-flex items-center justify-center w-5 h-5 rounded ${style.badgeBg} ${style.badgeText}`}>
+                                    <Icon size={12} />
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                    <span className={`block text-[13px] font-medium leading-snug ${style.text}`} title={node.label}>
                                         {node.label}
-                                    </p>
-                                    <div className="mt-1.5 flex items-center justify-between gap-1">
+                                    </span>
+                                    <span className="mt-1 flex items-center gap-1.5 flex-wrap">
                                         <NodeBadge kind={node.kind} />
                                         {altCount > 0 && (
                                             <span
@@ -149,25 +145,40 @@ export function FlowJourney({
                                                 {altCount} alt
                                             </span>
                                         )}
-                                    </div>
-                                </button>
-                                {!isLast && (
-                                    <div
-                                        aria-hidden="true"
-                                        className="flex items-center"
-                                    >
-                                        <span className="block h-px w-6 bg-neutral-300" />
-                                        <span className="block w-0 h-0 border-y-4 border-y-transparent border-l-[6px] border-l-neutral-300" />
-                                    </div>
-                                )}
-                            </li>
-                        );
-                    })}
-                </ol>
-            </div>
+                                    </span>
+                                </span>
+                                <ChevronRight
+                                    size={14}
+                                    className="shrink-0 mt-1 text-neutral-300 group-hover:text-indigo-400 transition-colors"
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </li>
+                    );
+                })}
+            </ol>
 
-            <div className="mt-3 pt-3 border-t border-neutral-100">
-                <Legend />
+            {/* Compact, collapsible legend — the per-row kind badges already
+                label each node, so the color key is opt-in. */}
+            <div className="mt-1 pt-2 border-t border-neutral-100">
+                <button
+                    type="button"
+                    onClick={() => setLegendOpen(o => !o)}
+                    aria-expanded={legendOpen}
+                    className="inline-flex items-center gap-1 text-[10px] font-medium text-neutral-400 hover:text-neutral-600 transition-colors"
+                >
+                    <ChevronRight
+                        size={11}
+                        className={`transition-transform ${legendOpen ? 'rotate-90' : ''}`}
+                        aria-hidden="true"
+                    />
+                    Legend
+                </button>
+                {legendOpen && (
+                    <div className="mt-2">
+                        <Legend />
+                    </div>
+                )}
             </div>
         </section>
     );

--- a/src/components/renderers/userFlows/FlowSidebar.tsx
+++ b/src/components/renderers/userFlows/FlowSidebar.tsx
@@ -1,5 +1,7 @@
-import { useEffect } from 'react';
-import { Clock, GitBranch, Menu, Sparkles, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+    Clock, GitBranch, Menu, PanelLeftClose, PanelLeftOpen, Sparkles, X,
+} from 'lucide-react';
 import type { FlowCategory, FlowIssueKind, FlowRiskLevel, ParsedFlow } from './types';
 import { CATEGORY_ORDER } from './categorize';
 
@@ -57,6 +59,11 @@ export function FlowSidebar({
 }: Props) {
     const grouped = groupFlows(flows);
     const selected = flows[selectedIndex];
+    // Desktop rail collapses to a narrow numbered strip so the flow list is
+    // one click away without permanently dominating horizontal space. A
+    // single-flow artifact never needs a switcher, so the rail hides entirely.
+    const [railExpanded, setRailExpanded] = useState(false);
+    const multiFlow = flows.length > 1;
 
     useEffect(() => {
         if (!isMobileOpen) return;
@@ -168,23 +175,75 @@ export function FlowSidebar({
         </div>
     );
 
+    // Narrow collapsed rail: numbered buttons only, name on hover/tooltip.
+    const renderCollapsedRail = () => (
+        <ul className="space-y-1.5" aria-label="Flows">
+            {flows.map((flow, i) => {
+                const active = i === selectedIndex;
+                const showRisk = flow.risk !== 'low' || flow.issues.length > 0;
+                const risk = RISK_DOT[flow.risk];
+                return (
+                    <li key={i} className="relative flex justify-center">
+                        <button
+                            type="button"
+                            onClick={() => onSelect(i)}
+                            aria-current={active ? 'true' : undefined}
+                            title={`Flow ${i + 1}: ${flow.title}`}
+                            className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold transition ${
+                                active
+                                    ? 'bg-indigo-600 text-white shadow-sm'
+                                    : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'
+                            }`}
+                        >
+                            {i + 1}
+                        </button>
+                        {showRisk && (
+                            <span
+                                className={`absolute top-0 right-1 w-2 h-2 rounded-full ring-2 ring-white ${risk.color}`}
+                                title={risk.label}
+                                aria-label={risk.label}
+                            />
+                        )}
+                    </li>
+                );
+            })}
+        </ul>
+    );
+
     return (
         <>
-            {/* Desktop rail */}
-            <aside
-                className="hidden md:block w-72 shrink-0 self-start sticky top-0 max-h-[calc(100vh-6rem)] overflow-y-auto pr-2 border-r border-neutral-200"
-                aria-label="Flow navigation"
-            >
-                <div className="px-2 mb-3 flex items-center justify-between">
-                    <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-700">
-                        User Flows
-                    </p>
-                    <span className="text-[10px] text-neutral-400 font-mono">{flows.length}</span>
-                </div>
-                {renderList(onSelect)}
-            </aside>
+            {/* Desktop rail — collapsible; hidden entirely for single-flow artifacts */}
+            {multiFlow && (
+                <aside
+                    className={`hidden md:block shrink-0 self-start sticky top-0 max-h-[calc(100vh-6rem)] overflow-y-auto border-r border-neutral-200 transition-[width] duration-200 ${
+                        railExpanded ? 'w-64 pr-2' : 'w-14 pr-1'
+                    }`}
+                    aria-label="Flow navigation"
+                >
+                    <div className={`mb-3 flex items-center ${railExpanded ? 'px-2 justify-between' : 'justify-center'}`}>
+                        {railExpanded && (
+                            <p className="text-[11px] font-semibold uppercase tracking-wider text-neutral-700">
+                                User Flows
+                            </p>
+                        )}
+                        <button
+                            type="button"
+                            onClick={() => setRailExpanded(e => !e)}
+                            aria-expanded={railExpanded}
+                            aria-label={railExpanded ? 'Collapse flow list' : 'Expand flow list'}
+                            title={railExpanded ? 'Collapse flow list' : 'Expand flow list'}
+                            className="p-1.5 rounded hover:bg-neutral-100 text-neutral-500"
+                        >
+                            {railExpanded ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
+                        </button>
+                    </div>
+                    {railExpanded ? renderList(onSelect) : renderCollapsedRail()}
+                </aside>
+            )}
 
-            {/* Mobile trigger — full-width current-flow selector that opens the drawer */}
+            {/* Mobile trigger — full-width current-flow selector that opens the
+                drawer. Single-flow artifacts have nothing to switch between. */}
+            {multiFlow && (
             <div className="md:hidden mb-3">
                 <button
                     type="button"
@@ -212,6 +271,7 @@ export function FlowSidebar({
                     <Menu size={16} className="shrink-0 text-neutral-400" />
                 </button>
             </div>
+            )}
 
             {/* Mobile drawer overlay + panel */}
             {isMobileOpen && (

--- a/src/components/renderers/userFlows/FlowSidebar.tsx
+++ b/src/components/renderers/userFlows/FlowSidebar.tsx
@@ -188,6 +188,7 @@ export function FlowSidebar({
                             type="button"
                             onClick={() => onSelect(i)}
                             aria-current={active ? 'true' : undefined}
+                            aria-label={`Flow ${i + 1}: ${flow.title}`}
                             title={`Flow ${i + 1}: ${flow.title}`}
                             className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold transition ${
                                 active

--- a/src/components/renderers/userFlows/FlowSummaryCard.tsx
+++ b/src/components/renderers/userFlows/FlowSummaryCard.tsx
@@ -1,13 +1,14 @@
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import {
-    AlertTriangle, Bookmark, Clock, DoorOpen, GitBranch, ListChecks,
-    MoreHorizontal, Server, Share2, ShieldCheck, Sparkles, Target,
+    AlertTriangle, ChevronRight, Clock, DoorOpen, GitBranch, ListChecks,
+    MoreHorizontal, Network, Server, ShieldCheck, Sparkles, Target,
 } from 'lucide-react';
 import type { Feature } from '../../../types';
 import type { FeatureRef, FlowRiskLevel, ParsedFlow } from './types';
 import { inlineMd } from './markdown';
 import { inlineWithFeatures } from './inlineWithFeatures';
-import { FeatureReferenceChip } from './FeatureReferenceChip';
+import type { RelatedArtifacts } from './relatedArtifacts';
+import { relatedSummaryParts } from './relatedArtifacts';
 
 interface Props {
     flow: ParsedFlow;
@@ -15,72 +16,55 @@ interface Props {
     timeToValue: string | null;
     featuresById?: Map<string, Feature>;
     onSelectFeature: (refToken: FeatureRef) => void;
+    /** Precomputed heuristic join, used for the compact relationship summary. */
+    related: RelatedArtifacts;
 }
 
-type StatTone = 'neutral' | 'amber' | 'sky' | 'emerald' | 'red';
+type BadgeTone = 'neutral' | 'amber' | 'sky' | 'emerald' | 'red' | 'indigo';
 
 const RISK_LEVEL_LABEL: Record<FlowRiskLevel, string> = {
-    low: 'Low',
-    medium: 'Medium',
-    high: 'High',
+    low: 'Low risk',
+    medium: 'Medium risk',
+    high: 'High risk',
 };
 
-const RISK_TONE: Record<FlowRiskLevel, StatTone> = {
+const RISK_TONE: Record<FlowRiskLevel, BadgeTone> = {
     low: 'emerald',
     medium: 'amber',
     high: 'red',
 };
 
-const STAT_VALUE_COLOR: Record<StatTone, string> = {
-    neutral: 'text-neutral-900',
-    amber: 'text-amber-700',
-    sky: 'text-sky-700',
-    emerald: 'text-emerald-700',
-    red: 'text-red-700',
+const BADGE_CLASS: Record<BadgeTone, string> = {
+    neutral: 'bg-neutral-100 text-neutral-600 border-neutral-200',
+    amber: 'bg-amber-50 text-amber-700 border-amber-200',
+    sky: 'bg-sky-50 text-sky-700 border-sky-200',
+    emerald: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    red: 'bg-red-50 text-red-700 border-red-200',
+    indigo: 'bg-indigo-50 text-indigo-700 border-indigo-200',
 };
 
-const STAT_ICON_COLOR: Record<StatTone, string> = {
-    neutral: 'text-neutral-400',
-    amber: 'text-amber-500',
-    sky: 'text-sky-500',
-    emerald: 'text-emerald-500',
-    red: 'text-red-500',
-};
-
-/** A single aligned metric in the flow's stat grid. */
-function StatCell({
-    icon, value, label, tone = 'neutral',
-}: { icon: ReactNode; value: string; label: string; tone?: StatTone }) {
+/** A compact inline metadata pill — replaces the old large stat cards. */
+function MetaBadge({
+    icon, children, tone = 'neutral', title,
+}: { icon?: ReactNode; children: ReactNode; tone?: BadgeTone; title?: string }) {
     return (
-        <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50/70 px-2.5 py-2">
-            <span className={`shrink-0 ${STAT_ICON_COLOR[tone]}`}>{icon}</span>
-            <div className="min-w-0 leading-tight">
-                <div className={`text-sm font-semibold truncate ${STAT_VALUE_COLOR[tone]}`} title={value}>
-                    {value}
-                </div>
-                <div className="text-[10px] font-medium uppercase tracking-wider text-neutral-500">
-                    {label}
-                </div>
-            </div>
-        </div>
+        <span
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[11px] font-medium ${BADGE_CLASS[tone]}`}
+            title={title}
+        >
+            {icon}
+            {children}
+        </span>
     );
 }
 
-function FullWidthSection({
+function GoalBlock({
     title, accent, icon, children,
-}: { title: string; accent: 'emerald' | 'indigo' | 'amber' | 'neutral'; icon: ReactNode; children: ReactNode }) {
-    const palette = {
-        emerald: 'border-emerald-100 bg-emerald-50/40',
-        indigo: 'border-indigo-100 bg-indigo-50/40',
-        amber: 'border-amber-100 bg-amber-50/40',
-        neutral: 'border-neutral-200 bg-neutral-50/60',
-    }[accent];
-    const headColor = {
-        emerald: 'text-emerald-700',
-        indigo: 'text-indigo-700',
-        amber: 'text-amber-700',
-        neutral: 'text-neutral-600',
-    }[accent];
+}: { title: string; accent: 'emerald' | 'indigo'; icon: ReactNode; children: ReactNode }) {
+    const palette = accent === 'emerald'
+        ? 'border-emerald-100 bg-emerald-50/40'
+        : 'border-indigo-100 bg-indigo-50/40';
+    const headColor = accent === 'emerald' ? 'text-emerald-700' : 'text-indigo-700';
     return (
         <section className={`rounded-lg border ${palette} p-3.5`}>
             <p className={`text-[10px] font-semibold uppercase tracking-wider mb-1.5 inline-flex items-center gap-1 ${headColor}`}>
@@ -91,21 +75,8 @@ function FullWidthSection({
     );
 }
 
-function HalfSection({
-    title, icon, children,
-}: { title: string; icon: ReactNode; children: ReactNode }) {
-    return (
-        <section className="rounded-lg border border-neutral-200 bg-white p-3.5">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5 inline-flex items-center gap-1">
-                {icon} {title}
-            </p>
-            <div className="text-sm text-neutral-700 leading-relaxed">{children}</div>
-        </section>
-    );
-}
-
 export function FlowSummaryCard({
-    flow, index, timeToValue, featuresById, onSelectFeature,
+    flow, index, timeToValue, featuresById, onSelectFeature, related,
 }: Props) {
     const stepCount = flow.steps.length;
     const altPaths = flow.issues.filter(i => i.kind === 'alternate_path' || i.kind === 'failure_mode').length;
@@ -115,17 +86,21 @@ export function FlowSummaryCard({
 
     const showRisk = flow.risk !== 'low' || flow.issues.length > 0;
 
-    // Drop preconditions block entirely when there's nothing useful to add —
-    // older artifacts sometimes emit a precondition identical to the entry
-    // point sentence, which we want to avoid double-rendering.
+    // Drop preconditions block entirely when there's nothing useful to add.
     const hasPreconditions = Boolean(flow.preconditions && flow.preconditions.trim().length > 0);
     const hasEntryPoints = flow.entryPoints.length > 0;
+    const hasSystems = flow.inferredSystems.length > 0;
+    const hasDetails = hasPreconditions || hasEntryPoints || hasSystems;
+
+    const [detailsOpen, setDetailsOpen] = useState(false);
+
+    const summaryParts = relatedSummaryParts(related);
 
     return (
         <section className="bg-white rounded-xl border border-neutral-200 p-4 sm:p-5 mb-4">
-            <header className="flex items-start gap-3 pb-3 mb-3 border-b border-neutral-100">
-                <div className="shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-md bg-indigo-50 text-indigo-600">
-                    <GitBranch size={18} />
+            <header className="flex items-start gap-3">
+                <div className="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-md bg-indigo-50 text-indigo-600">
+                    <GitBranch size={17} />
                 </div>
                 <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2 flex-wrap">
@@ -139,145 +114,147 @@ export function FlowSummaryCard({
                     <h3 className="text-base font-bold text-neutral-900 leading-snug mt-1">
                         {flow.title}
                     </h3>
+
+                    {/* Compact inline metadata — replaces the old 2×4 stat-card grid */}
+                    <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+                        <MetaBadge icon={<ListChecks size={12} />}>
+                            {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+                        </MetaBadge>
+                        {altPaths > 0 && (
+                            <MetaBadge icon={<GitBranch size={12} />} tone="amber">
+                                {altPaths} alt {altPaths === 1 ? 'path' : 'paths'}
+                            </MetaBadge>
+                        )}
+                        {edgeCount > 0 && (
+                            <MetaBadge icon={<AlertTriangle size={12} />} tone="sky">
+                                {edgeCount} edge {edgeCount === 1 ? 'case' : 'cases'}
+                            </MetaBadge>
+                        )}
+                        {timeToValue && (
+                            <MetaBadge icon={<Clock size={12} />} tone="emerald">
+                                {timeToValue} to value
+                            </MetaBadge>
+                        )}
+                        {showRisk && (
+                            <MetaBadge
+                                icon={<span className="inline-block w-2 h-2 rounded-full bg-current" />}
+                                tone={RISK_TONE[flow.risk]}
+                            >
+                                {RISK_LEVEL_LABEL[flow.risk]}
+                            </MetaBadge>
+                        )}
+                    </div>
+
+                    {/* Compact relationship summary — replaces the repeated
+                        feature chip row; full chips live in Related Artifacts. */}
+                    {summaryParts.length > 0 && (
+                        <p className="mt-2 text-[11px] text-neutral-500 inline-flex items-center gap-1.5">
+                            <Network size={11} className="shrink-0 text-neutral-400" />
+                            <span>Related: {summaryParts.join(' · ')}</span>
+                        </p>
+                    )}
                 </div>
-                <div className="hidden sm:flex items-center gap-1 shrink-0">
-                    <button
-                        type="button"
-                        title="Bookmark flow"
-                        aria-label="Bookmark flow"
-                        className="p-1.5 rounded hover:bg-neutral-100 text-neutral-500"
-                    >
-                        <Bookmark size={14} />
-                    </button>
-                    <button
-                        type="button"
-                        title="Share flow"
-                        aria-label="Share flow"
-                        className="p-1.5 rounded hover:bg-neutral-100 text-neutral-500"
-                    >
-                        <Share2 size={14} />
-                    </button>
+                <div className="hidden sm:flex items-center shrink-0">
                     <button
                         type="button"
                         title="More actions"
                         aria-label="More actions"
-                        className="p-1.5 rounded hover:bg-neutral-100 text-neutral-500"
+                        className="p-1.5 rounded hover:bg-neutral-100 text-neutral-400"
                     >
-                        <MoreHorizontal size={14} />
+                        <MoreHorizontal size={16} />
                     </button>
                 </div>
             </header>
 
-            {/* Metrics + related features — an aligned grid instead of loose chips */}
-            <div className="mb-4">
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                    <StatCell
-                        icon={<ListChecks size={14} />}
-                        value={String(stepCount)}
-                        label={stepCount === 1 ? 'Step' : 'Steps'}
-                    />
-                    {altPaths > 0 && (
-                        <StatCell
-                            icon={<GitBranch size={14} />}
-                            value={String(altPaths)}
-                            label={altPaths === 1 ? 'Alt path' : 'Alt paths'}
-                            tone="amber"
-                        />
-                    )}
-                    {edgeCount > 0 && (
-                        <StatCell
-                            icon={<AlertTriangle size={14} />}
-                            value={String(edgeCount)}
-                            label={edgeCount === 1 ? 'Edge case' : 'Edge cases'}
-                            tone="sky"
-                        />
-                    )}
-                    {timeToValue && (
-                        <StatCell
-                            icon={<Clock size={14} />}
-                            value={timeToValue}
-                            label="To value"
-                            tone="emerald"
-                        />
-                    )}
-                    {showRisk && (
-                        <StatCell
-                            icon={<span className="inline-block w-2.5 h-2.5 rounded-full bg-current" />}
-                            value={RISK_LEVEL_LABEL[flow.risk]}
-                            label="Risk"
-                            tone={RISK_TONE[flow.risk]}
-                        />
-                    )}
-                </div>
-
-                {flow.featureRefs.length > 0 && (
-                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
-                        <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mr-0.5">
-                            Related features
-                        </span>
-                        {flow.featureRefs.map(ref => (
-                            <FeatureReferenceChip
-                                key={ref.id}
-                                refToken={ref}
-                                feature={featuresById?.get(ref.id)}
-                                onSelect={onSelectFeature}
-                            />
-                        ))}
-                    </div>
-                )}
-            </div>
-
-            <div className="space-y-3">
+            {/* Flow Summary body: Goal + Success outcome visible by default. */}
+            <div className="mt-4 space-y-3">
                 {flow.goal && (
-                    <FullWidthSection title="Goal" accent="emerald" icon={<Target size={11} />}>
+                    <GoalBlock title="Goal" accent="indigo" icon={<Target size={11} />}>
                         {renderText(flow.goal)}
-                    </FullWidthSection>
-                )}
-
-                {(hasPreconditions || hasEntryPoints) && (
-                    <div className={`grid grid-cols-1 ${hasPreconditions && hasEntryPoints ? 'sm:grid-cols-2' : ''} gap-3`}>
-                        {hasPreconditions && (
-                            <HalfSection title="Preconditions" icon={<ShieldCheck size={11} />}>
-                                {renderText(flow.preconditions!)}
-                            </HalfSection>
-                        )}
-                        {hasEntryPoints && (
-                            <HalfSection title="Entry points" icon={<DoorOpen size={11} />}>
-                                <ul className="space-y-1">
-                                    {flow.entryPoints.slice(0, 5).map((ep, i) => (
-                                        <li key={i} className="flex gap-2">
-                                            <span className="text-neutral-400">•</span>
-                                            <span className="min-w-0 flex-1">{renderText(ep)}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </HalfSection>
-                        )}
-                    </div>
+                    </GoalBlock>
                 )}
 
                 {flow.successOutcome && (
-                    <FullWidthSection title="Success outcome" accent="emerald" icon={<Sparkles size={11} />}>
+                    <GoalBlock title="Success outcome" accent="emerald" icon={<Sparkles size={11} />}>
                         {renderText(flow.successOutcome)}
-                    </FullWidthSection>
+                    </GoalBlock>
                 )}
 
-                {flow.inferredSystems.length > 0 && (
-                    <section className="rounded-lg border border-neutral-200 bg-white p-3.5">
-                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1.5 inline-flex items-center gap-1">
-                            <Server size={11} /> Core systems / dependencies
-                        </p>
-                        <div className="flex flex-wrap gap-1.5">
-                            {flow.inferredSystems.map((s, i) => (
-                                <code
-                                    key={i}
-                                    className="text-[11px] bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded"
-                                >
-                                    {s}
-                                </code>
-                            ))}
-                        </div>
-                    </section>
+                {/* Preconditions, entry points, dependencies — compact, tucked
+                    behind a disclosure so the page reaches Journey/Steps faster. */}
+                {hasDetails && (
+                    <div className="rounded-lg border border-neutral-200 bg-neutral-50/50">
+                        <button
+                            type="button"
+                            onClick={() => setDetailsOpen(o => !o)}
+                            aria-expanded={detailsOpen}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-neutral-100/60 rounded-lg transition-colors"
+                        >
+                            <ChevronRight
+                                size={13}
+                                className={`shrink-0 text-neutral-400 transition-transform ${detailsOpen ? 'rotate-90' : ''}`}
+                                aria-hidden="true"
+                            />
+                            <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                                Preconditions &amp; dependencies
+                            </span>
+                            {!detailsOpen && (
+                                <span className="ml-auto text-[10px] text-neutral-400">
+                                    {[
+                                        hasPreconditions ? 'preconditions' : null,
+                                        hasEntryPoints ? `${flow.entryPoints.length} entry ${flow.entryPoints.length === 1 ? 'point' : 'points'}` : null,
+                                        hasSystems ? `${flow.inferredSystems.length} ${flow.inferredSystems.length === 1 ? 'system' : 'systems'}` : null,
+                                    ].filter(Boolean).join(' · ')}
+                                </span>
+                            )}
+                        </button>
+                        {detailsOpen && (
+                            <div className="px-3.5 pb-3.5 pt-1 space-y-3 text-sm">
+                                {hasPreconditions && (
+                                    <div>
+                                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1 inline-flex items-center gap-1">
+                                            <ShieldCheck size={11} /> Preconditions
+                                        </p>
+                                        <div className="text-neutral-700 leading-relaxed">
+                                            {renderText(flow.preconditions!)}
+                                        </div>
+                                    </div>
+                                )}
+                                {hasEntryPoints && (
+                                    <div>
+                                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1 inline-flex items-center gap-1">
+                                            <DoorOpen size={11} /> Entry points
+                                        </p>
+                                        <ul className="space-y-1 text-neutral-700">
+                                            {flow.entryPoints.slice(0, 5).map((ep, i) => (
+                                                <li key={i} className="flex gap-2">
+                                                    <span className="text-neutral-400">•</span>
+                                                    <span className="min-w-0 flex-1">{renderText(ep)}</span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+                                {hasSystems && (
+                                    <div>
+                                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1 inline-flex items-center gap-1">
+                                            <Server size={11} /> Core systems / dependencies
+                                        </p>
+                                        <div className="flex flex-wrap gap-1.5">
+                                            {flow.inferredSystems.map((s, i) => (
+                                                <code
+                                                    key={i}
+                                                    className="text-[11px] bg-neutral-100 text-neutral-700 px-1.5 py-0.5 rounded"
+                                                >
+                                                    {s}
+                                                </code>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </div>
                 )}
             </div>
 

--- a/src/components/renderers/userFlows/IssuesPanel.tsx
+++ b/src/components/renderers/userFlows/IssuesPanel.tsx
@@ -3,6 +3,7 @@ import type { Feature } from '../../../types';
 import type { FeatureRef, FlowIssue, FlowIssueKind, ParsedStep } from './types';
 import { ISSUE_KIND_META } from './issueMeta';
 import { inlineWithFeatures } from './inlineWithFeatures';
+import { CollapsibleSection } from './CollapsibleSection';
 
 interface Props {
     flowIndex: number;
@@ -75,10 +76,11 @@ export function IssuesPanel({
         inlineWithFeatures(text, { featuresById, onSelectFeature });
 
     return (
-        <section className="mb-4">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2 inline-flex items-center gap-1">
-                <AlertTriangle size={11} /> Alternate paths & edge cases
-            </p>
+        <CollapsibleSection
+            title="Alternate paths & edge cases"
+            icon={<AlertTriangle size={12} className="text-amber-500" />}
+            count={all.length}
+        >
             <div className="space-y-3">
                 {KIND_ORDER.map(kind => {
                     const list = grouped[kind];
@@ -124,6 +126,6 @@ export function IssuesPanel({
                     );
                 })}
             </div>
-        </section>
+        </CollapsibleSection>
     );
 }

--- a/src/components/renderers/userFlows/RelatedArtifactsPanel.tsx
+++ b/src/components/renderers/userFlows/RelatedArtifactsPanel.tsx
@@ -1,81 +1,26 @@
-import { useMemo } from 'react';
+import type { ReactNode } from 'react';
 import { AppWindow, Database, ListChecks, Network, Sparkles } from 'lucide-react';
-import type {
-    DomainEntity, Feature, FeatureSystem, ImplementationPlan, UXPage,
-} from '../../../types';
-import type { FeatureRef, ParsedFlow } from './types';
+import type { Feature } from '../../../types';
+import type { FeatureRef } from './types';
+import type { RelatedArtifacts } from './relatedArtifacts';
+import { hasAnyRelated, relatedSummaryParts } from './relatedArtifacts';
 import { FeatureReferenceChip } from './FeatureReferenceChip';
+import { CollapsibleSection } from './CollapsibleSection';
 
 interface Props {
-    flow: ParsedFlow;
+    /** Precomputed heuristic join (shared with the flow header summary). */
+    related: RelatedArtifacts;
     featuresById?: Map<string, Feature>;
     onSelectFeature: (refToken: FeatureRef) => void;
-    /** PRD-derived screen / page catalog. Heuristic matching only. */
-    uxPages?: UXPage[];
-    /** PRD-derived domain entities. Heuristic matching only. */
-    domainEntities?: DomainEntity[];
-    /** PRD-derived implementation plan; we surface phases whose
-     *  feature ids overlap with this flow's referenced features. */
-    implementationPlan?: ImplementationPlan;
-    /** PRD-derived feature systems; we surface ones whose feature ids
-     *  overlap with this flow's referenced features. */
-    featureSystems?: FeatureSystem[];
-}
-
-/**
- * Normalize a string for fuzzy contains-matching. Lowercase + strip
- * non-alphanumerics so "Active Workout" matches "active-workout" and
- * "ActiveWorkout".
- */
-function fold(text: string): string {
-    return text.toLowerCase().replace(/[^a-z0-9]+/g, '');
-}
-
-function flowTextCorpus(flow: ParsedFlow): string {
-    const parts: string[] = [
-        flow.title,
-        flow.goal ?? '',
-        flow.preconditions ?? '',
-        flow.successOutcome ?? '',
-        flow.edgeCases ?? '',
-        flow.assumptions ?? '',
-        flow.openQuestions ?? '',
-        ...flow.entryPoints,
-        ...flow.inferredSystems,
-    ];
-    for (const step of flow.steps) {
-        parts.push(
-            step.title ?? '',
-            step.userAction ?? '',
-            step.systemBehavior ?? '',
-            step.uiFeedback ?? '',
-            step.rawText,
-            ...step.decisions,
-            ...step.errorRefs,
-            ...step.apiRefs,
-        );
-    }
-    return parts.join(' ');
-}
-
-/**
- * Heuristic membership test: does `needle` appear in the flow text?
- * Uses folded substring matching plus a quick word-boundary check so
- * short tokens like "DB" don't match "feedback".
- */
-function flowMentions(corpus: string, needle: string): boolean {
-    const trimmed = needle.trim();
-    if (trimmed.length < 3) return false;
-    return fold(corpus).includes(fold(trimmed));
 }
 
 function Section({
     title, icon, children, count,
 }: {
     title: string;
-    icon: React.ReactNode;
+    icon: ReactNode;
     count?: number;
-    children: React.ReactNode;
+    children: ReactNode;
 }) {
     return (
         <section className="rounded-lg border border-neutral-200 bg-white p-3.5">
@@ -99,79 +44,37 @@ function EmptyChip({ label }: { label: string }) {
     );
 }
 
-export function RelatedArtifactsPanel({
-    flow,
-    featuresById,
-    onSelectFeature,
-    uxPages,
-    domainEntities,
-    implementationPlan,
-    featureSystems,
-}: Props) {
-    const corpus = useMemo(() => flowTextCorpus(flow), [flow]);
-    const featureIds = useMemo(() => new Set(flow.featureRefs.map(r => r.id)), [flow.featureRefs]);
+/**
+ * Progressive-disclosure panel of PRD artifacts this flow touches. The
+ * heuristic join is computed once by the parent and shared with the compact
+ * relationship summary in the flow header, so counts never disagree.
+ * Collapsed by default — secondary context, not primary reading flow.
+ */
+export function RelatedArtifactsPanel({ related, featuresById, onSelectFeature }: Props) {
+    // If literally nothing connects, render nothing — avoids an empty panel
+    // that adds noise without information.
+    if (!hasAnyRelated(related)) return null;
 
-    // Heuristic matching — keep it cheap and explainable. We surface pages
-    // whose name appears in the flow text *or* whose component list shows
-    // up among the step titles.
-    const linkedScreens = useMemo(() => {
-        if (!uxPages || uxPages.length === 0) return [];
-        return uxPages.filter(p => flowMentions(corpus, p.name));
-    }, [uxPages, corpus]);
-
-    const linkedEntities = useMemo(() => {
-        if (!domainEntities || domainEntities.length === 0) return [];
-        return domainEntities.filter(e => flowMentions(corpus, e.name));
-    }, [domainEntities, corpus]);
-
-    // For implementation plan + systems we rely on feature-id overlap
-    // first (more reliable than name matching), and fall back to name
-    // matching for systems that don't list features.
-    const linkedPhases = useMemo(() => {
-        const phases = implementationPlan?.phases ?? [];
-        if (phases.length === 0 || featureIds.size === 0) return [];
-        return phases.filter(phase => {
-            const ids = phase.featureIds ?? [];
-            return ids.some(id => featureIds.has(id.toLowerCase().replace(/-/g, '')));
-        });
-    }, [implementationPlan, featureIds]);
-
-    const linkedSystems = useMemo(() => {
-        if (!featureSystems || featureSystems.length === 0) return [];
-        return featureSystems.filter(sys => {
-            const overlap = sys.featureIds.some(
-                id => featureIds.has(id.toLowerCase().replace(/-/g, '')),
-            );
-            return overlap || flowMentions(corpus, sys.name);
-        });
-    }, [featureSystems, featureIds, corpus]);
-
-    const hasFeatures = flow.featureRefs.length > 0;
-    const hasScreens = linkedScreens.length > 0;
-    const hasEntities = linkedEntities.length > 0;
-    const hasPhases = linkedPhases.length > 0;
-    const hasSystems = linkedSystems.length > 0;
-
-    // If literally nothing connects, render nothing — avoids an empty
-    // panel that adds noise without information.
-    if (!hasFeatures && !hasScreens && !hasEntities && !hasPhases && !hasSystems) {
-        return null;
-    }
+    const { features, screens, entities, phases, systems } = related;
+    const total = features.length + screens.length + entities.length
+        + phases.length + systems.length;
 
     return (
-        <section className="mb-4">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-2 inline-flex items-center gap-1">
-                <Network size={11} /> Related artifacts
-            </p>
+        <CollapsibleSection
+            title="Related artifacts"
+            icon={<Network size={12} />}
+            count={total}
+            collapsedSummary={relatedSummaryParts(related).join(' · ')}
+        >
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {hasFeatures && (
+                {features.length > 0 && (
                     <Section
                         title="Features"
                         icon={<Sparkles size={11} className="text-fuchsia-600" />}
-                        count={flow.featureRefs.length}
+                        count={features.length}
                     >
                         <div className="flex flex-wrap gap-1.5">
-                            {flow.featureRefs.map(ref => (
+                            {features.map(ref => (
                                 <FeatureReferenceChip
                                     key={ref.id}
                                     refToken={ref}
@@ -183,18 +86,18 @@ export function RelatedArtifactsPanel({
                     </Section>
                 )}
 
-                {(uxPages !== undefined) && (
+                {related.hasScreenCatalog && (
                     <Section
                         title="Screens"
                         icon={<AppWindow size={11} className="text-indigo-600" />}
-                        count={linkedScreens.length}
+                        count={screens.length}
                     >
-                        {hasScreens ? (
+                        {screens.length > 0 ? (
                             <div className="flex flex-wrap gap-1.5">
-                                {linkedScreens.map(p => (
+                                {screens.map(p => (
                                     <span
                                         key={p.id || p.name}
-                                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-indigo-50 border border-indigo-200 text-indigo-700 text-[11px] font-medium"
+                                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-neutral-50 border border-neutral-200 text-neutral-700 text-[11px] font-medium"
                                         title={p.purpose}
                                     >
                                         {p.name}
@@ -207,18 +110,18 @@ export function RelatedArtifactsPanel({
                     </Section>
                 )}
 
-                {(domainEntities !== undefined) && (
+                {related.hasEntityCatalog && (
                     <Section
                         title="Data entities"
                         icon={<Database size={11} className="text-emerald-600" />}
-                        count={linkedEntities.length}
+                        count={entities.length}
                     >
-                        {hasEntities ? (
+                        {entities.length > 0 ? (
                             <div className="flex flex-wrap gap-1.5">
-                                {linkedEntities.map(e => (
+                                {entities.map(e => (
                                     <span
                                         key={e.name}
-                                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-emerald-50 border border-emerald-200 text-emerald-800 text-[11px] font-medium"
+                                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-neutral-50 border border-neutral-200 text-neutral-700 text-[11px] font-medium"
                                         title={e.description ?? ''}
                                     >
                                         {e.name}
@@ -231,14 +134,14 @@ export function RelatedArtifactsPanel({
                     </Section>
                 )}
 
-                {hasPhases && (
+                {phases.length > 0 && (
                     <Section
                         title="Implementation phases"
                         icon={<ListChecks size={11} className="text-sky-600" />}
-                        count={linkedPhases.length}
+                        count={phases.length}
                     >
                         <ul className="space-y-1">
-                            {linkedPhases.map((phase, i) => (
+                            {phases.map((phase, i) => (
                                 <li
                                     key={i}
                                     className="flex items-start gap-1.5 text-[11px] text-neutral-700"
@@ -258,17 +161,17 @@ export function RelatedArtifactsPanel({
                     </Section>
                 )}
 
-                {hasSystems && (
+                {systems.length > 0 && (
                     <Section
                         title="Feature systems"
                         icon={<Network size={11} className="text-violet-600" />}
-                        count={linkedSystems.length}
+                        count={systems.length}
                     >
                         <div className="flex flex-wrap gap-1.5">
-                            {linkedSystems.map(s => (
+                            {systems.map(s => (
                                 <span
                                     key={s.id}
-                                    className="inline-flex items-center px-2 py-0.5 rounded-md bg-violet-50 border border-violet-200 text-violet-700 text-[11px] font-medium"
+                                    className="inline-flex items-center px-2 py-0.5 rounded-md bg-neutral-50 border border-neutral-200 text-neutral-700 text-[11px] font-medium"
                                     title={s.purpose}
                                 >
                                     {s.name}
@@ -278,6 +181,6 @@ export function RelatedArtifactsPanel({
                     </Section>
                 )}
             </div>
-        </section>
+        </CollapsibleSection>
     );
 }

--- a/src/components/renderers/userFlows/StepCard.tsx
+++ b/src/components/renderers/userFlows/StepCard.tsx
@@ -95,29 +95,30 @@ export function StepCard({
                 </dl>
             )}
 
+            {/* Quiet inline "Uses:" reference instead of a row of large colored
+                chips — the same features are shown prominently elsewhere
+                (flow header summary + Related Artifacts). Each name stays
+                clickable to open the feature drawer. */}
             {step.featureRefs.length > 0 && (
-                <div className="mt-3 flex flex-wrap gap-1">
-                    {step.featureRefs.map(ref => {
+                <p className="mt-3 text-[11px] text-neutral-500 leading-relaxed">
+                    <span className="font-medium text-neutral-400 uppercase tracking-wider mr-1">Uses</span>
+                    {step.featureRefs.map((ref, i) => {
                         const feature = featuresById?.get(ref.id);
-                        const idLabel = feature?.id ?? ref.id.toUpperCase();
-                        const name = feature?.name;
+                        const label = feature?.name ?? feature?.id ?? ref.id.toUpperCase();
                         return (
-                            <button
-                                key={ref.id}
-                                type="button"
-                                onClick={() => onSelectFeature(ref)}
-                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-fuchsia-50 hover:bg-fuchsia-100 border border-fuchsia-200 text-fuchsia-700 text-[11px] font-semibold transition-colors"
-                            >
-                                <span className="font-mono uppercase">{idLabel}</span>
-                                {name && (
-                                    <span className="font-medium normal-case text-fuchsia-800">
-                                        {name}
-                                    </span>
-                                )}
-                            </button>
+                            <span key={ref.id}>
+                                {i > 0 && <span className="text-neutral-300">, </span>}
+                                <button
+                                    type="button"
+                                    onClick={() => onSelectFeature(ref)}
+                                    className="text-neutral-600 hover:text-fuchsia-700 hover:underline transition-colors"
+                                >
+                                    {label}
+                                </button>
+                            </span>
                         );
                     })}
-                </div>
+                </p>
             )}
 
             {step.decisions.length > 0 && (

--- a/src/components/renderers/userFlows/SuccessCriteriaBlock.tsx
+++ b/src/components/renderers/userFlows/SuccessCriteriaBlock.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle2, Sparkles, TestTube2 } from 'lucide-react';
 import type { ParsedFlow } from './types';
 import { inlineMd } from './markdown';
+import { CollapsibleSection } from './CollapsibleSection';
 
 interface Props {
     flow: ParsedFlow;
@@ -34,7 +35,8 @@ function extractFromSteps(flow: ParsedFlow): { qa: string[]; criteria: string[] 
 
 export function SuccessCriteriaBlock({ flow }: Props) {
     const lines = flow.successOutcome ? splitToLines(flow.successOutcome) : [];
-    const userOutcome = lines[0] ?? flow.successOutcome;
+    // Line 0 is the headline user outcome (shown in the Flow Summary card);
+    // the remaining lines carry measurable criteria / QA checks.
     const remaining = lines.slice(1);
 
     const productCriteria: string[] = remaining.filter(l => MEASURABLE_RE.test(l));
@@ -44,25 +46,18 @@ export function SuccessCriteriaBlock({ flow }: Props) {
     const productAll = Array.from(new Set([...productCriteria, ...fromSteps.criteria]));
     const qaAll = Array.from(new Set([...engineeringChecks, ...fromSteps.qa]));
 
-    if (!userOutcome && productAll.length === 0 && qaAll.length === 0) return null;
+    // The headline success outcome is already shown in the Flow Summary card.
+    // Only surface this (collapsed) detail block when there's measurable
+    // product criteria or engineering/QA checks to add beyond that headline.
+    if (productAll.length === 0 && qaAll.length === 0) return null;
 
     return (
-        <section className="bg-white rounded-xl border border-neutral-200 p-4 sm:p-5 mb-4">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700 flex items-center gap-1 mb-3">
-                <Sparkles size={11} /> Success criteria
-            </p>
+        <CollapsibleSection
+            title="Success criteria & checks"
+            icon={<Sparkles size={12} className="text-emerald-600" />}
+            count={productAll.length + qaAll.length}
+        >
             <div className="space-y-3 text-sm">
-                {userOutcome && (
-                    <div>
-                        <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">
-                            User outcome
-                        </p>
-                        <div className="flex items-start gap-2 text-neutral-800">
-                            <CheckCircle2 size={14} className="shrink-0 mt-0.5 text-emerald-600" />
-                            <div className="min-w-0">{inlineMd(userOutcome)}</div>
-                        </div>
-                    </div>
-                )}
                 {productAll.length > 0 && (
                     <div>
                         <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 mb-1">
@@ -94,6 +89,6 @@ export function SuccessCriteriaBlock({ flow }: Props) {
                     </div>
                 )}
             </div>
-        </section>
+        </CollapsibleSection>
     );
 }

--- a/src/components/renderers/userFlows/UserFlowsRenderer.tsx
+++ b/src/components/renderers/userFlows/UserFlowsRenderer.tsx
@@ -15,6 +15,7 @@ import { IssuesPanel } from './IssuesPanel';
 import { FeatureDetailDrawer } from './FeatureDetailDrawer';
 import { RelatedArtifactsPanel } from './RelatedArtifactsPanel';
 import { AssumptionsPanel } from './AssumptionsPanel';
+import { computeRelatedArtifacts } from './relatedArtifacts';
 
 interface Props {
     content: string;
@@ -118,6 +119,12 @@ export function UserFlowsRenderer({
 
     const drawerFeature = drawerRef ? featuresById?.get(drawerRef.id) : undefined;
 
+    // Heuristic join computed once, shared by the header relationship summary
+    // and the Related Artifacts panel so their counts never disagree.
+    const related = computeRelatedArtifacts(flow, {
+        uxPages, domainEntities, implementationPlan, featureSystems,
+    });
+
     return (
         // `not-prose` opts out of the surrounding ArtifactWorkspace `prose`
         // typography, which would otherwise indent <dd> values, and add stray
@@ -138,6 +145,7 @@ export function UserFlowsRenderer({
                     timeToValue={ttvByFlow[safeIndex]}
                     featuresById={featuresById}
                     onSelectFeature={onSelectFeature}
+                    related={related}
                 />
 
                 <FlowJourney
@@ -175,13 +183,9 @@ export function UserFlowsRenderer({
                 <SuccessCriteriaBlock flow={flow} />
 
                 <RelatedArtifactsPanel
-                    flow={flow}
+                    related={related}
                     featuresById={featuresById}
                     onSelectFeature={onSelectFeature}
-                    uxPages={uxPages}
-                    domainEntities={domainEntities}
-                    featureSystems={featureSystems}
-                    implementationPlan={implementationPlan}
                 />
 
                 <IssuesPanel

--- a/src/components/renderers/userFlows/__tests__/UserFlowsRendererCleanup.test.tsx
+++ b/src/components/renderers/userFlows/__tests__/UserFlowsRendererCleanup.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { DomainEntity, Feature, UXPage } from '../../../../types';
+import { UserFlowsRenderer } from '../UserFlowsRenderer';
+
+const SINGLE_FLOW = `### Flow: Recipe ingestion (Core Experience)
+**Goal:** Import a recipe via [f1] NLP Recipe Importer.
+**Preconditions:** User is logged in.
+**Steps:**
+1. [NLP Recipe Importer] — User pastes URL → System scrapes and parses via [f1]
+2. [Save Recipe to Library] — User clicks Save → System persists JSON
+**Success Outcome:** The recipe is saved within < 5 seconds.
+**Edge Cases:** First-time user with no saved recipes.`;
+
+const TWO_FLOWS = `### Flow: Onboarding (First-Time User Onboarding)
+**Goal:** Reach the dashboard.
+**Steps:**
+1. [Landing Page] — User taps Get started → System routes to sign-in
+2. [Dashboard] — User arrives → System loads workspace
+**Success Outcome:** Done.
+
+### Flow: Recipe ingestion (Core Experience)
+**Goal:** Import a recipe.
+**Steps:**
+1. [Importer] — User pastes URL → System parses
+**Success Outcome:** Saved.`;
+
+const FEATURES: Feature[] = [
+    {
+        id: 'f1',
+        name: 'NLP Recipe Importer',
+        description: 'Import recipes from a URL or raw text.',
+        userValue: 'Saves manual entry.',
+        complexity: 'medium',
+        priority: 'must',
+    },
+];
+
+const UX_PAGES: UXPage[] = [
+    { id: 'p1', name: 'Save Recipe to Library', purpose: 'Persist a parsed recipe' },
+];
+
+const ENTITIES: DomainEntity[] = [
+    { name: 'Recipe', description: 'A saved recipe record' },
+];
+
+describe('UserFlowsRenderer — desktop cleanup', () => {
+    it('shows a compact relationship summary instead of a repeated feature chip row', () => {
+        render(
+            <UserFlowsRenderer
+                content={SINGLE_FLOW}
+                features={FEATURES}
+                uxPages={UX_PAGES}
+                domainEntities={ENTITIES}
+            />,
+        );
+        // The header carries a compact "Related: … features …" summary line
+        // (distinct from the collapsible "Related artifacts" panel below).
+        expect(screen.getByText(/Related: 1 feature/i)).toBeInTheDocument();
+    });
+
+    it('keeps Related Artifacts collapsed by default and reveals it on toggle', () => {
+        render(
+            <UserFlowsRenderer
+                content={SINGLE_FLOW}
+                features={FEATURES}
+                uxPages={UX_PAGES}
+                domainEntities={ENTITIES}
+            />,
+        );
+        const toggle = screen.getByRole('button', { name: /Related artifacts/i });
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        // The inner "Data entities" subsection isn't in the DOM while collapsed.
+        expect(screen.queryByText(/Data entities/i)).toBeNull();
+        fireEvent.click(toggle);
+        expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText(/Data entities/i)).toBeInTheDocument();
+    });
+
+    it('renders step feature references as a quiet inline "Uses:" list, not large chips', () => {
+        render(<UserFlowsRenderer content={SINGLE_FLOW} features={FEATURES} />);
+        // The inline label is present…
+        expect(screen.getAllByText(/^Uses$/i).length).toBeGreaterThan(0);
+        // …and the feature name is a plain clickable button, not the old
+        // fuchsia chip (which rendered a monospace uppercase id token).
+        const usesButtons = screen.getAllByRole('button', { name: 'NLP Recipe Importer' });
+        expect(usesButtons.length).toBeGreaterThan(0);
+    });
+
+    it('switches flows from the collapsed desktop rail', () => {
+        render(<UserFlowsRenderer content={TWO_FLOWS} features={FEATURES} />);
+        // Flow 1 is selected initially — its goal is visible.
+        expect(screen.getByText(/Reach the dashboard\./i)).toBeInTheDocument();
+        expect(screen.queryByText(/Import a recipe\./i)).toBeNull();
+        // The collapsed rail exposes a labelled switcher button for flow 2.
+        const flow2 = screen.getByRole('button', { name: /Flow 2:/i });
+        fireEvent.click(flow2);
+        // The header now shows flow 2's goal, not flow 1's.
+        expect(screen.getByText(/Import a recipe\./i)).toBeInTheDocument();
+        expect(screen.queryByText(/Reach the dashboard\./i)).toBeNull();
+    });
+
+    it('expands the desktop rail to the full grouped list', () => {
+        render(<UserFlowsRenderer content={TWO_FLOWS} features={FEATURES} />);
+        const expand = screen.getByRole('button', { name: /Expand flow list/i });
+        fireEvent.click(expand);
+        // Expanded rail surfaces the category group header + full titles.
+        const nav = screen.getByRole('complementary', { name: /Flow navigation/i });
+        expect(within(nav).getByText(/User Flows/)).toBeInTheDocument();
+        expect(within(nav).getByText(/Onboarding/)).toBeInTheDocument();
+    });
+});

--- a/src/components/renderers/userFlows/__tests__/UserFlowsRendererCleanup.test.tsx
+++ b/src/components/renderers/userFlows/__tests__/UserFlowsRendererCleanup.test.tsx
@@ -37,7 +37,13 @@ const FEATURES: Feature[] = [
 ];
 
 const UX_PAGES: UXPage[] = [
-    { id: 'p1', name: 'Save Recipe to Library', purpose: 'Persist a parsed recipe' },
+    {
+        id: 'p1',
+        name: 'Save Recipe to Library',
+        purpose: 'Persist a parsed recipe',
+        components: ['Save button'],
+        interactions: ['Click save'],
+    },
 ];
 
 const ENTITIES: DomainEntity[] = [

--- a/src/components/renderers/userFlows/relatedArtifacts.ts
+++ b/src/components/renderers/userFlows/relatedArtifacts.ts
@@ -1,0 +1,133 @@
+import type {
+    DomainEntity, FeatureSystem, ImplementationPlan, UXPage,
+} from '../../../types';
+import type { FeatureRef, ParsedFlow } from './types';
+
+/**
+ * Normalize a string for fuzzy contains-matching. Lowercase + strip
+ * non-alphanumerics so "Active Workout" matches "active-workout" and
+ * "ActiveWorkout".
+ */
+function fold(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function flowTextCorpus(flow: ParsedFlow): string {
+    const parts: string[] = [
+        flow.title,
+        flow.goal ?? '',
+        flow.preconditions ?? '',
+        flow.successOutcome ?? '',
+        flow.edgeCases ?? '',
+        flow.assumptions ?? '',
+        flow.openQuestions ?? '',
+        ...flow.entryPoints,
+        ...flow.inferredSystems,
+    ];
+    for (const step of flow.steps) {
+        parts.push(
+            step.title ?? '',
+            step.userAction ?? '',
+            step.systemBehavior ?? '',
+            step.uiFeedback ?? '',
+            step.rawText,
+            ...step.decisions,
+            ...step.errorRefs,
+            ...step.apiRefs,
+        );
+    }
+    return parts.join(' ');
+}
+
+/**
+ * Heuristic membership test: does `needle` appear in the flow text?
+ * Uses folded substring matching plus a length floor so short tokens
+ * like "DB" don't match "feedback".
+ */
+function flowMentions(corpus: string, needle: string): boolean {
+    const trimmed = needle.trim();
+    if (trimmed.length < 3) return false;
+    return corpus.includes(fold(trimmed));
+}
+
+export interface RelatedArtifacts {
+    features: FeatureRef[];
+    screens: UXPage[];
+    entities: DomainEntity[];
+    phases: NonNullable<ImplementationPlan['phases']>;
+    systems: FeatureSystem[];
+    /** Whether page/entity catalogs were provided (drives empty-state hints). */
+    hasScreenCatalog: boolean;
+    hasEntityCatalog: boolean;
+}
+
+export interface RelatedArtifactSources {
+    uxPages?: UXPage[];
+    domainEntities?: DomainEntity[];
+    implementationPlan?: ImplementationPlan;
+    featureSystems?: FeatureSystem[];
+}
+
+/**
+ * Pure heuristic join of a flow against the PRD-derived catalogs. Shared by
+ * the compact relationship summary in the flow header and the full Related
+ * Artifacts panel so the two never drift.
+ */
+export function computeRelatedArtifacts(
+    flow: ParsedFlow,
+    sources: RelatedArtifactSources,
+): RelatedArtifacts {
+    const { uxPages, domainEntities, implementationPlan, featureSystems } = sources;
+    const corpus = fold(flowTextCorpus(flow));
+    const featureIds = new Set(flow.featureRefs.map(r => r.id));
+
+    const screens = (uxPages ?? []).filter(p => flowMentions(corpus, p.name));
+    const entities = (domainEntities ?? []).filter(e => flowMentions(corpus, e.name));
+
+    const phases = (implementationPlan?.phases ?? []).filter(phase => {
+        const ids = phase.featureIds ?? [];
+        return ids.some(id => featureIds.has(id.toLowerCase().replace(/-/g, '')));
+    });
+
+    const systems = (featureSystems ?? []).filter(sys => {
+        const overlap = sys.featureIds.some(
+            id => featureIds.has(id.toLowerCase().replace(/-/g, '')),
+        );
+        return overlap || flowMentions(corpus, sys.name);
+    });
+
+    return {
+        features: flow.featureRefs,
+        screens,
+        entities,
+        phases,
+        systems,
+        hasScreenCatalog: uxPages !== undefined,
+        hasEntityCatalog: domainEntities !== undefined,
+    };
+}
+
+/** True when there is at least one linked artifact of any kind. */
+export function hasAnyRelated(r: RelatedArtifacts): boolean {
+    return (
+        r.features.length > 0
+        || r.screens.length > 0
+        || r.entities.length > 0
+        || r.phases.length > 0
+        || r.systems.length > 0
+    );
+}
+
+/** Compact "6 features · 4 screens · 2 entities" summary parts. */
+export function relatedSummaryParts(r: RelatedArtifacts): string[] {
+    const parts: string[] = [];
+    const push = (n: number, singular: string, plural: string) => {
+        if (n > 0) parts.push(`${n} ${n === 1 ? singular : plural}`);
+    };
+    push(r.features.length, 'feature', 'features');
+    push(r.screens.length, 'screen', 'screens');
+    push(r.entities.length, 'entity', 'entities');
+    push(r.phases.length, 'phase', 'phases');
+    push(r.systems.length, 'system', 'systems');
+    return parts;
+}


### PR DESCRIPTION
## Summary

Focused, renderer-only cleanup of the **User Flows artifact** so it reads like an interactive workspace instead of a dense generated document. No changes to artifact generation prompts, schemas, or downstream artifact contracts — this is entirely presentation/layout. All information that was previously shown is preserved; secondary detail now lives behind progressive disclosure.

Applies to desktop and mobile (mobile especially benefits — the cramped horizontal journey strip becomes a readable vertical timeline).

## What changed

- **Less-dominant flow navigation** (`FlowSidebar`): the always-on `w-72` desktop left panel is now a collapsible rail — a narrow numbered strip by default, expandable to the full grouped list. Single-flow artifacts show no rail at all. The selected flow stays obvious via the header and the rail highlight. Collapsed rail buttons carry `aria-label`s for keyboard/screen-reader access.
- **Compact header** (`FlowSummaryCard`): the large 2×4 stat-card grid becomes inline metadata badges (steps / alt paths / edge cases / to-value / risk). The repeated "Related features" chip row is removed and replaced by a compact relationship summary — e.g. `Related: 6 features · 4 screens · 2 entities`. Full feature chips remain in the Related Artifacts section.
- **Consolidated Flow Summary**: Goal + Success Outcome are visible by default; Preconditions / Entry points / Core systems are tucked into one compact in-card disclosure, so the page reaches the Journey and Steps faster. A single-endpoint dependency no longer gets its own heavy card.
- **Readable Flow Journey** (`FlowJourney`): redesigned from a cramped horizontal `w-40` scroll strip into a vertical timeline whose rows line up 1:1 with the Step-by-Step cards. Node numbering/names match the steps below, clicking a node still scrolls (or navigates to a screen) as before, and the legend is now compact and collapsible.
- **Quieter step cards** (`StepCard`): the redundant row of large colored feature chips at the bottom of each step becomes a quiet inline `Uses: A, B` reference (names stay clickable to open the feature drawer). Decision/branch blocks stay prominent.
- **Progressive disclosure** (new shared `CollapsibleSection`): Related Artifacts, Alternate Paths & Edge Cases, Success criteria, and Assumptions are collapsed by default. Ordinary artifact references (screens/entities/systems) restyled to quieter neutral chips while risk/decision/warning states stay prominent.
- **Shared join helper** (new pure `relatedArtifacts.ts`): the heuristic flow→artifact join is computed once and shared by the header summary and the Related Artifacts panel, so their counts never drift.

## Information preserved vs. moved behind disclosure

- **Still visible by default:** flow title, category, step/alt-path/edge-case/risk metadata, relationship summary, Goal, Success Outcome, the full Flow Journey, and every Step-by-Step card.
- **Moved behind a toggle (nothing removed):** Preconditions, Entry points, Core systems/dependencies, the journey color legend, Related Artifacts (full chips), Alternate Paths & Edge Cases, detailed Success criteria / QA checks, and Assumptions & Open Questions.

## Downstream safety

- `FlowJourney` and `StepCard` are also used by `experience/ScreenDetailView.tsx`; their public props are unchanged and the new behavior is internal, so that surface improves consistently without breakage.
- `journeyNode.ts` colors and `FeatureReferenceChip` are scoped to the User Flows renderer — no global/shared chip restyle, so other artifact pages are untouched.
- No schema/prompt/pipeline/sync/snapshot changes; no persisted state added. `ParsedFlow` output is identical.

## Testing

- `npm run build` (tsc -b + vite build) — passes.
- `npm run lint` — clean.
- `npm test` — 870 tests pass, including a new `UserFlowsRendererCleanup.test.tsx` covering the relationship summary, default-collapsed Related Artifacts, quiet inline step references, flow switching from the collapsed rail, and rail expand-to-full-list.
- Visual check via rendered screenshots at desktop (1100px), tablet (768px), and mobile (390px) widths.

## Known limitations

- The inline `[fN]` feature chip inside step body text (via `inlineWithFeatures`) is unchanged — only the redundant bottom-of-card chip row was quieted.
- No artifact snapshots, generated fixtures, or cloud snapshots need regeneration — this is a pure read-side rendering change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxqXzW2ZoXkEvRGSrFQ4CN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxqXzW2ZoXkEvRGSrFQ4CN)_