### PR TITLE
Improve project settings layout: declutter, collapse local keys, unify model config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -704,10 +704,19 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     IDB-backed `screenInventoryImageStore` keyed by the mockup version id);
     otherwise the OpenAI gpt-image-2 generator (`MockupScreenImage`).
     `MockupImageStatusChip` summarizes per-version status (AI-generated /
-    uploaded / awaiting). The Settings section is `settings/ArtifactModelsSection.tsx`
-    (PRD shown as expandable "Multi", text artifacts with Complex/Simple badges,
-    Mockups with an "Image Source" select); the model list is the shared
-    `src/lib/modelCatalog.ts`.
+    uploaded / awaiting). The Settings section is `settings/ArtifactModelsSection.tsx`,
+    now the single place PRD **and** artifact models are configured: the PRD row
+    (badge "Per-section") expands to reveal the authoritative Fast (Flash) /
+    Expert (Pro) model pickers **plus** a read-only per-section preview showing
+    which tier each PRD section actually runs on — this replaced the old,
+    separate "PRD Generation Models" block in `SettingsModal` (removing the
+    redundancy that made PRD look like it "defaulted to Flash"). Text artifacts
+    have one selector each; Mockups has an "Image Source" select. The `SettingsModal`
+    itself groups advanced/fallback controls (Gemini billing project, Local
+    browser keys, Integrations, Refine & enhance model) behind collapsed
+    `Disclosure` sections; the Gemini billing project ID sits with the vault (it
+    applies to every Gemini request regardless of key source), not buried in the
+    local-keys fallback. The model list is the shared `src/lib/modelCatalog.ts`.
     Three of these
     (screen/data/component inventory) use Gemini JSON mode with schemas in
     `schemas/artifactSchemas.ts`, then convert to markdown via

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase, Sparkles, Zap, Brain, Github, ChevronRight, Bug } from 'lucide-react';
+import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase, Sparkles, Github, ChevronRight, Bug, KeyRound } from 'lucide-react';
 import { getOwnerToken } from '../lib/snapshotClient';
 import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
 import { ProviderKeysSection } from './settings/ProviderKeysSection';
 import { ConnectedAccountsSection } from './settings/ConnectedAccountsSection';
 import { ArtifactModelsSection } from './settings/ArtifactModelsSection';
-import { MODEL_CATALOG, CURRENT_MODELS, LEGACY_MODELS, type ModelOption } from '../lib/modelCatalog';
+import { CURRENT_MODELS, LEGACY_MODELS, type ModelOption } from '../lib/modelCatalog';
 import {
     getArtifactModelOverrides,
     setArtifactModelOverrides,
@@ -62,6 +62,48 @@ function ModelRadio({
                 <p className="text-xs text-neutral-400">{option.description}</p>
             </div>
         </button>
+    );
+}
+
+/**
+ * Progressive-disclosure section for the settings modal. Collapsed by default
+ * so advanced/fallback controls (local browser keys, integrations, refine
+ * model) don't clutter the primary view. Dark-themed to match the modal.
+ */
+function Disclosure({
+    icon,
+    title,
+    subtitle,
+    defaultOpen = false,
+    children,
+}: {
+    icon: ReactNode;
+    title: string;
+    subtitle?: string;
+    defaultOpen?: boolean;
+    children: ReactNode;
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+    return (
+        <div className="border border-white/10 rounded-2xl bg-white/[0.02] overflow-hidden">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+                className="w-full flex items-center gap-3 px-4 py-3.5 text-left hover:bg-white/[0.03] transition-colors"
+            >
+                <div className="text-neutral-400 shrink-0">{icon}</div>
+                <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-neutral-200">{title}</p>
+                    {subtitle && <p className="text-[11px] text-neutral-500 leading-snug">{subtitle}</p>}
+                </div>
+                <ChevronDown
+                    size={16}
+                    className={`shrink-0 text-neutral-500 transition-transform ${open ? 'rotate-180' : ''}`}
+                />
+            </button>
+            {open && <div className="px-4 pb-4 pt-1 space-y-3 border-t border-white/5">{children}</div>}
+        </div>
     );
 }
 
@@ -157,51 +199,15 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                     {/* Encrypted, server-side provider key vault (recommended) */}
                     <ProviderKeysSection />
 
-                    <div className="border-t border-white/5 pt-6 space-y-1">
-                        <h3 className="text-sm font-semibold text-neutral-400">Local browser keys (advanced fallback)</h3>
-                        <p className="text-[11px] text-neutral-500 leading-relaxed">
-                            These keys are stored only in this browser's localStorage. The encrypted
-                            vault above is preferred; local keys are used as a fallback when no vault key
-                            is configured (e.g. offline or local development).
-                        </p>
-                    </div>
-
-                    {/* API Key Section */}
-                    <div className="space-y-3">
-                        <div className="flex items-center justify-between">
-                            <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                                <Shield size={14} className="text-indigo-400" />
-                                Google Gemini API Key
-                            </label>
-                            <a
-                                href="https://aistudio.google.com/app/apikey"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-[11px] font-bold uppercase tracking-wider text-indigo-400 hover:text-indigo-300 transition flex items-center gap-1"
-                            >
-                                Get Key <ExternalLink size={10} />
-                            </a>
-                        </div>
-                        <input
-                            type="password"
-                            value={apiKey}
-                            onChange={(e) => setApiKey(e.target.value)}
-                            className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
-                            placeholder="Paste your AIzaSy... key here"
-                            autoFocus
-                        />
-                        <p className="text-[11px] text-neutral-500 leading-relaxed px-1">
-                            Your key is stored locally in your browser and never leaves your machine.
-                        </p>
-                    </div>
-
-                    {/* Billing Project ID — forces paid-tier quota */}
-                    <div className="space-y-3">
-                        <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                            <Briefcase size={14} className="text-indigo-400" />
-                            Billing Project ID
-                            <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Optional</span>
-                        </label>
+                    {/* Gemini billing project — a Gemini-wide setting applied to
+                        every request regardless of key source (vault OR local),
+                        so it sits with the vault above rather than only in the
+                        local-keys fallback. Collapsed to keep the primary view clean. */}
+                    <Disclosure
+                        icon={<Briefcase size={16} />}
+                        title="Gemini billing project"
+                        subtitle="Optional — force paid-tier quota for your Gemini key"
+                    >
                         <input
                             type="text"
                             value={projectId}
@@ -209,57 +215,100 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                             className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
                             placeholder="e.g. my-gcp-project-123"
                         />
-                        <p className="text-[11px] text-neutral-500 leading-relaxed px-1">
-                            If you enabled billing on a specific Google Cloud project, paste its ID here.
-                            Synapse sends it as <code className="text-neutral-400">x-goog-user-project</code> so
-                            Gemini meters requests against that project — fixes the case where a key defaults
-                            to free-tier quota even after billing is on.
+                        <p className="text-[11px] text-neutral-500 leading-relaxed">
+                            Applies to <strong>all</strong> Gemini requests — whether the key comes from
+                            the encrypted vault above or the local fallback below. If you enabled billing
+                            on a specific Google Cloud project, paste its ID here; Synapse sends it as{' '}
+                            <code className="text-neutral-400">x-goog-user-project</code> so Gemini meters
+                            requests against that project — fixing the case where a key defaults to
+                            free-tier quota even after billing is on.
                         </p>
-                        <p className="text-[11px] text-amber-300/80 leading-relaxed px-1">
+                        <p className="text-[11px] text-amber-300/80 leading-relaxed">
                             Use the Project <strong>ID</strong> (e.g. <code className="text-neutral-400">my-project-123</code>),
                             not the Project Number. The <strong>Generative Language API</strong> must be
                             enabled on this project (Google Cloud Console → APIs &amp; Services → Library).
                         </p>
-                    </div>
+                    </Disclosure>
 
-                    {/* OpenAI image preview (optional) */}
-                    <div className="space-y-3">
-                        <div className="flex items-center justify-between">
-                            <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                                <Sparkles size={14} className="text-indigo-400" />
-                                OpenAI Image Preview
-                                <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Optional</span>
-                            </label>
-                            <a
-                                href="https://platform.openai.com/api-keys"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-[11px] font-bold uppercase tracking-wider text-indigo-400 hover:text-indigo-300 transition flex items-center gap-1"
-                            >
-                                Get Key <ExternalLink size={10} />
-                            </a>
-                        </div>
-                        <input
-                            type="password"
-                            value={openaiKey}
-                            onChange={(e) => setOpenaiKey(e.target.value)}
-                            className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
-                            placeholder="Paste your sk-... OpenAI key here"
-                        />
-                        <p className="text-[11px] text-neutral-500 leading-relaxed px-1">
-                            Adds an "AI Image" tab to each mockup screen, powered by OpenAI <code className="text-neutral-400">gpt-image-2</code>.
-                            Click to generate a low-quality draft image; if you like it, regenerate at high quality.
-                            Your key is stored locally in your browser and never leaves your machine.
+                    {/* Local browser keys — advanced fallback, collapsed by default. */}
+                    <Disclosure
+                        icon={<KeyRound size={16} />}
+                        title="Local browser keys"
+                        subtitle="Advanced fallback — stored only in this browser"
+                    >
+                        <p className="text-[11px] text-neutral-500 leading-relaxed">
+                            These keys are stored only in this browser's localStorage. The encrypted
+                            vault above is preferred; local keys are used as a fallback when no vault key
+                            is configured (e.g. offline or local development).
                         </p>
-                    </div>
 
-                    {/* Integrations — credentials for task export targets */}
-                    <div className="space-y-3">
+                        {/* Local Gemini key */}
+                        <div className="space-y-2 pt-1">
+                            <div className="flex items-center justify-between">
+                                <label className="text-xs font-semibold text-neutral-300 flex items-center gap-2">
+                                    <Shield size={13} className="text-indigo-400" />
+                                    Google Gemini API Key
+                                </label>
+                                <a
+                                    href="https://aistudio.google.com/app/apikey"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-[11px] font-bold uppercase tracking-wider text-indigo-400 hover:text-indigo-300 transition flex items-center gap-1"
+                                >
+                                    Get Key <ExternalLink size={10} />
+                                </a>
+                            </div>
+                            <input
+                                type="password"
+                                value={apiKey}
+                                onChange={(e) => setApiKey(e.target.value)}
+                                className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
+                                placeholder="Paste your AIzaSy... key here"
+                            />
+                        </div>
+
+                        {/* Local OpenAI key */}
+                        <div className="space-y-2 pt-2">
+                            <div className="flex items-center justify-between">
+                                <label className="text-xs font-semibold text-neutral-300 flex items-center gap-2">
+                                    <Sparkles size={13} className="text-indigo-400" />
+                                    OpenAI Image Preview
+                                    <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Optional</span>
+                                </label>
+                                <a
+                                    href="https://platform.openai.com/api-keys"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-[11px] font-bold uppercase tracking-wider text-indigo-400 hover:text-indigo-300 transition flex items-center gap-1"
+                                >
+                                    Get Key <ExternalLink size={10} />
+                                </a>
+                            </div>
+                            <input
+                                type="password"
+                                value={openaiKey}
+                                onChange={(e) => setOpenaiKey(e.target.value)}
+                                className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
+                                placeholder="Paste your sk-... OpenAI key here"
+                            />
+                            <p className="text-[11px] text-neutral-500 leading-relaxed">
+                                Adds an "AI Image" tab to each mockup screen, powered by OpenAI <code className="text-neutral-400">gpt-image-2</code>.
+                                Click to generate a low-quality draft image; if you like it, regenerate at high quality.
+                            </p>
+                        </div>
+                    </Disclosure>
+
+                    {/* Integrations — task-export credentials, collapsed by default.
+                        Not a key-vault fallback, so it lives in its own group. */}
+                    <Disclosure
+                        icon={<Github size={16} />}
+                        title="Integrations"
+                        subtitle="Optional — GitHub for exporting tasks"
+                    >
                         <div className="flex items-center justify-between">
-                            <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                                <Github size={14} className="text-indigo-400" />
+                            <label className="text-xs font-semibold text-neutral-300 flex items-center gap-2">
+                                <Github size={13} className="text-indigo-400" />
                                 GitHub Integration
-                                <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Optional</span>
                             </label>
                             <a
                                 href="https://github.com/settings/tokens?type=beta"
@@ -284,80 +333,39 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                             className="w-full bg-black/40 border border-white/10 rounded-xl px-5 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 placeholder:text-neutral-600 transition-all font-mono text-sm"
                             placeholder="owner/repo (default destination for exported tasks)"
                         />
-                        <p className="text-[11px] text-neutral-500 leading-relaxed px-1">
+                        <p className="text-[11px] text-neutral-500 leading-relaxed">
                             Used by <strong>Convert to Tasks</strong> on the Implementation Plan artifact to create
                             real GitHub issues. Token needs <code className="text-neutral-400">issues:write</code>
                             scope on the target repo. Stored locally in your browser only.
                         </p>
+                    </Disclosure>
+
+                    {/* Generation models — the single place PRD + artifact models
+                        are configured (the PRD row now owns the Fast/Expert controls). */}
+                    <div className="border-t border-white/5 pt-6">
+                        <ArtifactModelsSection
+                            fastModel={fastModel}
+                            strongModel={strongModel}
+                            onFastModelChange={setFastModel}
+                            onStrongModelChange={setStrongModel}
+                            overrides={artifactOverrides}
+                            onOverridesChange={setArtifactOverrides}
+                            mockupMode={mockupMode}
+                            onMockupModeChange={setMockupMode}
+                        />
                     </div>
 
-                    {/* Model Tiers for Progressive PRD */}
-                    <div className="space-y-4">
-                        <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                            <Brain size={14} className="text-indigo-400" />
-                            PRD Generation Models
-                        </label>
-                        <p className="text-[11px] text-neutral-500 leading-relaxed -mt-1">
-                            PRD sections are generated concurrently using two models: Flash for simpler sections (product basics, grounding, risks, metrics) and Pro for complex sections (features, architecture, data model). If you hit rate limits, set both to the same model.
-                        </p>
-                        <div className="grid grid-cols-2 gap-3">
-                            <div className="space-y-2">
-                                <label className="flex items-center gap-1.5 text-xs font-semibold text-teal-400">
-                                    <Zap size={11} />
-                                    Fast model (Flash)
-                                </label>
-                                <select
-                                    value={fastModel}
-                                    onChange={(e) => setFastModel(e.target.value)}
-                                    className="w-full bg-black/40 border border-white/10 rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500/50 focus:border-teal-500 text-neutral-100 text-xs transition-all"
-                                >
-                                    {MODEL_CATALOG.map((m) => (
-                                        <option key={m.id} value={m.id}>{m.name}</option>
-                                    ))}
-                                </select>
-                            </div>
-                            <div className="space-y-2">
-                                <label className="flex items-center gap-1.5 text-xs font-semibold text-indigo-400">
-                                    <Brain size={11} />
-                                    Expert model (Pro)
-                                </label>
-                                <select
-                                    value={strongModel}
-                                    onChange={(e) => setStrongModel(e.target.value)}
-                                    className="w-full bg-black/40 border border-white/10 rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-neutral-100 text-xs transition-all"
-                                >
-                                    {MODEL_CATALOG.map((m) => (
-                                        <option key={m.id} value={m.id}>{m.name}</option>
-                                    ))}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Per-artifact model routing */}
-                    <ArtifactModelsSection
-                        fastModel={fastModel}
-                        strongModel={strongModel}
-                        overrides={artifactOverrides}
-                        onOverridesChange={setArtifactOverrides}
-                        mockupMode={mockupMode}
-                        onMockupModeChange={setMockupMode}
-                    />
-
-                    {/* Model Selection */}
-                    <div className="space-y-4">
-                        <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                            <Cpu size={14} className="text-indigo-400" />
-                            Default model
-                            <span className="text-[10px] uppercase tracking-wider font-bold text-neutral-500">Refine & enhance</span>
-                        </label>
-                        <p className="text-[11px] text-neutral-500 leading-relaxed -mt-1">
-                            Used for everything that isn't tiered above — the PRD refinement
-                            conversations (highlight &rarr; branch &rarr; consolidate) and the
-                            "Enhance" prompt helper. PRD sections and the core artifacts route
-                            automatically between the Fast and Expert models by complexity (see
-                            "PRD Generation Models"); this also acts as the fallback for those
-                            tiers when they're left unset.
+                    {/* Refine & enhance model — advanced, collapsed by default. */}
+                    <Disclosure
+                        icon={<Cpu size={16} />}
+                        title="Refine & enhance model"
+                        subtitle="Default model for PRD refinement and the Enhance helper"
+                    >
+                        <p className="text-[11px] text-neutral-500 leading-relaxed">
+                            Used for everything that isn't a Generation Model above — the PRD
+                            refinement conversations (highlight &rarr; branch &rarr; consolidate) and the
+                            "Enhance" prompt helper. It also acts as the fallback for the Fast/Expert
+                            tiers when either is left unset.
                         </p>
 
                         <div className="grid grid-cols-1 gap-3">
@@ -410,7 +418,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                                 </div>
                             )}
                         </div>
-                    </div>
+                    </Disclosure>
 
                     {/* Orchestration Metrics link */}
                     <div className="pt-4 border-t border-white/5">

--- a/src/components/settings/ArtifactModelsSection.tsx
+++ b/src/components/settings/ArtifactModelsSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, FileText, Image as ImageIcon, ChevronDown, Sparkles } from 'lucide-react';
+import { Box, FileText, Image as ImageIcon, ChevronDown, Sparkles, Zap, Brain } from 'lucide-react';
 import { MODEL_CATALOG, modelDisplayName } from '../../lib/modelCatalog';
 import { CORE_ARTIFACT_DISPLAY_ORDER, isRetiredArtifactSubtype } from '../../lib/coreArtifactPipeline';
 import { CORE_ARTIFACT_COMPLEXITY } from '../../lib/artifactModelSettings';
@@ -8,9 +8,16 @@ import { DEFAULT_PRD_SECTIONS, selectModelTier } from '../../lib/services/progre
 import type { CoreArtifactSubtype } from '../../types';
 
 interface ArtifactModelsSectionProps {
-    /** Live Fast/Expert model ids from the PRD Generation Models pickers (unsaved edits included). */
+    /**
+     * Fast/Expert model ids used by the PRD per-section router. These are the
+     * authoritative control for PRD generation (see the expandable PRD row) —
+     * simple sections run on the Fast model, complex sections on the Expert
+     * model. Editable here so there is ONE place that governs PRD models.
+     */
     fastModel: string;
     strongModel: string;
+    onFastModelChange: (modelId: string) => void;
+    onStrongModelChange: (modelId: string) => void;
     /** Per-artifact model overrides (controlled). */
     overrides: Partial<Record<CoreArtifactSubtype, string>>;
     onOverridesChange: (next: Partial<Record<CoreArtifactSubtype, string>>) => void;
@@ -39,15 +46,15 @@ function ArtifactRow({
         <div className="bg-white/5 border border-white/5 rounded-2xl p-4 space-y-3">
             <div className="flex items-start gap-3">
                 <div className="text-neutral-400 mt-0.5 shrink-0">{icon}</div>
-                <div className="min-w-0">
-                    <h4 className="text-sm font-bold text-white">{title}</h4>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <h4 className="text-sm font-bold text-white">{title}</h4>
+                        {badge}
+                    </div>
                     <p className="text-[11px] text-neutral-400 leading-snug">{description}</p>
                 </div>
             </div>
-            <div className="space-y-2">
-                {children}
-                {badge && <div>{badge}</div>}
-            </div>
+            <div className="space-y-2">{children}</div>
         </div>
     );
 }
@@ -55,6 +62,8 @@ function ArtifactRow({
 export function ArtifactModelsSection({
     fastModel,
     strongModel,
+    onFastModelChange,
+    onStrongModelChange,
     overrides,
     onOverridesChange,
     mockupMode,
@@ -69,31 +78,41 @@ export function ArtifactModelsSection({
         onOverridesChange({ ...overrides, [subtype]: modelId });
     };
 
+    // Section routing split, computed from the live Fast/Expert selections so
+    // the collapsed PRD summary always reflects the current models (and makes
+    // clear PRD is NOT a single "Flash" model — simple vs complex sections
+    // route differently).
+    const fastSectionCount = DEFAULT_PRD_SECTIONS.filter((s) => selectModelTier(s.risk) === 'fast').length;
+    const strongSectionCount = DEFAULT_PRD_SECTIONS.length - fastSectionCount;
+
     return (
         <div className="space-y-4">
             <div className="space-y-1">
                 <label className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
                     <Box size={14} className="text-indigo-400" />
-                    Artifact Generation Models
+                    Generation Models
                     <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
                         Recommended
                     </span>
                 </label>
                 <p className="text-[11px] text-neutral-500 leading-relaxed">
-                    Choose the AI model for each type of artifact. By default we use Flash for
-                    simple tasks and Pro for complex reasoning — override any of them here.
+                    The AI model used for each thing Synapse generates. The PRD routes each section
+                    automatically (simple sections on the Fast model, complex ones on the Expert
+                    model); every other artifact uses a single model you can override.
                 </p>
             </div>
 
             <div className="space-y-3">
-                {/* PRD — multi-model, expandable (configured in PRD Generation Models). */}
+                {/* PRD — multi-model. Expanding reveals the Fast/Expert controls
+                    that govern the whole PRD run, plus a per-section preview so
+                    it's transparent which model each section actually uses. */}
                 <ArtifactRow
                     icon={<FileText size={18} />}
                     title="PRD"
-                    description="Final product requirements document"
+                    description="Final product requirements document — generated section by section"
                     badge={
                         <span className="inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-violet-500/15 text-violet-300 border border-violet-500/30">
-                            Multi
+                            Per-section
                         </span>
                     }
                 >
@@ -103,34 +122,80 @@ export function ArtifactModelsSection({
                         className={`${selectClass} flex items-center justify-between text-left`}
                         aria-expanded={prdExpanded}
                     >
-                        <span className="text-neutral-300">Per-section routing (Flash / Pro)</span>
+                        <span className="text-neutral-300 truncate min-w-0">
+                            {fastSectionCount} simple → {modelDisplayName(fastModel)} · {strongSectionCount} complex → {modelDisplayName(strongModel)}
+                        </span>
                         <ChevronDown
                             size={14}
-                            className={`transition-transform ${prdExpanded ? 'rotate-180' : ''}`}
+                            className={`shrink-0 ml-2 transition-transform ${prdExpanded ? 'rotate-180' : ''}`}
                         />
                     </button>
                     {prdExpanded && (
-                        <div className="rounded-xl border border-white/5 bg-black/20 divide-y divide-white/5">
-                            {DEFAULT_PRD_SECTIONS.map((section) => {
-                                const tier = selectModelTier(section.risk);
-                                const model = tier === 'fast' ? fastModel : strongModel;
-                                return (
-                                    <div
-                                        key={section.id}
-                                        className="flex items-center justify-between gap-2 px-3 py-2"
+                        <div className="space-y-3">
+                            {/* Authoritative Fast/Expert controls for PRD generation. */}
+                            <div className="grid grid-cols-2 gap-2">
+                                <div className="space-y-1.5">
+                                    <label className="flex items-center gap-1.5 text-[11px] font-semibold text-teal-400">
+                                        <Zap size={11} />
+                                        Fast model (Flash)
+                                    </label>
+                                    <select
+                                        value={fastModel}
+                                        onChange={(e) => onFastModelChange(e.target.value)}
+                                        className={selectClass}
+                                        aria-label="PRD fast (Flash) model"
                                     >
-                                        <span className="text-[11px] text-neutral-300 min-w-0 truncate">
-                                            {section.title}
-                                        </span>
-                                        <span className="text-[11px] text-neutral-400 shrink-0">
-                                            {modelDisplayName(model)}
-                                        </span>
-                                    </div>
-                                );
-                            })}
-                            <p className="text-[10px] text-neutral-500 px-3 py-2">
-                                PRD sections route automatically by complexity. Change the underlying
-                                models in “PRD Generation Models” above.
+                                        {MODEL_CATALOG.map((m) => (
+                                            <option key={m.id} value={m.id}>{m.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="space-y-1.5">
+                                    <label className="flex items-center gap-1.5 text-[11px] font-semibold text-indigo-400">
+                                        <Brain size={11} />
+                                        Expert model (Pro)
+                                    </label>
+                                    <select
+                                        value={strongModel}
+                                        onChange={(e) => onStrongModelChange(e.target.value)}
+                                        className={selectClass}
+                                        aria-label="PRD expert (Pro) model"
+                                    >
+                                        {MODEL_CATALOG.map((m) => (
+                                            <option key={m.id} value={m.id}>{m.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            {/* Per-section preview: which model each section runs on. */}
+                            <div className="rounded-xl border border-white/5 bg-black/20 divide-y divide-white/5">
+                                {DEFAULT_PRD_SECTIONS.map((section) => {
+                                    const tier = selectModelTier(section.risk);
+                                    const model = tier === 'fast' ? fastModel : strongModel;
+                                    const isFast = tier === 'fast';
+                                    return (
+                                        <div
+                                            key={section.id}
+                                            className="flex items-center justify-between gap-2 px-3 py-2"
+                                        >
+                                            <span className="text-[11px] text-neutral-300 min-w-0 truncate flex items-center gap-1.5">
+                                                {isFast
+                                                    ? <Zap size={10} className="text-teal-400 shrink-0" />
+                                                    : <Brain size={10} className="text-indigo-400 shrink-0" />}
+                                                {section.title}
+                                            </span>
+                                            <span className="text-[11px] text-neutral-400 shrink-0">
+                                                {modelDisplayName(model)}
+                                            </span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                            <p className="text-[10px] text-neutral-500 leading-relaxed">
+                                Sections are routed by complexity — you can't override a single
+                                section, but changing the Fast or Expert model above updates every
+                                section on that tier. If you hit rate limits, set both to the same model.
                             </p>
                         </div>
                     )}


### PR DESCRIPTION
## Summary

Reworks the **Project Settings** modal to address three usability issues raised from the mobile screenshots.

### 1. Clutter
The modal was one long flat scroll where every section carried equal visual weight and always-visible explanatory text. Advanced/fallback controls are now grouped behind collapsed **`Disclosure`** sections (a small dark-themed progressive-disclosure component), so the primary view stays focused:

- **Gemini billing project** (collapsed)
- **Local browser keys** (collapsed)
- **Integrations** — GitHub (collapsed)
- **Refine & enhance model** (collapsed)

### 2. Local browser keys + billing inconsistency
- The local fallback keys (Gemini key, OpenAI key) now live in a **collapsed-by-default** disclosure.
- The **Billing Project ID** moves *out* of the local-keys block and *up* next to the encrypted vault, with copy clarifying it applies to **every** Gemini request regardless of key source (vault or local). This directly resolves the "why is billing asked here but not above?" question — it now sits with the vault, where it belongs.
- GitHub moves into its own **Integrations** group (it isn't a key-vault fallback).

### 3. PRD model transparency
The redundant standalone **"PRD Generation Models"** block is folded into the **Generation Models** list. The **PRD** row now:
- owns the authoritative **Fast (Flash)** / **Expert (Pro)** model pickers, and
- shows a **per-section preview** of exactly which model each PRD section runs on (Product Basics → Flash, Features → Pro, …), with tier icons and an explanatory note.

This makes it obvious that the PRD uses deliberate per-section routing rather than "defaulting to Flash," and removes the duplication that caused the confusion.

## Changes
- `src/components/SettingsModal.tsx` — new `Disclosure` helper; reorganized form into progressive-disclosure groups; relocated Billing Project ID; removed the redundant PRD Generation Models block; wires Fast/Expert setters into `ArtifactModelsSection`.
- `src/components/settings/ArtifactModelsSection.tsx` — PRD row now hosts the Fast/Expert controls + per-section preview; badge changed `Multi` → `Per-section`; section heading renamed to "Generation Models".
- `CLAUDE.md` — updated the Settings/Artifact-models description to match.

## Testing
- `npm run build` (tsc -b && vite build) — passes.
- `npm run lint` — passes.
- Drove the app with Playwright and screenshotted the redesigned modal (collapsed groups + expanded PRD routing) to confirm rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzkNsUHTheRzFBKwPMPUc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzkNsUHTheRzFBKwPMPUc6)_