### PR TITLE
Phase 2 reliability: cross-device conflict protection for project sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,30 +253,74 @@ device-scoped and never syncs) and full design.
   `{userId,deletedAt}` indexes via the new `createIndexes` db action.
   `api/projects.js` is the session-gated, rate-limited CRUD endpoint (list,
   fetch-one, PUT upsert — covers PRD/artifact saves, bulk import, soft-delete/
-  restore, archive toggles, hard-delete). No public/shared access exists.
+  restore, archive toggles, hard-delete). No public/shared access exists. Each
+  doc carries a monotonic `revision` counter (`$inc` per upsert); `upsertProject`
+  returns the new revision and accepts an optional **`expectedRevision`**
+  (threaded from `?expectedRevision`) — an **optimistic-concurrency guard**: when
+  the caller's expected revision no longer matches the stored one (another device
+  saved in the interim), it does NOT write and returns `{ conflict, currentRevision }`,
+  which the handler maps to **HTTP 409**. A first-time save (no expectedRevision)
+  is unaffected.
 - **Client serialization.** A **ProjectBundle** (`src/lib/projectBundle.ts`,
   pure) is the transport unit: `extractProjectBundle` gathers a project's nine
   store slices; `mergeBundlesIntoSource` merges server bundles back **additively
-  — local always wins on id collision** (a pull only ADDs projects this device
-  lacks; it never clobbers local in-progress work — per-project server-newer
-  reconciliation is deferred, see `tasks/TODO.md`). `src/lib/projectsClient.ts`
-  is the `/api/projects` transport (`credentials: 'include'`; throws on non-2xx
-  so a failure never silently drops projects).
+  — local always wins on id collision** (an additive pull only ADDs projects this
+  device lacks). `overwriteBundlesIntoSource` is the deliberate exception —
+  REPLACES a project's local slices with the server copy, used only for a safe
+  server-newer refresh (local clean) or an explicit "use cloud" conflict
+  resolution. `src/lib/projectsClient.ts` is the `/api/projects` transport
+  (`credentials: 'include'`; throws on non-2xx so a failure never silently drops
+  projects; `saveProject` sends `expectedRevision` and throws a typed
+  `RevisionConflictError` on 409).
+- **Durable sync metadata** (`src/lib/projectSyncMeta.ts`). A per-user
+  localStorage map (`synapse-project-sync-meta::u:<userId>`, mirrors
+  `projectMigration.ts`) recording, **separately from user-authored project
+  content**, each project's `lastSeenServerRevision`/`lastSeenServerUpdatedAt`
+  (the conflict-detection baseline), `lastCloudSavedAt`, `lastCloudSaveError`,
+  `hasUnsyncedChanges` (durable dirty flag — survives reload so an offline edit
+  isn't forgotten), and `conflict`. `isServerNewer(server, meta)` compares
+  revision-first, `updatedAt` fallback, false when there's no baseline. All
+  fields optional → legacy/anonymous data is unaffected.
 - **Sync orchestrator** (`src/store/projectServerSync.ts`). `startProjectSync`/
   `stopProjectSync` are driven from `authStore.setUser`. On sign-in it
-  **reconciles** (pull server projects this device is missing → apply; upload
-  local-only projects → migrate) then subscribes to the store to **push**
-  changed projects (debounced, per-project) and remote-delete locally-deleted
-  ones. **A failed save never drops local data** — it stays in localStorage and
-  surfaces a per-project `error` sync state. `suspendPush` silences the echo
-  while applying pulled bundles. The read-only demo project
-  (`DEMO_PROJECT_ID`) is never synced.
+  **reconciles**: for a project missing locally → additive pull; for a project on
+  **both** sides → compare the server summary against the durable baseline
+  (`isServerNewer`) — **server-newer + local clean** overwrites local with the
+  newer copy and re-baselines (safe refresh), **server-newer + local dirty** flags
+  a **`conflict`** and touches neither side; local-only projects still migrate
+  (push). It then subscribes to the store to **push** changed projects (debounced,
+  per-project) and remote-delete locally-deleted ones. Every push is a
+  **conditional write** — it sends the last-seen `expectedRevision`, so a stale
+  push (server advanced on another device) is rejected (409 →
+  `RevisionConflictError`) and becomes a `conflict` instead of clobbering the
+  newer copy; a conflicted project is not auto-pushed. **A failed save never drops
+  local data** — it stays in localStorage and surfaces a per-project `error` sync
+  state (+ durable `lastCloudSaveError`). Conflict resolution is **explicit, never
+  silent**: `resolveConflictUseCloud` (adopt cloud, discard local — offer a
+  recovery download first) and `resolveConflictKeepLocal` (overwrite cloud from
+  local, re-baselined so the conditional push wins). `suspendPush` silences the
+  echo while applying pulled/overwritten bundles. The read-only demo project
+  (`DEMO_PROJECT_ID`) is never synced. A `beforeunload` guard warns only when
+  cloud state is genuinely stuck (`conflict`/`error`), never for normal pending
+  pushes.
 - **Sync UI state** (`src/store/projectSyncStore.ts`,
   `src/components/sync/ProjectSyncStatus.tsx`). Overall `phase`
-  (idle/loading/ready/error) + `online` + per-project saving/saved/error/dirty,
-  surfaced in `ProjectDrawer` (a `SyncStatusBanner` with a retry on failure, a
-  per-row `ProjectSyncDot`, and a loading guard so the drawer never flashes a
-  false "no projects" state while the session or initial pull is resolving).
+  (idle/loading/ready/error) + `online` + per-project
+  saving/saved/error/dirty/**conflict** (with `lastCloudSavedAt`/
+  `lastCloudSaveError`/`conflict` details; `patchProjectSync` merges partial
+  updates). Surfaced as: a `SyncStatusBanner` (retry on failure, conflict count)
+  and per-row `ProjectSyncDot` in `ProjectDrawer`; a compact `ProjectCloudStatus`
+  pill in the workspace header distinguishing saved-on-device / synced-to-cloud
+  ("synced Nm ago") / cloud-sync-pending / cloud-save-failed / conflict; and a
+  `ProjectConflictBanner` above the workspace body ("Cloud version changed on
+  another device" → keep local / use cloud / download local copy). `ExportModal`
+  shows an at-risk banner + recovery download when the project's cloud state is
+  failed/conflict.
+- **Recovery bundle** (`src/lib/projectRecovery.ts`). A network-free JSON
+  download of one project's LOCAL state (the `ProjectBundle` in a self-describing
+  envelope) for at-risk cloud durability — failed save, expired session, network
+  outage, server body-limit rejection, or an unresolved conflict. Reachable from
+  the conflict banner and the export modal.
 - **Migration markers** (`src/lib/projectMigration.ts`). A per-user localStorage
   set (`synapse-projects-server-migrated::u:<userId>`) of project ids already
   pushed. The server upsert is idempotent on the stable UUID, so duplicates are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,12 +255,15 @@ device-scoped and never syncs) and full design.
   fetch-one, PUT upsert — covers PRD/artifact saves, bulk import, soft-delete/
   restore, archive toggles, hard-delete). No public/shared access exists. Each
   doc carries a monotonic `revision` counter (`$inc` per upsert); `upsertProject`
-  returns the new revision and accepts an optional **`expectedRevision`**
-  (threaded from `?expectedRevision`) — an **optimistic-concurrency guard**: when
-  the caller's expected revision no longer matches the stored one (another device
-  saved in the interim), it does NOT write and returns `{ conflict, currentRevision }`,
-  which the handler maps to **HTTP 409**. A first-time save (no expectedRevision)
-  is unaffected.
+  returns the new revision and accepts an optional **`expectedRevision`** (or, for
+  legacy rows with no revision yet, **`expectedUpdatedAt`**; both threaded from the
+  query string) — an **atomic optimistic-concurrency guard**: the expected version
+  is pinned INTO the `updateOne` filter (`upsert:false`), so the check-and-write
+  is atomic and two devices saving concurrently with the same baseline can't both
+  win — the loser's filter misses and it gets `{ conflict, currentRevision }`
+  (mapped to **HTTP 409**) rather than a silent overwrite. On a miss the store
+  distinguishes conflict (row advanced) from a remotely-deleted row (re-created
+  via the unconditional path). A first-time save (no guard) is unaffected.
 - **Client serialization.** A **ProjectBundle** (`src/lib/projectBundle.ts`,
   pure) is the transport unit: `extractProjectBundle` gathers a project's nine
   store slices; `mergeBundlesIntoSource` merges server bundles back **additively

--- a/api/__tests__/projects.test.js
+++ b/api/__tests__/projects.test.js
@@ -133,7 +133,29 @@ describe('PUT /api/projects', () => {
     await handler({ method: 'PUT', query: { id: 'p1' }, headers: {}, body }, res);
     expect(res.statusCode).toBe(200);
     // URL id + session user win — the body's project.id never selects the row.
-    expect(dataLayer.upsertProject).toHaveBeenCalledWith('user-a', 'p1', body.bundle);
+    expect(dataLayer.upsertProject).toHaveBeenCalledWith('user-a', 'p1', body.bundle, {
+      expectedRevision: undefined,
+    });
+  });
+
+  it('passes ?expectedRevision through to the conditional upsert', async () => {
+    dataLayer.upsertProject.mockResolvedValue({ id: 'p1', revision: 6 });
+    const res = mockRes();
+    const body = { bundle: { project: { id: 'p1', name: 'X' } } };
+    await handler({ method: 'PUT', query: { id: 'p1', expectedRevision: '5' }, headers: {}, body }, res);
+    expect(res.statusCode).toBe(200);
+    expect(dataLayer.upsertProject).toHaveBeenCalledWith('user-a', 'p1', body.bundle, {
+      expectedRevision: 5,
+    });
+  });
+
+  it('returns 409 when the data layer reports a revision conflict (no overwrite)', async () => {
+    dataLayer.upsertProject.mockResolvedValue({ conflict: true, currentRevision: 9, id: 'p1' });
+    const res = mockRes();
+    const body = { bundle: { project: { id: 'p1', name: 'X' } } };
+    await handler({ method: 'PUT', query: { id: 'p1', expectedRevision: '4' }, headers: {}, body }, res);
+    expect(res.statusCode).toBe(409);
+    expect(parsed(res)).toMatchObject({ error: 'revision_conflict', currentRevision: 9 });
   });
 
   it('rejects a body with no project', async () => {

--- a/api/_lib/__tests__/projectsStore.test.js
+++ b/api/_lib/__tests__/projectsStore.test.js
@@ -108,9 +108,9 @@ describe('upsertProject', () => {
     await expect(store.upsertProject('user-a', 'bad id', bundle())).rejects.toThrow(/invalid/);
   });
 
-  it('returns the new revision derived from the prior one', async () => {
+  it('reads back the authoritative revision on an unconditional upsert', async () => {
     runMongoAction.mockImplementation(async (action) => {
-      if (action === 'findOne') return { document: { revision: 5 } };
+      if (action === 'findOne') return { document: { revision: 6 } }; // post-write readback
       if (action === 'updateOne') return { matchedCount: 1 };
       return {};
     });
@@ -119,40 +119,64 @@ describe('upsertProject', () => {
     expect(saved.conflict).toBeUndefined();
   });
 
-  it('writes when expectedRevision matches the stored revision', async () => {
-    runMongoAction.mockImplementation(async (action) => {
-      if (action === 'findOne') return { document: { revision: 5 } };
-      if (action === 'updateOne') return { matchedCount: 1 };
+  it('writes atomically when expectedRevision matches (revision is IN the filter)', async () => {
+    runMongoAction.mockImplementation(async (action, payload) => {
+      // Only the guarded (upsert:false) conditional write should run.
+      if (action === 'updateOne' && payload.upsert === false) return { matchedCount: 1 };
       return {};
     });
     const saved = await store.upsertProject('user-a', 'p1', bundle(), { expectedRevision: 5 });
     expect(saved.revision).toBe(6);
-    // The conditional write did proceed.
-    expect(runMongoAction.mock.calls.some(([a]) => a === 'updateOne')).toBe(true);
+    const guarded = runMongoAction.mock.calls.find(([a, p]) => a === 'updateOne' && p.upsert === false)[1];
+    // The atomicity guarantee: the expected revision is part of the write filter.
+    expect(guarded.filter).toEqual({ userId: 'user-a', id: 'p1', revision: 5 });
+    // No unconditional (upsert:true) overwrite path was taken.
+    expect(runMongoAction.mock.calls.some(([a, p]) => a === 'updateOne' && p.upsert === true)).toBe(false);
   });
 
   it('blocks a stale write (expectedRevision mismatch) without overwriting', async () => {
-    runMongoAction.mockImplementation(async (action) => {
+    runMongoAction.mockImplementation(async (action, payload) => {
+      // Guarded conditional write finds no matching doc (server advanced).
+      if (action === 'updateOne' && payload.upsert === false) return { matchedCount: 0 };
+      // Re-read of current state after the miss.
       if (action === 'findOne') return { document: { revision: 7 } };
-      if (action === 'updateOne') return { matchedCount: 1 };
       return {};
     });
     const result = await store.upsertProject('user-a', 'p1', bundle(), { expectedRevision: 5 });
     expect(result).toMatchObject({ conflict: true, currentRevision: 7, id: 'p1' });
-    // Crucially, no write happened — the newer server copy is preserved.
-    expect(runMongoAction.mock.calls.some(([a]) => a === 'updateOne')).toBe(false);
+    // Crucially, no unconditional overwrite/insert happened.
+    expect(runMongoAction.mock.calls.some(([a, p]) => a === 'updateOne' && p.upsert === true)).toBe(false);
   });
 
-  it('ignores expectedRevision for a brand-new project (no existing row)', async () => {
-    runMongoAction.mockImplementation(async (action) => {
-      if (action === 'findOne') return {}; // no existing doc
-      if (action === 'updateOne') return { matchedCount: 0, upsertedId: { _id: 'x' } };
+  it('guards a legacy row on expectedUpdatedAt when it has no revision', async () => {
+    let guardFilter = null;
+    runMongoAction.mockImplementation(async (action, payload) => {
+      if (action === 'updateOne' && payload.upsert === false) {
+        guardFilter = payload.filter;
+        return { matchedCount: 0 }; // server advanced under the stale device
+      }
+      if (action === 'findOne') return { document: { revision: 1 } };
+      return {};
+    });
+    const result = await store.upsertProject('user-a', 'p1', bundle(), {
+      expectedUpdatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(result).toMatchObject({ conflict: true, currentRevision: 1 });
+    // The updatedAt condition is part of the atomic write filter.
+    expect(guardFilter.updatedAt).toBeInstanceOf(Date);
+    expect(runMongoAction.mock.calls.some(([a, p]) => a === 'updateOne' && p.upsert === true)).toBe(false);
+  });
+
+  it('re-creates a remotely-deleted row instead of reporting a phantom conflict', async () => {
+    runMongoAction.mockImplementation(async (action, payload) => {
+      if (action === 'updateOne' && payload.upsert === false) return { matchedCount: 0 };
+      if (action === 'findOne') return {}; // row is gone
+      if (action === 'updateOne' && payload.upsert === true) return { matchedCount: 0, upsertedId: { _id: 'x' } };
       return {};
     });
     const saved = await store.upsertProject('user-a', 'p1', bundle(), { expectedRevision: 3 });
     expect(saved.conflict).toBeUndefined();
     expect(saved.created).toBe(true);
-    expect(saved.revision).toBe(1);
   });
 });
 

--- a/api/_lib/__tests__/projectsStore.test.js
+++ b/api/_lib/__tests__/projectsStore.test.js
@@ -107,6 +107,53 @@ describe('upsertProject', () => {
   it('rejects an invalid project id', async () => {
     await expect(store.upsertProject('user-a', 'bad id', bundle())).rejects.toThrow(/invalid/);
   });
+
+  it('returns the new revision derived from the prior one', async () => {
+    runMongoAction.mockImplementation(async (action) => {
+      if (action === 'findOne') return { document: { revision: 5 } };
+      if (action === 'updateOne') return { matchedCount: 1 };
+      return {};
+    });
+    const saved = await store.upsertProject('user-a', 'p1', bundle());
+    expect(saved.revision).toBe(6);
+    expect(saved.conflict).toBeUndefined();
+  });
+
+  it('writes when expectedRevision matches the stored revision', async () => {
+    runMongoAction.mockImplementation(async (action) => {
+      if (action === 'findOne') return { document: { revision: 5 } };
+      if (action === 'updateOne') return { matchedCount: 1 };
+      return {};
+    });
+    const saved = await store.upsertProject('user-a', 'p1', bundle(), { expectedRevision: 5 });
+    expect(saved.revision).toBe(6);
+    // The conditional write did proceed.
+    expect(runMongoAction.mock.calls.some(([a]) => a === 'updateOne')).toBe(true);
+  });
+
+  it('blocks a stale write (expectedRevision mismatch) without overwriting', async () => {
+    runMongoAction.mockImplementation(async (action) => {
+      if (action === 'findOne') return { document: { revision: 7 } };
+      if (action === 'updateOne') return { matchedCount: 1 };
+      return {};
+    });
+    const result = await store.upsertProject('user-a', 'p1', bundle(), { expectedRevision: 5 });
+    expect(result).toMatchObject({ conflict: true, currentRevision: 7, id: 'p1' });
+    // Crucially, no write happened — the newer server copy is preserved.
+    expect(runMongoAction.mock.calls.some(([a]) => a === 'updateOne')).toBe(false);
+  });
+
+  it('ignores expectedRevision for a brand-new project (no existing row)', async () => {
+    runMongoAction.mockImplementation(async (action) => {
+      if (action === 'findOne') return {}; // no existing doc
+      if (action === 'updateOne') return { matchedCount: 0, upsertedId: { _id: 'x' } };
+      return {};
+    });
+    const saved = await store.upsertProject('user-a', 'p1', bundle(), { expectedRevision: 3 });
+    expect(saved.conflict).toBeUndefined();
+    expect(saved.created).toBe(true);
+    expect(saved.revision).toBe(1);
+  });
 });
 
 describe('soft delete / restore / archive', () => {

--- a/api/_lib/projectsStore.js
+++ b/api/_lib/projectsStore.js
@@ -122,10 +122,16 @@ export async function getProject(userId, projectId) {
 /**
  * Create or update (upsert) a project from a client bundle. Covers PRD updates
  * and artifact saves — the whole project state is one bundle. Returns the saved
- * summary. The id is owner-scoped, so a client can never overwrite another
- * user's project even by guessing its id (the filter pins `userId`).
+ * summary (including the new `revision`). The id is owner-scoped, so a client
+ * can never overwrite another user's project even by guessing its id (the
+ * filter pins `userId`).
+ *
+ * When `expectedRevision` is supplied and the stored revision has advanced past
+ * it (a concurrent save on another device), this does NOT write — it returns
+ * `{ conflict: true, currentRevision }` so the caller can surface a conflict
+ * instead of clobbering the newer copy.
  */
-export async function upsertProject(userId, projectId, bundle, { createdAt } = {}) {
+export async function upsertProject(userId, projectId, bundle, { createdAt, expectedRevision } = {}) {
   if (!userId) throw new Error('upsertProject: userId is required');
   if (!isValidProjectId(projectId)) throw new Error('upsertProject: invalid project id');
   await ensureProjectIndexes();
@@ -134,6 +140,29 @@ export async function upsertProject(userId, projectId, bundle, { createdAt } = {
   const { title, idea } = deriveMeta(bundle);
   const archived = bundle?.project?.archived === true;
   const status = archived ? 'archived' : 'active';
+
+  // Read the prior revision so we can return the new one (Mongo's updateOne
+  // doesn't echo the incremented value). Also lets us reject a stale write when
+  // the caller supplies the revision it expects to overwrite.
+  const existing = await runMongoAction('findOne', {
+    collection: PROJECTS_COLLECTION,
+    filter: { userId, id: projectId },
+    projection: { _id: 0, revision: 1 },
+  });
+  const priorRevision =
+    typeof existing?.document?.revision === 'number' ? existing.document.revision : null;
+
+  // Optimistic-concurrency guard: when the caller passes the revision it last
+  // saw and the server has since advanced (another device saved), do NOT
+  // overwrite — report the conflict so the client can resolve it. A brand-new
+  // project (no existing row) skips the guard.
+  if (
+    typeof expectedRevision === 'number' &&
+    priorRevision !== null &&
+    priorRevision !== expectedRevision
+  ) {
+    return { conflict: true, currentRevision: priorRevision, id: projectId };
+  }
 
   const result = await runMongoAction('updateOne', {
     collection: PROJECTS_COLLECTION,
@@ -159,7 +188,8 @@ export async function upsertProject(userId, projectId, bundle, { createdAt } = {
   });
 
   const created = Boolean(result?.upsertedId);
-  return { id: projectId, title, idea, status, archived, updatedAt: now, created };
+  const revision = priorRevision === null ? 1 : priorRevision + 1;
+  return { id: projectId, title, idea, status, archived, updatedAt: now, revision, created };
 }
 
 /**

--- a/api/_lib/projectsStore.js
+++ b/api/_lib/projectsStore.js
@@ -126,12 +126,21 @@ export async function getProject(userId, projectId) {
  * can never overwrite another user's project even by guessing its id (the
  * filter pins `userId`).
  *
- * When `expectedRevision` is supplied and the stored revision has advanced past
- * it (a concurrent save on another device), this does NOT write — it returns
+ * When `expectedRevision` (or, for legacy rows without a revision counter,
+ * `expectedUpdatedAt`) is supplied and the stored version has advanced past it
+ * (a concurrent save on another device), this does NOT write — it returns
  * `{ conflict: true, currentRevision }` so the caller can surface a conflict
- * instead of clobbering the newer copy.
+ * instead of clobbering the newer copy. The guard is applied as part of the SAME
+ * updateOne filter, so the check-and-write is ATOMIC: two devices saving
+ * concurrently with the same expected version can't both win — the loser's
+ * filter no longer matches and it gets the conflict, not a silent overwrite.
  */
-export async function upsertProject(userId, projectId, bundle, { createdAt, expectedRevision } = {}) {
+export async function upsertProject(
+  userId,
+  projectId,
+  bundle,
+  { createdAt, expectedRevision, expectedUpdatedAt } = {},
+) {
   if (!userId) throw new Error('upsertProject: userId is required');
   if (!isValidProjectId(projectId)) throw new Error('upsertProject: invalid project id');
   await ensureProjectIndexes();
@@ -141,44 +150,79 @@ export async function upsertProject(userId, projectId, bundle, { createdAt, expe
   const archived = bundle?.project?.archived === true;
   const status = archived ? 'archived' : 'active';
 
-  // Read the prior revision so we can return the new one (Mongo's updateOne
-  // doesn't echo the incremented value). Also lets us reject a stale write when
-  // the caller supplies the revision it expects to overwrite.
-  const existing = await runMongoAction('findOne', {
-    collection: PROJECTS_COLLECTION,
-    filter: { userId, id: projectId },
-    projection: { _id: 0, revision: 1 },
-  });
-  const priorRevision =
-    typeof existing?.document?.revision === 'number' ? existing.document.revision : null;
+  const setFields = {
+    userId,
+    id: projectId,
+    title,
+    idea,
+    status,
+    archived,
+    deletedAt: null,
+    data: bundle,
+    updatedAt: now,
+  };
 
-  // Optimistic-concurrency guard: when the caller passes the revision it last
-  // saw and the server has since advanced (another device saved), do NOT
-  // overwrite — report the conflict so the client can resolve it. A brand-new
-  // project (no existing row) skips the guard.
-  if (
-    typeof expectedRevision === 'number' &&
-    priorRevision !== null &&
-    priorRevision !== expectedRevision
-  ) {
-    return { conflict: true, currentRevision: priorRevision, id: projectId };
+  const hasRevisionGuard = typeof expectedRevision === 'number';
+  const hasUpdatedAtGuard =
+    !hasRevisionGuard && typeof expectedUpdatedAt === 'string' && expectedUpdatedAt.length > 0;
+
+  // Conditional (guarded) write: pin the expected version INTO the update
+  // filter, with upsert:false, so the increment only lands on the exact version
+  // the caller expected. A concurrent writer that already advanced the row makes
+  // this filter miss — atomic, no read-then-write race.
+  if (hasRevisionGuard || hasUpdatedAtGuard) {
+    const guardFilter = { userId, id: projectId };
+    if (hasRevisionGuard) guardFilter.revision = expectedRevision;
+    else guardFilter.updatedAt = new Date(expectedUpdatedAt);
+
+    const guarded = await runMongoAction('updateOne', {
+      collection: PROJECTS_COLLECTION,
+      filter: guardFilter,
+      update: { $set: setFields, $inc: { revision: 1 } },
+      upsert: false,
+    });
+
+    if ((guarded?.matchedCount ?? 0) > 0) {
+      // We matched exactly the expected version and incremented it atomically.
+      // For the revision guard the new value is expectedRevision + 1; for the
+      // updatedAt guard we don't know it, so read it back.
+      let revision = hasRevisionGuard ? expectedRevision + 1 : undefined;
+      if (revision === undefined) {
+        const after = await runMongoAction('findOne', {
+          collection: PROJECTS_COLLECTION,
+          filter: { userId, id: projectId },
+          projection: { _id: 0, revision: 1 },
+        });
+        revision = typeof after?.document?.revision === 'number' ? after.document.revision : undefined;
+      }
+      return { id: projectId, title, idea, status, archived, updatedAt: now, revision, created: false };
+    }
+
+    // No match: the row either advanced under us (conflict) or no longer exists.
+    const current = await runMongoAction('findOne', {
+      collection: PROJECTS_COLLECTION,
+      filter: { userId, id: projectId },
+      projection: { _id: 0, revision: 1 },
+    });
+    if (current?.document) {
+      return {
+        conflict: true,
+        currentRevision:
+          typeof current.document.revision === 'number' ? current.document.revision : null,
+        id: projectId,
+      };
+    }
+    // Row is gone (remote-deleted) — fall through to a fresh insert below.
   }
 
+  // Unconditional upsert: first save / migration / re-create after a remote
+  // delete. No concurrency guard here by design (the caller has no baseline to
+  // protect), so last-writer-wins is acceptable — no NEWER copy is at risk.
   const result = await runMongoAction('updateOne', {
     collection: PROJECTS_COLLECTION,
     filter: { userId, id: projectId },
     update: {
-      $set: {
-        userId,
-        id: projectId,
-        title,
-        idea,
-        status,
-        archived,
-        deletedAt: null,
-        data: bundle,
-        updatedAt: now,
-      },
+      $set: setFields,
       $setOnInsert: {
         createdAt: createdAt ? new Date(createdAt) : now,
       },
@@ -188,7 +232,15 @@ export async function upsertProject(userId, projectId, bundle, { createdAt, expe
   });
 
   const created = Boolean(result?.upsertedId);
-  const revision = priorRevision === null ? 1 : priorRevision + 1;
+  // Read back the authoritative revision so the returned baseline reflects the
+  // actual post-write value (avoids returning a stale computed number).
+  const after = await runMongoAction('findOne', {
+    collection: PROJECTS_COLLECTION,
+    filter: { userId, id: projectId },
+    projection: { _id: 0, revision: 1 },
+  });
+  const revision =
+    typeof after?.document?.revision === 'number' ? after.document.revision : created ? 1 : undefined;
   return { id: projectId, title, idea, status, archived, updatedAt: now, revision, created };
 }
 

--- a/api/projects.js
+++ b/api/projects.js
@@ -263,7 +263,24 @@ export default async function handler(req, res) {
       }
       // The project id is owner-scoped on the server; ignore any id in the body
       // that disagrees with the URL.
-      const saved = await upsertProject(userId, id, bundle);
+      //
+      // Optimistic concurrency: if the client tells us which server revision it
+      // expects to overwrite (its last-seen baseline) and the server has since
+      // advanced on another device, reject with 409 instead of clobbering the
+      // newer copy. A first-time save (no expectedRevision) is unaffected.
+      const expectedRaw = req.query?.expectedRevision;
+      const expectedRevision =
+        expectedRaw !== undefined && expectedRaw !== '' && Number.isFinite(Number(expectedRaw))
+          ? Number(expectedRaw)
+          : undefined;
+      const saved = await upsertProject(userId, id, bundle, { expectedRevision });
+      if (saved?.conflict) {
+        return json(res, 409, {
+          error: 'revision_conflict',
+          currentRevision: saved.currentRevision,
+          id,
+        });
+      }
       return json(res, 200, { project: saved });
     }
 

--- a/api/projects.js
+++ b/api/projects.js
@@ -273,7 +273,12 @@ export default async function handler(req, res) {
         expectedRaw !== undefined && expectedRaw !== '' && Number.isFinite(Number(expectedRaw))
           ? Number(expectedRaw)
           : undefined;
-      const saved = await upsertProject(userId, id, bundle, { expectedRevision });
+      // Fallback guard for legacy rows that predate the revision counter: the
+      // client sends the updatedAt it last saw instead.
+      const expectedUpdatedAtRaw = req.query?.expectedUpdatedAt;
+      const expectedUpdatedAt =
+        typeof expectedUpdatedAtRaw === 'string' && expectedUpdatedAtRaw ? expectedUpdatedAtRaw : undefined;
+      const saved = await upsertProject(userId, id, bundle, { expectedRevision, expectedUpdatedAt });
       if (saved?.conflict) {
         return json(res, 409, {
           error: 'revision_conflict',

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Download, X, FileText, Package, Copy, Check, Bot } from 'lucide-react';
 import { useProjectStore } from '../store/projectStore';
+import { useProjectSyncStore } from '../store/projectSyncStore';
 import { useToastStore } from '../store/toastStore';
+import { downloadProjectRecoveryBundle } from '../lib/projectRecovery';
+import { AlertTriangle } from 'lucide-react';
 import { parseScreenInventory, screenInventoryToMarkdown } from '../lib/screenInventoryNormalize';
 import { downloadFile } from '../lib/utils/downloadFile';
 import { copyToClipboard } from '../lib/utils/copyToClipboard';
@@ -32,9 +35,14 @@ interface ExportModalProps {
 export function ExportModal({ projectId, onClose }: ExportModalProps) {
     const { getProject, getLatestSpine, getArtifacts, getArtifactVersions } = useProjectStore();
     const { addToast } = useToastStore();
+    const syncInfo = useProjectSyncStore((s) => s.projects[projectId]);
     const [exporting, setExporting] = useState(false);
     // Which card most recently showed a "Copied" confirmation.
     const [copiedKey, setCopiedKey] = useState<string | null>(null);
+    const [recoverySaved, setRecoverySaved] = useState(false);
+    // Surface a durability warning right where the user is about to rely on the
+    // export: their latest changes may not have reached the cloud.
+    const cloudAtRisk = syncInfo?.state === 'error' || syncInfo?.state === 'conflict';
 
     const flashCopied = (key: string) => {
         setCopiedKey(key);
@@ -177,6 +185,35 @@ export function ExportModal({ projectId, onClose }: ExportModalProps) {
                 </div>
 
                 <div className="p-4 space-y-3 overflow-y-auto min-h-0">
+                    {cloudAtRisk && (
+                        <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-amber-900">
+                            <div className="flex items-start gap-2">
+                                <AlertTriangle size={15} className="mt-0.5 shrink-0 text-amber-600" />
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-sm font-medium">
+                                        {syncInfo?.state === 'conflict'
+                                            ? 'This project has an unresolved cloud conflict'
+                                            : 'Recent changes may not have reached the cloud'}
+                                    </p>
+                                    <p className="mt-0.5 text-xs text-amber-800">
+                                        Your work is safe on this device. Download a recovery bundle so
+                                        you have a complete copy regardless of cloud sync.
+                                    </p>
+                                    <button
+                                        onClick={() => {
+                                            const ok = downloadProjectRecoveryBundle(projectId, 'export-cloud-at-risk');
+                                            setRecoverySaved(ok);
+                                        }}
+                                        className="mt-2 inline-flex items-center gap-1 rounded-md bg-amber-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-amber-700"
+                                    >
+                                        {recoverySaved ? <Check size={12} /> : <Download size={12} />}
+                                        {recoverySaved ? 'Recovery bundle saved' : 'Download recovery bundle'}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
                     {/* --- EXPORT: whole-project bundles --- */}
                     <span className="text-xs font-medium text-neutral-400 uppercase tracking-wider">Export</span>
 

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -42,6 +42,7 @@ import { SECTION_TITLES } from '../lib/prompts/prdSectionPrompts';
 import type { SectionId } from '../lib/schemas/prdSchemas';
 import type { Branch, PipelineStage, FeedbackItem } from '../types';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
+import { ProjectCloudStatus, ProjectConflictBanner } from './sync/ProjectSyncStatus';
 
 export function ProjectWorkspace() {
     const { projectId } = useParams<{ projectId: string }>();
@@ -630,6 +631,11 @@ export function ProjectWorkspace() {
                                     : `${getVersionLabel(activeSpine.id)} ${activeSpine.isFinal ? '(FINAL)' : ''}`
                             : 'Initializing...'}
                     </span>
+                    {projectId !== DEMO_PROJECT_ID && (
+                        <span className="hidden md:inline-flex shrink-0">
+                            <ProjectCloudStatus projectId={projectId} signedIn={!!authUser} />
+                        </span>
+                    )}
                 </div>
 
                 {/* Primary nav actions — always visible */}
@@ -877,6 +883,15 @@ export function ProjectWorkspace() {
                     <span>
                         You&apos;re viewing the demo project. Regenerating or refining requires your own Gemini API key — add one in Settings to customize.
                     </span>
+                </div>
+            )}
+
+            {/* Cross-device conflict banner: the cloud copy changed on another
+                device while this device has unsynced edits. Blocks silent
+                overwrite — the user picks keep-local / use-cloud / download. */}
+            {projectId !== DEMO_PROJECT_ID && authUser && (
+                <div className="shrink-0 px-4 py-2 z-10 empty:hidden">
+                    <ProjectConflictBanner projectId={projectId} />
                 </div>
             )}
 

--- a/src/components/sync/ProjectSyncStatus.tsx
+++ b/src/components/sync/ProjectSyncStatus.tsx
@@ -1,17 +1,31 @@
-import { Cloud, CloudOff, RefreshCw, AlertTriangle, Check, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import {
+  Cloud, CloudOff, RefreshCw, AlertTriangle, Check, Loader2, GitMerge, Download,
+} from 'lucide-react';
 import { useProjectSyncStore } from '../../store/projectSyncStore';
-import { refreshProjectsFromServer } from '../../store/projectServerSync';
+import {
+  refreshProjectsFromServer,
+  resolveConflictUseCloud,
+  resolveConflictKeepLocal,
+} from '../../store/projectServerSync';
+import { downloadProjectRecoveryBundle } from '../../lib/projectRecovery';
 
 // UI states for server-backed project sync. Reads the projectSyncStore (driven
 // by projectServerSync.ts) and renders: loading, offline, sync-failed (with
-// retry), and a one-line "synced / N migrated" steady state. A failed save
+// retry), a one-line "synced / N migrated" steady state, and — new in phase 2 —
+// per-project cloud durability + cross-device conflict resolution. A failed save
 // never loses local data, so the error copy is reassuring, not alarming.
+
+function conflictCount(projects: Record<string, { state: string }>): number {
+  return Object.values(projects).filter((p) => p.state === 'conflict').length;
+}
 
 export function SyncStatusBanner({ signedIn }: { signedIn: boolean }) {
   const phase = useProjectSyncStore((s) => s.phase);
   const online = useProjectSyncStore((s) => s.online);
   const error = useProjectSyncStore((s) => s.error);
   const migratedCount = useProjectSyncStore((s) => s.migratedCount);
+  const conflicts = useProjectSyncStore((s) => conflictCount(s.projects));
 
   if (!signedIn) return null;
 
@@ -48,6 +62,15 @@ export function SyncStatusBanner({ signedIn }: { signedIn: boolean }) {
   }
 
   if (phase === 'ready') {
+    if (conflicts > 0) {
+      return (
+        <Row tone="amber" icon={<GitMerge size={13} />}>
+          {conflicts === 1
+            ? '1 project changed on another device — resolve it below.'
+            : `${conflicts} projects changed on another device — resolve them below.`}
+        </Row>
+      );
+    }
     return (
       <Row tone="neutral" icon={<Cloud size={13} />}>
         {migratedCount > 0
@@ -88,14 +111,186 @@ function Row({
 export function ProjectSyncDot({ projectId }: { projectId: string }) {
   const info = useProjectSyncStore((s) => s.projects[projectId]);
   if (!info) return null;
+  if (info.state === 'conflict') {
+    return <GitMerge size={12} className="text-amber-500" aria-label="Cloud conflict — needs resolution" />;
+  }
   if (info.state === 'saving') {
     return <Loader2 size={12} className="text-neutral-500 animate-spin" aria-label="Saving" />;
   }
   if (info.state === 'dirty') {
-    return <Cloud size={12} className="text-neutral-600" aria-label="Unsaved changes" />;
+    return <Cloud size={12} className="text-neutral-600" aria-label="Unsaved to cloud" />;
   }
   if (info.state === 'error') {
-    return <AlertTriangle size={12} className="text-amber-500" aria-label="Sync failed" />;
+    return <AlertTriangle size={12} className="text-amber-500" aria-label="Cloud sync failed" />;
   }
-  return <Check size={12} className="text-emerald-500/70" aria-label="Saved" />;
+  return <Check size={12} className="text-emerald-500/70" aria-label="Synced to cloud" />;
+}
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return 'just now';
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Compact per-project cloud-durability status for a project header. Makes the
+ * distinction visible: saved-on-device vs synced-to-cloud vs pending vs failed
+ * vs conflict — so "saved locally" is never mistaken for "safe in the cloud".
+ */
+export function ProjectCloudStatus({
+  projectId,
+  signedIn,
+}: {
+  projectId: string;
+  signedIn: boolean;
+}) {
+  const info = useProjectSyncStore((s) => s.projects[projectId]);
+  const online = useProjectSyncStore((s) => s.online);
+  if (!signedIn) return null;
+
+  // No sync record yet: saved locally, cloud state not yet known.
+  const state = info?.state;
+  const savedAt = info?.lastCloudSavedAt;
+
+  let icon: React.ReactNode;
+  let label: string;
+  let tone: string;
+  let title: string | undefined;
+
+  if (state === 'conflict') {
+    icon = <GitMerge size={12} />;
+    label = 'Cloud conflict';
+    tone = 'text-amber-400';
+    title = 'This project changed on another device. Resolve the conflict to sync.';
+  } else if (!online) {
+    icon = <CloudOff size={12} />;
+    label = 'Offline';
+    tone = 'text-amber-400';
+    title = 'Offline — changes are on this device and sync when you reconnect.';
+  } else if (state === 'error') {
+    icon = <AlertTriangle size={12} />;
+    label = 'Cloud save failed';
+    tone = 'text-amber-400';
+    title = info?.lastCloudSaveError
+      ? `Last cloud save failed: ${info.lastCloudSaveError}`
+      : 'Last cloud save failed — changes are safe on this device.';
+  } else if (state === 'saving') {
+    icon = <Loader2 size={12} className="animate-spin" />;
+    label = 'Saving to cloud…';
+    tone = 'text-neutral-400';
+  } else if (state === 'dirty') {
+    icon = <Cloud size={12} />;
+    label = 'Cloud sync pending';
+    tone = 'text-neutral-400';
+    title = 'Changes saved on this device; not yet synced to the cloud.';
+  } else if (state === 'saved') {
+    icon = <Check size={12} />;
+    label = savedAt ? `Synced ${relativeTime(savedAt)}` : 'Synced to cloud';
+    tone = 'text-emerald-500/80';
+    title = savedAt ? `Last synced to the cloud at ${new Date(savedAt).toLocaleString()}` : undefined;
+  } else {
+    icon = <Cloud size={12} />;
+    label = 'Saved on this device';
+    tone = 'text-neutral-500';
+    title = 'Saved on this device. Cloud sync status not yet known.';
+  }
+
+  return (
+    <span className={`inline-flex items-center gap-1 text-[11px] ${tone}`} title={title}>
+      <span className="shrink-0">{icon}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+/**
+ * Cross-device conflict banner: shown when a project changed on another device
+ * while this device also has unsynced edits. Offers the three safe resolutions —
+ * keep local (overwrite cloud), use cloud (discard local), or download a
+ * recovery copy of the local work first. Never resolves silently.
+ */
+export function ProjectConflictBanner({ projectId }: { projectId: string }) {
+  const info = useProjectSyncStore((s) => s.projects[projectId]);
+  const [busy, setBusy] = useState<null | 'local' | 'cloud'>(null);
+  const [downloaded, setDownloaded] = useState(false);
+
+  if (!info || info.state !== 'conflict') return null;
+
+  const keepLocal = async () => {
+    if (busy) return;
+    setBusy('local');
+    try {
+      await resolveConflictKeepLocal(projectId);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const useCloud = async () => {
+    if (busy) return;
+    if (
+      !window.confirm(
+        'Replace this device\'s copy with the cloud version? Your local changes will be discarded. Consider downloading a recovery copy first.',
+      )
+    ) {
+      return;
+    }
+    setBusy('cloud');
+    try {
+      await resolveConflictUseCloud(projectId);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const download = () => {
+    const ok = downloadProjectRecoveryBundle(projectId, 'cross-device-conflict');
+    setDownloaded(ok);
+  };
+
+  return (
+    <div className="rounded-lg border border-amber-700/60 bg-amber-900/20 p-3 text-amber-100">
+      <div className="flex items-start gap-2">
+        <GitMerge size={16} className="mt-0.5 shrink-0 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium">Cloud version changed on another device</p>
+          <p className="mt-0.5 text-xs text-amber-200/80">
+            This project was updated elsewhere while you also have unsynced changes here.
+            Choose which copy to keep — nothing is overwritten until you decide.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <button
+              onClick={keepLocal}
+              disabled={!!busy}
+              className="inline-flex items-center gap-1 rounded-md bg-amber-600/90 px-2.5 py-1 text-xs font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+            >
+              {busy === 'local' ? <Loader2 size={12} className="animate-spin" /> : null}
+              Keep this device's version
+            </button>
+            <button
+              onClick={useCloud}
+              disabled={!!busy}
+              className="inline-flex items-center gap-1 rounded-md border border-amber-600/60 px-2.5 py-1 text-xs font-medium text-amber-100 hover:bg-amber-800/40 disabled:opacity-50"
+            >
+              {busy === 'cloud' ? <Loader2 size={12} className="animate-spin" /> : null}
+              Use cloud version
+            </button>
+            <button
+              onClick={download}
+              disabled={!!busy}
+              className="inline-flex items-center gap-1 rounded-md border border-amber-700/50 px-2.5 py-1 text-xs font-medium text-amber-200 hover:bg-amber-800/30 disabled:opacity-50"
+            >
+              {downloaded ? <Check size={12} /> : <Download size={12} />}
+              {downloaded ? 'Downloaded' : 'Download local copy'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/lib/__tests__/projectSyncMeta.test.ts
+++ b/src/lib/__tests__/projectSyncMeta.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getProjectSyncMeta,
+  setProjectSyncMeta,
+  removeProjectSyncMeta,
+  getAllProjectSyncMeta,
+  isServerNewer,
+} from '../projectSyncMeta';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('projectSyncMeta persistence', () => {
+  it('returns an empty object for an unknown project (back-compat)', () => {
+    expect(getProjectSyncMeta('u1', 'p1')).toEqual({});
+  });
+
+  it('shallow-merges patches and survives a reload (durable baseline)', () => {
+    setProjectSyncMeta('u1', 'p1', { lastSeenServerRevision: 3, hasUnsyncedChanges: true });
+    setProjectSyncMeta('u1', 'p1', { lastCloudSavedAt: 1234 });
+    // A fresh read (simulating a reload) sees both patches.
+    expect(getProjectSyncMeta('u1', 'p1')).toEqual({
+      lastSeenServerRevision: 3,
+      hasUnsyncedChanges: true,
+      lastCloudSavedAt: 1234,
+    });
+  });
+
+  it('namespaces per user — one user cannot read another\'s meta', () => {
+    setProjectSyncMeta('u1', 'p1', { lastSeenServerRevision: 5 });
+    expect(getProjectSyncMeta('u2', 'p1')).toEqual({});
+    expect(getAllProjectSyncMeta('u2')).toEqual({});
+  });
+
+  it('lets null explicitly clear lastCloudSaveError', () => {
+    setProjectSyncMeta('u1', 'p1', { lastCloudSaveError: 'boom' });
+    setProjectSyncMeta('u1', 'p1', { lastCloudSaveError: null });
+    expect(getProjectSyncMeta('u1', 'p1').lastCloudSaveError).toBeNull();
+  });
+
+  it('removeProjectSyncMeta drops a single project', () => {
+    setProjectSyncMeta('u1', 'p1', { lastSeenServerRevision: 1 });
+    setProjectSyncMeta('u1', 'p2', { lastSeenServerRevision: 2 });
+    removeProjectSyncMeta('u1', 'p1');
+    expect(getProjectSyncMeta('u1', 'p1')).toEqual({});
+    expect(getProjectSyncMeta('u1', 'p2').lastSeenServerRevision).toBe(2);
+  });
+});
+
+describe('isServerNewer', () => {
+  it('prefers the monotonic revision counter', () => {
+    expect(isServerNewer({ revision: 4 }, { lastSeenServerRevision: 3 })).toBe(true);
+    expect(isServerNewer({ revision: 3 }, { lastSeenServerRevision: 3 })).toBe(false);
+    expect(isServerNewer({ revision: 2 }, { lastSeenServerRevision: 3 })).toBe(false);
+  });
+
+  it('falls back to updatedAt when revisions are unavailable', () => {
+    expect(
+      isServerNewer({ updatedAt: '2026-02-02' }, { lastSeenServerUpdatedAt: '2026-01-01' }),
+    ).toBe(true);
+    expect(
+      isServerNewer({ updatedAt: '2026-01-01' }, { lastSeenServerUpdatedAt: '2026-02-02' }),
+    ).toBe(false);
+  });
+
+  it('returns false when there is no baseline to compare against', () => {
+    expect(isServerNewer({ revision: 9, updatedAt: '2026-02-02' }, {})).toBe(false);
+  });
+});

--- a/src/lib/__tests__/projectsClient.test.ts
+++ b/src/lib/__tests__/projectsClient.test.ts
@@ -67,6 +67,22 @@ describe('projectsClient', () => {
     await expect(saveProject('p1', bundle)).rejects.toThrow(/projects_failed/);
   });
 
+  it('saveProject sends expectedRevision as a query param (conditional write)', async () => {
+    const fetchMock = vi.fn(async () => okJson({ project: { id: 'p1', revision: 6 } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await saveProject('p1', bundle, { expectedRevision: 5 });
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toBe('/api/projects?id=p1&expectedRevision=5');
+  });
+
+  it('saveProject throws a typed RevisionConflictError on 409 (stale push blocked)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errJson(409, { error: 'revision_conflict', currentRevision: 9 })));
+    await expect(saveProject('p1', bundle, { expectedRevision: 4 })).rejects.toMatchObject({
+      code: 'revision_conflict',
+      currentRevision: 9,
+    });
+  });
+
   it('deleteProject tolerates a 404 (already gone)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => errJson(404, { error: 'not_found' })));
     await expect(deleteProject('p1')).resolves.toBeUndefined();

--- a/src/lib/__tests__/projectsClient.test.ts
+++ b/src/lib/__tests__/projectsClient.test.ts
@@ -75,6 +75,24 @@ describe('projectsClient', () => {
     expect(url).toBe('/api/projects?id=p1&expectedRevision=5');
   });
 
+  it('saveProject falls back to expectedUpdatedAt when there is no revision baseline', async () => {
+    const fetchMock = vi.fn(async () => okJson({ project: { id: 'p1', revision: 1 } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await saveProject('p1', bundle, { expectedUpdatedAt: '2026-01-01T00:00:00.000Z' });
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toContain('expectedUpdatedAt=2026-01-01');
+    expect(url).not.toContain('expectedRevision');
+  });
+
+  it('saveProject prefers expectedRevision over expectedUpdatedAt when both are given', async () => {
+    const fetchMock = vi.fn(async () => okJson({ project: { id: 'p1', revision: 3 } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await saveProject('p1', bundle, { expectedRevision: 2, expectedUpdatedAt: '2026-01-01T00:00:00.000Z' });
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toContain('expectedRevision=2');
+    expect(url).not.toContain('expectedUpdatedAt');
+  });
+
   it('saveProject throws a typed RevisionConflictError on 409 (stale push blocked)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => errJson(409, { error: 'revision_conflict', currentRevision: 9 })));
     await expect(saveProject('p1', bundle, { expectedRevision: 4 })).rejects.toMatchObject({

--- a/src/lib/projectBundle.ts
+++ b/src/lib/projectBundle.ts
@@ -111,6 +111,43 @@ export function mergeBundlesIntoSource(
 }
 
 /**
+ * REPLACE the slices for each bundle's project id with the server copy. Unlike
+ * mergeBundlesIntoSource (which is additive and lets local win), this overwrites
+ * existing local slices — used ONLY for a safe server-newer refresh when the
+ * local copy has no unsynced changes, or when the user explicitly chooses "use
+ * the cloud version" to resolve a conflict. Never call this over dirty local
+ * work without the user's consent. Returns the updated slice maps.
+ */
+export function overwriteBundlesIntoSource(
+  source: BundleSource,
+  bundles: ProjectBundle[],
+): { next: BundleSource; replacedIds: string[] } {
+  const next: BundleSource = {
+    projects: { ...source.projects },
+    spineVersions: { ...source.spineVersions },
+    historyEvents: { ...source.historyEvents },
+    branches: { ...source.branches },
+    artifacts: { ...source.artifacts },
+    artifactVersions: { ...source.artifactVersions },
+    feedbackItems: { ...source.feedbackItems },
+    tasks: { ...source.tasks },
+    workflowRuns: { ...source.workflowRuns },
+  };
+  const replacedIds: string[] = [];
+  for (const bundle of bundles) {
+    if (!isValidBundle(bundle)) continue;
+    const id = bundle.project.id;
+    next.projects[id] = bundle.project;
+    for (const key of ARRAY_COLLECTIONS) {
+      const value = (bundle as unknown as Record<string, unknown>)[key];
+      (next[key] as Record<string, unknown[]>)[id] = Array.isArray(value) ? (value as unknown[]) : [];
+    }
+    replacedIds.push(id);
+  }
+  return { next, replacedIds };
+}
+
+/**
  * Reference-equality check for whether project `projectId`'s slices changed
  * between two store snapshots. Relies on the store's immutable updates (spreads),
  * so a changed slice is a new reference. Used to decide which project to push.

--- a/src/lib/projectRecovery.ts
+++ b/src/lib/projectRecovery.ts
@@ -1,0 +1,91 @@
+// Recovery bundle: a self-contained JSON download of a single project's LOCAL
+// state, for the cases where cloud durability is in doubt — a failed cloud save,
+// an expired session, a network outage, a server body-limit rejection, or an
+// unresolved cross-device conflict. It lets the user get their work off the
+// device even when sync can't, and is enough to restore or debug the project.
+//
+// This is deliberately the local-first escape hatch: it never touches the
+// network and never mutates any state. It reuses the same ProjectBundle shape
+// the sync layer transports, plus a small envelope so the file is
+// self-describing.
+
+import { useProjectStore } from '../store/projectStore';
+import { extractProjectBundle, type BundleSource, type ProjectBundle } from './projectBundle';
+
+const RECOVERY_FORMAT = 'synapse-project-recovery/v1';
+
+export interface ProjectRecoveryBundle {
+  format: typeof RECOVERY_FORMAT;
+  exportedAt: string;
+  projectId: string;
+  projectName: string;
+  /** Why the recovery download was offered, for debugging. */
+  reason?: string;
+  bundle: ProjectBundle;
+}
+
+function bundleSourceOfStore(): BundleSource {
+  const state = useProjectStore.getState();
+  return {
+    projects: state.projects,
+    spineVersions: state.spineVersions,
+    historyEvents: state.historyEvents,
+    branches: state.branches,
+    artifacts: state.artifacts,
+    artifactVersions: state.artifactVersions,
+    feedbackItems: state.feedbackItems,
+    tasks: state.tasks,
+    workflowRuns: state.workflowRuns,
+  };
+}
+
+/** Assemble a recovery bundle for one project from the live local store, or null
+ *  if the project doesn't exist locally. Pure w.r.t. the network. */
+export function buildProjectRecoveryBundle(
+  projectId: string,
+  reason?: string,
+): ProjectRecoveryBundle | null {
+  const bundle = extractProjectBundle(bundleSourceOfStore(), projectId);
+  if (!bundle) return null;
+  return {
+    format: RECOVERY_FORMAT,
+    exportedAt: new Date().toISOString(),
+    projectId,
+    projectName: bundle.project.name || 'Untitled project',
+    reason,
+    bundle,
+  };
+}
+
+function slugify(name: string): string {
+  return (name || 'project')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'project';
+}
+
+/**
+ * Trigger a browser download of a project's recovery bundle. Returns true if the
+ * project existed and a download was started. Safe no-op outside the browser.
+ */
+export function downloadProjectRecoveryBundle(projectId: string, reason?: string): boolean {
+  const recovery = buildProjectRecoveryBundle(projectId, reason);
+  if (!recovery) return false;
+  if (typeof document === 'undefined' || typeof URL === 'undefined' || !URL.createObjectURL) {
+    return false;
+  }
+  const json = JSON.stringify(recovery, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const stamp = recovery.exportedAt.slice(0, 10);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `synapse-recovery-${slugify(recovery.projectName)}-${stamp}.json`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke on the next tick so the download has a chance to start.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+  return true;
+}

--- a/src/lib/projectSyncMeta.ts
+++ b/src/lib/projectSyncMeta.ts
@@ -1,0 +1,134 @@
+// Durable, per-user, per-project sync metadata — kept SEPARATE from the
+// user-authored project content (the Zustand `projects` slice) so it never
+// contaminates a bundle or an export. This is the local record of what we last
+// knew about the server copy of each project, and whether local edits are still
+// waiting to reach the cloud.
+//
+// Why a dedicated localStorage map (not the in-memory projectSyncStore): the
+// sync store is reset on every reload, but cross-device conflict detection needs
+// a baseline that SURVIVES a reload — "the last server revision this device
+// observed" and "does this device have unsynced edits". Without a durable
+// baseline, a stale client can't tell whether the server advanced underneath it.
+//
+// Leaf module (localStorage only), mirroring projectMigration.ts's per-user
+// namespacing. Back-compat: a project with no stored meta simply returns {} and
+// every field is optional, so legacy/anonymous data behaves exactly as before.
+
+const META_PREFIX = 'synapse-project-sync-meta::u:';
+
+export interface ProjectSyncMeta {
+  /** Server `revision` counter this device last observed (pulled or saved). */
+  lastSeenServerRevision?: number;
+  /** Server `updatedAt` (ISO string) this device last observed. Fallback when
+   *  the server row predates the revision counter. */
+  lastSeenServerUpdatedAt?: string;
+  /** Epoch ms of the last successful push of this project to the cloud. */
+  lastCloudSavedAt?: number;
+  /** Message from the last failed cloud save, or null once a save succeeds. */
+  lastCloudSaveError?: string | null;
+  /** True while local edits exist that have not been confirmed saved to the
+   *  cloud. Durable across reloads so an offline edit isn't forgotten. */
+  hasUnsyncedChanges?: boolean;
+  /** True when the server copy advanced beyond `lastSeenServerRevision` while
+   *  this device also has unsynced edits — a genuine cross-device conflict. */
+  conflict?: boolean;
+}
+
+type MetaMap = Record<string, ProjectSyncMeta>;
+
+function keyFor(userId: string): string {
+  return `${META_PREFIX}${userId}`;
+}
+
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable / full — non-fatal for sync bookkeeping.
+  }
+}
+
+/** Read the whole per-user meta map (defensive; never throws). */
+export function getAllProjectSyncMeta(userId: string): MetaMap {
+  if (!userId) return {};
+  const raw = safeGet(keyFor(userId));
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as MetaMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Read one project's durable sync meta (empty object if none recorded). */
+export function getProjectSyncMeta(userId: string, projectId: string): ProjectSyncMeta {
+  if (!userId || !projectId) return {};
+  const map = getAllProjectSyncMeta(userId);
+  return map[projectId] ?? {};
+}
+
+/**
+ * Shallow-merge a patch into a project's durable sync meta. Passing `undefined`
+ * for a field leaves the existing value; pass an explicit value (including
+ * `null` for `lastCloudSaveError`) to overwrite. Returns the merged record.
+ */
+export function setProjectSyncMeta(
+  userId: string,
+  projectId: string,
+  patch: Partial<ProjectSyncMeta>,
+): ProjectSyncMeta {
+  if (!userId || !projectId) return {};
+  const map = getAllProjectSyncMeta(userId);
+  const current = map[projectId] ?? {};
+  const next: ProjectSyncMeta = { ...current };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) continue;
+    (next as Record<string, unknown>)[k] = v;
+  }
+  map[projectId] = next;
+  safeSet(keyFor(userId), JSON.stringify(map));
+  return next;
+}
+
+/** Remove a project's durable sync meta (e.g. after a hard delete). */
+export function removeProjectSyncMeta(userId: string, projectId: string): void {
+  if (!userId || !projectId) return;
+  const map = getAllProjectSyncMeta(userId);
+  if (!(projectId in map)) return;
+  delete map[projectId];
+  safeSet(keyFor(userId), JSON.stringify(map));
+}
+
+/**
+ * Compare a server revision/timestamp against the last-seen baseline. Prefers
+ * the monotonic `revision` counter; falls back to `updatedAt` string ordering
+ * when a revision isn't available on either side. Returns false when there's no
+ * baseline to compare against (we can't claim "newer" without a reference).
+ */
+export function isServerNewer(
+  server: { revision?: number | null; updatedAt?: string | null },
+  meta: ProjectSyncMeta,
+): boolean {
+  const serverRev = typeof server.revision === 'number' ? server.revision : null;
+  const seenRev =
+    typeof meta.lastSeenServerRevision === 'number' ? meta.lastSeenServerRevision : null;
+  if (serverRev !== null && seenRev !== null) {
+    return serverRev > seenRev;
+  }
+  const serverAt = typeof server.updatedAt === 'string' ? server.updatedAt : null;
+  const seenAt =
+    typeof meta.lastSeenServerUpdatedAt === 'string' ? meta.lastSeenServerUpdatedAt : null;
+  if (serverAt !== null && seenAt !== null) {
+    return serverAt > seenAt;
+  }
+  return false;
+}

--- a/src/lib/projectsClient.ts
+++ b/src/lib/projectsClient.ts
@@ -101,11 +101,15 @@ export class RevisionConflictError extends Error {
 export async function saveProject(
   id: string,
   bundle: ProjectBundle,
-  opts: { expectedRevision?: number } = {},
+  opts: { expectedRevision?: number; expectedUpdatedAt?: string } = {},
 ): Promise<ServerProjectSummary> {
   const params = new URLSearchParams({ id });
   if (typeof opts.expectedRevision === 'number') {
     params.set('expectedRevision', String(opts.expectedRevision));
+  } else if (opts.expectedUpdatedAt) {
+    // Legacy fallback: guard on the last-seen updatedAt when the row has no
+    // revision baseline yet.
+    params.set('expectedUpdatedAt', opts.expectedUpdatedAt);
   }
   const resp = await fetch(`${API_BASE}?${params.toString()}`, {
     method: 'PUT',

--- a/src/lib/projectsClient.ts
+++ b/src/lib/projectsClient.ts
@@ -79,17 +79,51 @@ export async function fetchProject(id: string): Promise<ServerProject | null> {
   return data.project ?? null;
 }
 
-/** Create-or-update (upsert) a project from a bundle. */
-export async function saveProject(id: string, bundle: ProjectBundle): Promise<ServerProjectSummary> {
-  const data = await requestJson<{ project: ServerProjectSummary }>(
-    `${API_BASE}?id=${encodeURIComponent(id)}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ bundle }),
-    },
-    'save_failed',
-  );
+/** Raised when a conditional save is rejected because the server copy advanced
+ *  on another device. Carries the current server revision so the client can
+ *  mark the project as conflicted. */
+export class RevisionConflictError extends Error {
+  code = 'revision_conflict' as const;
+  currentRevision?: number;
+  constructor(currentRevision?: number) {
+    super('revision_conflict');
+    this.name = 'RevisionConflictError';
+    this.currentRevision = currentRevision;
+  }
+}
+
+/**
+ * Create-or-update (upsert) a project from a bundle. When `expectedRevision` is
+ * supplied, the save is conditional: the server rejects it (throwing
+ * `RevisionConflictError`) if the stored revision no longer matches, so a stale
+ * client can't blindly overwrite a newer copy saved on another device.
+ */
+export async function saveProject(
+  id: string,
+  bundle: ProjectBundle,
+  opts: { expectedRevision?: number } = {},
+): Promise<ServerProjectSummary> {
+  const params = new URLSearchParams({ id });
+  if (typeof opts.expectedRevision === 'number') {
+    params.set('expectedRevision', String(opts.expectedRevision));
+  }
+  const resp = await fetch(`${API_BASE}?${params.toString()}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ bundle }),
+  });
+  if (resp.status === 409) {
+    let body: { currentRevision?: number } | null = null;
+    try {
+      body = (await resp.json()) as { currentRevision?: number };
+    } catch {
+      body = null;
+    }
+    throw new RevisionConflictError(body?.currentRevision);
+  }
+  if (!resp.ok) throw await parseError(resp, 'save_failed');
+  const data = (await resp.json()) as { project: ServerProjectSummary };
   return data.project;
 }
 

--- a/src/store/__tests__/projectServerSync.test.ts
+++ b/src/store/__tests__/projectServerSync.test.ts
@@ -247,6 +247,31 @@ describe('push guard → a stale push is rejected and becomes a conflict', () =>
   });
 });
 
+describe('dirty project is retried on reconcile after a reload', () => {
+  it('re-pushes a pending (dirty, not server-newer) project instead of leaving it stuck', async () => {
+    seedLocalProject('p1', 'Local p1');
+    // A prior save failed / the tab closed after schedulePush — durable dirty
+    // flag survived the reload; server has NOT advanced.
+    setProjectSyncMeta('user-a', 'p1', { lastSeenServerRevision: 2, hasUnsyncedChanges: true });
+    client.fetchProjectList.mockResolvedValue([{ id: 'p1', revision: 2 }]);
+    client.saveProject.mockResolvedValue({ id: 'p1', revision: 3 });
+
+    startProjectSync('user-a');
+
+    await vi.waitFor(() => {
+      expect(client.saveProject).toHaveBeenCalledWith(
+        'p1',
+        expect.objectContaining({ project: expect.any(Object) }),
+        expect.objectContaining({ expectedRevision: 2 }),
+      );
+    });
+    // The pending upload cleared.
+    await vi.waitFor(() => {
+      expect(getProjectSyncMeta('user-a', 'p1').hasUnsyncedChanges).toBe(false);
+    });
+  });
+});
+
 describe('cloud save failure exposes unsynced / failed durability state', () => {
   it('sets an error state and records the failure without dropping local data', async () => {
     seedLocalProject('p1', 'Local p1');

--- a/src/store/__tests__/projectServerSync.test.ts
+++ b/src/store/__tests__/projectServerSync.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../lib/projectsClient', () => client);
 import { useProjectStore } from '../projectStore';
 import { useProjectSyncStore } from '../projectSyncStore';
 import { startProjectSync, stopProjectSync } from '../projectServerSync';
+import { setProjectSyncMeta, getProjectSyncMeta } from '../../lib/projectSyncMeta';
 import type { ProjectBundle } from '../../lib/projectBundle';
 
 function emptyState() {
@@ -162,5 +163,115 @@ describe('live local changes push (debounced) after the initial reconcile', () =
     await vi.advanceTimersByTimeAsync(2000); // past the push debounce
 
     expect(client.saveProject).toHaveBeenCalledWith(projectId, expect.objectContaining({ project: expect.any(Object) }), expect.anything());
+  });
+});
+
+function seedLocalProject(id: string, name: string) {
+  useProjectStore.setState({
+    ...emptyState(),
+    projects: { [id]: { id, name, createdAt: 1 } },
+    spineVersions: { [id]: [] },
+  });
+}
+
+describe('server-newer + local clean → safe refresh (no data loss)', () => {
+  it('overwrites the clean local copy with the newer server copy and re-baselines', async () => {
+    seedLocalProject('p1', 'Local p1');
+    // Baseline: we last saw revision 1 and have no unsynced edits.
+    setProjectSyncMeta('user-a', 'p1', { lastSeenServerRevision: 1, hasUnsyncedChanges: false });
+
+    client.fetchProjectList.mockResolvedValue([{ id: 'p1', revision: 2, updatedAt: '2026-02-02' }]);
+    client.fetchProject.mockResolvedValue({ id: 'p1', revision: 2, data: serverBundle('p1') });
+
+    startProjectSync('user-a');
+
+    await vi.waitFor(() => {
+      expect(useProjectStore.getState().projects['p1']?.name).toBe('Server p1');
+    });
+    expect(useProjectSyncStore.getState().projects['p1']?.state).toBe('saved');
+    expect(getProjectSyncMeta('user-a', 'p1').lastSeenServerRevision).toBe(2);
+    expect(getProjectSyncMeta('user-a', 'p1').conflict).toBe(false);
+  });
+});
+
+describe('server-newer + local dirty → conflict (client B does NOT overwrite client A)', () => {
+  it('flags conflict and preserves BOTH the local edits and the server copy', async () => {
+    // Client B has an older local copy WITH unsynced edits.
+    seedLocalProject('p1', 'Local edit on device B');
+    setProjectSyncMeta('user-a', 'p1', { lastSeenServerRevision: 1, hasUnsyncedChanges: true });
+
+    // Client A already saved a newer revision to the server.
+    client.fetchProjectList.mockResolvedValue([{ id: 'p1', revision: 5, updatedAt: '2026-03-03' }]);
+
+    startProjectSync('user-a');
+
+    await vi.waitFor(() => {
+      expect(useProjectSyncStore.getState().projects['p1']?.state).toBe('conflict');
+    });
+    // Local edits are untouched — not silently overwritten by the server copy.
+    expect(useProjectStore.getState().projects['p1']?.name).toBe('Local edit on device B');
+    // We did NOT pull/overwrite (no full fetch for a conflicted project).
+    expect(client.fetchProject).not.toHaveBeenCalled();
+    // Durable conflict recorded so it survives a reload.
+    expect(getProjectSyncMeta('user-a', 'p1').conflict).toBe(true);
+  });
+});
+
+describe('push guard → a stale push is rejected and becomes a conflict', () => {
+  it('marks conflict (not a plain error) and keeps local data when the server advanced', async () => {
+    seedLocalProject('p1', 'Local p1');
+    // We have a baseline and are in sync at reconcile time.
+    setProjectSyncMeta('user-a', 'p1', { lastSeenServerRevision: 3, hasUnsyncedChanges: false });
+    client.fetchProjectList.mockResolvedValue([{ id: 'p1', revision: 3, updatedAt: '2026-01-01' }]);
+
+    startProjectSync('user-a');
+    await vi.waitFor(() => {
+      expect(useProjectSyncStore.getState().phase).toBe('ready');
+    });
+
+    // The server advances on another device; our conditional push is rejected.
+    client.saveProject.mockRejectedValue(new client.RevisionConflictError(9));
+
+    vi.useFakeTimers();
+    // A local edit to p1 schedules a push.
+    useProjectStore.getState().setProjectStage('p1', 'workspace');
+    await vi.advanceTimersByTimeAsync(2000);
+    vi.useRealTimers();
+
+    await vi.waitFor(() => {
+      expect(useProjectSyncStore.getState().projects['p1']?.state).toBe('conflict');
+    });
+    // Local data preserved.
+    expect(useProjectStore.getState().projects['p1']).toBeTruthy();
+    expect(getProjectSyncMeta('user-a', 'p1').conflict).toBe(true);
+  });
+});
+
+describe('cloud save failure exposes unsynced / failed durability state', () => {
+  it('sets an error state and records the failure without dropping local data', async () => {
+    seedLocalProject('p1', 'Local p1');
+    setProjectSyncMeta('user-a', 'p1', { lastSeenServerRevision: 2, hasUnsyncedChanges: false });
+    client.fetchProjectList.mockResolvedValue([{ id: 'p1', revision: 2 }]);
+
+    startProjectSync('user-a');
+    await vi.waitFor(() => {
+      expect(useProjectSyncStore.getState().phase).toBe('ready');
+    });
+
+    client.saveProject.mockRejectedValue(new Error('payload_too_large'));
+
+    vi.useFakeTimers();
+    useProjectStore.getState().setProjectStage('p1', 'workspace');
+    await vi.advanceTimersByTimeAsync(2000);
+    vi.useRealTimers();
+
+    await vi.waitFor(() => {
+      expect(useProjectSyncStore.getState().projects['p1']?.state).toBe('error');
+    });
+    const info = useProjectSyncStore.getState().projects['p1'];
+    expect(info?.lastCloudSaveError).toBe('payload_too_large');
+    // Local data intact + durable unsynced flag set.
+    expect(useProjectStore.getState().projects['p1']).toBeTruthy();
+    expect(getProjectSyncMeta('user-a', 'p1').hasUnsyncedChanges).toBe(true);
   });
 });

--- a/src/store/__tests__/projectServerSync.test.ts
+++ b/src/store/__tests__/projectServerSync.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock the server transport so we can drive reconcile/push without a backend.
-const client = vi.hoisted(() => ({
-  fetchProjectList: vi.fn(),
-  fetchProject: vi.fn(),
-  saveProject: vi.fn(),
-  deleteProject: vi.fn(),
-}));
+const client = vi.hoisted(() => {
+  class RevisionConflictError extends Error {
+    code = 'revision_conflict' as const;
+    currentRevision?: number;
+    constructor(currentRevision?: number) {
+      super('revision_conflict');
+      this.name = 'RevisionConflictError';
+      this.currentRevision = currentRevision;
+    }
+  }
+  return {
+    fetchProjectList: vi.fn(),
+    fetchProject: vi.fn(),
+    saveProject: vi.fn(),
+    deleteProject: vi.fn(),
+    RevisionConflictError,
+  };
+});
 vi.mock('../../lib/projectsClient', () => client);
 
 import { useProjectStore } from '../projectStore';
@@ -45,7 +57,9 @@ function serverBundle(id: string): ProjectBundle {
 }
 
 beforeEach(() => {
-  Object.values(client).forEach((fn) => fn.mockReset());
+  Object.values(client).forEach((fn) => {
+    if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset();
+  });
   useProjectStore.setState(emptyState());
   useProjectSyncStore.getState().reset();
   localStorage.clear();
@@ -86,7 +100,7 @@ describe('reconcile (push) — local-only projects migrate to the server', () =>
     startProjectSync('user-a');
 
     await vi.waitFor(() => {
-      expect(client.saveProject).toHaveBeenCalledWith('p1', expect.objectContaining({ project: expect.any(Object) }));
+      expect(client.saveProject).toHaveBeenCalledWith('p1', expect.objectContaining({ project: expect.any(Object) }), expect.anything());
     });
     expect(useProjectSyncStore.getState().migratedCount).toBe(1);
   });
@@ -147,6 +161,6 @@ describe('live local changes push (debounced) after the initial reconcile', () =
     const { projectId } = useProjectStore.getState().createProject('New', 'an idea');
     await vi.advanceTimersByTimeAsync(2000); // past the push debounce
 
-    expect(client.saveProject).toHaveBeenCalledWith(projectId, expect.objectContaining({ project: expect.any(Object) }));
+    expect(client.saveProject).toHaveBeenCalledWith(projectId, expect.objectContaining({ project: expect.any(Object) }), expect.anything());
   });
 });

--- a/src/store/projectServerSync.ts
+++ b/src/store/projectServerSync.ts
@@ -13,6 +13,7 @@ import { useProjectSyncStore } from './projectSyncStore';
 import {
   extractProjectBundle,
   mergeBundlesIntoSource,
+  overwriteBundlesIntoSource,
   projectSlicesChanged,
   type BundleSource,
   type ProjectBundle,
@@ -22,8 +23,16 @@ import {
   fetchProject,
   saveProject,
   deleteProject as deleteProjectRemote,
+  RevisionConflictError,
+  type ServerProjectSummary,
 } from '../lib/projectsClient';
 import { markProjectsMigrated, getMigratedProjectIds } from '../lib/projectMigration';
+import {
+  getProjectSyncMeta,
+  setProjectSyncMeta,
+  removeProjectSyncMeta,
+  isServerNewer,
+} from '../lib/projectSyncMeta';
 import { projectsDebug } from '../lib/projectsDebug';
 import { clearImageRefRegistry } from '../lib/imageRefRegistry';
 import {
@@ -62,32 +71,100 @@ function syncableIds(state: ReturnType<typeof useProjectStore.getState>): string
   return Object.keys(state.projects).filter((id) => id !== DEMO_PROJECT_ID);
 }
 
+/**
+ * Record a successful cloud save in both the durable meta (survives reload — the
+ * baseline reconcile compares against) and the in-memory sync store (drives UI).
+ */
+function recordCloudSaved(userId: string, projectId: string, saved: ServerProjectSummary): void {
+  const now = Date.now();
+  setProjectSyncMeta(userId, projectId, {
+    lastSeenServerRevision: typeof saved?.revision === 'number' ? saved.revision : undefined,
+    lastSeenServerUpdatedAt: typeof saved?.updatedAt === 'string' ? saved.updatedAt : undefined,
+    lastCloudSavedAt: now,
+    lastCloudSaveError: null,
+    hasUnsyncedChanges: false,
+    conflict: false,
+  });
+  useProjectSyncStore.getState().setProjectSync(projectId, {
+    state: 'saved',
+    updatedAt: now,
+    lastCloudSavedAt: now,
+  });
+}
+
+/**
+ * Mark a project conflicted: the server advanced on another device while this
+ * device still has unsynced edits. Local work is preserved untouched — the user
+ * must explicitly choose how to resolve (keep local / use cloud / download).
+ */
+function markConflict(
+  userId: string,
+  projectId: string,
+  detectedAt: 'reconcile' | 'push',
+  server: { revision?: number; updatedAt?: string },
+): void {
+  setProjectSyncMeta(userId, projectId, { conflict: true, hasUnsyncedChanges: true });
+  const meta = getProjectSyncMeta(userId, projectId);
+  useProjectSyncStore.getState().patchProjectSync(projectId, {
+    state: 'conflict',
+    updatedAt: Date.now(),
+    lastCloudSavedAt: meta.lastCloudSavedAt,
+    conflict: {
+      detectedAt,
+      serverRevision: server.revision,
+      serverUpdatedAt: server.updatedAt,
+    },
+  });
+  projectsDebug('project conflict detected', { projectId, detectedAt, server });
+}
+
 async function pushProjectNow(projectId: string): Promise<void> {
   if (activeUserId === null || projectId === DEMO_PROJECT_ID) return;
+  const userId = activeUserId;
   const sync = useProjectSyncStore.getState();
   const state = useProjectStore.getState();
   const bundle = extractProjectBundle(bundleSourceOf(state), projectId);
   if (!bundle) return; // deleted before the debounce fired
 
-  sync.setProjectSync(projectId, { state: 'saving', updatedAt: Date.now() });
+  // Do not auto-push a project that is standing in conflict — that would fight
+  // the guard and risk clobbering. Resolution is explicit (see resolveConflict*).
+  const meta = getProjectSyncMeta(userId, projectId);
+  if (meta.conflict) {
+    projectsDebug('push skipped — project in conflict', { projectId });
+    return;
+  }
+
+  sync.patchProjectSync(projectId, { state: 'saving', updatedAt: Date.now() });
   try {
-    await saveProject(projectId, bundle);
-    if (activeUserId) markProjectsMigrated(activeUserId, [projectId]);
-    useProjectSyncStore.getState().setProjectSync(projectId, { state: 'saved', updatedAt: Date.now() });
-    projectsDebug('project pushed to server', { projectId });
+    // Conditional write: send the revision we last saw so the server rejects the
+    // save (409) if it advanced on another device instead of overwriting it.
+    const expectedRevision =
+      typeof meta.lastSeenServerRevision === 'number' ? meta.lastSeenServerRevision : undefined;
+    const saved = await saveProject(projectId, bundle, { expectedRevision });
+    if (activeUserId === userId) markProjectsMigrated(userId, [projectId]);
+    recordCloudSaved(userId, projectId, saved);
+    projectsDebug('project pushed to server', { projectId, revision: saved?.revision });
     // Image sync runs AFTER (and never blocks) the text save. Fire-and-forget:
     // a Blob failure is non-fatal and retried on the next push.
-    if (activeUserId) {
-      void pushProjectImages(activeUserId, projectId, bundle.artifactVersions.map((v) => v.id));
+    if (activeUserId === userId) {
+      void pushProjectImages(userId, projectId, bundle.artifactVersions.map((v) => v.id));
     }
   } catch (error) {
+    if (error instanceof RevisionConflictError) {
+      // The server copy advanced under us and we still have local edits — a real
+      // cross-device conflict. Preserve local work; require explicit resolution.
+      markConflict(userId, projectId, 'push', { revision: error.currentRevision });
+      return;
+    }
     const message = error instanceof Error ? error.message : 'sync_failed';
     // A failed save NEVER drops local data — it stays in localStorage. Surface
     // the failure so the UI can show "Sync failed" and retry on the next change.
-    useProjectSyncStore.getState().setProjectSync(projectId, {
+    setProjectSyncMeta(userId, projectId, { lastCloudSaveError: message, hasUnsyncedChanges: true });
+    useProjectSyncStore.getState().patchProjectSync(projectId, {
       state: 'error',
       updatedAt: Date.now(),
       error: message,
+      lastCloudSaveError: message,
     });
     projectsDebug('project push failed', { projectId, message });
   }
@@ -95,7 +172,10 @@ async function pushProjectNow(projectId: string): Promise<void> {
 
 function schedulePush(projectId: string): void {
   if (activeUserId === null || projectId === DEMO_PROJECT_ID) return;
-  useProjectSyncStore.getState().setProjectSync(projectId, { state: 'dirty', updatedAt: Date.now() });
+  // Durably mark unsynced edits so an offline/interrupted change isn't forgotten
+  // across a reload, and so reconcile can tell a dirty project from a clean one.
+  setProjectSyncMeta(activeUserId, projectId, { hasUnsyncedChanges: true });
+  useProjectSyncStore.getState().patchProjectSync(projectId, { state: 'dirty', updatedAt: Date.now() });
   const existing = pushTimers.get(projectId);
   if (existing) clearTimeout(existing);
   pushTimers.set(
@@ -112,6 +192,7 @@ async function deleteRemote(projectId: string): Promise<void> {
   try {
     await deleteProjectRemote(projectId);
     useProjectSyncStore.getState().removeProjectSync(projectId);
+    if (activeUserId) removeProjectSyncMeta(activeUserId, projectId);
     projectsDebug('project deleted on server', { projectId });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'delete_failed';
@@ -135,10 +216,48 @@ function applyBundles(bundles: ProjectBundle[]): string[] {
 }
 
 /**
+ * REPLACE existing local slices with the server copy, without echoing a push.
+ * Used for a safe server-newer refresh (local clean) or an explicit "use cloud"
+ * conflict resolution. Also refreshes the knownProjectIds snapshot so the
+ * overwrite isn't mistaken for a local change that needs pushing back.
+ */
+function applyBundlesOverwrite(bundles: ProjectBundle[]): string[] {
+  if (bundles.length === 0) return [];
+  const state = useProjectStore.getState();
+  const { next, replacedIds } = overwriteBundlesIntoSource(bundleSourceOf(state), bundles);
+  if (replacedIds.length === 0) return [];
+  suspendPush = true;
+  try {
+    useProjectStore.setState(next);
+  } finally {
+    suspendPush = false;
+  }
+  knownProjectIds = new Set(syncableIds(useProjectStore.getState()));
+  return replacedIds;
+}
+
+/**
  * Initial reconcile on sign-in: pull server projects this device doesn't have,
  * and upload local projects the server doesn't have (migration). Idempotent and
  * non-destructive — additive in both directions.
  */
+/** Record the observed server baseline for a freshly pulled/refreshed project. */
+function recordPulledBaseline(userId: string, summary: ServerProjectSummary): void {
+  setProjectSyncMeta(userId, summary.id, {
+    lastSeenServerRevision: typeof summary.revision === 'number' ? summary.revision : undefined,
+    lastSeenServerUpdatedAt: typeof summary.updatedAt === 'string' ? summary.updatedAt : undefined,
+    lastCloudSavedAt: Date.now(),
+    lastCloudSaveError: null,
+    hasUnsyncedChanges: false,
+    conflict: false,
+  });
+  useProjectSyncStore.getState().setProjectSync(summary.id, {
+    state: 'saved',
+    updatedAt: Date.now(),
+    lastCloudSavedAt: Date.now(),
+  });
+}
+
 async function reconcile(userId: string): Promise<void> {
   useProjectSyncStore.getState().setPhase('loading');
   try {
@@ -146,23 +265,75 @@ async function reconcile(userId: string): Promise<void> {
     const serverIds = new Set(summaries.map((s) => s.id));
     const localIds = new Set(syncableIds(useProjectStore.getState()));
 
-    // Server -> local: fetch full bundles for projects this device is missing.
-    const toPull = summaries.filter((s) => !localIds.has(s.id));
-    const pulled: ProjectBundle[] = [];
-    for (const summary of toPull) {
+    // Server -> local: fetch full bundles for projects this device is MISSING
+    // (additive pull, unchanged) OR that the server has advanced on another
+    // device while the local copy is clean (a safe refresh — overwrite local).
+    const toAdd: ServerProjectSummary[] = [];
+    const toRefresh: ServerProjectSummary[] = [];
+    for (const summary of summaries) {
+      if (!localIds.has(summary.id)) {
+        toAdd.push(summary);
+        continue;
+      }
+      // Both sides have this project — decide server-newer vs conflict.
+      const meta = getProjectSyncMeta(userId, summary.id);
+      const serverNewer = isServerNewer(summary, meta);
+      const dirty = meta.hasUnsyncedChanges === true;
+      if (serverNewer && !dirty) {
+        toRefresh.push(summary); // safe: pull the newer server copy over clean local
+      } else if (serverNewer && dirty) {
+        markConflict(userId, summary.id, 'reconcile', {
+          revision: summary.revision,
+          updatedAt: summary.updatedAt,
+        });
+      } else if (meta.lastSeenServerRevision === undefined && !meta.conflict) {
+        // First time we've reconciled this project post-baseline (e.g. data
+        // saved before conflict tracking existed) — record the current server
+        // revision so future reconciles can detect divergence. Does not touch a
+        // pending unsynced flag.
+        setProjectSyncMeta(userId, summary.id, {
+          lastSeenServerRevision: typeof summary.revision === 'number' ? summary.revision : undefined,
+          lastSeenServerUpdatedAt: typeof summary.updatedAt === 'string' ? summary.updatedAt : undefined,
+        });
+      }
+    }
+
+    async function fetchBundle(summary: ServerProjectSummary): Promise<ProjectBundle | null> {
       try {
         const full = await fetchProject(summary.id);
-        if (full?.data) pulled.push(full.data);
+        return full?.data ?? null;
       } catch (error) {
         projectsDebug('project pull failed', {
           projectId: summary.id,
           message: error instanceof Error ? error.message : 'error',
         });
+        return null;
       }
     }
-    const addedIds = applyBundles(pulled);
-    for (const id of addedIds) {
-      useProjectSyncStore.getState().setProjectSync(id, { state: 'saved', updatedAt: Date.now() });
+
+    const added: ProjectBundle[] = [];
+    for (const summary of toAdd) {
+      const bundle = await fetchBundle(summary);
+      if (bundle) added.push(bundle);
+    }
+    applyBundles(added);
+    for (const summary of toAdd) {
+      if (added.some((b) => b.project.id === summary.id)) recordPulledBaseline(userId, summary);
+    }
+
+    const refreshed: ProjectBundle[] = [];
+    for (const summary of toRefresh) {
+      const bundle = await fetchBundle(summary);
+      if (bundle) refreshed.push(bundle);
+    }
+    if (refreshed.length > 0) {
+      applyBundlesOverwrite(refreshed);
+      for (const summary of toRefresh) {
+        if (refreshed.some((b) => b.project.id === summary.id)) recordPulledBaseline(userId, summary);
+      }
+      projectsDebug('server-newer projects refreshed over clean local', {
+        count: refreshed.length,
+      });
     }
 
     // Local -> server: upload local-only projects (migration).
@@ -187,7 +358,8 @@ async function reconcile(userId: string): Promise<void> {
 
     projectsDebug('project sync reconciled', {
       userId,
-      pulled: addedIds.length,
+      added: added.length,
+      refreshed: refreshed.length,
       migrated: migratedCount,
     });
   } catch (error) {
@@ -268,6 +440,72 @@ export function stopProjectSync(): void {
 /** Force an immediate re-pull from the server (e.g. a "retry sync" button). */
 export function refreshProjectsFromServer(): void {
   if (activeUserId) void reconcile(activeUserId);
+}
+
+/**
+ * Resolve a conflict by ADOPTING THE CLOUD VERSION: overwrite the local copy
+ * with the server bundle and re-baseline. The local edits are discarded — the
+ * UI should only offer this after the user has (optionally) downloaded a
+ * recovery copy of their local work. Returns true on success.
+ */
+export async function resolveConflictUseCloud(projectId: string): Promise<boolean> {
+  const userId = activeUserId;
+  if (!userId || projectId === DEMO_PROJECT_ID) return false;
+  useProjectSyncStore.getState().patchProjectSync(projectId, { state: 'saving', updatedAt: Date.now() });
+  try {
+    const full = await fetchProject(projectId);
+    if (!full?.data) {
+      // Server copy is gone — nothing to adopt. Clear the conflict so the local
+      // copy can push normally as a (re-)create.
+      setProjectSyncMeta(userId, projectId, { conflict: false });
+      useProjectSyncStore.getState().patchProjectSync(projectId, { state: 'dirty', conflict: undefined });
+      return false;
+    }
+    applyBundlesOverwrite([full.data]);
+    recordPulledBaseline(userId, full);
+    projectsDebug('conflict resolved — used cloud version', { projectId });
+    return true;
+  } catch (error) {
+    projectsDebug('conflict resolve (use cloud) failed', {
+      projectId,
+      message: error instanceof Error ? error.message : 'error',
+    });
+    return false;
+  }
+}
+
+/**
+ * Resolve a conflict by KEEPING THE LOCAL VERSION: overwrite the cloud with the
+ * local copy. Adopts the server's current revision as the expected baseline so
+ * the conditional push succeeds (an explicit, user-authorized overwrite), then
+ * pushes. Returns true if the push landed without re-conflicting.
+ */
+export async function resolveConflictKeepLocal(projectId: string): Promise<boolean> {
+  const userId = activeUserId;
+  if (!userId || projectId === DEMO_PROJECT_ID) return false;
+  try {
+    // Read the server's current revision so our next push expects it and wins.
+    const full = await fetchProject(projectId);
+    setProjectSyncMeta(userId, projectId, {
+      lastSeenServerRevision: typeof full?.revision === 'number' ? full.revision : undefined,
+      lastSeenServerUpdatedAt: typeof full?.updatedAt === 'string' ? full.updatedAt : undefined,
+      conflict: false,
+      hasUnsyncedChanges: true,
+    });
+    useProjectSyncStore.getState().patchProjectSync(projectId, {
+      state: 'dirty',
+      updatedAt: Date.now(),
+      conflict: undefined,
+    });
+    await pushProjectNow(projectId);
+    return getProjectSyncMeta(userId, projectId).conflict !== true;
+  } catch (error) {
+    projectsDebug('conflict resolve (keep local) failed', {
+      projectId,
+      message: error instanceof Error ? error.message : 'error',
+    });
+    return false;
+  }
 }
 
 // Track browser online/offline so the UI can show an offline state.

--- a/src/store/projectServerSync.ts
+++ b/src/store/projectServerSync.ts
@@ -515,4 +515,23 @@ if (typeof window !== 'undefined') {
     refreshProjectsFromServer();
   });
   window.addEventListener('offline', () => useProjectSyncStore.getState().setOnline(false));
+
+  // Warn on close/navigation ONLY when cloud durability is genuinely stuck — a
+  // standing conflict or a failed cloud save that won't clear on its own. Normal
+  // 'dirty' (about to push) and 'saving' states are not blocked, to avoid
+  // nagging. Local data is never lost either way (localStorage persists); this
+  // guards against a user walking away believing work reached the cloud.
+  window.addEventListener('beforeunload', (event) => {
+    if (activeUserId === null) return;
+    const projects = useProjectSyncStore.getState().projects;
+    const stuck = Object.values(projects).some(
+      (p) => p.state === 'conflict' || p.state === 'error',
+    );
+    if (stuck) {
+      event.preventDefault();
+      // Legacy browsers require returnValue to be set to trigger the prompt.
+      event.returnValue = '';
+      return '';
+    }
+  });
 }

--- a/src/store/projectServerSync.ts
+++ b/src/store/projectServerSync.ts
@@ -137,10 +137,16 @@ async function pushProjectNow(projectId: string): Promise<void> {
   sync.patchProjectSync(projectId, { state: 'saving', updatedAt: Date.now() });
   try {
     // Conditional write: send the revision we last saw so the server rejects the
-    // save (409) if it advanced on another device instead of overwriting it.
+    // save (409) if it advanced on another device instead of overwriting it. For
+    // a legacy row with no revision baseline, fall back to the last-seen
+    // updatedAt so the guard still applies instead of pushing unconditionally.
     const expectedRevision =
       typeof meta.lastSeenServerRevision === 'number' ? meta.lastSeenServerRevision : undefined;
-    const saved = await saveProject(projectId, bundle, { expectedRevision });
+    const expectedUpdatedAt =
+      expectedRevision === undefined && typeof meta.lastSeenServerUpdatedAt === 'string'
+        ? meta.lastSeenServerUpdatedAt
+        : undefined;
+    const saved = await saveProject(projectId, bundle, { expectedRevision, expectedUpdatedAt });
     if (activeUserId === userId) markProjectsMigrated(userId, [projectId]);
     recordCloudSaved(userId, projectId, saved);
     projectsDebug('project pushed to server', { projectId, revision: saved?.revision });
@@ -270,6 +276,11 @@ async function reconcile(userId: string): Promise<void> {
     // device while the local copy is clean (a safe refresh — overwrite local).
     const toAdd: ServerProjectSummary[] = [];
     const toRefresh: ServerProjectSummary[] = [];
+    // Both-exist projects with unsynced local edits that the server has NOT
+    // advanced past — a failed save or a tab-close after schedulePush can leave
+    // these pending across a reload. Re-push them so they don't silently linger
+    // as local-only while the banner reads "synced".
+    const toRetryPush: string[] = [];
     for (const summary of summaries) {
       if (!localIds.has(summary.id)) {
         toAdd.push(summary);
@@ -286,15 +297,20 @@ async function reconcile(userId: string): Promise<void> {
           revision: summary.revision,
           updatedAt: summary.updatedAt,
         });
-      } else if (meta.lastSeenServerRevision === undefined && !meta.conflict) {
-        // First time we've reconciled this project post-baseline (e.g. data
-        // saved before conflict tracking existed) — record the current server
-        // revision so future reconciles can detect divergence. Does not touch a
-        // pending unsynced flag.
-        setProjectSyncMeta(userId, summary.id, {
-          lastSeenServerRevision: typeof summary.revision === 'number' ? summary.revision : undefined,
-          lastSeenServerUpdatedAt: typeof summary.updatedAt === 'string' ? summary.updatedAt : undefined,
-        });
+      } else {
+        // Not server-newer.
+        if (meta.lastSeenServerRevision === undefined && !meta.conflict) {
+          // First reconcile post-baseline (e.g. data saved before conflict
+          // tracking existed) — record the current server version so future
+          // reconciles can detect divergence. Does not touch the unsynced flag.
+          setProjectSyncMeta(userId, summary.id, {
+            lastSeenServerRevision: typeof summary.revision === 'number' ? summary.revision : undefined,
+            lastSeenServerUpdatedAt: typeof summary.updatedAt === 'string' ? summary.updatedAt : undefined,
+          });
+        }
+        if (dirty && !meta.conflict) {
+          toRetryPush.push(summary.id); // pending upload survived a reload — retry it
+        }
       }
     }
 
@@ -344,6 +360,14 @@ async function reconcile(userId: string): Promise<void> {
       const wasMigrated = migrated.has(id);
       await pushProjectNow(id);
       if (!wasMigrated) migratedCount += 1;
+    }
+
+    // Retry pending uploads (dirty, both-exist, not server-newer) that a prior
+    // failed save / tab-close left unsynced. pushProjectNow is conditional, so a
+    // race that advanced the server since fetchProjectList still becomes a
+    // conflict rather than an overwrite.
+    for (const id of toRetryPush) {
+      await pushProjectNow(id);
     }
 
     knownProjectIds = new Set(syncableIds(useProjectStore.getState()));

--- a/src/store/projectSyncStore.ts
+++ b/src/store/projectSyncStore.ts
@@ -10,12 +10,30 @@ export type SyncPhase =
   | 'ready' // pulled at least once, in steady state
   | 'error'; // last pull/push failed (local data is intact)
 
-export type ProjectSyncState = 'saving' | 'saved' | 'error' | 'dirty';
+export type ProjectSyncState = 'saving' | 'saved' | 'error' | 'dirty' | 'conflict';
 
 export interface ProjectSyncInfo {
   state: ProjectSyncState;
   updatedAt: number;
   error?: string;
+  /** Epoch ms of the last successful cloud save (mirrors durable meta so the UI
+   *  can show "Synced 2m ago" without reaching into localStorage). */
+  lastCloudSavedAt?: number;
+  /** Last failed cloud-save message, surfaced next to the status indicator. */
+  lastCloudSaveError?: string;
+  /** True when the server copy advanced on another device while this device has
+   *  unsynced edits. Carries the details needed to resolve the conflict. */
+  conflict?: ProjectConflictInfo;
+}
+
+export interface ProjectConflictInfo {
+  /** Server revision that superseded this device's last-seen revision. */
+  serverRevision?: number;
+  /** Server `updatedAt` of the superseding version (ISO string). */
+  serverUpdatedAt?: string;
+  /** How the conflict was detected: during the sign-in reconcile, or when a
+   *  push was rejected because the server had advanced. */
+  detectedAt: 'reconcile' | 'push';
 }
 
 interface SyncStore {
@@ -36,6 +54,9 @@ interface SyncStore {
   setOnline: (online: boolean) => void;
   markPulled: (migratedCount: number) => void;
   setProjectSync: (projectId: string, info: ProjectSyncInfo) => void;
+  /** Merge a partial update into a project's sync info (preserves other fields
+   *  like a standing conflict or last-saved timestamp). */
+  patchProjectSync: (projectId: string, patch: Partial<ProjectSyncInfo>) => void;
   removeProjectSync: (projectId: string) => void;
   reset: () => void;
 }
@@ -54,6 +75,12 @@ export const useProjectSyncStore = create<SyncStore>((set) => ({
     set({ phase: 'ready', error: null, lastPulledAt: Date.now(), migratedCount }),
   setProjectSync: (projectId, info) =>
     set((s) => ({ projects: { ...s.projects, [projectId]: info } })),
+  patchProjectSync: (projectId, patch) =>
+    set((s) => {
+      const prev = s.projects[projectId];
+      const base: ProjectSyncInfo = prev ?? { state: 'saved', updatedAt: Date.now() };
+      return { projects: { ...s.projects, [projectId]: { ...base, ...patch } } };
+    }),
   removeProjectSync: (projectId) =>
     set((s) => {
       if (!(projectId in s.projects)) return s;


### PR DESCRIPTION
## Summary

Phase 2 of the reliability audit: stop signed-in users from silently losing project work to cross-device races, and make cloud durability visible. Conservative, additive, backward-compatible — anonymous/local-only mode and legacy saved projects are unaffected.

Focused on three risks:
1. Same-project cross-device conflicts could be silently ignored and later overwritten.
2. Local persistence success could be mistaken for cloud durability.
3. Large/failed cloud saves lacked a clear recovery path.

## What changed

**Metadata foundation**
- `src/lib/projectSyncMeta.ts` — durable, per-user localStorage map (kept *separate* from user-authored project content) recording `lastSeenServerRevision`/`updatedAt` (the conflict-detection baseline), `lastCloudSavedAt`, `lastCloudSaveError`, `hasUnsyncedChanges`, and `conflict`. `isServerNewer()` compares revision-first with an `updatedAt` fallback. All fields optional.
- Server `upsertProject` now returns the new `revision` and accepts an optional `expectedRevision` **optimistic-concurrency guard** — on mismatch it does NOT write and returns `{ conflict, currentRevision }`; the `api/projects.js` PUT maps that to **HTTP 409**.
- `projectsClient.saveProject` sends `expectedRevision` and throws a typed `RevisionConflictError` on 409.

**Conflict detection & guarded writes** (`projectServerSync.ts`, `projectBundle.ts`)
- Reconcile now handles the both-sides-present case: server-newer + local **clean** → safe refresh (overwrite local, re-baseline); server-newer + local **dirty** → mark `conflict`, overwrite **neither** side.
- Every push is a conditional write with the last-seen revision, so a stale push is rejected → becomes a `conflict` rather than clobbering the newer server copy. Conflicted projects are not auto-pushed.
- `overwriteBundlesIntoSource` is the deliberate (consent-only) counterpart to the additive `mergeBundlesIntoSource`.
- Explicit resolution: `resolveConflictUseCloud` / `resolveConflictKeepLocal` — no silent overwrite in either direction.

**Durability made visible** (`ProjectSyncStatus.tsx`, `ProjectWorkspace`, `ExportModal`)
- New `'conflict'` sync state; `ProjectCloudStatus` pill distinguishing saved-on-device / synced-to-cloud ("synced Nm ago") / cloud-sync-pending / cloud-save-failed / conflict.
- `ProjectConflictBanner` ("Cloud version changed on another device" → keep local / use cloud / download local copy) above the workspace body.
- Export modal shows an at-risk banner + recovery download when cloud state is failed/conflict.
- `beforeunload` guard warns only when cloud state is genuinely stuck (conflict/failed), never for normal pending pushes. Persistent indicators, not toast spam.

**Recovery bundle** (`src/lib/projectRecovery.ts`)
- Network-free JSON download of a project's local state for at-risk durability (failed save, expired session, network outage, body-limit rejection, unresolved conflict). Reachable from the conflict banner and export modal.

## Tests

997 tests pass (`npm test`), plus build (`tsc -b && vite build`) and lint clean. New focused coverage:
- Two clients, same project id → client B does **not** silently overwrite client A's newer version.
- Server newer + local clean → safe refresh.
- Server newer + local dirty → conflict/stale state, both copies preserved.
- Cloud save failure → sync state exposes failed/unsynced durability.
- Expected-revision mismatch → server + client reject/block the stale push.

## Remaining limitations / follow-up

- "Duplicate local copy" is served by the recovery-bundle download (a safe, no-overwrite escape hatch) rather than an in-store project clone — avoids risky artifact-version-id remapping (mockup images are keyed by version id in IndexedDB). A true in-app duplicate could be added later.
- The server has no cross-request lock; the guard reads-then-writes, so an extremely tight concurrent race could still slip a write. Acceptable for this product; a real atomic conditional update is a future hardening.
- Pre-feature saved projects have no baseline until their first post-upgrade reconcile bootstraps one; going forward the push guard protects them.

Notes: the stale-client-overwrite risk this phase targets is closed — a stale client's push is rejected (409) and reconcile refuses to overwrite dirty local work. README's cross-device-sync feature description remains accurate (this hardens durability rather than adding a headline capability), so it was left unchanged; CLAUDE.md's server-storage section was updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCHaBux1SPV41gSBmi292m

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCHaBux1SPV41gSBmi292m)_