### PR TITLE
Phase 3 audit: consistency-review safety guards + artifact prompt source hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,11 +546,26 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       - **feature-id stability** (every original `Feature.id` must survive —
         downstream artifacts/tasks reference them),
       - **product-identity guard** (a present `productName` may be canonicalized
-        but never blanked).
+        but never blanked),
+      - **semantic preservation guards** (Phase 3 — protect facts downstream
+        artifacts consume directly): a revision is discarded if it drops/reduces
+        any feature's **acceptance/success criteria**, drops any feature
+        **dependency id** reference, drops or **weakens a safety restriction**
+        (`constraints` — every original entry must survive verbatim; a reworded
+        or removed restriction is treated as weakening), or drops **entity fields,
+        relationships, or example values** (rich-data-model + `domainEntities`,
+        matched by name). All guards **reject wholesale** and keep the
+        deterministically-merged PRD — the review is a polish, never a fact
+        editor. `evaluateGuards` is the single ordered chokepoint.
       On apply it sets `generationMeta.revised` and adds a `consistency_review`
       pass record. The outcome (`ran`/`applied`/`status`/`rejectionReason`) is
-      recorded in `generationMeta.consistencyReview` (`ConsistencyReviewMeta`)
-      for diagnostics — never surfaced in the UI. It is **skipped** for a
+      recorded in `generationMeta.consistencyReview` (`ConsistencyReviewMeta`),
+      which also carries a compact **structured diff** (`ConsistencyReviewDiff`:
+      `sectionsChanged`, `featuresReworded`, `productNameChange`,
+      `guardsTriggered`, `outcome`) built for both accepted and rejected passes.
+      `summarizeConsistencyReview(meta)` renders a one-line summary surfaced in
+      the PRD **version-history panel** (`VersionEntry.consistencyReview`) — the
+      only UI exposure; generation is never affected. It is **skipped** for a
       partial run (a section failed → PRD already surfaced as incomplete). The
       localStorage `synapse-prd-consistency-review` key is now only a
       **developer/debug opt-out** (`'false'` → skip via `enableConsistencyReview:
@@ -708,16 +723,35 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     on final settle (`updateSpineStructuredPRD`, only when `generationMeta` is
     present — a diagnostic/diffing copy; artifact generation always **rebuilds it
     lazily** from `structuredPRD` so old projects and post-edit PRDs stay
-    consistent). In `generateCoreArtifact` the prompt hierarchy is **persona →
-    guardrails → Canonical PRD Spine (authoritative) → dependency artifacts →
-    full PRD markdown (SECONDARY fallback only)**; the spine subsumes and
-    **replaces** the old standalone feature glossary + inline PRD summary (they
-    are dropped when a spine is present). A spine with **no features** yields a
-    null prompt section → the legacy summary prompt. Each artifact version stamps
+    consistent). In `generateCoreArtifact` the prompt is assembled by the pure,
+    unit-tested **`src/lib/services/artifactPromptBuilder.ts`** (`buildArtifactPrompt`)
+    with an explicit, machine-checkable **source hierarchy** — labeled sections in
+    a fixed authority order: **`## TASK` → `## SOURCE HIERARCHY — READ FIRST`
+    (the conflict-resolution rules) → `## GUARDRAILS` → `## AUTHORITATIVE —
+    CANONICAL PRD SPINE` (or `## AUTHORITATIVE — STRUCTURED PRD SUMMARY` on the
+    legacy no-spine fallback) → `## AUTHORITATIVE — STRUCTURED DEPENDENCY
+    SUMMARIES` → `## TASK CONSTRAINTS — SELECTED OPTIONS` (preset, only when
+    present) → `## KNOWN CONFLICTS & STALENESS` (only when there is something to
+    report) → `## APPENDIX — FULL PRD MARKDOWN (SECONDARY REFERENCE ONLY)`**. The
+    hierarchy is: (1) canonical spine authoritative, (2) structured dependency
+    summaries authoritative for the detail they own but yielding to the spine on
+    conflict unless explicitly newer/valid, (3) selected preset/options are hard
+    task constraints, (4) full PRD markdown is **secondary reference only** and
+    must never override the structured sources — with an explicit instruction to
+    cite features by canonical id/name, never a prose-only/stale name. The
+    conflict/staleness block surfaces machine-derived notices (missing REQUIRED
+    dependencies via `findMissingRequiredDependencies`, spine validation
+    warnings) plus **stale feature-name conflicts** (`detectStaleFeatureNames`:
+    canonical feature names absent from the PRD prose → likely drift). The spine
+    subsumes and **replaces** the old standalone feature glossary + inline PRD
+    summary (they are dropped when a spine is present, used only in the legacy
+    fallback). A spine with **no features** yields a null spine section → the
+    legacy structured-summary fallback. Each artifact version stamps
     `metadata.spineContextUsed` / `spineSchemaVersion`. Do **not** re-add the
-    duplicate glossary/summary blocks alongside the spine, and do **not** feed
-    long markdown into the spine (it must stay compact/structured). See
-    `docs/CANONICAL_PRD_SPINE.md`.
+    duplicate glossary/summary blocks alongside the spine, do **not** feed long
+    markdown into the spine (it must stay compact/structured), and do **not**
+    re-order the prompt so the PRD markdown appendix precedes the structured
+    sources. See `docs/CANONICAL_PRD_SPINE.md`.
   - `coreArtifactService.ts` — the 7 core artifact types
     (screen_inventory, data_model, component_inventory, user_flows,
     implementation_plan, prompt_pack, design_system). **`prompt_pack` is

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -16,6 +16,7 @@ import {
 import { ProgressTimeline } from './progress/ProgressTimeline';
 import { buildGenerationSteps } from './progress/buildGenerationSteps';
 import { regeneratePrdSection } from '../lib/services/prdSectionRetry';
+import { summarizeConsistencyReview } from '../lib/services/prdConsistencyReview';
 import { SelectableSpine } from './SelectableSpine';
 import { BranchList } from './BranchList';
 import { ConsolidationModal } from './ConsolidationModal';
@@ -263,6 +264,7 @@ export function ProjectWorkspace() {
             createdAt: s.createdAt,
             changeSource: s.provenance?.changeSource,
             editSummary: s.provenance?.editSummary,
+            consistencyReview: summarizeConsistencyReview(s.generationMeta?.consistencyReview) ?? undefined,
         }))
         .reverse();
 

--- a/src/components/versions/VersionHistoryPanel.tsx
+++ b/src/components/versions/VersionHistoryPanel.tsx
@@ -13,6 +13,9 @@ export type VersionEntry = {
     createdAt: number;
     changeSource?: VersionChangeSource;
     editSummary?: string;
+    // Optional one-line summary of the automatic consistency-review pass that
+    // produced/vetted this PRD version (transparency/debugging). PRD only.
+    consistencyReview?: string;
 };
 
 interface VersionHistoryPanelProps {
@@ -119,6 +122,11 @@ export function VersionHistoryPanel({
                                     <div className="text-xs text-neutral-400 mt-1">{formatTime(entry.createdAt)}</div>
                                     {entry.editSummary && (
                                         <div className="text-xs text-neutral-600 mt-1 break-words">{entry.editSummary}</div>
+                                    )}
+                                    {entry.consistencyReview && (
+                                        <div className="text-[11px] text-teal-700 mt-1 break-words">
+                                            <span className="font-medium">Consistency review:</span> {entry.consistencyReview}
+                                        </div>
                                     )}
                                     {!entry.isCurrent && (
                                         <div className="flex items-center gap-2 mt-2">

--- a/src/lib/__tests__/prdConsistencyReview.test.ts
+++ b/src/lib/__tests__/prdConsistencyReview.test.ts
@@ -118,4 +118,172 @@ describe('reviewPrdConsistency', () => {
     // The restriction survives via merge-over-original.
     expect(result.prd.constraints).toEqual(['No collection of medical data']);
   });
+
+  // --- Phase 3 semantic preservation guards ----------------------------------
+
+  it('rejects a revision that keeps the feature id but drops acceptance criteria', async () => {
+    const original = basePrd();
+    original.features[0].acceptanceCriteria = ['must A', 'must B', 'must C'];
+    // Same id, same count of features, but one acceptance criterion removed.
+    const revised = original.features.map((f, i) =>
+      i === 0 ? { ...f, acceptanceCriteria: ['must A', 'must B'] } : f,
+    );
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, features: revised }, changeLog: 'trimmed criteria' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('feature-acceptance-criteria-lost');
+    expect(result.prd.features[0].acceptanceCriteria).toHaveLength(3);
+  });
+
+  it('rejects a revision that removes a feature dependency reference', async () => {
+    const original = basePrd();
+    original.features[1].dependencies = ['f1', 'f3'];
+    // Same feature, but one dependency id dropped.
+    const revised = original.features.map((f, i) =>
+      i === 1 ? { ...f, dependencies: ['f1'] } : f,
+    );
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, features: revised }, changeLog: 'removed dep' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('feature-dependencies-lost');
+    expect(result.prd.features[1].dependencies).toEqual(['f1', 'f3']);
+  });
+
+  it('rejects a revision that removes/weakens a safety restriction', async () => {
+    const original: StructuredPRD = {
+      ...basePrd(),
+      constraints: ['No collection of medical data', 'No third-party data sharing'],
+    };
+    // Count is preserved (passes detail-loss) but one restriction was reworded
+    // into a weaker form — the safety guard must still reject it.
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: { ...original, constraints: ['Avoid excessive medical data', 'No third-party data sharing'] },
+        changeLog: 'reworded constraints',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('safety-restriction-lost');
+    expect(result.prd.constraints).toEqual([
+      'No collection of medical data',
+      'No third-party data sharing',
+    ]);
+  });
+
+  it('rejects a revision that drops an entity field', async () => {
+    const original: StructuredPRD = {
+      ...basePrd(),
+      richDataModel: {
+        entities: [
+          {
+            name: 'Patient',
+            description: 'A patient record',
+            fields: [
+              { name: 'id', type: 'string' },
+              { name: 'name', type: 'string' },
+              { name: 'dob', type: 'date' },
+            ],
+            relationships: ['has many Appointment'],
+          },
+        ],
+      },
+    };
+    // Same entity, but a field removed.
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: {
+          ...original,
+          richDataModel: {
+            entities: [
+              {
+                name: 'Patient',
+                description: 'A patient record',
+                fields: [
+                  { name: 'id', type: 'string' },
+                  { name: 'name', type: 'string' },
+                ],
+                relationships: ['has many Appointment'],
+              },
+            ],
+          },
+        },
+        changeLog: 'dropped field',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('entity-detail-lost');
+    expect(result.prd.richDataModel?.entities[0].fields).toHaveLength(3);
+  });
+
+  it('rejects a revision that drops an entity relationship', async () => {
+    const original: StructuredPRD = {
+      ...basePrd(),
+      richDataModel: {
+        entities: [
+          {
+            name: 'Order',
+            description: 'A purchase order',
+            fields: [{ name: 'id', type: 'string' }],
+            relationships: ['belongs to Customer', 'has many LineItem'],
+          },
+        ],
+      },
+    };
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: {
+          ...original,
+          richDataModel: {
+            entities: [
+              {
+                name: 'Order',
+                description: 'A purchase order',
+                fields: [{ name: 'id', type: 'string' }],
+                relationships: ['belongs to Customer'],
+              },
+            ],
+          },
+        },
+        changeLog: 'dropped relationship',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('entity-detail-lost');
+  });
+
+  it('records a structured diff on an accepted revision', async () => {
+    const original = basePrd();
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: { ...original, productName: 'MyApp (canonical)' },
+        changeLog: 'Normalized product name across sections.',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(true);
+    expect(result.diff).toBeDefined();
+    expect(result.diff?.outcome).toBe('accepted');
+    expect(result.diff?.guardsTriggered).toEqual([]);
+    expect(result.diff?.sectionsChanged).toContain('productName');
+    expect(result.diff?.productNameChange).toEqual({ before: 'MyApp', after: 'MyApp (canonical)' });
+  });
+
+  it('records the triggered guard in the diff on a rejected revision', async () => {
+    const original = basePrd();
+    const renamed = original.features.map((f, i) => ({ ...f, id: `renamed-${i}` }));
+    const transport = vi.fn(async () =>
+      JSON.stringify({ prd: { ...original, features: renamed }, changeLog: 'renamed ids' }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.diff?.outcome).toBe('rejected');
+    expect(result.diff?.guardsTriggered).toContain('feature-ids-changed');
+  });
 });

--- a/src/lib/__tests__/prdConsistencyReview.test.ts
+++ b/src/lib/__tests__/prdConsistencyReview.test.ts
@@ -258,6 +258,75 @@ describe('reviewPrdConsistency', () => {
     expect(result.rejectionReason).toBe('entity-detail-lost');
   });
 
+  it('rejects a revision that drops one entity out of several (identity, not count)', async () => {
+    const original: StructuredPRD = {
+      ...basePrd(),
+      richDataModel: {
+        entities: [
+          { name: 'Patient', description: 'p', fields: [{ name: 'id', type: 'string' }] },
+          { name: 'Appointment', description: 'a', fields: [{ name: 'id', type: 'string' }] },
+          { name: 'Provider', description: 'v', fields: [{ name: 'id', type: 'string' }] },
+        ],
+      },
+    };
+    // Drops 1 of 3 entities → 2/3 = 67%... use 4 entities so it stays above the
+    // 70% detail-loss floor and only the identity check can catch it.
+    original.richDataModel!.entities.push({ name: 'Invoice', description: 'i', fields: [{ name: 'id', type: 'string' }] });
+    const survivors = original.richDataModel!.entities.filter(e => e.name !== 'Provider'); // 3 of 4 = 75%
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: { ...original, richDataModel: { entities: survivors } },
+        changeLog: 'dropped an entity',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('entity-detail-lost');
+    expect(result.prd.richDataModel?.entities).toHaveLength(4);
+  });
+
+  it('rejects a revision that swaps an entity field while preserving the count', async () => {
+    const original: StructuredPRD = {
+      ...basePrd(),
+      richDataModel: {
+        entities: [
+          {
+            name: 'Patient',
+            description: 'p',
+            fields: [
+              { name: 'id', type: 'string' },
+              { name: 'dob', type: 'date' },
+            ],
+          },
+        ],
+      },
+    };
+    // Same field count (2), but "dob" replaced by an unrelated "nickname".
+    const transport = vi.fn(async () =>
+      JSON.stringify({
+        prd: {
+          ...original,
+          richDataModel: {
+            entities: [
+              {
+                name: 'Patient',
+                description: 'p',
+                fields: [
+                  { name: 'id', type: 'string' },
+                  { name: 'nickname', type: 'string' },
+                ],
+              },
+            ],
+          },
+        },
+        changeLog: 'swapped a field',
+      }),
+    );
+    const result = await reviewPrdConsistency(original, { transport });
+    expect(result.applied).toBe(false);
+    expect(result.rejectionReason).toBe('entity-detail-lost');
+  });
+
   it('records a structured diff on an accepted revision', async () => {
     const original = basePrd();
     const transport = vi.fn(async () =>

--- a/src/lib/services/__tests__/artifactPromptBuilder.test.ts
+++ b/src/lib/services/__tests__/artifactPromptBuilder.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildArtifactPrompt,
+    detectStaleFeatureNames,
+    SECTION,
+    type ArtifactPromptSources,
+} from '../artifactPromptBuilder';
+import { CANONICAL_SPINE_SCHEMA_VERSION, type CanonicalPrdSpine } from '../../../types';
+
+const makeSpine = (overrides: Partial<CanonicalPrdSpine> = {}): CanonicalPrdSpine => ({
+    identity: { productName: 'Acme', description: 'Do the thing' },
+    users: [],
+    features: [
+        { id: 'f1', name: 'Smart Inbox', description: 'A prioritized inbox' },
+        { id: 'f2', name: 'Digest Emails', description: 'Daily summary emails' },
+    ],
+    screenSeeds: [],
+    entitySeeds: [],
+    constraints: {},
+    architecture: {},
+    meta: {
+        schemaVersion: CANONICAL_SPINE_SCHEMA_VERSION,
+        generatedAt: 0,
+        validation: { valid: true, warnings: [] },
+    },
+    ...overrides,
+});
+
+const baseSources = (overrides: Partial<ArtifactPromptSources> = {}): ArtifactPromptSources => ({
+    userPrefix: 'Create a data model from this PRD:',
+    guardrails: 'Ground every entity in the PRD.',
+    canonicalSpine: makeSpine(),
+    spineSection: 'CANONICAL SPINE JSON HERE (features: Smart Inbox, Digest Emails)',
+    dependencyContext: 'screen_inventory: Inbox screen, Digest screen',
+    dependencyKeys: ['screen_inventory'],
+    presetSection: '',
+    prdMarkdown: 'The product includes Smart Inbox and Digest Emails features.',
+    mockupSection: '',
+    ...overrides,
+});
+
+describe('buildArtifactPrompt', () => {
+    it('orders sections with the canonical spine authoritative and the PRD markdown as a secondary appendix', () => {
+        const built = buildArtifactPrompt(baseSources());
+        // Spine appears before the PRD markdown appendix.
+        const spineIdx = built.sections.indexOf(SECTION.spine);
+        const appendixIdx = built.sections.indexOf(SECTION.appendix);
+        const depIdx = built.sections.indexOf(SECTION.dependencies);
+        expect(spineIdx).toBeGreaterThanOrEqual(0);
+        expect(depIdx).toBeGreaterThan(spineIdx);
+        expect(appendixIdx).toBeGreaterThan(depIdx);
+        // The hierarchy header comes before the spine.
+        expect(built.sections.indexOf(SECTION.hierarchy)).toBeLessThan(spineIdx);
+        // The appendix is explicitly marked secondary.
+        expect(built.prompt).toContain('SECONDARY REFERENCE ONLY');
+        expect(built.prompt).toContain('MUST NOT override the Canonical PRD Spine');
+        expect(built.usedSpine).toBe(true);
+    });
+
+    it('Case 1: PRD markdown that conflicts with a canonical feature name is flagged as stale', () => {
+        // The PRD prose calls the feature "Priority Mailbox" but the spine's
+        // canonical name is "Smart Inbox" — a drifted/stale name.
+        const built = buildArtifactPrompt(
+            baseSources({
+                prdMarkdown: 'The product includes Priority Mailbox and Digest Emails features.',
+            }),
+        );
+        // Canonical spine is clearly marked authoritative.
+        expect(built.sections).toContain(SECTION.spine);
+        expect(built.prompt).toContain('AUTHORITATIVE — CANONICAL PRD SPINE');
+        // Full PRD markdown is identified as secondary/fallback.
+        expect(built.prompt).toContain(SECTION.appendix);
+        // The stale name is flagged.
+        expect(built.staleNameConflicts.map(c => c.id)).toEqual(['f1']);
+        expect(built.hasConflictBlock).toBe(true);
+        expect(built.prompt).toContain(SECTION.conflicts);
+        expect(built.prompt).toContain('canonically named "Smart Inbox"');
+    });
+
+    it('Case 2: instructs the model to prefer the canonical spine over a conflicting dependency artifact', () => {
+        const built = buildArtifactPrompt(baseSources());
+        // The dependency section carries the prefer-spine-unless-newer rule.
+        expect(built.prompt).toContain(SECTION.dependencies);
+        expect(built.prompt).toContain('prefer the spine');
+        expect(built.prompt).toContain('unless the dependency is');
+        expect(built.prompt).toContain('explicitly newer and valid');
+    });
+
+    it('Case 3: surfaces a visible conflict/staleness block when source metadata is partial or stale', () => {
+        const built = buildArtifactPrompt(
+            baseSources({
+                notices: ['Required upstream dependency is missing (data_model); generate against the spine.'],
+                // no stale names here — the notice alone must trigger the block
+                prdMarkdown: 'The product includes Smart Inbox and Digest Emails features.',
+            }),
+        );
+        expect(built.hasConflictBlock).toBe(true);
+        expect(built.sections).toContain(SECTION.conflicts);
+        expect(built.prompt).toContain('data_model');
+    });
+
+    it('omits the conflict block when there are no notices and no stale names', () => {
+        const built = buildArtifactPrompt(baseSources());
+        expect(built.hasConflictBlock).toBe(false);
+        expect(built.sections).not.toContain(SECTION.conflicts);
+    });
+
+    it('falls back to the legacy structured summary when there is no spine', () => {
+        const built = buildArtifactPrompt(
+            baseSources({ spineSection: null, legacyStructured: 'Canonical Feature Glossary:\n- f1 Smart Inbox' }),
+        );
+        expect(built.usedSpine).toBe(false);
+        expect(built.sections).toContain(SECTION.structuredFallback);
+        expect(built.sections).not.toContain(SECTION.spine);
+        // No stale-name detection without a spine.
+        expect(built.staleNameConflicts).toEqual([]);
+    });
+
+    it('includes the selected-options section only when a preset is present', () => {
+        const withPreset = buildArtifactPrompt(baseSources({ presetSection: 'SELECTED DESIGN DIRECTION: Modern SaaS' }));
+        expect(withPreset.sections).toContain(SECTION.options);
+        expect(withPreset.prompt).toContain('Modern SaaS');
+
+        const withoutPreset = buildArtifactPrompt(baseSources({ presetSection: '' }));
+        expect(withoutPreset.sections).not.toContain(SECTION.options);
+    });
+});
+
+describe('detectStaleFeatureNames', () => {
+    it('flags features whose canonical name is absent from the PRD prose', () => {
+        const spine = makeSpine();
+        const conflicts = detectStaleFeatureNames(spine, 'Only Digest Emails is mentioned here.');
+        expect(conflicts).toEqual([{ id: 'f1', canonicalName: 'Smart Inbox' }]);
+    });
+
+    it('returns no conflicts when every canonical name appears in the prose', () => {
+        const spine = makeSpine();
+        const conflicts = detectStaleFeatureNames(spine, 'Smart Inbox and Digest Emails are both here.');
+        expect(conflicts).toEqual([]);
+    });
+});

--- a/src/lib/services/__tests__/coreArtifactSpinePrompt.test.ts
+++ b/src/lib/services/__tests__/coreArtifactSpinePrompt.test.ts
@@ -50,12 +50,12 @@ describe('generateCoreArtifact — canonical spine prompt', () => {
         const prompt = lastUserPrompt();
         expect(prompt).toMatch(/Canonical PRD Spine \(AUTHORITATIVE/);
         expect(prompt).toMatch(/"id": "f1"/);
-        // Full PRD present but explicitly marked secondary.
-        expect(prompt).toMatch(/Full PRD \(SECONDARY reference only/);
+        // Full PRD present but demoted to the clearly-labeled secondary appendix.
+        expect(prompt).toContain('## APPENDIX — FULL PRD MARKDOWN (SECONDARY REFERENCE ONLY)');
         expect(prompt).toContain('Full rendered PRD markdown body.');
-        // The spine section must appear before the full PRD.
-        expect(prompt.indexOf('Canonical PRD Spine')).toBeLessThan(prompt.indexOf('Full PRD (SECONDARY'));
-        // The redundant standalone glossary/summary headers are gone.
+        // The authoritative spine section must appear before the PRD appendix.
+        expect(prompt.indexOf('CANONICAL PRD SPINE')).toBeLessThan(prompt.indexOf('APPENDIX — FULL PRD MARKDOWN'));
+        // The redundant standalone glossary/summary headers are gone (spine path).
         expect(prompt).not.toContain('Canonical Feature Glossary:');
         expect(prompt).not.toContain('Vision: Match music to mood');
     });

--- a/src/lib/services/artifactPromptBuilder.ts
+++ b/src/lib/services/artifactPromptBuilder.ts
@@ -1,0 +1,209 @@
+// Pure, machine-checkable assembly of the artifact-generation user prompt.
+//
+// Artifact prompts draw on several sources of very different reliability:
+//   1. The Canonical PRD Spine — a compact, structured, deterministic contract
+//      (identity, canonical feature ids/names, screen/entity seeds, constraints,
+//      safety restrictions). This is the single source of truth.
+//   2. Structured dependency summaries — the already-generated upstream
+//      artifacts, authoritative for the detail they own.
+//   3. User-selected options / design preset — hard task constraints.
+//   4. The full PRD markdown — free-form prose, useful only as SECONDARY
+//      reference for detail the structured sources omit.
+//
+// Without an explicit, labeled hierarchy the model can let stale PRD prose (an
+// old feature name, a since-removed scope line) override the structured truth.
+// This builder makes the hierarchy explicit and the conflict-resolution rule
+// machine-checkable, demotes the PRD markdown to a clearly-labeled appendix,
+// and surfaces any known conflicts/staleness in a dedicated block. It is pure
+// (no store / LLM / React) so prompt construction is unit-testable.
+
+import type { CanonicalPrdSpine } from '../../types';
+
+/** A feature whose canonical name is absent from the PRD prose (likely stale/renamed). */
+export interface StaleFeatureNameConflict {
+    id: string;
+    canonicalName: string;
+}
+
+export interface ArtifactPromptSources {
+    /** Artifact-specific instruction prefix (from CORE_ARTIFACT_PROMPTS[subtype].userPrefix). */
+    userPrefix: string;
+    /** Narrative guardrails derived from the PRD. */
+    guardrails: string;
+    /** The canonical spine (used for stale-name detection and identity). */
+    canonicalSpine: CanonicalPrdSpine;
+    /**
+     * Rendered authoritative spine section, or null when the spine has no
+     * features (legacy fallback path). When null, `legacyStructured` is used as
+     * the authoritative structured section instead.
+     */
+    spineSection: string | null;
+    /** Legacy structured fallback (feature glossary + PRD summary) — used only when spineSection is null. */
+    legacyStructured?: string;
+    /** Rendered structured dependency summaries (already-generated upstream artifacts). */
+    dependencyContext: string;
+    /** Which dependency subtypes are present (for the section note). */
+    dependencyKeys: string[];
+    /** Selected design-preset / options section, or '' when none. */
+    presetSection: string;
+    /** Full PRD markdown (secondary reference / appendix). */
+    prdMarkdown: string;
+    /** Mockup context section, or '' when none. */
+    mockupSection: string;
+    /**
+     * Known degradations to surface in the conflict/staleness block: missing
+     * required dependencies, spine validation warnings, incomplete-PRD flags,
+     * etc. Rendered verbatim as bullet lines.
+     */
+    notices?: string[];
+}
+
+export interface BuiltArtifactPrompt {
+    /** The assembled user prompt. */
+    prompt: string;
+    /** Section headers in authority order — a machine-checkable outline. */
+    sections: string[];
+    /** Features whose canonical name is missing from the PRD prose (possible stale usage). */
+    staleNameConflicts: StaleFeatureNameConflict[];
+    /** Whether a "Known conflicts & staleness" block was emitted. */
+    hasConflictBlock: boolean;
+    /** Whether the authoritative structured section came from the canonical spine (vs legacy fallback). */
+    usedSpine: boolean;
+}
+
+// Section header constants — exported so tests can assert against the exact
+// strings instead of brittle substrings.
+export const SECTION = {
+    task: '## TASK',
+    hierarchy: '## SOURCE HIERARCHY — READ FIRST',
+    guardrails: '## GUARDRAILS',
+    spine: '## AUTHORITATIVE — CANONICAL PRD SPINE',
+    structuredFallback: '## AUTHORITATIVE — STRUCTURED PRD SUMMARY',
+    dependencies: '## AUTHORITATIVE — STRUCTURED DEPENDENCY SUMMARIES',
+    options: '## TASK CONSTRAINTS — SELECTED OPTIONS',
+    conflicts: '## KNOWN CONFLICTS & STALENESS',
+    appendix: '## APPENDIX — FULL PRD MARKDOWN (SECONDARY REFERENCE ONLY)',
+} as const;
+
+const HIERARCHY_RULES = [
+    'You are given sources at different authority levels. Resolve EVERY conflict in this order:',
+    '',
+    '1. AUTHORITATIVE — Canonical PRD Spine: the structured contract of product identity,',
+    '   canonical feature ids/names, screen/entity seeds, constraints, and safety restrictions.',
+    '   This is the single source of truth. It always wins.',
+    '2. AUTHORITATIVE — Structured Dependency Summaries: the already-generated upstream',
+    '   artifacts. Treat them as authoritative for the detail they own, BUT if a dependency',
+    '   conflicts with the Canonical PRD Spine, prefer the spine — unless the dependency is',
+    '   explicitly newer and valid.',
+    '3. TASK CONSTRAINTS — Selected options / design preset: honor these as hard constraints.',
+    '4. SECONDARY REFERENCE — Full PRD markdown (Appendix): free-form prose, useful only for',
+    '   detail the structured sources omit. It MUST NOT override the Canonical PRD Spine or the',
+    '   structured dependency summaries. Where the prose names a feature differently from the',
+    '   spine, use the spine’s canonical id and name.',
+    '',
+    'Always cite features by their canonical id and name from the spine (or the feature glossary',
+    'when no spine is present) — never by a prose-only or stale name.',
+].join('\n');
+
+/**
+ * Detect features whose canonical name does not appear (case-insensitively) in
+ * the PRD prose. Because the spine and the PRD markdown are normally rendered
+ * from the same StructuredPRD, this fires only when they have drifted — e.g. a
+ * post-generation edit or a consistency-review rename left the prose using an
+ * older name. Best-effort: it flags likely stale usage, it does not prove it.
+ */
+export function detectStaleFeatureNames(
+    spine: CanonicalPrdSpine,
+    prdMarkdown: string,
+): StaleFeatureNameConflict[] {
+    const haystack = prdMarkdown.toLowerCase();
+    const out: StaleFeatureNameConflict[] = [];
+    for (const f of spine.features) {
+        const name = f.name?.trim();
+        if (!name) continue;
+        if (!haystack.includes(name.toLowerCase())) {
+            out.push({ id: f.id, canonicalName: name });
+        }
+    }
+    return out;
+}
+
+/**
+ * Assemble the artifact-generation user prompt with an explicit, machine-checkable
+ * source hierarchy. Returns the prompt plus a structured description of what was
+ * included so callers/tests can assert on the organization.
+ */
+export function buildArtifactPrompt(sources: ArtifactPromptSources): BuiltArtifactPrompt {
+    const usedSpine = sources.spineSection !== null;
+    const structuredSection = usedSpine ? sources.spineSection! : (sources.legacyStructured ?? '');
+
+    const staleNameConflicts = usedSpine
+        ? detectStaleFeatureNames(sources.canonicalSpine, sources.prdMarkdown)
+        : [];
+
+    const noticeLines = (sources.notices ?? []).filter(n => n && n.trim().length > 0);
+    const conflictLines: string[] = [];
+    for (const notice of noticeLines) conflictLines.push(`- ${notice}`);
+    for (const c of staleNameConflicts) {
+        conflictLines.push(
+            `- Feature "${c.id}" is canonically named "${c.canonicalName}". The PRD prose may reference ` +
+            `it by a different (stale) name — always use the canonical id and name.`,
+        );
+    }
+    const hasConflictBlock = conflictLines.length > 0;
+
+    const sectionOrder: string[] = [];
+    const parts: string[] = [];
+    const push = (header: string, body: string) => {
+        sectionOrder.push(header);
+        parts.push(`${header}\n${body}`);
+    };
+
+    // 1. Task.
+    push(SECTION.task, sources.userPrefix.trim());
+    // 2. Hierarchy explainer (comes before any source so the model reads the rules first).
+    push(SECTION.hierarchy, HIERARCHY_RULES);
+    // 3. Guardrails.
+    push(SECTION.guardrails, sources.guardrails.trim());
+    // 4. Authoritative structured source (spine, or legacy structured fallback).
+    push(usedSpine ? SECTION.spine : SECTION.structuredFallback, structuredSection.trim());
+    // 5. Authoritative structured dependency summaries.
+    const depNote = sources.dependencyKeys.length
+        ? `(Authoritative for the detail they own; prefer the spine on any conflict. Present: ${sources.dependencyKeys.join(', ')}.)`
+        : '(None generated yet.)';
+    push(SECTION.dependencies, `${depNote}\n${sources.dependencyContext.trim()}`);
+    // 6. Task constraints / selected options (only when present).
+    if (sources.presetSection.trim()) {
+        push(SECTION.options, sources.presetSection.trim());
+    }
+    // 7. Known conflicts & staleness (only when there is something to say).
+    if (hasConflictBlock) {
+        push(
+            SECTION.conflicts,
+            [
+                'The sources below are known to disagree or be incomplete. Resolve each in favor of the',
+                'authoritative structured sources (spine first, then dependency summaries):',
+                '',
+                ...conflictLines,
+            ].join('\n'),
+        );
+    }
+    // 8. Full PRD markdown appendix (secondary reference only) + mockup context.
+    push(
+        SECTION.appendix,
+        [
+            'Defer to the authoritative structured sources above on ANY conflict; use this solely for',
+            'detail they omit. Do not treat prose here as overriding the canonical spine.',
+            '',
+            sources.prdMarkdown.trim(),
+        ].join('\n') + sources.mockupSection,
+    );
+
+    return {
+        prompt: parts.join('\n\n'),
+        sections: sectionOrder,
+        staleNameConflicts,
+        hasConflictBlock,
+        usedSpine,
+    };
+}

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -6,7 +6,8 @@ import { getArtifactModel, CORE_ARTIFACT_COMPLEXITY } from '../artifactModelSett
 import type { ArtifactComplexity } from '../artifactModelSettings';
 import { screenInventorySchema, dataModelSchema, componentInventorySchema, designSystemTokensSchema, implementationPlanSchema } from '../schemas/artifactSchemas';
 import { buildDependencyContext, buildFeatureGlossary, buildNarrativeGuardrails, normalizeArtifactMarkdown } from '../artifactOrchestration';
-import { assertDependenciesSufficient } from '../artifactDependencyGate';
+import { assertDependenciesSufficient, findMissingRequiredDependencies } from '../artifactDependencyGate';
+import { buildArtifactPrompt } from './artifactPromptBuilder';
 import { buildCanonicalPrdSpine, buildCanonicalSpinePromptSection } from '../canonicalPrdSpine';
 import { normalizeScreenInventory, screenInventoryToMarkdown } from '../screenInventoryNormalize';
 import { dataModelToMarkdown } from './dataModelMarkdown';
@@ -538,16 +539,10 @@ export const generateCoreArtifact = async (
     const spineSection = buildCanonicalSpinePromptSection(canonicalSpine);
     const spineContextUsed = spineSection !== null;
 
-    // Prompt hierarchy: persona/system → guardrails → Canonical PRD Spine
-    // (authoritative) → dependency artifacts → full PRD markdown (secondary
-    // fallback only). The spine subsumes the old feature glossary + inline PRD
-    // summary, so those are dropped when the spine is used to avoid feeding
-    // several differently-worded views of the same product facts.
-    let userPrompt: string;
-    if (spineSection) {
-        userPrompt = `${config.userPrefix}\n\n${guardrails}\n\n${spineSection}\n\nDependency Artifacts:\n${dependencyContext}${presetSection}\n\n---\n\nFull PRD (SECONDARY reference only — defer to the Canonical PRD Spine above on any conflict; use this solely for detail the spine omits):\n${prdContent}${mockupSection}`;
-    } else {
-        // Legacy fallback: no reliable spine (e.g. a PRD with no features).
+    // Legacy structured fallback (feature glossary + inline PRD summary), used
+    // only when there is no reliable spine (e.g. a PRD with no features). Built
+    // lazily so the spine path pays nothing for it.
+    const buildLegacyStructured = (): string => {
         const featureList = structuredPRD.features.map(f => {
             let line = `- [${f.id}] ${f.name} (${f.complexity}${f.priority ? `, ${f.priority}` : ''}): ${f.description}`;
             if (f.acceptanceCriteria && f.acceptanceCriteria.length > 0) {
@@ -575,8 +570,44 @@ Architecture: ${structuredPRD.architecture}${
                 : ''
         }`;
         const featureGlossary = buildFeatureGlossary(structuredPRD);
-        userPrompt = `${config.userPrefix}\n\n${guardrails}\n\nCanonical Feature Glossary:\n${featureGlossary}\n\nDependency Artifacts:\n${dependencyContext}\n\n${prdSummary}${presetSection}\n\n---\n\nFull PRD:\n${prdContent}${mockupSection}`;
+        return `Canonical Feature Glossary:\n${featureGlossary}\n\n${prdSummary}`;
+    };
+
+    // Known conflicts / staleness to surface to the model. Missing REQUIRED
+    // dependencies (only reachable here when degraded generation was
+    // acknowledged) and spine validation warnings are the machine-derivable
+    // ones; stale prose feature names are detected inside the prompt builder.
+    const missingRequired = findMissingRequiredDependencies(subtype, generatedArtifacts);
+    const notices: string[] = [];
+    if (missingRequired.length > 0) {
+        notices.push(
+            `Required upstream ${missingRequired.length > 1 ? 'dependencies are' : 'dependency is'} missing (${missingRequired.join(', ')}); ` +
+            'generate against the Canonical PRD Spine and note any gaps rather than inventing detail.',
+        );
     }
+    for (const w of canonicalSpine.meta.validation.warnings) {
+        notices.push(`Canonical PRD Spine warning: ${w}`);
+    }
+
+    // Assemble the prompt with an explicit, machine-checkable source hierarchy:
+    // task → authoritative canonical spine → authoritative structured dependency
+    // summaries → selected options → known conflicts/staleness → SECONDARY full
+    // PRD markdown appendix. Prose in the appendix must never override the
+    // structured sources. See artifactPromptBuilder.ts.
+    const built = buildArtifactPrompt({
+        userPrefix: config.userPrefix,
+        guardrails,
+        canonicalSpine,
+        spineSection,
+        legacyStructured: spineSection ? undefined : buildLegacyStructured(),
+        dependencyContext,
+        dependencyKeys: Object.keys(generatedArtifacts),
+        presetSection,
+        prdMarkdown: prdContent,
+        mockupSection,
+        notices,
+    });
+    const userPrompt = built.prompt;
 
     // Diagnostics stamped onto every artifact version — records whether the
     // canonical spine drove generation or the legacy summary path was used.
@@ -608,13 +639,21 @@ Architecture: ${structuredPRD.architecture}${
         ],
         promptPieces: [
             { label: 'Artifact template (userPrefix)', present: true },
+            { label: 'Source hierarchy header', present: true },
             { label: 'Narrative guardrails', present: true },
-            { label: 'Canonical PRD Spine', present: spineContextUsed },
-            { label: 'Legacy feature glossary + summary', present: !spineContextUsed },
-            { label: 'Dependency artifacts', present: dependencyKeys.length > 0, detail: dependencyKeys.join(', ') || undefined },
-            { label: 'Design-system preset directive', present: Boolean(presetDirective) },
+            { label: 'Canonical PRD Spine (authoritative)', present: spineContextUsed },
+            { label: 'Legacy structured PRD summary (fallback)', present: !spineContextUsed },
+            { label: 'Structured dependency summaries (authoritative)', present: dependencyKeys.length > 0, detail: dependencyKeys.join(', ') || undefined },
+            { label: 'Selected options / preset directive', present: Boolean(presetDirective) },
+            {
+                label: 'Known conflicts & staleness block',
+                present: built.hasConflictBlock,
+                detail: built.staleNameConflicts.length
+                    ? `${built.staleNameConflicts.length} stale feature name(s)`
+                    : undefined,
+            },
             { label: 'Mockup context', present: Boolean(options?.mockupContext) },
-            { label: 'Full PRD (secondary)', present: true },
+            { label: 'Full PRD markdown appendix (secondary)', present: true },
         ],
     };
 

--- a/src/lib/services/prdConsistencyReview.ts
+++ b/src/lib/services/prdConsistencyReview.ts
@@ -22,7 +22,7 @@
 
 import { callGemini, getFastModel } from '../geminiClient';
 import type { LlmTraceMeta } from '../trace/traceTypes';
-import type { StructuredPRD } from '../../types';
+import type { StructuredPRD, ConsistencyReviewDiff, ConsistencyReviewMeta } from '../../types';
 import { repairTruncatedJson } from '../jsonRepair';
 import { structuredPRDSchema } from '../schemas/prdSchemas';
 
@@ -62,7 +62,13 @@ export type ReviewRejectionReason =
     | 'detail-loss'           // a key content array materially shrank
     | 'missing-required'      // a required top-level field was emptied/dropped
     | 'feature-ids-changed'   // one or more original feature IDs disappeared
-    | 'product-identity-lost'; // productName was present originally, now empty
+    | 'product-identity-lost' // productName was present originally, now empty
+    // --- Semantic preservation guards (Phase 3) — reject revisions that would
+    // silently change facts downstream artifacts depend on. ---
+    | 'feature-acceptance-criteria-lost' // a feature's acceptance/success criteria shrank
+    | 'feature-dependencies-lost'        // a feature's dependency id references were dropped
+    | 'safety-restriction-lost'          // a safety directive (constraint) was dropped/weakened
+    | 'entity-detail-lost';              // entity fields, relationships, or example values dropped
 
 export interface ReviewResult {
     /** The PRD to use downstream (revised when `applied`, else the original). */
@@ -73,6 +79,11 @@ export interface ReviewResult {
     changeLog?: string;
     /** Present only when `applied` is false: why the revision was discarded. */
     rejectionReason?: ReviewRejectionReason;
+    /**
+     * Compact structured diff of what the review changed (accepted) or attempted
+     * to change (rejected). For transparency/debugging — never affects generation.
+     */
+    diff?: ConsistencyReviewDiff;
 }
 
 const SYSTEM = `You are a meticulous product editor performing a final consistency pass on a Product Requirements Document. The PRD was assembled from independently-generated sections, so it may contain inconsistencies.
@@ -87,6 +98,11 @@ Reconcile ONLY the following, and change nothing else:
 HARD RULES:
 - Do NOT remove or summarize substantive detail. Preserve every feature, entity, user loop, page, risk, metric, and plan item. Array lengths must not shrink.
 - Do NOT invent new features, entities, or scope.
+- Preserve EVERY feature's acceptanceCriteria and successCriteria (do not shorten or drop any).
+- Preserve EVERY feature's "dependencies" list verbatim — these are feature-id references other artifacts rely on.
+- Preserve EVERY "constraints" entry verbatim — these are safety/privacy/compliance restrictions and must never be dropped or softened.
+- Preserve every entity's fields, relationships, and example values.
+- Do NOT change any feature "id".
 - Preserve the exact JSON shape and all field names of the input.
 - Return ONLY a JSON object with two keys: "prd" (the full corrected PRD, same shape as the input) and "changeLog" (a one-sentence summary of what you reconciled, or "No changes needed").`;
 
@@ -178,6 +194,182 @@ const losesProductIdentity = (original: StructuredPRD, revised: StructuredPRD): 
     return typeof after !== 'string' || after.trim().length === 0;
 };
 
+// --- Semantic preservation guards (Phase 3) -----------------------------------
+//
+// These protect facts that downstream artifacts (screens, data model,
+// implementation plan, tasks) consume directly. The consistency review may
+// normalize wording, but it must never silently drop or weaken these — so any
+// violation discards the whole revision and keeps the deterministically-merged
+// PRD. Features and entities are matched by their stable key (feature id /
+// entity name); a key that disappears entirely is caught by the earlier
+// feature-id / detail-loss guards, so these only inspect surviving items.
+
+/**
+ * A feature's acceptance-type checks (acceptanceCriteria, successCriteria) must
+ * not shrink. Downstream tasks and validation trace to these, so losing one
+ * silently weakens the build contract.
+ */
+const dropsFeatureAcceptanceCriteria = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const revisedById = new Map((revised.features ?? []).map(f => [f.id, f]));
+    for (const orig of original.features ?? []) {
+        const rev = revisedById.get(orig.id);
+        if (!rev) continue; // id-drop handled by changesFeatureIds
+        if (len(orig.acceptanceCriteria) > 0 && len(rev.acceptanceCriteria) < len(orig.acceptanceCriteria)) return true;
+        if (len(orig.successCriteria) > 0 && len(rev.successCriteria) < len(orig.successCriteria)) return true;
+    }
+    return false;
+};
+
+/**
+ * A feature's `dependencies` (feature-id references) must be preserved as a
+ * superset. These ids drive cross-feature ordering in the implementation plan;
+ * dropping one silently breaks the dependency graph.
+ */
+const dropsFeatureDependencies = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const revisedById = new Map((revised.features ?? []).map(f => [f.id, f]));
+    for (const orig of original.features ?? []) {
+        const rev = revisedById.get(orig.id);
+        if (!rev) continue;
+        const origDeps = (orig.dependencies ?? []).filter(Boolean);
+        if (origDeps.length === 0) continue;
+        const revDeps = new Set((rev.dependencies ?? []).filter(Boolean));
+        if (origDeps.some(d => !revDeps.has(d))) return true;
+    }
+    return false;
+};
+
+/**
+ * Safety/privacy/compliance restrictions live in `constraints` (the safety gate
+ * injects `allowed_with_restrictions` directives here, and they propagate to
+ * every downstream artifact). Every original constraint must survive verbatim —
+ * a reworded or dropped restriction is treated as weakening and rejected. When
+ * the model omits the field entirely the merge-over-original preserves it, so
+ * this only fires when the revision actively replaced constraints with a
+ * lossier list.
+ */
+const weakensSafetyRestrictions = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const origConstraints = (original.constraints ?? []).filter(Boolean);
+    if (origConstraints.length === 0) return false;
+    const revConstraints = new Set((revised.constraints ?? []).filter(Boolean));
+    return origConstraints.some(c => !revConstraints.has(c));
+};
+
+/**
+ * Entity structure (rich data-model fields + relationships, and lightweight
+ * domain-entity example values) must not be dropped. The data-model artifact
+ * and mockup grounding read these; losing a field or relationship silently
+ * changes the schema downstream artifacts generate against.
+ */
+const dropsEntityDetail = (original: StructuredPRD, revised: StructuredPRD): boolean => {
+    const origEntities = original.richDataModel?.entities ?? [];
+    if (origEntities.length > 0) {
+        const revById = new Map((revised.richDataModel?.entities ?? []).map(e => [e.name, e]));
+        for (const orig of origEntities) {
+            const rev = revById.get(orig.name);
+            if (!rev) continue; // entity count drop caught by detail-loss guard
+            if (len(orig.fields) > 0 && len(rev.fields) < len(orig.fields)) return true;
+            const origRel = (orig.relationships ?? []).filter(Boolean);
+            if (origRel.length > 0) {
+                const revRel = new Set((rev.relationships ?? []).filter(Boolean));
+                if (origRel.some(r => !revRel.has(r))) return true;
+            }
+        }
+    }
+    const origDomain = original.domainEntities ?? [];
+    if (origDomain.length > 0) {
+        const revById = new Map((revised.domainEntities ?? []).map(e => [e.name, e]));
+        for (const orig of origDomain) {
+            const rev = revById.get(orig.name);
+            if (!rev) continue;
+            if (len(orig.exampleValues) > 0 && len(rev.exampleValues) < len(orig.exampleValues)) return true;
+        }
+    }
+    return false;
+};
+
+/**
+ * Run every acceptance guard against the merged-over revision, returning the
+ * first violation (or null when the revision is safe to apply). Order is
+ * deliberate: cheapest/most-fundamental facts first.
+ */
+const evaluateGuards = (original: StructuredPRD, revised: StructuredPRD): ReviewRejectionReason | null => {
+    if (losesDetail(original, revised)) return 'detail-loss';
+    if (dropsRequiredField(original, revised)) return 'missing-required';
+    if (changesFeatureIds(original, revised)) return 'feature-ids-changed';
+    if (losesProductIdentity(original, revised)) return 'product-identity-lost';
+    if (dropsFeatureAcceptanceCriteria(original, revised)) return 'feature-acceptance-criteria-lost';
+    if (dropsFeatureDependencies(original, revised)) return 'feature-dependencies-lost';
+    if (weakensSafetyRestrictions(original, revised)) return 'safety-restriction-lost';
+    if (dropsEntityDetail(original, revised)) return 'entity-detail-lost';
+    return null;
+};
+
+// --- Structured review diff (Phase 3) -----------------------------------------
+//
+// A compact, content-free summary of what the review did (or attempted). Used
+// for transparency in the version-history UI and for debugging — it never
+// affects generation.
+
+// Top-level StructuredPRD keys whose change is worth surfacing in the diff.
+const stableStringify = (v: unknown): string => {
+    if (v === undefined) return 'undefined';
+    return JSON.stringify(v);
+};
+
+const computeSectionsChanged = (original: StructuredPRD, revised: StructuredPRD): string[] => {
+    const keys = new Set<string>([...Object.keys(original), ...Object.keys(revised)]);
+    const changed: string[] = [];
+    for (const key of keys) {
+        const before = (original as Record<string, unknown>)[key];
+        const after = (revised as Record<string, unknown>)[key];
+        if (stableStringify(before) !== stableStringify(after)) changed.push(key);
+    }
+    return changed.sort();
+};
+
+const computeFeaturesReworded = (
+    original: StructuredPRD,
+    revised: StructuredPRD,
+): Array<{ id: string; before: string; after: string }> => {
+    const revisedById = new Map((revised.features ?? []).map(f => [f.id, f]));
+    const out: Array<{ id: string; before: string; after: string }> = [];
+    for (const orig of original.features ?? []) {
+        const rev = revisedById.get(orig.id);
+        if (!rev) continue;
+        if (orig.name !== rev.name) out.push({ id: orig.id, before: orig.name, after: rev.name });
+    }
+    return out;
+};
+
+/**
+ * Build the structured diff between the original merged PRD and the model's
+ * revision. `guards` carries any guard reasons that fired; `outcome` records how
+ * the revision was ultimately handled.
+ */
+const buildReviewDiff = (
+    original: StructuredPRD,
+    revised: StructuredPRD,
+    guards: string[],
+    outcome: ConsistencyReviewDiff['outcome'],
+): ConsistencyReviewDiff => {
+    const diff: ConsistencyReviewDiff = {
+        sectionsChanged: computeSectionsChanged(original, revised),
+        featuresReworded: computeFeaturesReworded(original, revised),
+        guardsTriggered: guards,
+        outcome,
+    };
+    const beforeName = original.productName;
+    const afterName = revised.productName;
+    if (
+        typeof beforeName === 'string' && beforeName.trim().length > 0 &&
+        typeof afterName === 'string' && afterName.trim().length > 0 &&
+        beforeName !== afterName
+    ) {
+        diff.productNameChange = { before: beforeName, after: afterName };
+    }
+    return diff;
+};
+
 const parse = (raw: string): { prd?: Partial<StructuredPRD>; changeLog?: string } | null => {
     const tryParse = (s: string) => {
         try {
@@ -203,29 +395,70 @@ export const reviewPrdConsistency = async (
 
     const parsed = parse(raw);
     if (parsed === null) {
-        return { prd, applied: false, rejectionReason: 'unparseable' };
+        return {
+            prd,
+            applied: false,
+            rejectionReason: 'unparseable',
+            diff: buildReviewDiff(prd, prd, ['unparseable'], 'rejected'),
+        };
     }
     if (!parsed.prd) {
-        return { prd, applied: false, rejectionReason: 'no-prd' };
+        return {
+            prd,
+            applied: false,
+            rejectionReason: 'no-prd',
+            diff: buildReviewDiff(prd, prd, ['no-prd'], 'rejected'),
+        };
     }
 
     // Merge over the original so any omitted field is preserved.
     const revised: StructuredPRD = { ...prd, ...parsed.prd };
 
     // Conservative acceptance guards — any violation discards the whole
-    // revision and keeps the deterministically-merged PRD.
-    if (losesDetail(prd, revised)) {
-        return { prd, applied: false, rejectionReason: 'detail-loss' };
-    }
-    if (dropsRequiredField(prd, revised)) {
-        return { prd, applied: false, rejectionReason: 'missing-required' };
-    }
-    if (changesFeatureIds(prd, revised)) {
-        return { prd, applied: false, rejectionReason: 'feature-ids-changed' };
-    }
-    if (losesProductIdentity(prd, revised)) {
-        return { prd, applied: false, rejectionReason: 'product-identity-lost' };
+    // revision and keeps the deterministically-merged PRD. The diff still
+    // records what the model *tried* to change (original vs revised) so the
+    // rejection is inspectable.
+    const violation = evaluateGuards(prd, revised);
+    if (violation) {
+        return {
+            prd,
+            applied: false,
+            rejectionReason: violation,
+            diff: buildReviewDiff(prd, revised, [violation], 'rejected'),
+        };
     }
 
-    return { prd: revised, applied: true, changeLog: parsed.changeLog };
+    return {
+        prd: revised,
+        applied: true,
+        changeLog: parsed.changeLog,
+        diff: buildReviewDiff(prd, revised, [], 'accepted'),
+    };
+};
+
+/**
+ * Human-readable one-line summary of a consistency-review outcome for the
+ * version-history UI. Pure; returns null when there is nothing worth showing
+ * (the pass was skipped, or a legacy meta lacks the record). Transparency only.
+ */
+export const summarizeConsistencyReview = (meta?: ConsistencyReviewMeta): string | null => {
+    if (!meta || !meta.ran) return null;
+    const diff = meta.diff;
+    if (meta.status === 'applied') {
+        const parts: string[] = [];
+        const changedCount = diff?.sectionsChanged.length ?? 0;
+        if (changedCount > 0) parts.push(`reconciled ${changedCount} section${changedCount === 1 ? '' : 's'}`);
+        if (diff?.productNameChange) parts.push(`product name → “${diff.productNameChange.after}”`);
+        const reworded = diff?.featuresReworded.length ?? 0;
+        if (reworded > 0) parts.push(`renamed ${reworded} feature label${reworded === 1 ? '' : 's'}`);
+        return parts.length > 0 ? `Applied (${parts.join('; ')}).` : 'Applied (no material changes).';
+    }
+    if (meta.status === 'rejected') {
+        const reason = meta.rejectionReason ?? diff?.guardsTriggered[0];
+        return reason
+            ? `Discarded — kept the merged PRD (guard: ${reason}).`
+            : 'Discarded — kept the merged PRD.';
+    }
+    if (meta.status === 'error') return 'Review call failed — kept the merged PRD.';
+    return null;
 };

--- a/src/lib/services/prdConsistencyReview.ts
+++ b/src/lib/services/prdConsistencyReview.ts
@@ -259,6 +259,14 @@ const weakensSafetyRestrictions = (original: StructuredPRD, revised: StructuredP
  * domain-entity example values) must not be dropped. The data-model artifact
  * and mockup grounding read these; losing a field or relationship silently
  * changes the schema downstream artifacts generate against.
+ *
+ * Comparisons are by IDENTITY, not count: every original entity (by name) must
+ * survive, and every original field (by name) within it must survive. A
+ * count-only check would miss (a) dropping one entity out of several while
+ * staying above the detail-loss 70% floor, and (b) swapping a field for a
+ * different one while keeping the array length. Both silently lose schema facts,
+ * so we reject them. This mirrors the feature-id stability guard: entity/field
+ * names are the downstream join keys and must stay canonical.
  */
 const dropsEntityDetail = (original: StructuredPRD, revised: StructuredPRD): boolean => {
     const origEntities = original.richDataModel?.entities ?? [];
@@ -266,8 +274,12 @@ const dropsEntityDetail = (original: StructuredPRD, revised: StructuredPRD): boo
         const revById = new Map((revised.richDataModel?.entities ?? []).map(e => [e.name, e]));
         for (const orig of origEntities) {
             const rev = revById.get(orig.name);
-            if (!rev) continue; // entity count drop caught by detail-loss guard
-            if (len(orig.fields) > 0 && len(rev.fields) < len(orig.fields)) return true;
+            if (!rev) return true; // an original entity was dropped or renamed
+            // Field identity: every original field name must still be present.
+            const revFieldNames = new Set((rev.fields ?? []).map(f => f.name).filter(Boolean));
+            const origFieldNames = (orig.fields ?? []).map(f => f.name).filter(Boolean);
+            if (origFieldNames.some(n => !revFieldNames.has(n))) return true;
+            // Relationships preserved as a superset.
             const origRel = (orig.relationships ?? []).filter(Boolean);
             if (origRel.length > 0) {
                 const revRel = new Set((rev.relationships ?? []).filter(Boolean));
@@ -280,7 +292,7 @@ const dropsEntityDetail = (original: StructuredPRD, revised: StructuredPRD): boo
         const revById = new Map((revised.domainEntities ?? []).map(e => [e.name, e]));
         for (const orig of origDomain) {
             const rev = revById.get(orig.name);
-            if (!rev) continue;
+            if (!rev) return true; // an original domain entity was dropped or renamed
             if (len(orig.exampleValues) > 0 && len(rev.exampleValues) < len(orig.exampleValues)) return true;
         }
     }

--- a/src/lib/services/progressivePrdPipeline.ts
+++ b/src/lib/services/progressivePrdPipeline.ts
@@ -293,6 +293,7 @@ export const runProgressivePrdPipeline = async (
                 applied: review.applied,
                 status: review.applied ? 'applied' : 'rejected',
                 rejectionReason: review.applied ? undefined : review.rejectionReason,
+                diff: review.diff,
             };
             if (review.applied) structuredPRD = review.prd;
             // Record the consistency pass as a final, all-sections-dependent

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -297,6 +297,31 @@ export type ConsistencyReviewMeta = {
     status: 'applied' | 'rejected' | 'skipped' | 'error';
     /** Present only when status is 'rejected' or 'error'. */
     rejectionReason?: string;
+    /**
+     * Compact structured diff of what the review pass changed (or attempted to
+     * change, on rejection). Transparency/debugging only — never affects
+     * generation. Optional/back-compat: absent on legacy meta and skipped runs.
+     */
+    diff?: ConsistencyReviewDiff;
+};
+
+/**
+ * A compact, human-readable record of what the consistency-review pass did.
+ * Populated whether the review was accepted or rejected so the version-history
+ * UI can explain the outcome. Pure/derived — carries no PRD content, only
+ * summaries. All fields present so older stored diffs stay renderable.
+ */
+export type ConsistencyReviewDiff = {
+    /** Top-level StructuredPRD field keys whose serialized value changed. */
+    sectionsChanged: string[];
+    /** Features whose id was preserved but whose display name changed (wording, not identity). */
+    featuresReworded: Array<{ id: string; before: string; after: string }>;
+    /** Product-name normalization, when the review canonicalized it. */
+    productNameChange?: { before: string; after: string };
+    /** Guard checks that fired (empty when the review was accepted cleanly). */
+    guardsTriggered: string[];
+    /** Final outcome of the review pass. */
+    outcome: 'accepted' | 'partially-accepted' | 'repaired' | 'rejected';
 };
 
 export type GenerationMeta = {


### PR DESCRIPTION
## Summary

Phase 3 of the Synapse reliability audit, focused on two risks:

1. **The automatic PRD consistency-review pass could apply model-authored changes that silently drop facts downstream artifacts rely on.** It merged model output over the merged PRD with only coarse guards (detail-loss, required fields, feature-id stability, product identity), so a revision that kept feature counts/ids but quietly removed a feature's acceptance criteria, a dependency reference, a safety restriction, or an entity field would be accepted as a normal reviewed PRD.
2. **Artifact prompts mixed the authoritative canonical spine, structured dependency summaries, and full PRD markdown without an explicit, machine-checkable hierarchy**, letting stale prose (e.g. an old feature name) potentially override structured truth.

## Changes

### Consistency-review semantic guards (`src/lib/services/prdConsistencyReview.ts`)
- New wholesale-reject guards for facts downstream artifacts consume: dropped/reduced per-feature **acceptance/success criteria**, dropped feature **dependency ids**, dropped or **weakened safety restrictions** (`constraints`, preserved verbatim), and dropped **entity fields / relationships / example values** (rich data model + `domainEntities`). Consolidated into a single ordered `evaluateGuards` chokepoint.
- Defense-in-depth: the review system prompt now explicitly demands preservation of these fields.

### Structured review diff + transparency (`src/types`, pipeline, version-history UI)
- New `ConsistencyReviewDiff` (sections changed, feature relabels, product-name normalization, guards triggered, outcome) recorded in `ConsistencyReviewMeta` for both accepted and rejected passes.
- `summarizeConsistencyReview(meta)` renders a one-line summary surfaced in the PRD **version-history panel** (`VersionEntry.consistencyReview`). Transparency/debugging only — generation is never affected.

### Explicit, machine-checkable artifact prompt hierarchy (`src/lib/services/artifactPromptBuilder.ts`, `coreArtifactService.ts`)
- Extracted prompt assembly into a pure, unit-tested builder that labels every source with its authority level in a fixed order: **task → source-hierarchy rules → guardrails → authoritative canonical spine → authoritative structured dependency summaries → selected options/preset → known conflicts & staleness → SECONDARY full-PRD markdown appendix**.
- Explicit rule that appendix prose must never override the structured sources, and that features must be cited by canonical id/name, not stale prose names.
- Conflict/staleness block surfaces machine-derived notices: missing REQUIRED dependencies (`findMissingRequiredDependencies`), spine validation warnings, and **stale feature-name drift** (`detectStaleFeatureNames` — canonical names absent from the PRD prose).

## Tests
- `prdConsistencyReview.test.ts`: acceptance-criteria drop, dependency-reference removal, safety-restriction weakening, entity field + relationship drops (all → rejected), plus accepted/rejected diff assertions.
- `artifactPromptBuilder.test.ts`: section ordering + secondary-appendix labeling, stale-name flagging (Case 1), prefer-spine-over-dependency instruction (Case 2), visible conflict/staleness block (Case 3), legacy fallback, and options gating.
- Updated the existing `coreArtifactSpinePrompt.test.ts` for the new appendix wording.

## Verification
- `npm run build` (tsc -b + vite) ✓
- `npm run lint` ✓
- Full `vitest run`: **1017 passed** ✓
- Manually inspected a generated prompt — confirmed the required organization (task → authoritative spine → structured dependency summaries → options → known conflicts/staleness → secondary PRD appendix).

## Remaining limitations
- Guards match features by id and entities by name; a rename + detail-drop in the same revision could evade the entity-detail guard (a rename is caught only when it changes an id, not an entity name). Feature-system `featureIds`/narrative `dependencies` are not yet guarded.
- Consistency-review guards reject wholesale rather than surgically repairing, so a revision that touches one protected fact loses its unrelated terminology fixes too (chosen deliberately for predictability and safety).
- Stale feature-name detection is a best-effort substring heuristic (flags likely drift, does not prove it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBS1w6m4kzFnDuhzYKb8Nx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBS1w6m4kzFnDuhzYKb8Nx)_