### PR TITLE
Fix strong-tier model defaulting to Flash instead of Pro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,8 +768,15 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     else **(2)** the complexity recommendation — `high` (screen_inventory,
     user_flows, data_model, implementation_plan) → Expert/Pro (`getStrongModel`),
     `low` (component_inventory, design_system, prompt_pack) → Fast/Flash
-    (`getFastModel`), else **(3)** the tier fallback to the single Default model
-    (`getModel`) → `DEFAULT_GEMINI_MODEL`. `coreArtifactService.selectArtifactModel`
+    (`getFastModel`), else **(3)** the tier fallback in `getFastModel`/
+    `getStrongModel`: an explicit tier model → the single Default model
+    (`GEMINI_MODEL`) → the **tier's own default** (`DEFAULT_FAST_MODEL` = Flash,
+    `DEFAULT_STRONG_MODEL` = Pro, both in `geminiClient.ts`). The strong tier
+    defaults to **Pro**, matching the Settings pickers — it must never collapse
+    to the Flash global default (the old `getStrongModel → getModel →
+    DEFAULT_GEMINI_MODEL` chain did, so complex PRD sections / high-complexity
+    artifacts silently ran on Flash even though Settings advertised Pro).
+    `coreArtifactService.selectArtifactModel`
     delegates to `getArtifactModel` and re-exports `CORE_ARTIFACT_COMPLEXITY` for
     back-compat. Existing projects have no override key, so behaviour is
     unchanged until the user picks a model (no migration). The resolved model is

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X, Key, Cpu, Shield, ExternalLink, Activity, ChevronDown, AlertTriangle, Briefcase, Sparkles, Github, ChevronRight, Bug, KeyRound } from 'lucide-react';
 import { getOwnerToken } from '../lib/snapshotClient';
-import { DEFAULT_GEMINI_MODEL } from '../lib/geminiClient';
+import { DEFAULT_GEMINI_MODEL, DEFAULT_FAST_MODEL, DEFAULT_STRONG_MODEL } from '../lib/geminiClient';
 import { ProviderKeysSection } from './settings/ProviderKeysSection';
 import { ConnectedAccountsSection } from './settings/ConnectedAccountsSection';
 import { ArtifactModelsSection } from './settings/ArtifactModelsSection';
@@ -23,9 +23,6 @@ import {
     OPENAI_API_KEY,
     GITHUB_TOKEN,
 } from '../lib/localCredentials';
-
-const DEFAULT_FAST_MODEL = 'gemini-3.5-flash';
-const DEFAULT_STRONG_MODEL = 'gemini-3.1-pro-preview';
 
 interface SettingsModalProps {
     onClose: () => void;

--- a/src/lib/__tests__/artifactModelSettings.test.ts
+++ b/src/lib/__tests__/artifactModelSettings.test.ts
@@ -10,7 +10,7 @@ import {
     DEFAULT_MOCKUP_IMAGE_MODE,
     resolveMockupRender,
 } from '../artifactModelSettings';
-import { DEFAULT_GEMINI_MODEL } from '../geminiClient';
+import { DEFAULT_GEMINI_MODEL, DEFAULT_FAST_MODEL, DEFAULT_STRONG_MODEL } from '../geminiClient';
 import type { CoreArtifactSubtype } from '../../types';
 
 describe('artifact model settings — persistence & defaults', () => {
@@ -28,12 +28,21 @@ describe('artifact model settings — persistence & defaults', () => {
         expect(getArtifactModel('design_system')).toBe('flash-x');
     });
 
-    it('falls back through the tier resolvers to the single Default model', () => {
-        // Nothing set at all → DEFAULT_GEMINI_MODEL for every artifact.
+    it('falls back through the tier resolvers to the per-tier defaults', () => {
+        // Nothing set at all → each tier's own default: high artifacts get the
+        // strong (Pro) default, low artifacts get the fast (Flash) default. The
+        // strong default must NOT collapse to Flash, or Settings' advertised
+        // "Pro for complex" would silently run on Flash.
         for (const subtype of Object.keys(CORE_ARTIFACT_COMPLEXITY) as CoreArtifactSubtype[]) {
-            expect(getArtifactModel(subtype)).toBe(DEFAULT_GEMINI_MODEL);
+            const expected = CORE_ARTIFACT_COMPLEXITY[subtype] === 'high'
+                ? DEFAULT_STRONG_MODEL
+                : DEFAULT_FAST_MODEL;
+            expect(getArtifactModel(subtype)).toBe(expected);
         }
+        expect(DEFAULT_FAST_MODEL).toBe(DEFAULT_GEMINI_MODEL);
+        expect(DEFAULT_STRONG_MODEL).not.toBe(DEFAULT_GEMINI_MODEL);
 
+        // With only the single Default model set, both tiers resolve to it.
         localStorage.setItem('GEMINI_MODEL', 'single-x');
         expect(getArtifactModel('data_model')).toBe('single-x');
         expect(getArtifactModel('prompt_pack')).toBe('single-x');

--- a/src/lib/artifactModelSettings.ts
+++ b/src/lib/artifactModelSettings.ts
@@ -11,8 +11,11 @@ import { getFastModel, getStrongModel } from './geminiClient';
  * Resolution order for a given artifact subtype:
  *   1. explicit user override (Settings)               — `getArtifactModelOverrides()`
  *   2. complexity recommendation (Flash vs Pro)        — `CORE_ARTIFACT_COMPLEXITY`
- *   3. tier-model fallback to the single Default model  — `getFastModel`/`getStrongModel`
- *      → `getModel()` → `DEFAULT_GEMINI_MODEL`
+ *   3. tier-model fallback via `getFastModel`/`getStrongModel` — an explicit
+ *      tier model, else the single Default model, else the tier's own default
+ *      (`DEFAULT_FAST_MODEL` = Flash / `DEFAULT_STRONG_MODEL` = Pro). The strong
+ *      tier defaults to Pro, matching Settings — it must NOT collapse to the
+ *      Flash global default, or "Pro for complex artifacts" silently runs Flash.
  *
  * Existing projects have no override key, so behaviour is unchanged until the
  * user picks a model — no migration is required.

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -102,15 +102,30 @@ const getApiKey = () => {
  */
 export const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
 
-const getModel = () => {
-    return localStorage.getItem('GEMINI_MODEL') || DEFAULT_GEMINI_MODEL;
-};
+/**
+ * Per-tier defaults. These MUST match the tier defaults advertised in the
+ * Settings model pickers (`SettingsModal`/`ArtifactModelsSection`) — the Fast
+ * tier defaults to Flash, the Expert (strong) tier defaults to Pro. If the
+ * runtime and the UI disagree here, the app silently generates complex PRD
+ * sections / high-complexity artifacts on Flash while Settings claims Pro.
+ */
+export const DEFAULT_FAST_MODEL = DEFAULT_GEMINI_MODEL;
+export const DEFAULT_STRONG_MODEL = 'gemini-3.1-pro-preview';
 
+/** The single "Default model" override, when the user has set one. */
+const getStoredDefaultModel = () => localStorage.getItem('GEMINI_MODEL') || '';
+
+const getModel = () => getStoredDefaultModel() || DEFAULT_GEMINI_MODEL;
+
+// Resolution order per tier: explicit tier override → the single Default model
+// override (so "set both to the same model" still works) → the tier default.
+// The final fallback is the crux: the strong tier defaults to Pro (matching the
+// UI), NOT to the Flash global default.
 export const getFastModel = (): string =>
-    localStorage.getItem('GEMINI_FAST_MODEL') || getModel();
+    localStorage.getItem('GEMINI_FAST_MODEL') || getStoredDefaultModel() || DEFAULT_FAST_MODEL;
 
 export const getStrongModel = (): string =>
-    localStorage.getItem('GEMINI_STRONG_MODEL') || getModel();
+    localStorage.getItem('GEMINI_STRONG_MODEL') || getStoredDefaultModel() || DEFAULT_STRONG_MODEL;
 
 /**
  * Optional Google Cloud project ID. When present, we forward it as the

--- a/src/lib/services/__tests__/artifactModelRouting.test.ts
+++ b/src/lib/services/__tests__/artifactModelRouting.test.ts
@@ -3,7 +3,7 @@ import {
     CORE_ARTIFACT_COMPLEXITY,
     selectArtifactModel,
 } from '../coreArtifactService';
-import { DEFAULT_GEMINI_MODEL } from '../../geminiClient';
+import { DEFAULT_GEMINI_MODEL, DEFAULT_STRONG_MODEL } from '../../geminiClient';
 import type { CoreArtifactSubtype } from '../../../types';
 
 const ALL_SUBTYPES: CoreArtifactSubtype[] = [
@@ -58,10 +58,12 @@ describe('core artifact complexity routing', () => {
         }
     });
 
-    it('falls back to the single Intelligence Level model when tier models are unset', () => {
-        // No GEMINI_FAST_MODEL / GEMINI_STRONG_MODEL and no GEMINI_MODEL → default.
+    it('falls back to the per-tier defaults when tier models are unset', () => {
+        // No GEMINI_FAST_MODEL / GEMINI_STRONG_MODEL and no GEMINI_MODEL → each
+        // tier's default. Low → Flash default; high → the Pro (strong) default,
+        // which must NOT collapse to Flash (that was the "Pro never used" bug).
         expect(selectArtifactModel('design_system')).toBe(DEFAULT_GEMINI_MODEL);
-        expect(selectArtifactModel('implementation_plan')).toBe(DEFAULT_GEMINI_MODEL);
+        expect(selectArtifactModel('implementation_plan')).toBe(DEFAULT_STRONG_MODEL);
 
         // With only the single model set, both tiers resolve to it.
         localStorage.setItem('GEMINI_MODEL', 'gemini-single-test');


### PR DESCRIPTION
## Problem

The project's model settings advertise that complex PRD sections and high-complexity artifacts run on the **Expert (Pro)** model (e.g. Gemini 3.1 Pro), but generation was silently using **Flash** for everything.

The LLM Trace Viewer confirmed it: every PRD section — including the ones that should route to the strong tier (`features`, `architecture`, `ux_loops`, `data_model`) — ran on `gemini-3.5-flash`.

## Root cause

A default mismatch between the Settings UI and the runtime resolver:

- **Settings UI** (`SettingsModal.tsx`) shows the Expert/strong default as `DEFAULT_STRONG_MODEL = 'gemini-3.1-pro-preview'` (Pro). This is only a *display* default for the picker.
- **Runtime** (`geminiClient.ts`) resolved `getStrongModel() = localStorage 'GEMINI_STRONG_MODEL' || getModel()`, and `getModel()` falls back to `DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash'` (Flash).

When `GEMINI_STRONG_MODEL` was never explicitly persisted (the common case — the picker shows Pro because it falls back to its own display default, but the value was never saved to localStorage), the strong tier collapsed to the Flash global default. So complex PRD sections and high-complexity artifacts (User Flows, Screen Inventory, Data Model, Implementation Plan) all ran on Flash despite Settings claiming Pro.

## Fix

Align the runtime tier defaults with what the UI advertises:

- Introduce shared `DEFAULT_FAST_MODEL` (Flash) and `DEFAULT_STRONG_MODEL` (Pro) constants in `geminiClient.ts`.
- Resolve each tier as: **explicit tier model → single Default model (`GEMINI_MODEL`) → the tier's own default**. The strong tier now defaults to **Pro**, never collapsing to the Flash global default. The fast tier is unchanged (already Flash).
- `SettingsModal.tsx` now imports these shared constants instead of redefining its own copies, so the UI and runtime can't drift again.

The "set both tiers to the same model" escape hatch (for rate limits) still works via the single `GEMINI_MODEL` override, which is honored ahead of the tier default.

## Impact

- Users with no explicit strong-model selection now get Pro for complex PRD sections and high-complexity artifacts — matching the Settings display.
- No migration needed; behavior for users who explicitly selected a strong model, or set the single Default model, is unchanged.

## Testing

- Updated `artifactModelSettings.test.ts` and `artifactModelRouting.test.ts`, which previously encoded the buggy "high artifacts default to Flash" behavior, to assert the corrected per-tier defaults.
- `npm run build` ✅, `npm run lint` ✅, full `vitest` suite ✅ (1019 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVdMFVZnmsq1wdVnY1xw43

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVdMFVZnmsq1wdVnY1xw43)_