### PR TITLE
Auto-repair traceability-only artifact blockers before "needs review"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -922,6 +922,40 @@ cleared (post-reload). UI: an amber `ShieldAlert` `StatusDot` + an in-view
 "Needs review" banner listing the issues with a Regenerate action. Keep the
 blocker list conservative — advisory warnings must stay non-blocking.
 
+**Automatic traceability repair — never surface a "no traceability" blocker
+before attempting repair** (`src/lib/artifactTraceabilityRepair.ts`, pure).
+Blocker (3) — missing PRD-feature traceability — is often a false positive: an
+artifact genuinely derived from the product's features but not spelling out a
+feature id/name verbatim. So `runCoreArtifactSlot` reclassifies blockers via
+`classifyBlockers` and, when the traceability blocker is the **sole** issue (the
+artifact is otherwise structurally valid — `otherBlockers.length === 0`),
+attempts a deterministic enrichment pass **before** exposing any blocker:
+`repairTraceability` runs `matchFeaturesToContent` (token-overlap match of the
+canonical PRD features against the artifact's own content — it can NEVER invent
+an id, every mapped id/name comes from `prd.features`) and, on a confident
+match, **appends** a `## PRD Feature Traceability` section citing the mapped
+ids/names (append-only — substantive content is never rewritten). The artifact
+is then **re-validated**; if clean it saves as normal `done`, and a small
+neutral advisory note (not the amber banner) is shown. Repair provenance is
+stamped into version metadata regardless of outcome (`repairAttempted`,
+`repairType: 'traceability_enrichment'`, `repairSucceeded`,
+`originalValidationBlockers`, `postRepairValidationBlockers`, `repairWarnings`,
+`traceabilityMappedFeatures`) and the version's change summary notes the
+enrichment, so history distinguishes an original vs. auto-enriched preferred
+version. When repair is **ineligible** (other blockers present) or **fails** (no
+confident feature match), the slot stays `needs_review` but the raw blocker is
+reworded to the clearer `TRACEABILITY_UNRESOLVED_MESSAGE` ("Synapse could not
+verify how this artifact maps back to the PRD…") rather than "references none of
+the PRD features". Only the initial validation is stricter now-structural:
+traceability is emitted **structurally** by generation (data_model entities carry
+`featureRefs`, rendered as a `**Related Features:**` line; user_flows emit a
+`**Related Features:**` line per flow; implementation_plan carries per-task
+`linkedArtifacts.prd` in its `synapse-plan` JSON fence), reducing how often
+repair is even needed. Legacy artifacts are unaffected on load — blockers are
+only computed at generation time and read from persisted metadata, so an old
+artifact without structured traceability never shows a blocking banner unless it
+is regenerated/revalidated.
+
 ### Dependency sufficiency gate (`src/lib/artifactDependencyGate.ts`)
 
 An artifact must not silently generate from missing/errored **required** upstream

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
     FileText, Image, Package, CheckCircle2, Loader2, Circle, AlertTriangle,
-    RefreshCcw, Menu, X, ListChecks, History, Lock, ShieldAlert,
+    RefreshCcw, Menu, X, ListChecks, History, Lock, ShieldAlert, ShieldCheck,
     Layers, Database, Code2, AppWindow, Waypoints,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
@@ -1060,11 +1060,26 @@ export function ArtifactWorkspace({
             }
             : undefined;
         const blockingIssues = readValidationBlockers(preferred.metadata);
+        // Small advisory note when a clean artifact was auto-enriched with PRD
+        // traceability (repair succeeded → no blocking banner, just a note).
+        const traceabilityRepaired =
+            blockingIssues.length === 0 &&
+            preferred.metadata?.repairType === 'traceability_enrichment' &&
+            preferred.metadata?.repairSucceeded === true;
         return (
             <div className="max-w-3xl xl:max-w-5xl 2xl:max-w-6xl mx-auto space-y-4">
                 <div className="flex items-center justify-start">
                     {renderVersionControls(artifact.id, preferred)}
                 </div>
+                {traceabilityRepaired && (
+                    <div className="flex items-start gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2">
+                        <ShieldCheck size={14} className="mt-0.5 shrink-0 text-emerald-600" />
+                        <p className="text-xs text-neutral-600">
+                            Synapse automatically mapped this artifact back to the PRD's features.
+                            See the <span className="font-medium">PRD Feature Traceability</span> section below.
+                        </p>
+                    </div>
+                )}
                 {blockingIssues.length > 0 && (
                     <div className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4">
                         <ShieldAlert size={18} className="mt-0.5 shrink-0 text-amber-600" />

--- a/src/lib/__tests__/artifactBlockingValidation.test.ts
+++ b/src/lib/__tests__/artifactBlockingValidation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { detectArtifactBlockers, readValidationBlockers } from '../artifactBlockingValidation';
+import {
+    detectArtifactBlockers,
+    readValidationBlockers,
+    classifyBlockers,
+    isTraceabilityBlocker,
+    TRACEABILITY_BLOCKER_MESSAGE,
+} from '../artifactBlockingValidation';
 import type { StructuredPRD } from '../../types';
 
 // Minimal PRD with one feature so traceability checks have something to match.
@@ -50,6 +56,28 @@ describe('detectArtifactBlockers', () => {
         const content = '# User Flows\n\n## Some flow\nStep 1.\nError handled.\n';
         const blockers = detectArtifactBlockers('user_flows', content, prd);
         expect(blockers.some(b => /traceability/i.test(b))).toBe(true);
+    });
+});
+
+describe('classifyBlockers', () => {
+    it('recognizes the traceability blocker', () => {
+        expect(isTraceabilityBlocker(TRACEABILITY_BLOCKER_MESSAGE)).toBe(true);
+        expect(isTraceabilityBlocker('some other blocker')).toBe(false);
+    });
+
+    it('isolates a traceability-only blocker set (repair-eligible)', () => {
+        const { traceabilityBlockers, otherBlockers } = classifyBlockers([TRACEABILITY_BLOCKER_MESSAGE]);
+        expect(traceabilityBlockers).toEqual([TRACEABILITY_BLOCKER_MESSAGE]);
+        expect(otherBlockers).toEqual([]);
+    });
+
+    it('keeps other structural blockers separate (repair-ineligible)', () => {
+        const { traceabilityBlockers, otherBlockers } = classifyBlockers([
+            TRACEABILITY_BLOCKER_MESSAGE,
+            'Data model parsed but contains no entities.',
+        ]);
+        expect(traceabilityBlockers).toEqual([TRACEABILITY_BLOCKER_MESSAGE]);
+        expect(otherBlockers).toEqual(['Data model parsed but contains no entities.']);
     });
 });
 

--- a/src/lib/__tests__/artifactTraceabilityRepair.test.ts
+++ b/src/lib/__tests__/artifactTraceabilityRepair.test.ts
@@ -6,6 +6,7 @@ import {
     TRACEABILITY_SECTION_HEADING,
 } from '../artifactTraceabilityRepair';
 import { detectArtifactBlockers } from '../artifactBlockingValidation';
+import { parseDataModelMarkdown } from '../services/dataModelMarkdown';
 import type { StructuredPRD } from '../../types';
 
 // A "Take A Hike"-style PRD: features whose names/tokens appear in generated
@@ -129,6 +130,16 @@ describe('repairTraceability — data_model', () => {
         // Original entity headings are untouched.
         expect(repair.content).toContain('## TripItinerary');
         expect(repair.content).toContain('## RouteSegments');
+    });
+
+    it('does not render the appended traceability section as a bogus entity', () => {
+        const repair = repairTraceability('data_model', dataModelContent, prd);
+        const parsed = parseDataModelMarkdown(repair.content);
+        expect(parsed).not.toBeNull();
+        const entityNames = parsed!.entities.map(e => e.name);
+        expect(entityNames).not.toContain(TRACEABILITY_SECTION_HEADING);
+        // The real entities still parse.
+        expect(entityNames).toContain('TripItinerary');
     });
 });
 

--- a/src/lib/__tests__/artifactTraceabilityRepair.test.ts
+++ b/src/lib/__tests__/artifactTraceabilityRepair.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+    matchFeaturesToContent,
+    repairTraceability,
+    filterKnownFeatureIds,
+    TRACEABILITY_SECTION_HEADING,
+} from '../artifactTraceabilityRepair';
+import { detectArtifactBlockers } from '../artifactBlockingValidation';
+import type { StructuredPRD } from '../../types';
+
+// A "Take A Hike"-style PRD: features whose names/tokens appear in generated
+// artifact content only implicitly (via entity/flow names), never verbatim.
+const prd = {
+    vision: 'Plan safe multi-day hikes.',
+    coreProblem: 'Planning hazard-aware backcountry trips is hard.',
+    targetUsers: ['Backpackers'],
+    architecture: 'SPA + API',
+    risks: [],
+    features: [
+        {
+            id: 'f1',
+            name: 'Trip Creation',
+            description: 'Create a multi-day trip itinerary for a chosen park.',
+            userValue: 'Get started planning fast.',
+            complexity: 'medium',
+        },
+        {
+            id: 'f2',
+            name: 'Route Planning',
+            description: 'Plan hazard-aware routes with waypoints and segments.',
+            userValue: 'Avoid dangerous terrain.',
+            complexity: 'high',
+        },
+        {
+            id: 'f3',
+            name: 'Daily Scheduling',
+            description: 'Break a trip into daily schedules.',
+            userValue: 'Pace the hike.',
+            complexity: 'low',
+        },
+    ],
+} as unknown as StructuredPRD;
+
+const dataModelContent = `# Data Model
+
+## How This Data Model Works
+
+Stores a hiker's plan.
+
+## TripItinerary
+
+Represents a planned multi-day journey through a park.
+
+**Fields**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| id | string | Yes | Identifier |
+| park | string | Yes | Chosen park |
+
+## DailySchedules
+
+A per-day plan within an itinerary.
+
+## RouteSegments
+
+An ordered leg of the route between waypoints.
+
+## Waypoints
+
+A named point along the route.
+
+## API Endpoints
+
+| Method | Path | Description | Entity |
+|--------|------|-------------|--------|
+| GET | /itineraries | List itineraries | TripItinerary |
+`;
+
+describe('matchFeaturesToContent', () => {
+    it('matches features by token overlap even without explicit names/ids', () => {
+        const matches = matchFeaturesToContent(dataModelContent, prd);
+        const ids = matches.map(m => m.featureId).sort();
+        // "trip"/"itinerary", "route"/"waypoints", "daily"/"schedules" all appear.
+        expect(ids).toContain('f1');
+        expect(ids).toContain('f2');
+        expect(ids).toContain('f3');
+    });
+
+    it('never returns a feature id that is not in the PRD', () => {
+        const matches = matchFeaturesToContent(dataModelContent, prd);
+        const known = new Set(prd.features.map(f => f.id));
+        for (const m of matches) expect(known.has(m.featureId)).toBe(true);
+    });
+
+    it('returns no matches for content unrelated to the PRD', () => {
+        const unrelated = `# Data Model\n\n## WeatherTile\nShows the forecast temperature.\n\n## API Endpoints\n| GET | /weather |\n`;
+        expect(matchFeaturesToContent(unrelated, prd)).toEqual([]);
+    });
+
+    it('scores a direct id/name reference highest', () => {
+        const withId = dataModelContent + '\n\nImplements f1.';
+        const matches = matchFeaturesToContent(withId, prd);
+        const f1 = matches.find(m => m.featureId === 'f1');
+        expect(f1?.score).toBe(100);
+    });
+});
+
+describe('repairTraceability — data_model', () => {
+    it('enriches a structurally-valid data model and clears the traceability blocker', () => {
+        // Precondition: the artifact trips ONLY the traceability blocker.
+        const before = detectArtifactBlockers('data_model', dataModelContent, prd);
+        expect(before.some(b => /traceability/i.test(b))).toBe(true);
+        expect(before.some(b => /API surface/i.test(b))).toBe(false);
+
+        const repair = repairTraceability('data_model', dataModelContent, prd);
+        expect(repair.repaired).toBe(true);
+        expect(repair.content).toContain(TRACEABILITY_SECTION_HEADING);
+        expect(repair.mappedFeatures.length).toBeGreaterThan(0);
+
+        // Revalidation: the traceability blocker is gone after repair.
+        const after = detectArtifactBlockers('data_model', repair.content, prd);
+        expect(after).toEqual([]);
+    });
+
+    it('preserves the original content (append-only, no rewrite)', () => {
+        const repair = repairTraceability('data_model', dataModelContent, prd);
+        expect(repair.content.startsWith(dataModelContent.replace(/\s+$/, ''))).toBe(true);
+        // Original entity headings are untouched.
+        expect(repair.content).toContain('## TripItinerary');
+        expect(repair.content).toContain('## RouteSegments');
+    });
+});
+
+describe('repairTraceability — user_flows', () => {
+    it('enriches a flow that has project-relevant content but no explicit feature ids', () => {
+        const flows = `# User Flows
+
+### Flow: First-Time User Onboarding and Journey Setup
+**Goal:** Set up an initial itinerary and plan a route.
+**Steps:**
+1. Home — User picks a park.
+2. Route — User adds waypoints and segments.
+**Error Paths:**
+- Network error → retry.
+`;
+        const before = detectArtifactBlockers('user_flows', flows, prd);
+        expect(before.some(b => /traceability/i.test(b))).toBe(true);
+
+        const repair = repairTraceability('user_flows', flows, prd);
+        expect(repair.repaired).toBe(true);
+        const after = detectArtifactBlockers('user_flows', repair.content, prd);
+        expect(after).toEqual([]);
+    });
+});
+
+describe('repairTraceability — failure cases', () => {
+    it('fails (no change) when nothing maps to the PRD', () => {
+        const unrelated = `# User Flows\n\n### Flow: Weather Forecast\n**Goal:** Show temperature.\n**Error Paths:**\n- none.\n`;
+        const repair = repairTraceability('user_flows', unrelated, prd);
+        expect(repair.repaired).toBe(false);
+        expect(repair.content).toBe(unrelated);
+        expect(repair.warnings.length).toBeGreaterThan(0);
+        // Blocker survives a failed repair.
+        const after = detectArtifactBlockers('user_flows', repair.content, prd);
+        expect(after.some(b => /traceability/i.test(b))).toBe(true);
+    });
+
+    it('fails when the PRD has no features', () => {
+        const noFeatures = { ...prd, features: [] } as unknown as StructuredPRD;
+        const repair = repairTraceability('data_model', dataModelContent, noFeatures);
+        expect(repair.repaired).toBe(false);
+    });
+});
+
+describe('filterKnownFeatureIds', () => {
+    it('drops invented ids, keeps canonical ids (case-insensitive, deduped)', () => {
+        expect(filterKnownFeatureIds(['f1', 'F2', 'f99', 'f1'], prd)).toEqual(['f1', 'f2']);
+    });
+});

--- a/src/lib/artifactBlockingValidation.ts
+++ b/src/lib/artifactBlockingValidation.ts
@@ -27,6 +27,42 @@ const TRACEABILITY_CRITICAL: ReadonlySet<CoreArtifactSubtype> = new Set<CoreArti
     'implementation_plan',
 ]);
 
+// The exact blocker string emitted for a missing-traceability defect. Exported
+// so the job controller can (a) recognize a traceability-only blocker set as
+// eligible for automatic repair and (b) swap in clearer wording after a repair
+// fails. Keep this in sync with the message pushed below.
+export const TRACEABILITY_BLOCKER_MESSAGE =
+    'Artifact references none of the PRD features — no traceability to the PRD.';
+
+// User-facing wording shown when automatic traceability repair was attempted
+// and could not confidently map the artifact to any PRD feature. Deliberately
+// less alarming than the raw blocker — the content may still be useful.
+export const TRACEABILITY_UNRESOLVED_MESSAGE =
+    'Synapse could not verify how this artifact maps back to the PRD (automatic ' +
+    'traceability repair found no confident feature match). The content is preserved for review.';
+
+/** True when the blocker is the missing-traceability defect (repair-eligible). */
+export function isTraceabilityBlocker(blocker: string): boolean {
+    return blocker === TRACEABILITY_BLOCKER_MESSAGE;
+}
+
+/**
+ * Split a blocker list into traceability-only vs. everything else. A blocker set
+ * is eligible for automatic traceability repair only when the traceability
+ * blocker is the SOLE issue (the artifact is otherwise structurally valid).
+ */
+export function classifyBlockers(blockers: string[]): {
+    traceabilityBlockers: string[];
+    otherBlockers: string[];
+} {
+    const traceabilityBlockers: string[] = [];
+    const otherBlockers: string[] = [];
+    for (const b of blockers) {
+        (isTraceabilityBlocker(b) ? traceabilityBlockers : otherBlockers).push(b);
+    }
+    return { traceabilityBlockers, otherBlockers };
+}
+
 export function detectArtifactBlockers(
     subtype: CoreArtifactSubtype,
     content: string,
@@ -52,7 +88,7 @@ export function detectArtifactBlockers(
             f => lc.includes(f.id.toLowerCase()) || lc.includes(f.name.toLowerCase()),
         );
         if (!referenced) {
-            blockers.push('Artifact references none of the PRD features — no traceability to the PRD.');
+            blockers.push(TRACEABILITY_BLOCKER_MESSAGE);
         }
     }
 

--- a/src/lib/artifactTraceabilityRepair.ts
+++ b/src/lib/artifactTraceabilityRepair.ts
@@ -1,0 +1,212 @@
+// Automatic traceability repair/enrichment for artifacts that are structurally
+// valid and clearly project-specific but do not *explicitly* reference the PRD's
+// features by canonical id or name.
+//
+// Context: `detectArtifactBlockers` (artifactBlockingValidation.ts) flags an
+// implementation-critical artifact as `needs_review` when it references NONE of
+// the PRD features. That text-search is deliberately strict — but the generator
+// is not always required to spell out a feature id/name verbatim, so a useful,
+// on-topic Data Model or set of User Flows can trip the blocker even though the
+// content is genuinely derived from the product's features. Rather than surface
+// a scary blocking banner immediately, Synapse first attempts a high-confidence,
+// deterministic repair: match the canonical PRD features to the artifact's own
+// content and, when confident matches exist, append an explicit
+// "PRD Feature Traceability" section citing the mapped feature ids/names.
+//
+// This module is pure (no store / React / LLM). Repair is deterministic and can
+// NEVER invent a feature id — every mapped id/name comes from `prd.features`.
+
+import type { CoreArtifactSubtype, StructuredPRD } from '../types';
+
+/** A canonical PRD feature that was confidently matched to artifact content. */
+export interface FeatureMatch {
+    /** Canonical PRD feature id (always from prd.features — never invented). */
+    featureId: string;
+    /** Canonical PRD feature name. */
+    featureName: string;
+    /** Human-readable justification for the mapping (which tokens matched). */
+    reason: string;
+    /** Internal relevance score (higher = stronger match). */
+    score: number;
+}
+
+export interface TraceabilityRepairResult {
+    /** Whether the content was modified (a traceability section was appended). */
+    repaired: boolean;
+    /** The (possibly enriched) artifact content. */
+    content: string;
+    /** Features the repair mapped to this artifact. */
+    mappedFeatures: FeatureMatch[];
+    /** Non-fatal notes about the repair (e.g. why it could not proceed). */
+    warnings: string[];
+}
+
+// Very common English + product words that carry little discriminating signal.
+// Kept deliberately small: over-filtering would drop legitimate feature tokens.
+const STOPWORDS = new Set<string>([
+    'the', 'and', 'for', 'with', 'that', 'this', 'from', 'into', 'over', 'your',
+    'user', 'users', 'data', 'system', 'systems', 'page', 'pages', 'screen',
+    'screens', 'view', 'views', 'feature', 'features', 'app', 'apps',
+    'application', 'applications', 'product', 'products', 'service', 'services',
+    'management', 'support', 'enable', 'enables', 'allow', 'allows', 'provide',
+    'provides', 'using', 'based', 'able', 'when', 'where', 'their', 'them',
+    'they', 'will', 'must', 'should', 'each', 'other', 'more', 'have', 'has',
+]);
+
+const TOKEN_RE = /[a-z0-9]+/g;
+
+/** Extract discriminating lowercase tokens (len ≥ 4, non-stopword) from text. */
+function significantTokens(text: string | undefined): string[] {
+    if (!text) return [];
+    const out = new Set<string>();
+    for (const m of text.toLowerCase().matchAll(TOKEN_RE)) {
+        const tok = m[0];
+        if (tok.length >= 4 && !STOPWORDS.has(tok)) out.add(tok);
+    }
+    return [...out];
+}
+
+/** Escape a string for safe use inside a RegExp. */
+function escapeRegExp(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Filter a list of feature ids down to those that actually exist in the
+ * canonical PRD. Used to reject invented ids (e.g. from an LLM enrichment pass)
+ * before they are ever stamped onto an artifact. Case-insensitive.
+ */
+export function filterKnownFeatureIds(ids: string[], prd: StructuredPRD): string[] {
+    const known = new Map((prd.features ?? []).map(f => [f.id.toLowerCase(), f.id]));
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const id of ids) {
+        const canonical = known.get(String(id).toLowerCase());
+        if (canonical && !seen.has(canonical)) {
+            seen.add(canonical);
+            out.push(canonical);
+        }
+    }
+    return out;
+}
+
+/**
+ * Deterministically match the PRD's canonical features to the artifact's own
+ * content. A feature matches when the content already names it, or when enough
+ * of its discriminating name/description tokens appear in the content to be
+ * confident the artifact is derived from that feature. Never invents ids.
+ */
+export function matchFeaturesToContent(content: string, prd: StructuredPRD): FeatureMatch[] {
+    const contentLc = content.toLowerCase();
+    const features = prd.features ?? [];
+    const matches: FeatureMatch[] = [];
+
+    for (const f of features) {
+        if (!f?.id) continue;
+        const name = (f.name ?? '').trim();
+
+        // Direct reference: id (word-bounded) or the full feature name.
+        const idHit = new RegExp(`\\b${escapeRegExp(f.id)}\\b`, 'i').test(content);
+        const nameHit = name.length > 0 && contentLc.includes(name.toLowerCase());
+        if (idHit || nameHit) {
+            matches.push({
+                featureId: f.id,
+                featureName: name || f.id,
+                reason: idHit
+                    ? `Content references feature id ${f.id}.`
+                    : `Content references the feature name "${name}".`,
+                score: 100,
+            });
+            continue;
+        }
+
+        // Token-overlap match. Require corroborating name-token coverage so a
+        // stray description word alone can't map an unrelated feature.
+        const nameTokens = significantTokens(name);
+        const descText = [
+            f.description,
+            f.userValue,
+            ...(f.acceptanceCriteria ?? []),
+        ]
+            .filter(Boolean)
+            .join(' ');
+        const descTokens = significantTokens(descText).filter(t => !nameTokens.includes(t));
+
+        const matchedName = nameTokens.filter(t => contentLc.includes(t));
+        const matchedDesc = descTokens.filter(t => contentLc.includes(t));
+
+        // Confidence: at least one name token present AND either half of the
+        // name tokens matched, or a name token plus a corroborating desc token.
+        const nameCoverageOk =
+            matchedName.length > 0 &&
+            (matchedName.length >= Math.ceil(nameTokens.length / 2) ||
+                matchedName.length + matchedDesc.length >= 2);
+
+        if (nameCoverageOk) {
+            const matchedTerms = [...new Set([...matchedName, ...matchedDesc])];
+            matches.push({
+                featureId: f.id,
+                featureName: name || f.id,
+                reason: `Automatically matched via: ${matchedTerms.join(', ')}.`,
+                score: matchedName.length * 2 + matchedDesc.length,
+            });
+        }
+    }
+
+    return matches.sort((a, b) => b.score - a.score);
+}
+
+/** Heading Synapse uses for the appended traceability block. */
+export const TRACEABILITY_SECTION_HEADING = 'PRD Feature Traceability';
+
+function renderTraceabilitySection(matches: FeatureMatch[]): string {
+    const lines: string[] = [
+        `## ${TRACEABILITY_SECTION_HEADING}`,
+        '',
+        '_Synapse mapped this artifact back to the following PRD features automatically. ' +
+            'Feature IDs and names are drawn from the canonical PRD._',
+        '',
+    ];
+    for (const m of matches) {
+        lines.push(`- **[${m.featureId}] ${m.featureName}** — ${m.reason}`);
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Attempt a deterministic traceability-enrichment repair. When the artifact's
+ * own content confidently maps to one or more canonical PRD features, append an
+ * explicit traceability section (which restores id/name references and clears
+ * the traceability blocker). Content is only ever *appended to* — no substantive
+ * content is rewritten, so the artifact's meaning is preserved.
+ */
+export function repairTraceability(
+    _subtype: CoreArtifactSubtype,
+    content: string,
+    prd: StructuredPRD,
+): TraceabilityRepairResult {
+    if (!prd.features || prd.features.length === 0) {
+        return {
+            repaired: false,
+            content,
+            mappedFeatures: [],
+            warnings: ['PRD has no features to trace to.'],
+        };
+    }
+
+    const matches = matchFeaturesToContent(content, prd);
+    if (matches.length === 0) {
+        return {
+            repaired: false,
+            content,
+            mappedFeatures: [],
+            warnings: [
+                'No PRD feature could be confidently matched to this artifact by automatic analysis.',
+            ],
+        };
+    }
+
+    const section = renderTraceabilitySection(matches);
+    const enriched = `${content.replace(/\s+$/, '')}\n\n${section}\n`;
+    return { repaired: true, content: enriched, mappedFeatures: matches, warnings: [] };
+}

--- a/src/lib/schemas/artifactSchemas.ts
+++ b/src/lib/schemas/artifactSchemas.ts
@@ -134,6 +134,11 @@ export const dataModelSchema = {
                     constraints: { type: "ARRAY", items: { type: "STRING" } },
                     privacyRules: { type: "ARRAY", items: { type: "STRING" } },
                     exampleRecord: { type: "STRING" },
+                    featureRefs: {
+                        type: "ARRAY",
+                        description: "Canonical PRD feature ids (and/or names) this entity supports, drawn from the Canonical Feature Glossary. Do not invent ids.",
+                        items: { type: "STRING" },
+                    },
                 },
                 required: ["name", "description", "fields", "relationships"],
             },

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -13,7 +13,14 @@ import { buildCanonicalPrdSpine } from '../canonicalPrdSpine';
 import { generateMockup } from './mockupService';
 import { validateArtifactContent } from '../artifactValidation';
 import { validateCrossArtifactConsistency } from '../artifactOrchestration';
-import { detectArtifactBlockers, readValidationBlockers } from '../artifactBlockingValidation';
+import {
+    detectArtifactBlockers,
+    readValidationBlockers,
+    classifyBlockers,
+    isTraceabilityBlocker,
+    TRACEABILITY_UNRESOLVED_MESSAGE,
+} from '../artifactBlockingValidation';
+import { repairTraceability } from '../artifactTraceabilityRepair';
 import {
     CORE_ARTIFACT_PIPELINE,
     MOCKUP_DEPENDENCIES,
@@ -234,14 +241,68 @@ async function runCoreArtifactSlot(
     // user-facing defects mean the artifact must not read as a trustworthy
     // completed output. The content is still saved (for review), but the slot
     // is flagged needs_review rather than done.
-    const blockers = detectArtifactBlockers(subtype, content, structuredPRD);
+    const initialBlockers = detectArtifactBlockers(subtype, content, structuredPRD);
+
+    // Automatic traceability repair. A missing-traceability blocker is often a
+    // false positive — the artifact is genuinely derived from the product's
+    // features but never spells out a feature id/name verbatim. When the ONLY
+    // blocker is traceability (the artifact is otherwise structurally valid), we
+    // attempt a deterministic enrichment pass BEFORE surfacing any blocker: map
+    // canonical PRD features to the content and, on a confident match, append an
+    // explicit traceability section, then re-validate. Repair only ever appends
+    // (never rewrites substantive content), so the artifact's meaning is
+    // preserved. Repair provenance is stamped into version metadata regardless
+    // of outcome.
+    let effectiveContent = content;
+    let blockers = initialBlockers;
+    let repairMetadata: Record<string, unknown> = {};
+    const { traceabilityBlockers, otherBlockers } = classifyBlockers(initialBlockers);
+    if (traceabilityBlockers.length > 0 && otherBlockers.length === 0) {
+        const repair = repairTraceability(subtype, content, structuredPRD);
+        const postRepairBlockers = repair.repaired
+            ? detectArtifactBlockers(subtype, repair.content, structuredPRD)
+            : initialBlockers;
+        const repairSucceeded = repair.repaired && postRepairBlockers.length === 0;
+        if (repairSucceeded) {
+            effectiveContent = repair.content;
+            blockers = postRepairBlockers; // now []
+        } else {
+            // Repair ineligible/failed: keep the blocker but reword it so the UI
+            // says "could not verify mapping", not "references none of the PRD".
+            blockers = [
+                ...otherBlockers,
+                ...postRepairBlockers.map(b =>
+                    isTraceabilityBlocker(b) ? TRACEABILITY_UNRESOLVED_MESSAGE : b,
+                ),
+            ];
+        }
+        repairMetadata = {
+            repairAttempted: true,
+            repairType: 'traceability_enrichment',
+            repairSucceeded,
+            originalValidationBlockers: initialBlockers,
+            postRepairValidationBlockers: postRepairBlockers,
+            ...(repair.warnings.length ? { repairWarnings: repair.warnings } : {}),
+            ...(repair.mappedFeatures.length
+                ? {
+                      traceabilityMappedFeatures: repair.mappedFeatures.map(m => ({
+                          id: m.featureId,
+                          name: m.featureName,
+                          reason: m.reason,
+                      })),
+                  }
+                : {}),
+        };
+    }
+
     // Only expose this artifact as dependency context to later layers in this
-    // run when it passed blocking validation. A needs_review artifact must not
-    // silently feed a dependent — a required dependent then correctly blocks
-    // (DependencyInsufficiencyError) instead of being saved as done from
-    // untrustworthy input; an optional dependent degrades as if it were missing.
+    // run when it passed blocking validation (post-repair). A needs_review
+    // artifact must not silently feed a dependent — a required dependent then
+    // correctly blocks (DependencyInsufficiencyError) instead of being saved as
+    // done from untrustworthy input; an optional dependent degrades as if it
+    // were missing.
     if (blockers.length === 0) {
-        generatedArtifacts[subtype] = content;
+        generatedArtifacts[subtype] = effectiveContent;
     }
 
     const writeStore = useProjectStore.getState();
@@ -286,10 +347,11 @@ async function runCoreArtifactSlot(
     // a non-empty `missing` list means the artifact was knowingly degraded.
     const missingRequiredDeps = findMissingRequiredDependencies(subtype, generatedArtifacts);
 
+    const repairApplied = repairMetadata.repairSucceeded === true;
     writeStore.createArtifactVersion(
         projectId,
         artifactId,
-        content,
+        effectiveContent,
         {
             subtype,
             dependencyTrace,
@@ -300,10 +362,12 @@ async function runCoreArtifactSlot(
             ...(incompletePrdSections.length
                 ? { generatedFromIncompletePrd: true, incompletePrdSections }
                 : {}),
+            ...repairMetadata,
             ...extraMetadata,
         },
         sourceRefs,
-        `Generate ${meta.title} from PRD${dependencyTrace ? ` (after: ${dependencyTrace})` : ''}`,
+        `Generate ${meta.title} from PRD${dependencyTrace ? ` (after: ${dependencyTrace})` : ''}` +
+            (repairApplied ? ' · auto-enriched PRD traceability' : ''),
         parentVersionId,
     );
 

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -79,6 +79,7 @@ For each flow, use this exact format:
 
 ### Flow: [Flow Name]
 **Goal:** What the user is trying to accomplish.
+**Related Features:** the canonical PRD feature ids and names this flow implements, drawn from the Canonical Feature Glossary / Canonical PRD Spine (e.g. "[f1] Trip Creation, [f2] Route Planning"). Every flow MUST map to at least one real feature; use ONLY ids/names from the glossary — never invent a feature id.
 **Preconditions:** What must be true before this flow starts.
 **Steps:**
 1. [Screen Name] — User action → System response
@@ -164,7 +165,7 @@ Per task:
 - status: ALWAYS "todo", without exception. You are generating a plan, not tracking execution; never emit any other status value.
 - dependencies: array of OTHER task ids (from this same plan) that must be done first. Empty array if none.
 - linkedArtifacts: { prd, dataModel, mockups }
-  - prd: PRD feature names this task implements, drawn from the Canonical Feature Glossary in the user prompt.
+  - prd: PRD feature names (and/or ids) this task implements, drawn from the Canonical Feature Glossary in the user prompt. Across the whole plan, every canonical feature should be implemented by at least one task; use ONLY names/ids from the glossary — never invent a feature reference.
   - dataModel: entity names from the data_model dependency context that this task touches.
   - mockups: screen names from the screen_inventory dependency context that this task implements.
   - Link an artifact only when the task directly implements or modifies it. Omit (or use empty arrays) otherwise. Don't invent artifact references.
@@ -220,6 +221,7 @@ For each entity, populate:
   - "System Metadata" (id, created_at, updated_at, version, audit fields)
   - "API / Integration" (webhook URLs, external IDs, integration payloads)
   - "Privacy / Safety" (PII, secrets, sensitive data subject to safety rules)
+- featureRefs: the canonical PRD feature ids (e.g. "f1", "f3") — and/or their exact names — that this entity supports, drawn from the Canonical Feature Glossary in the user prompt. EVERY entity must map to at least one real feature. Use ONLY ids/names that appear in the glossary; never invent a feature id. If an entity is cross-cutting, list multiple.
 - relationships: existing array of { type: has_many|belongs_to|has_one|many_to_many, target, description? }.
 - indexes: recommended database indexes for query performance; name the field(s) each index covers.
 - constraints: business/database constraints (uniqueness, check constraints, cardinality limits) — NOT privacy concerns.

--- a/src/lib/services/dataModelMarkdown.ts
+++ b/src/lib/services/dataModelMarkdown.ts
@@ -281,7 +281,10 @@ export function dataModelToMarkdown(model: DataModelContent): string {
         if (mut) {
             lines.push(`**Mutability:** ${mut}`);
         }
-        if (entity.purpose || entity.userFacing !== undefined || mut) {
+        if (entity.featureRefs?.length) {
+            lines.push(`**Related Features:** ${entity.featureRefs.join(', ')}`);
+        }
+        if (entity.purpose || entity.userFacing !== undefined || mut || entity.featureRefs?.length) {
             lines.push('');
         }
 

--- a/src/lib/services/dataModelMarkdown.ts
+++ b/src/lib/services/dataModelMarkdown.ts
@@ -5,6 +5,7 @@ import type {
     FieldGroup,
     FieldGroupName,
 } from '../../types';
+import { TRACEABILITY_SECTION_HEADING } from '../artifactTraceabilityRepair';
 
 const GROUP_ORDER: FieldGroupName[] = [
     'Key Product Fields',
@@ -22,6 +23,10 @@ const TOP_SECTION_HEADINGS = new Set([
     'API Endpoints',
     'How This Appears in the Product',
     'Data Model',
+    // Appended by automatic traceability repair (artifactTraceabilityRepair.ts).
+    // It is metadata, not a data entity — skip it here so it never renders as a
+    // bogus 0-field entity in the outline/card view.
+    TRACEABILITY_SECTION_HEADING,
 ]);
 
 const CALLOUT_RE = /^>\s*\[!(CONSTRAINT|PRIVACY|INDEX|RELATIONSHIP)\]\s*(.*)$/i;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -792,6 +792,13 @@ export interface DataEntity {
     privacyRules?: string[];
     /** Stored as a JSON-encoded string in Gemini output; the converter parses it. */
     exampleRecord?: string;
+    /**
+     * Canonical PRD feature ids/names this entity supports (structured
+     * traceability back to the PRD). Optional & backward-compatible — legacy
+     * data models lack it. Rendered into the markdown so traceability validation
+     * can see the mapping without prose text-search.
+     */
+    featureRefs?: string[];
 }
 
 export interface DataModelOverview {


### PR DESCRIPTION
## Problem

The recent reliability patches made artifact validation stricter, which is good — but the app now surfaces a **blocking** "Needs review — Artifact references none of the PRD features — no traceability to the PRD" error immediately, even for artifacts that are useful and clearly project-specific.

Example (a "Take A Hike" project): a Data Model with entities `TripItinerary`, `DailySchedules`, `RouteSegments`, `Waypoints` and User Flows like "First-Time User Trip Creation and Onboarding" are genuinely derived from the PRD's features but never spell out a feature id/name verbatim, so the strict text-search traceability check blocks them. This was a generator/validator contract mismatch with **no repair attempted before surfacing the blocker**.

## What changed

Synapse now attempts an automatic, high-confidence repair before showing a blocking traceability error. Flow: generate → validate → *(traceability-only blocker?)* repair → revalidate → save `done` (or keep `needs_review` if repair is ineligible/fails).

### Structural traceability (generator side)
- **`data_model`**: new optional `DataEntity.featureRefs` (type + JSON schema), rendered as a `**Related Features:**` line by `dataModelToMarkdown`; prompt requires every entity to map to ≥1 canonical feature.
- **`user_flows`**: prompt now requires a `**Related Features:**` line per flow.
- **`implementation_plan`**: prompt emphasizes per-task `linkedArtifacts.prd` coverage (already embedded in the stored `synapse-plan` JSON fence).
- Models must draw ids from the canonical feature glossary and **never invent** them. All fields optional/backward-compatible.

### Automatic traceability repair (`src/lib/artifactTraceabilityRepair.ts`, pure)
- `matchFeaturesToContent` maps canonical PRD features to the artifact's own content by token overlap. It can **never invent an id** — every mapping comes from `prd.features`.
- `repairTraceability` **appends** a `## PRD Feature Traceability` section (append-only; substantive content is never rewritten). Deterministic, no LLM call.
- `filterKnownFeatureIds` rejects any id absent from the canonical PRD.

### Reclassification & wiring
- `classifyBlockers` / `isTraceabilityBlocker` split blockers into traceability-only vs. structural. Repair runs only when the traceability blocker is the **sole** issue.
- `runCoreArtifactSlot` repairs → re-validates → saves the enriched content, deriving final status from **post-repair** validation. Provenance is stamped in version metadata (`repairAttempted`, `repairType: 'traceability_enrichment'`, `repairSucceeded`, `originalValidationBlockers`, `postRepairValidationBlockers`, `repairWarnings`, `traceabilityMappedFeatures`) and the change summary; history distinguishes original vs. auto-enriched.
- When repair is ineligible (other blockers) or fails (no confident match), the slot stays `needs_review` but the wording softens to `TRACEABILITY_UNRESOLVED_MESSAGE` ("Synapse could not verify how this artifact maps back to the PRD…"), never implying the whole artifact is useless.

### UI
- On successful repair: a small neutral advisory note ("Synapse automatically mapped this artifact back to the PRD's features") instead of the amber blocking banner.

### Backward compatibility
- Blockers are only computed at generation time and read from persisted metadata, so **legacy artifacts are never retroactively blocked on load** — only on regenerate/revalidate.

## Tests
- `artifactTraceabilityRepair.test.ts`: repair success (data model), user-flow enrichment, repair failure (unrelated content / no features), append-only preservation, no-invented-ids, direct-reference scoring.
- `artifactBlockingValidation.test.ts`: `classifyBlockers` / `isTraceabilityBlocker`.

## Verification
- `npm run build` ✅ · `npm run lint` ✅ · `npm test` ✅ (1032 passing)

## Remaining limitations
- Repair is deterministic (token-overlap), not an LLM pass — extremely terse content with zero token overlap to any feature will still fail repair and correctly land in `needs_review`.
- `data_model` markdown renders `featureRefs` but the markdown parser does not round-trip them back into structured fields (not required — the JSON-mode content is the source of truth at generation time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANCVGHvT7nQT1UqaXbKxQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANCVGHvT7nQT1UqaXbKxQf)_