### PR TITLE
Collapse Sections and Entities outline accordions by default

### DIFF
--- a/src/components/renderers/DataModelRenderer.tsx
+++ b/src/components/renderers/DataModelRenderer.tsx
@@ -287,6 +287,7 @@ export function DataModelRenderer({ content }: Props) {
                     items={outlineItems}
                     activeId={activeId}
                     activeLabel="Current entity"
+                    defaultExpanded={false}
                     collapseOnSelect={isMobile}
                     onSelect={scrollTo}
                 />

--- a/src/components/renderers/DesignSystemRenderer.tsx
+++ b/src/components/renderers/DesignSystemRenderer.tsx
@@ -85,6 +85,7 @@ function TokenizedDesignSystem({ tokens, projectId }: { tokens: DesignTokens; pr
                 items={items}
                 activeId={activeId}
                 activeLabel="Current section"
+                defaultExpanded={false}
                 collapseOnSelect={isMobile}
                 onSelect={scrollTo}
             />
@@ -833,6 +834,7 @@ function LegacyMarkdownDesignSystem({ content }: { content: string }) {
                     items={items}
                     activeId={activeId}
                     activeLabel="Current section"
+                    defaultExpanded={false}
                     collapseOnSelect={isMobile}
                     onSelect={scrollTo}
                 />


### PR DESCRIPTION
## Summary

Both the Design System and Data Model artifact pages open with their shared `ArtifactOutlineNav` accordion expanded, showing the full outline before any content. This changes both to open **collapsed** by default, so each page starts with a compact header the user expands on demand.

- **Design System** — the **"Sections"** outline nav now defaults to collapsed (both the tokenized renderer and the legacy-markdown path).
- **Data Model** — the **"Entities"** outline nav now defaults to collapsed.

## Changes

- `src/components/renderers/DesignSystemRenderer.tsx` — pass `defaultExpanded={false}` to the two "Sections" `ArtifactOutlineNav` usages.
- `src/components/renderers/DataModelRenderer.tsx` — pass `defaultExpanded={false}` to the "Entities" `ArtifactOutlineNav`.

`ArtifactOutlineNav` already supports `defaultExpanded` (previously defaulting to `true`), so this is a props-only change — the collapsed header still shows the current section/entity and expands on click. Entity content cards and design-system sections themselves are unchanged and remain fully visible.

## Testing

- `npm run build` (tsc -b && vite build) — passes
- `npm run lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EQdQ5GYDQTGsaKxSXFFgD

---
_Generated by [Claude Code](https://claude.ai/code/session_019EQdQ5GYDQTGsaKxSXFFgD)_