### PR TITLE
Redesign Data Model artifact as an interactive ER surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,6 +822,37 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     `schemas/artifactSchemas.ts`, then convert to markdown via
     `structuredArtifactToMarkdown()` for storage; renderers in
     `src/components/renderers/` parse that markdown back to card layouts.
+    The **`data_model` renderer** (`DataModelRenderer.tsx` +
+    `src/components/renderers/dataModel/`) presents the artifact as an
+    interactive entity-relationship design surface rather than a schema dump:
+    a compact **overview header** (`DataModelOverview` — provenance/freshness +
+    entity/relationship/constraint/index/PII counts), an **ER-style diagram**
+    (`EntityGraph`) that mirrors the artifact dependency graph / user-flow
+    diagrams (rounded node cards, deterministic layered SVG layout, directional
+    cardinality-labelled edges, click-a-node-to-open-its-card), and
+    **collapsible entity cards** (`EntityCard`) whose expanded state shows
+    grouped field tables (colour-coded type chips, required/indexed markers) and
+    compact **inspector rows** (`InspectorRow`) for relationships / constraints /
+    privacy / indexes in a fixed colour language (relationship=blue,
+    constraint=purple, privacy=rose, index=slate, warning=amber). All of it is
+    **derived, never hand-drawn**, by the pure, unit-tested
+    **`src/lib/dataModelGraph.ts`** (`analyzeDataModel` → graph + summary): it
+    recovers structured relationships from the parser's `RELATIONSHIP` callouts
+    (so cardinality is a faithful derivation of the schema's `DataRelationship`
+    `type`, never invented), **dedupes reciprocal `has_many`/`belongs_to` pairs**
+    into one parent→child edge, resolves plural/singular targets, tracks
+    unresolved/self references separately, and derives conservative entity
+    **categories** (`core`/`user_config`/`generated`/`system`/`external`, from
+    userFacing/mutability/integration-shaped signals only) used for the optional
+    "Group by category" swimlanes and node accents. The renderer keeps the legacy
+    ReactMarkdown fallback for unparseable content and preserves the
+    "How This Data Model Works", "How This Appears in the Product", and
+    "API Endpoints" sections. Multi-entity models start collapsed (single-entity
+    expanded) for scannability; provenance/freshness reach the overview via the
+    optional `prdVersionLabel`/`staleness` props threaded through
+    `ArtifactContentRenderer` for `data_model` only. Do **not** change
+    `dataModelMarkdown.ts`'s parser output shape without re-checking
+    `dataModelGraph.ts`, which consumes its `ParsedEntity.callouts`.
     The `component_inventory` renderer is a mobile-first, searchable
     component library (sticky search + category/complexity/used-in
     filters, expandable cards with live previews) decomposed under

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -1170,6 +1170,12 @@ export function ArtifactWorkspace({
                         onUpdatePromptEdits={handleUpdatePromptEdits}
                         generatedAt={subtype === 'prompt_pack' ? preferred.createdAt : undefined}
                         versionNumber={subtype === 'prompt_pack' ? preferred.versionNumber : undefined}
+                        prdVersionLabel={
+                            subtype === 'data_model'
+                                ? resolveSpineLabel(preferred.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId)
+                                : undefined
+                        }
+                        staleness={subtype === 'data_model' ? getArtifactStaleness(projectId, artifact.id) : undefined}
                     />
                     </MockupErrorBoundary>
                 </div>

--- a/src/components/renderers/DataModelRenderer.tsx
+++ b/src/components/renderers/DataModelRenderer.tsx
@@ -1,214 +1,37 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Sparkles, Database, Workflow, Layers } from 'lucide-react';
-import type { DataModelContent } from '../../types';
+import { ChevronsDownUp, ChevronsUpDown, Layers, Sparkles } from 'lucide-react';
+import type { DataModelContent, StalenessState } from '../../types';
 import {
     parseDataModelMarkdown,
     dataModelToMarkdown,
-    type ParsedCallout,
-    type ParsedCalloutKind,
     type ParsedDataModel,
     type ParsedEntity,
 } from '../../lib/services/dataModelMarkdown';
+import {
+    analyzeDataModel,
+    entityAnchorId,
+    resolveEntityId,
+    slugifyEntity,
+    ENTITY_CATEGORY_LABEL,
+    ENTITY_CATEGORY_ORDER,
+    type DataModelNode,
+} from '../../lib/dataModelGraph';
 import { ArtifactOutlineNav, type ArtifactOutlineItem } from '../ArtifactOutlineNav';
 import { useArtifactOutline } from '../../lib/useArtifactOutline';
 import { useIsMobile } from '../../lib/useIsMobile';
+import { DataModelOverview } from './dataModel/DataModelOverview';
+import { EntityGraph } from './dataModel/EntityGraph';
+import { EntityCard } from './dataModel/EntityCard';
+import { CategoryBadge } from './dataModel/badges';
 
 interface Props {
     content: string;
-}
-
-const CALLOUT_STYLES: Record<ParsedCalloutKind, { container: string; label: string; labelText: string }> = {
-    CONSTRAINT: {
-        container: 'border-purple-200 bg-purple-50 text-purple-900',
-        label: 'bg-purple-200 text-purple-900',
-        labelText: 'Constraint',
-    },
-    PRIVACY: {
-        container: 'border-rose-200 bg-rose-50 text-rose-900',
-        label: 'bg-rose-200 text-rose-900',
-        labelText: 'Privacy',
-    },
-    INDEX: {
-        container: 'border-slate-200 bg-slate-50 text-slate-900',
-        label: 'bg-slate-200 text-slate-900',
-        labelText: 'Index',
-    },
-    RELATIONSHIP: {
-        container: 'border-indigo-200 bg-indigo-50 text-indigo-900',
-        label: 'bg-indigo-200 text-indigo-900',
-        labelText: 'Relationship',
-    },
-};
-
-const CALLOUT_ORDER: ParsedCalloutKind[] = ['RELATIONSHIP', 'CONSTRAINT', 'PRIVACY', 'INDEX'];
-
-function DataModelCallout({ kind, text }: { kind: ParsedCalloutKind; text: string }) {
-    const styles = CALLOUT_STYLES[kind];
-    return (
-        <div className={`rounded-lg border ${styles.container} px-3 py-2`}>
-            <div className="flex items-start gap-2">
-                <span
-                    className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0 ${styles.label}`}
-                >
-                    {styles.labelText}
-                </span>
-                <p className="text-sm leading-relaxed">{text}</p>
-            </div>
-        </div>
-    );
-}
-
-function VisibilityBadge({ userFacing }: { userFacing: boolean }) {
-    return userFacing ? (
-        <span className="text-[10px] px-1.5 py-0.5 rounded border font-medium bg-emerald-50 text-emerald-700 border-emerald-200">
-            User-facing
-        </span>
-    ) : (
-        <span className="text-[10px] px-1.5 py-0.5 rounded border font-medium bg-neutral-100 text-neutral-600 border-neutral-200">
-            Internal
-        </span>
-    );
-}
-
-function MutabilityBadge({ mutability }: { mutability: string }) {
-    const m = mutability.toLowerCase();
-    const cls =
-        m.includes('immutable') && !m.includes('mostly')
-            ? 'bg-slate-50 text-slate-700 border-slate-200'
-            : m.includes('mostly')
-              ? 'bg-blue-50 text-blue-700 border-blue-200'
-              : 'bg-amber-50 text-amber-700 border-amber-200';
-    return (
-        <span className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${cls}`}>
-            {mutability.replace(/_/g, ' ')}
-        </span>
-    );
-}
-
-function MethodPill({ method }: { method: string }) {
-    const m = method.toUpperCase();
-    const color =
-        m === 'GET'
-            ? 'text-green-700 bg-green-50 border-green-200'
-            : m === 'POST'
-              ? 'text-blue-700 bg-blue-50 border-blue-200'
-              : m === 'PUT' || m === 'PATCH'
-                ? 'text-amber-700 bg-amber-50 border-amber-200'
-                : m === 'DELETE'
-                  ? 'text-red-700 bg-red-50 border-red-200'
-                  : 'text-neutral-700 bg-neutral-50 border-neutral-200';
-    return (
-        <span className={`font-mono text-[11px] font-bold px-1.5 py-0.5 rounded border ${color}`}>
-            {m}
-        </span>
-    );
-}
-
-function entityAnchorId(name: string): string {
-    return `data-model-entity-${name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '')}`;
-}
-
-function EntityCard({ entity }: { entity: ParsedEntity }) {
-    const groupedCallouts: Partial<Record<ParsedCalloutKind, ParsedCallout[]>> = {};
-    for (const c of entity.callouts) {
-        const list = groupedCallouts[c.kind] ?? [];
-        list.push(c);
-        groupedCallouts[c.kind] = list;
-    }
-
-    return (
-        <section
-            id={entityAnchorId(entity.name)}
-            className="bg-white rounded-lg border border-neutral-200 overflow-hidden scroll-mt-24"
-        >
-            <header className="bg-neutral-50 border-b border-neutral-200 px-4 py-3">
-                <div className="flex flex-wrap items-center gap-2 mb-1">
-                    <h4 className="font-semibold text-neutral-900 text-base">{entity.name}</h4>
-                    {entity.userFacing !== undefined && <VisibilityBadge userFacing={entity.userFacing} />}
-                    {entity.mutability && <MutabilityBadge mutability={entity.mutability} />}
-                </div>
-                {entity.description && (
-                    <p className="text-sm text-neutral-600">{entity.description}</p>
-                )}
-                {entity.purpose && (
-                    <p className="text-sm text-neutral-700 mt-1">
-                        <span className="font-medium text-neutral-900">Purpose: </span>
-                        {entity.purpose}
-                    </p>
-                )}
-            </header>
-
-            <div className="px-4 py-3 space-y-4">
-                {entity.groupsAutoDetected && (
-                    <p className="text-[11px] text-neutral-400 italic">
-                        Grouped automatically — refine the artifact for explicit grouping.
-                    </p>
-                )}
-                {entity.fieldGroups.map((group, gi) => (
-                    <div key={gi} className="space-y-1.5">
-                        <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
-                            {group.name}
-                        </h5>
-                        <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-                            <table className="w-full text-xs">
-                                <thead>
-                                    <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider text-[10px]">
-                                        <th className="text-left px-3 py-2 font-medium">Field</th>
-                                        <th className="text-left px-3 py-2 font-medium">Type</th>
-                                        <th className="text-center px-3 py-2 font-medium">Required</th>
-                                        <th className="text-left px-3 py-2 font-medium">Description</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {group.fields.map((f, fi) => (
-                                        <tr key={fi} className="border-t border-neutral-100 align-top">
-                                            <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">
-                                                {f.name}
-                                            </td>
-                                            <td className="px-3 py-1.5 font-mono text-indigo-600 whitespace-nowrap">
-                                                {f.type}
-                                            </td>
-                                            <td className="px-3 py-1.5 text-center text-neutral-600">
-                                                {f.required ? '✓' : ''}
-                                            </td>
-                                            <td className="px-3 py-1.5 text-neutral-600">{f.description}</td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                ))}
-
-                {CALLOUT_ORDER.some(k => (groupedCallouts[k]?.length ?? 0) > 0) && (
-                    <div className="space-y-2">
-                        {CALLOUT_ORDER.flatMap(kind =>
-                            (groupedCallouts[kind] ?? []).map((c, idx) => (
-                                <DataModelCallout key={`${kind}-${idx}`} kind={kind} text={c.text} />
-                            )),
-                        )}
-                    </div>
-                )}
-
-                {entity.exampleRecord && (
-                    <div className="space-y-1">
-                        <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
-                            Example record
-                        </h5>
-                        <p className="text-[11px] text-neutral-400 italic">Illustrative — not real data.</p>
-                        <pre className="font-mono text-xs bg-neutral-900 text-neutral-100 rounded-lg p-3 overflow-x-auto whitespace-pre">
-                            {entity.exampleRecord}
-                        </pre>
-                    </div>
-                )}
-            </div>
-        </section>
-    );
+    /** Optional provenance label ("Version 2") for the overview header. */
+    prdVersionLabel?: string;
+    /** Optional freshness state for the overview header. */
+    staleness?: StalenessState;
 }
 
 function tryParseAsJson(content: string): DataModelContent | null {
@@ -224,8 +47,6 @@ function tryParseAsJson(content: string): DataModelContent | null {
 }
 
 function markEntityGroupsAuto(parsed: ParsedDataModel, sourceMarkdown: string): void {
-    // If the markdown didn't include any explicit `**<GroupName>**` group headers,
-    // mark the entity as auto-grouped so the renderer surfaces the hint.
     const explicitGroupRe = /^\*\*(Key Product Fields|Relationships|System Metadata|API \/ Integration|Privacy \/ Safety)\*\*\s*$/m;
     const hasExplicitGroups = explicitGroupRe.test(sourceMarkdown);
     if (!hasExplicitGroups) {
@@ -237,37 +58,32 @@ function markEntityGroupsAuto(parsed: ParsedDataModel, sourceMarkdown: string): 
     }
 }
 
-function entityFieldCount(entity: ParsedEntity): number {
-    return entity.fieldGroups.reduce((sum, g) => sum + g.fields.length, 0);
+function MethodPill({ method }: { method: string }) {
+    const m = method.toUpperCase();
+    const color =
+        m === 'GET'
+            ? 'text-green-700 bg-green-50 border-green-200'
+            : m === 'POST'
+              ? 'text-blue-700 bg-blue-50 border-blue-200'
+              : m === 'PUT' || m === 'PATCH'
+                ? 'text-amber-700 bg-amber-50 border-amber-200'
+                : m === 'DELETE'
+                  ? 'text-red-700 bg-red-50 border-red-200'
+                  : 'text-neutral-700 bg-neutral-50 border-neutral-200';
+    return (
+        <span className={`font-mono text-[11px] font-bold px-1.5 py-0.5 rounded border ${color}`}>{m}</span>
+    );
 }
 
-export function DataModelRenderer({ content }: Props) {
-    const isMobile = useIsMobile();
-
+export function DataModelRenderer({ content, prdVersionLabel, staleness }: Props) {
     const { parsed, sourceMarkdown } = useMemo(() => {
         const json = tryParseAsJson(content);
         if (json) {
             const md = dataModelToMarkdown(json);
-            const result = parseDataModelMarkdown(md);
-            return { parsed: result, sourceMarkdown: md };
+            return { parsed: parseDataModelMarkdown(md), sourceMarkdown: md };
         }
-        const result = parseDataModelMarkdown(content);
-        return { parsed: result, sourceMarkdown: content };
+        return { parsed: parseDataModelMarkdown(content), sourceMarkdown: content };
     }, [content]);
-
-    const outlineItems: ArtifactOutlineItem[] = useMemo(() => {
-        if (!parsed) return [];
-        return parsed.entities.map(e => {
-            const count = entityFieldCount(e);
-            return {
-                id: entityAnchorId(e.name),
-                label: e.name,
-                countLabel: `${count} ${count === 1 ? 'field' : 'fields'}`,
-            };
-        });
-    }, [parsed]);
-    const outlineIds = useMemo(() => outlineItems.map(i => i.id), [outlineItems]);
-    const { activeId, scrollTo } = useArtifactOutline(outlineIds);
 
     if (!parsed) {
         return (
@@ -279,19 +95,101 @@ export function DataModelRenderer({ content }: Props) {
 
     markEntityGroupsAuto(parsed, sourceMarkdown);
 
+    // Remount the stateful body when the underlying model changes (e.g. version
+    // switch), so per-entity expansion defaults re-apply without a set-in-effect.
+    const signature = parsed.entities.map(e => e.name).join('|');
+    return (
+        <DataModelBody
+            key={signature}
+            parsed={parsed}
+            prdVersionLabel={prdVersionLabel}
+            staleness={staleness}
+        />
+    );
+}
+
+interface BodyProps {
+    parsed: ParsedDataModel;
+    prdVersionLabel?: string;
+    staleness?: StalenessState;
+}
+
+function DataModelBody({ parsed, prdVersionLabel, staleness }: BodyProps) {
+    const isMobile = useIsMobile();
+    const { graph, summary } = useMemo(() => analyzeDataModel(parsed), [parsed]);
+
+    const nodeById = useMemo(() => new Map(graph.nodes.map(n => [n.id, n])), [graph]);
+    const nodeIdSet = useMemo(() => new Set(graph.nodes.map(n => n.id)), [graph]);
+
+    // Entity + derived node pairs, in document order.
+    const pairs = useMemo(
+        () => parsed.entities
+            .map(entity => ({ entity, node: nodeById.get(slugifyEntity(entity.name)) }))
+            .filter((p): p is { entity: ParsedEntity; node: DataModelNode } => Boolean(p.node)),
+        [parsed, nodeById],
+    );
+
+    const distinctCategories = useMemo(
+        () => new Set(pairs.map(p => p.node.category)).size,
+        [pairs],
+    );
+    const canGroup = distinctCategories >= 2 && pairs.length >= 4;
+    const [grouped, setGrouped] = useState(canGroup);
+
+    const orderedPairs = useMemo(() => {
+        if (!grouped) return pairs;
+        return [...pairs].sort(
+            (a, b) => ENTITY_CATEGORY_ORDER.indexOf(a.node.category) - ENTITY_CATEGORY_ORDER.indexOf(b.node.category),
+        );
+    }, [pairs, grouped]);
+
+    // Expansion — single-entity models open by default; larger ones start
+    // collapsed for scannability.
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(
+        () => (pairs.length === 1 ? new Set(pairs.map(p => p.node.id)) : new Set()),
+    );
+
+    const outlineItems: ArtifactOutlineItem[] = useMemo(
+        () => orderedPairs.map(({ entity, node }) => ({
+            id: entityAnchorId(entity.name),
+            label: entity.name,
+            countLabel: `${node.fieldCount} ${node.fieldCount === 1 ? 'field' : 'fields'}`,
+        })),
+        [orderedPairs],
+    );
+    const outlineIds = useMemo(() => outlineItems.map(i => i.id), [outlineItems]);
+    const { activeId, scrollTo } = useArtifactOutline(outlineIds);
+
+    const toggleEntity = (nodeId: string) =>
+        setExpandedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(nodeId)) next.delete(nodeId);
+            else next.add(nodeId);
+            return next;
+        });
+
+    const focusEntity = (nodeId: string) => {
+        setExpandedIds(prev => (prev.has(nodeId) ? prev : new Set(prev).add(nodeId)));
+        const node = nodeById.get(nodeId);
+        if (node) scrollTo(entityAnchorId(node.name));
+    };
+
+    const allExpanded = expandedIds.size >= pairs.length;
+    const toggleAll = () =>
+        setExpandedIds(allExpanded ? new Set() : new Set(pairs.map(p => p.node.id)));
+
+    const resolveTargetId = (name: string) => resolveEntityId(name, nodeIdSet);
+
+    // Category boundaries for grouped rendering — derived purely so no variable
+    // is reassigned during render.
+    const orderedWithHeader = orderedPairs.map((pair, i) => ({
+        ...pair,
+        showHeader: grouped && (i === 0 || orderedPairs[i - 1].node.category !== pair.node.category),
+    }));
+
     return (
         <div className="space-y-6">
-            {parsed.entities.length > 1 && (
-                <ArtifactOutlineNav
-                    title="Entities"
-                    items={outlineItems}
-                    activeId={activeId}
-                    activeLabel="Current entity"
-                    defaultExpanded={false}
-                    collapseOnSelect={isMobile}
-                    onSelect={scrollTo}
-                />
-            )}
+            <DataModelOverview summary={summary} prdVersionLabel={prdVersionLabel} staleness={staleness} />
 
             {parsed.overview && (
                 <section className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-5">
@@ -302,9 +200,7 @@ export function DataModelRenderer({ content }: Props) {
                         </h3>
                     </div>
                     {parsed.overview.summary && (
-                        <p className="text-sm text-neutral-800 leading-relaxed mb-3">
-                            {parsed.overview.summary}
-                        </p>
+                        <p className="text-sm text-neutral-800 leading-relaxed mb-3">{parsed.overview.summary}</p>
                     )}
                     <div className="space-y-2">
                         {parsed.overview.dataFlow && (
@@ -323,43 +219,89 @@ export function DataModelRenderer({ content }: Props) {
                 </section>
             )}
 
-            {parsed.relationshipFlow && (
-                <section className="space-y-2">
-                    <div className="flex items-center gap-2">
-                        <Workflow className="w-4 h-4 text-neutral-500" />
-                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
-                            Relationship Flow
-                        </h3>
-                    </div>
-                    <pre className="font-mono text-xs bg-neutral-50 border border-neutral-200 rounded-lg p-4 overflow-x-auto whitespace-pre text-neutral-800">
-                        {parsed.relationshipFlow}
-                    </pre>
-                </section>
+            {graph.nodes.length > 0 && (
+                <EntityGraph graph={graph} onOpenEntity={focusEntity} />
             )}
 
-            {parsed.entities.length > 0 && (
-                <section className="space-y-4">
-                    <div className="flex items-center gap-2">
-                        <Database className="w-4 h-4 text-neutral-500" />
-                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
-                            Entities
+            {pairs.length > 0 && (
+                <section className="space-y-3">
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500 inline-flex items-center gap-1.5">
+                            <Layers className="w-4 h-4 text-neutral-400" /> Entities
                         </h3>
+                        <div className="flex items-center gap-1.5">
+                            {canGroup && (
+                                <button
+                                    type="button"
+                                    onClick={() => setGrouped(g => !g)}
+                                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium rounded-md border transition ${
+                                        grouped
+                                            ? 'bg-indigo-50 text-indigo-700 border-indigo-200'
+                                            : 'bg-white text-neutral-600 border-neutral-200 hover:bg-neutral-50'
+                                    }`}
+                                >
+                                    <Layers size={12} /> Group by category
+                                </button>
+                            )}
+                            {pairs.length > 1 && (
+                                <button
+                                    type="button"
+                                    onClick={toggleAll}
+                                    className="inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium rounded-md border border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-50 transition"
+                                >
+                                    {allExpanded ? <ChevronsDownUp size={12} /> : <ChevronsUpDown size={12} />}
+                                    {allExpanded ? 'Collapse all' : 'Expand all'}
+                                </button>
+                            )}
+                        </div>
                     </div>
-                    {parsed.entities.map((entity, ei) => (
-                        <EntityCard key={ei} entity={entity} />
-                    ))}
+
+                    {pairs.length > 1 && (
+                        <ArtifactOutlineNav
+                            title="Entities"
+                            items={outlineItems}
+                            activeId={activeId}
+                            activeLabel="Current entity"
+                            defaultExpanded={false}
+                            collapseOnSelect={isMobile}
+                            onSelect={scrollTo}
+                        />
+                    )}
+
+                    <div className="space-y-3">
+                        {orderedWithHeader.map(({ entity, node, showHeader }) => {
+                            return (
+                                <div key={node.id}>
+                                    {showHeader && (
+                                        <div className="flex items-center gap-2 pt-2 pb-1.5">
+                                            <CategoryBadge category={node.category} />
+                                            <span className="text-[11px] text-neutral-400">
+                                                {ENTITY_CATEGORY_LABEL[node.category]}
+                                            </span>
+                                            <span className="flex-1 h-px bg-neutral-100" />
+                                        </div>
+                                    )}
+                                    <EntityCard
+                                        entity={entity}
+                                        node={node}
+                                        expanded={expandedIds.has(node.id)}
+                                        onToggle={() => toggleEntity(node.id)}
+                                        resolveTargetId={resolveTargetId}
+                                        onNavigateToEntity={focusEntity}
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
                 </section>
             )}
 
             {parsed.productMapping.length > 0 && (
                 <section className="space-y-2">
-                    <div className="flex items-center gap-2">
-                        <Layers className="w-4 h-4 text-neutral-500" />
-                        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
-                            How This Appears in the Product
-                        </h3>
-                    </div>
-                    <div className="bg-white rounded-lg border border-neutral-200 overflow-x-auto">
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                        How This Appears in the Product
+                    </h3>
+                    <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-x-auto">
                         <table className="w-full text-xs">
                             <thead>
                                 <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider text-[10px]">
@@ -370,9 +312,7 @@ export function DataModelRenderer({ content }: Props) {
                             <tbody>
                                 {parsed.productMapping.map((m, mi) => (
                                     <tr key={mi} className="border-t border-neutral-100 align-top">
-                                        <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">
-                                            {m.field}
-                                        </td>
+                                        <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">{m.field}</td>
                                         <td className="px-3 py-1.5 text-neutral-600">{m.uiBehavior}</td>
                                     </tr>
                                 ))}
@@ -384,10 +324,8 @@ export function DataModelRenderer({ content }: Props) {
 
             {parsed.apiEndpoints.length > 0 && (
                 <section className="space-y-2">
-                    <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
-                        API Endpoints
-                    </h3>
-                    <div className="bg-white rounded-lg border border-neutral-200 overflow-x-auto">
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">API Endpoints</h3>
+                    <div className="bg-white rounded-xl border border-neutral-200 shadow-sm overflow-x-auto">
                         <table className="w-full text-xs">
                             <thead>
                                 <tr className="bg-neutral-50 text-neutral-500 uppercase tracking-wider text-[10px]">
@@ -400,16 +338,10 @@ export function DataModelRenderer({ content }: Props) {
                             <tbody>
                                 {parsed.apiEndpoints.map((ep, ei) => (
                                     <tr key={ei} className="border-t border-neutral-100 align-top">
-                                        <td className="px-3 py-1.5 whitespace-nowrap">
-                                            <MethodPill method={ep.method} />
-                                        </td>
-                                        <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">
-                                            {ep.path}
-                                        </td>
+                                        <td className="px-3 py-1.5 whitespace-nowrap"><MethodPill method={ep.method} /></td>
+                                        <td className="px-3 py-1.5 font-mono text-neutral-800 whitespace-nowrap">{ep.path}</td>
                                         <td className="px-3 py-1.5 text-neutral-600">{ep.description}</td>
-                                        <td className="px-3 py-1.5 text-neutral-700 whitespace-nowrap">
-                                            {ep.entity ?? ''}
-                                        </td>
+                                        <td className="px-3 py-1.5 text-neutral-700 whitespace-nowrap">{ep.entity ?? ''}</td>
                                     </tr>
                                 ))}
                             </tbody>

--- a/src/components/renderers/__tests__/DataModelRenderer.test.tsx
+++ b/src/components/renderers/__tests__/DataModelRenderer.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/react';
+import { DataModelRenderer } from '../DataModelRenderer';
+import type { DataModelContent } from '../../../types';
+
+// jsdom doesn't implement scrollIntoView; the outline/graph interactions call it.
+beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+const twoEntityModel: DataModelContent = {
+    entities: [
+        {
+            name: 'User',
+            description: 'Account holder.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'email', type: 'String', required: true, description: 'Login email' },
+            ],
+            relationships: [{ type: 'has_many', target: 'Order' }],
+        },
+        {
+            name: 'Order',
+            description: 'A purchase.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'total_cents', type: 'Integer', required: true, description: 'Order total' },
+            ],
+            relationships: [{ type: 'belongs_to', target: 'User' }],
+        },
+    ],
+    apiEndpoints: [],
+};
+
+function renderModel(content: DataModelContent, props: Partial<{ prdVersionLabel: string; staleness: 'current' | 'possibly_outdated' | 'outdated' }> = {}) {
+    return render(<DataModelRenderer content={JSON.stringify(content)} {...props} />);
+}
+
+describe('DataModelRenderer — overview header', () => {
+    it('renders a Data Model overview with entity/relationship counts', () => {
+        const { getByLabelText } = renderModel(twoEntityModel);
+        const overview = getByLabelText('Data model overview');
+        expect(overview).toHaveTextContent('Data Model');
+        expect(overview).toHaveTextContent('Entities');
+        // Singular label when there is exactly one deduped relationship.
+        expect(overview).toHaveTextContent('Relationship');
+        // 2 entities stat tile value.
+        expect(within(overview).getByText('2')).toBeInTheDocument();
+    });
+
+    it('shows optional PRD provenance and staleness when provided', () => {
+        const { getByLabelText } = renderModel(twoEntityModel, {
+            prdVersionLabel: 'Version 3',
+            staleness: 'possibly_outdated',
+        });
+        const overview = getByLabelText('Data model overview');
+        expect(overview).toHaveTextContent('From PRD Version 3');
+        expect(overview).toHaveTextContent('May be outdated');
+    });
+});
+
+describe('DataModelRenderer — ER diagram', () => {
+    it('renders directional edges with verb + cardinality labels', () => {
+        const { getByText } = renderModel(twoEntityModel);
+        expect(getByText('Entity relationships')).toBeInTheDocument();
+        expect(getByText('has many')).toBeInTheDocument();
+        expect(getByText('1 → many')).toBeInTheDocument();
+    });
+
+    it('shows an empty state when there are no relationships', () => {
+        const standalone: DataModelContent = {
+            entities: [
+                { name: 'Setting', description: 'A config value.', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: 'pk' }], relationships: [] },
+                { name: 'Flag', description: 'A toggle.', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: 'pk' }], relationships: [] },
+            ],
+            apiEndpoints: [],
+        };
+        const { getByText } = renderModel(standalone);
+        expect(getByText(/No relationships are defined/i)).toBeInTheDocument();
+    });
+});
+
+describe('DataModelRenderer — collapsible entity cards', () => {
+    it('collapses multi-entity cards by default and expands on click', () => {
+        const { container, queryByText, getByText } = renderModel(twoEntityModel);
+        // total_cents lives only inside the (collapsed) Order card body.
+        expect(queryByText('total_cents')).toBeNull();
+
+        const orderCard = container.querySelector('#data-model-entity-order');
+        expect(orderCard).toBeTruthy();
+        const header = orderCard!.querySelector('button');
+        fireEvent.click(header!);
+
+        expect(getByText('total_cents')).toBeInTheDocument();
+    });
+
+    it('expands a single-entity model by default', () => {
+        const single: DataModelContent = {
+            entities: [{
+                name: 'Session',
+                description: 'A login session.',
+                userFacing: false,
+                fields: [
+                    { name: 'id', type: 'UUID', required: true, description: 'pk' },
+                    { name: 'token', type: 'String', required: true, description: 'Sensitive session token' },
+                ],
+                relationships: [],
+            }],
+            apiEndpoints: [],
+        };
+        const { getByText } = renderModel(single);
+        // Field from the expanded body is visible without interaction.
+        expect(getByText('token')).toBeInTheDocument();
+    });
+});
+
+describe('DataModelRenderer — inspector rows + categories', () => {
+    it('renders relationship / constraint / privacy inspector rows when expanded', () => {
+        const model: DataModelContent = {
+            entities: [{
+                name: 'MoodSnapshot',
+                description: 'Captures a mood.',
+                userFacing: true,
+                mutability: 'mostly_immutable',
+                fields: [{ name: 'joy_score', type: 'Float', required: true, description: 'Joy 0-1' }],
+                relationships: [{ type: 'has_many', target: 'Playlist', description: 'derived' }],
+                constraints: ['joy_score must be between 0 and 1'],
+                privacyRules: ['raw_input must be redacted'],
+                indexes: ['idx_joy on (joy_score)'],
+            }],
+            apiEndpoints: [],
+        };
+        const { getByText, container } = renderModel(model);
+        // Single entity → expanded, inspector sections present.
+        expect(getByText('Relationships')).toBeInTheDocument();
+        expect(getByText('joy_score must be between 0 and 1')).toBeInTheDocument();
+        expect(getByText('raw_input must be redacted')).toBeInTheDocument();
+        // Category badge derived (mostly_immutable + user-facing → Generated Outputs).
+        expect(container).toHaveTextContent('Generated Outputs');
+    });
+
+    it('offers a group-by-category control for larger, mixed-category models', () => {
+        const model: DataModelContent = {
+            entities: [
+                { name: 'User', description: '', userFacing: true, mutability: 'mutable', fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [] },
+                { name: 'AuditLog', description: '', userFacing: false, fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [] },
+                { name: 'Receipt', description: '', userFacing: true, mutability: 'immutable', fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [] },
+                { name: 'WebhookDelivery', description: '', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [] },
+            ],
+            apiEndpoints: [],
+        };
+        const { getByRole } = renderModel(model);
+        expect(getByRole('button', { name: /Group by category/i })).toBeInTheDocument();
+    });
+});

--- a/src/components/renderers/dataModel/DataModelOverview.tsx
+++ b/src/components/renderers/dataModel/DataModelOverview.tsx
@@ -1,0 +1,101 @@
+import {
+    Database, GitBranch, ShieldCheck, ShieldAlert, SlidersHorizontal, KeyRound, Table2,
+} from 'lucide-react';
+import type { StalenessState } from '../../../types';
+import type { DataModelSummary } from '../../../lib/dataModelGraph';
+
+interface Props {
+    summary: DataModelSummary;
+    prdVersionLabel?: string;
+    staleness?: StalenessState;
+}
+
+const STALENESS_CONFIG: Record<StalenessState, { label: string; className: string }> = {
+    current: { label: 'Current', className: 'bg-green-50 text-green-700 ring-1 ring-green-200' },
+    possibly_outdated: { label: 'May be outdated', className: 'bg-amber-50 text-amber-700 ring-1 ring-amber-200' },
+    outdated: { label: 'Outdated', className: 'bg-red-50 text-red-700 ring-1 ring-red-200' },
+};
+
+function StatTile({
+    icon: Icon, value, label, tone = 'neutral',
+}: {
+    icon: typeof Database;
+    value: number | string;
+    label: string;
+    tone?: 'neutral' | 'indigo' | 'rose';
+}) {
+    const toneCls =
+        tone === 'indigo' ? 'text-indigo-600' : tone === 'rose' ? 'text-rose-600' : 'text-neutral-700';
+    return (
+        <div className="flex items-center gap-2.5 rounded-lg border border-neutral-200 bg-neutral-50/60 px-3 py-2">
+            <Icon size={16} className={`shrink-0 ${toneCls}`} aria-hidden="true" />
+            <div className="min-w-0">
+                <div className="text-base font-bold leading-none text-neutral-900 tabular-nums">{value}</div>
+                <div className="mt-0.5 text-[11px] text-neutral-500 truncate">{label}</div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Compact overview header for the Data Model artifact — a confidence check that
+ * summarizes provenance, freshness, and the shape of the model (entities,
+ * relationships, constraints, indexes, PII) before the user explores details.
+ */
+export function DataModelOverview({ summary, prdVersionLabel, staleness }: Props) {
+    const stale = staleness ? STALENESS_CONFIG[staleness] : undefined;
+    const piiLabel =
+        summary.piiEntityCount === 0
+            ? 'No PII entities'
+            : `${summary.piiEntityCount} ${summary.piiEntityCount === 1 ? 'entity' : 'entities'} with PII`;
+
+    return (
+        <section
+            aria-label="Data model overview"
+            className="rounded-xl border border-neutral-200 bg-white shadow-sm p-4 md:p-5"
+        >
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div className="flex items-start gap-3 min-w-0">
+                    <div className="p-2 rounded-lg bg-indigo-50 text-indigo-600 shrink-0">
+                        <Database size={18} />
+                    </div>
+                    <div className="min-w-0">
+                        <h2 className="text-base font-bold text-neutral-900">Data Model</h2>
+                        <p className="text-xs text-neutral-500 mt-0.5">
+                            {summary.entityCount} {summary.entityCount === 1 ? 'entity' : 'entities'}
+                            {summary.apiEndpointCount > 0 && ` · ${summary.apiEndpointCount} API ${summary.apiEndpointCount === 1 ? 'endpoint' : 'endpoints'}`}
+                        </p>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2 flex-wrap">
+                    {prdVersionLabel && (
+                        <span className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-full bg-neutral-100 text-neutral-600 font-medium">
+                            <Table2 size={11} /> From PRD {prdVersionLabel}
+                        </span>
+                    )}
+                    {stale && (
+                        <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-full font-medium ${stale.className}`}>
+                            {staleness === 'current'
+                                ? <ShieldCheck size={11} />
+                                : <ShieldAlert size={11} />}
+                            {stale.label}
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+                <StatTile icon={Database} value={summary.entityCount} label="Entities" tone="indigo" />
+                <StatTile icon={GitBranch} value={summary.relationshipCount} label={summary.relationshipCount === 1 ? 'Relationship' : 'Relationships'} />
+                <StatTile icon={SlidersHorizontal} value={summary.constraintCount} label={summary.constraintCount === 1 ? 'Constraint' : 'Constraints'} />
+                <StatTile icon={KeyRound} value={summary.indexCount} label={summary.indexCount === 1 ? 'Index' : 'Indexes'} />
+                <StatTile
+                    icon={summary.piiEntityCount > 0 ? ShieldAlert : ShieldCheck}
+                    value={summary.piiEntityCount > 0 ? summary.piiEntityCount : '—'}
+                    label={piiLabel}
+                    tone={summary.piiEntityCount > 0 ? 'rose' : 'neutral'}
+                />
+            </div>
+        </section>
+    );
+}

--- a/src/components/renderers/dataModel/EntityCard.tsx
+++ b/src/components/renderers/dataModel/EntityCard.tsx
@@ -1,0 +1,238 @@
+import { useMemo, type ReactNode } from 'react';
+import {
+    Braces, Check, ChevronDown, Database, GitBranch, KeyRound, ListTree, ShieldAlert, SlidersHorizontal,
+} from 'lucide-react';
+import type { ParsedEntity, ParsedFieldGroup } from '../../../lib/services/dataModelMarkdown';
+import type { DataModelNode } from '../../../lib/dataModelGraph';
+import {
+    classifyFieldType, entityAnchorId, indexedFieldNames, parseRelationshipCallout,
+} from '../../../lib/dataModelGraph';
+import { CategoryBadge, EntityAttributeBadges, FieldTypeChip, InspectorRow } from './badges';
+
+interface Props {
+    entity: ParsedEntity;
+    node: DataModelNode;
+    expanded: boolean;
+    onToggle: () => void;
+    /** Resolve a relationship target name to a known node id (for linking). */
+    resolveTargetId: (targetName: string) => string | undefined;
+    onNavigateToEntity: (nodeId: string) => void;
+}
+
+function CountChip({ icon: Icon, count, label, tone = 'neutral' }: {
+    icon: typeof Database; count: number; label: string; tone?: 'neutral' | 'rose';
+}) {
+    if (count <= 0) return null;
+    const toneCls = tone === 'rose'
+        ? 'bg-rose-50 text-rose-600 ring-rose-200'
+        : 'bg-neutral-100 text-neutral-600 ring-neutral-200';
+    return (
+        <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full ring-1 ${toneCls}`}>
+            <Icon size={10} className="shrink-0" />
+            <span className="tabular-nums">{count}</span>
+            <span className="hidden sm:inline">{label}</span>
+        </span>
+    );
+}
+
+function FieldTable({ group, indexed }: { group: ParsedFieldGroup; indexed: Set<string> }) {
+    return (
+        <div className="space-y-1.5">
+            <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">{group.name}</h5>
+            <div className="overflow-x-auto -mx-1">
+                <table className="w-full text-xs table-fixed">
+                    <colgroup>
+                        <col className="w-[34%]" />
+                        <col className="w-[22%]" />
+                        <col className="w-[10%]" />
+                        <col className="w-[34%]" />
+                    </colgroup>
+                    <thead>
+                        <tr className="text-neutral-400 uppercase tracking-wider text-[10px]">
+                            <th className="text-left px-2 py-1.5 font-medium">Field</th>
+                            <th className="text-left px-2 py-1.5 font-medium">Type</th>
+                            <th className="text-center px-2 py-1.5 font-medium">Req</th>
+                            <th className="text-left px-2 py-1.5 font-medium">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {group.fields.map((f, fi) => {
+                            const kind = classifyFieldType(f.type, f.name);
+                            const isIndexed = indexed.has(f.name);
+                            return (
+                                <tr key={fi} className="border-t border-neutral-100 align-top">
+                                    <td className="px-2 py-1.5">
+                                        <span className="inline-flex items-center gap-1 font-mono text-[11px] text-neutral-800 break-all">
+                                            {f.name}
+                                            {isIndexed && (
+                                                <KeyRound size={10} className="shrink-0 text-slate-400" aria-label="Indexed" />
+                                            )}
+                                        </span>
+                                    </td>
+                                    <td className="px-2 py-1.5">
+                                        <span className="inline-flex items-center gap-1">
+                                            <FieldTypeChip kind={kind} label={f.type} />
+                                            {kind === 'json' && (
+                                                <Braces size={11} className="text-fuchsia-400" aria-label="Structured / object" />
+                                            )}
+                                        </span>
+                                    </td>
+                                    <td className="px-2 py-1.5 text-center">
+                                        {f.required
+                                            ? <Check size={13} className="inline text-emerald-500" aria-label="Required" />
+                                            : <span className="text-neutral-300" aria-label="Optional">—</span>}
+                                    </td>
+                                    <td className="px-2 py-1.5 text-neutral-600 leading-relaxed">{f.description}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * A compact, collapsible entity card. Collapsed: name, one-line description,
+ * key badges, and counts. Expanded: overview, grouped field tables, and
+ * inspector-style rows for relationships / constraints / privacy / indexes,
+ * plus the example record.
+ */
+export function EntityCard({ entity, node, expanded, onToggle, resolveTargetId, onNavigateToEntity }: Props) {
+    const indexed = useMemo(() => indexedFieldNames(entity), [entity]);
+
+    const relationships = entity.callouts.filter(c => c.kind === 'RELATIONSHIP');
+    const constraints = entity.callouts.filter(c => c.kind === 'CONSTRAINT');
+    const privacy = entity.callouts.filter(c => c.kind === 'PRIVACY');
+    const indexes = entity.callouts.filter(c => c.kind === 'INDEX');
+
+    return (
+        <section id={entityAnchorId(entity.name)} className="scroll-mt-24 rounded-xl border border-neutral-200 bg-white shadow-sm overflow-hidden">
+            {/* Header — always visible, toggles expansion */}
+            <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={expanded}
+                className="w-full text-left px-4 py-3 flex items-start gap-3 hover:bg-neutral-50/60 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset"
+            >
+                <div className="mt-0.5 p-1.5 rounded-lg bg-neutral-100 text-neutral-500 shrink-0">
+                    <Database size={15} />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <h4 className="text-sm font-semibold text-neutral-900">{entity.name}</h4>
+                        <CategoryBadge category={node.category} size="xs" />
+                    </div>
+                    {entity.description && (
+                        <p className={`text-xs text-neutral-500 mt-0.5 ${expanded ? '' : 'line-clamp-1'}`}>
+                            {entity.description}
+                        </p>
+                    )}
+                    <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+                        <EntityAttributeBadges node={node} />
+                    </div>
+                    <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+                        <CountChip icon={ListTree} count={node.fieldCount} label="fields" />
+                        <CountChip icon={GitBranch} count={node.relationshipCount} label="relationships" />
+                        <CountChip icon={SlidersHorizontal} count={node.constraintCount} label="constraints" />
+                        <CountChip icon={ShieldAlert} count={node.privacyCount} label="privacy" tone="rose" />
+                        <CountChip icon={KeyRound} count={node.indexCount} label="indexes" />
+                    </div>
+                </div>
+                <ChevronDown
+                    size={18}
+                    className={`shrink-0 mt-1 text-neutral-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+                    aria-hidden="true"
+                />
+            </button>
+
+            {expanded && (
+                <div className="px-4 pb-4 pt-1 space-y-4 border-t border-neutral-100">
+                    {entity.purpose && (
+                        <div className="rounded-lg bg-indigo-50/50 border border-indigo-100 px-3 py-2">
+                            <p className="text-xs text-neutral-700">
+                                <span className="font-semibold text-indigo-900">Purpose: </span>
+                                {entity.purpose}
+                            </p>
+                        </div>
+                    )}
+
+                    {entity.groupsAutoDetected && (
+                        <p className="text-[11px] text-neutral-400 italic">
+                            Fields grouped automatically — refine the artifact for explicit grouping.
+                        </p>
+                    )}
+
+                    {entity.fieldGroups.map((group, gi) => (
+                        <FieldTable key={gi} group={group} indexed={indexed} />
+                    ))}
+
+                    {relationships.length > 0 && (
+                        <InspectorSection title="Relationships">
+                            {relationships.map((c, i) => {
+                                const rel = parseRelationshipCallout(c.text);
+                                if (!rel) return null;
+                                const targetId = resolveTargetId(rel.target);
+                                const label = rel.cardinality ? `${rel.verb} · ${rel.cardinality}` : rel.verb;
+                                return (
+                                    <InspectorRow
+                                        key={i}
+                                        category="relationship"
+                                        label={label}
+                                        description={rel.description}
+                                        linkLabel={rel.target}
+                                        onLink={targetId ? () => onNavigateToEntity(targetId) : undefined}
+                                    />
+                                );
+                            })}
+                        </InspectorSection>
+                    )}
+
+                    {constraints.length > 0 && (
+                        <InspectorSection title="Constraints">
+                            {constraints.map((c, i) => (
+                                <InspectorRow key={i} category="constraint" label="" description={c.text} />
+                            ))}
+                        </InspectorSection>
+                    )}
+
+                    {privacy.length > 0 && (
+                        <InspectorSection title="Privacy">
+                            {privacy.map((c, i) => (
+                                <InspectorRow key={i} category="privacy" label="" description={c.text} />
+                            ))}
+                        </InspectorSection>
+                    )}
+
+                    {indexes.length > 0 && (
+                        <InspectorSection title="Indexes">
+                            {indexes.map((c, i) => (
+                                <InspectorRow key={i} category="index" label="" description={c.text} />
+                            ))}
+                        </InspectorSection>
+                    )}
+
+                    {entity.exampleRecord && (
+                        <div className="space-y-1">
+                            <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">Example record</h5>
+                            <p className="text-[11px] text-neutral-400 italic">Illustrative — not real data.</p>
+                            <pre className="font-mono text-[11px] bg-neutral-900 text-neutral-100 rounded-lg p-3 overflow-x-auto whitespace-pre">
+                                {entity.exampleRecord}
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    );
+}
+
+function InspectorSection({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <div className="space-y-0.5">
+            <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 px-2.5">{title}</h5>
+            <div className="divide-y divide-neutral-50">{children}</div>
+        </div>
+    );
+}

--- a/src/components/renderers/dataModel/EntityGraph.tsx
+++ b/src/components/renderers/dataModel/EntityGraph.tsx
@@ -1,0 +1,276 @@
+import { useMemo, useState } from 'react';
+import { Database, GitBranch, MousePointerClick } from 'lucide-react';
+import {
+    computeDataModelLayout, type DataModelGraph, type DataModelNode,
+} from '../../../lib/dataModelGraph';
+import { CATEGORY_STYLES, EDGE_STROKE } from './dataModelStyles';
+import { CategoryBadge } from './badges';
+
+interface Props {
+    graph: DataModelGraph;
+    /** Jump to (and expand) an entity's detail card. */
+    onOpenEntity: (nodeId: string) => void;
+}
+
+// Deterministic canvas geometry — no DOM measurement (mirrors DependencyGraphView).
+const CARD_W = 224;
+const CARD_H = 118;
+const GAP_X = 40;
+const ROW_GAP = 92;
+
+type Selection = { type: 'node'; id: string } | { type: 'edge'; id: string } | null;
+
+function NodeCardInner({ node }: { node: DataModelNode }) {
+    return (
+        <>
+            <div className="flex items-center gap-1.5 min-w-0">
+                <Database size={13} className="shrink-0 text-neutral-400" />
+                <span className="text-sm font-semibold text-neutral-900 truncate">{node.name}</span>
+            </div>
+            <div className="mt-1.5">
+                <CategoryBadge category={node.category} size="xs" />
+            </div>
+            {node.description && (
+                <p className="mt-1.5 text-[11px] leading-snug text-neutral-500 line-clamp-2">
+                    {node.description}
+                </p>
+            )}
+            <div className="mt-auto pt-1.5 flex items-center gap-2 text-[10px] text-neutral-500">
+                <span className="inline-flex items-center gap-1">
+                    <span className="font-semibold text-neutral-700 tabular-nums">{node.fieldCount}</span> fields
+                </span>
+                <span className="inline-flex items-center gap-1">
+                    <GitBranch size={10} className="text-neutral-400" />
+                    <span className="font-semibold text-neutral-700 tabular-nums">{node.relationshipCount}</span> rel.
+                </span>
+            </div>
+        </>
+    );
+}
+
+/** Empty state / no-relationship layout: a responsive grid of entity cards. */
+function EntityGrid({ graph, onOpenEntity }: Props) {
+    return (
+        <div className="space-y-3">
+            <div className="rounded-lg border border-dashed border-neutral-200 bg-neutral-50/50 px-3 py-2 text-xs text-neutral-500">
+                No relationships are defined between these entities — they stand alone in the model.
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                {graph.nodes.map(node => (
+                    <button
+                        key={node.id}
+                        type="button"
+                        onClick={() => onOpenEntity(node.id)}
+                        className={`flex flex-col text-left rounded-xl border border-l-4 bg-white px-3 py-2.5 shadow-sm hover:border-indigo-300 hover:shadow transition ${CATEGORY_STYLES[node.category].accent}`}
+                        style={{ minHeight: CARD_H }}
+                    >
+                        <NodeCardInner node={node} />
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+/**
+ * ER-style entity-relationship diagram. Renders each entity as a rounded node
+ * card and each (deduped) relationship as a directional, cardinality-labelled
+ * edge — visually aligned with the artifact dependency graph and user-flow
+ * diagrams. Deterministic layered layout; horizontally scrollable on small
+ * screens. Clicking a node opens its detail card; clicking an edge highlights
+ * the entities it connects.
+ */
+export function EntityGraph(props: Props) {
+    const { graph, onOpenEntity } = props;
+    const [selection, setSelection] = useState<Selection>(null);
+
+    const layout = useMemo(() => computeDataModelLayout(graph), [graph]);
+
+    const geometry = useMemo(() => {
+        const maxCols = Math.max(1, ...layout.rows.map(r => r.length));
+        const canvasW = maxCols * CARD_W + (maxCols - 1) * GAP_X;
+        const canvasH = layout.rows.length * CARD_H + Math.max(0, layout.rows.length - 1) * ROW_GAP;
+        const positions = new Map<string, { x: number; y: number }>();
+        layout.rows.forEach((row, r) => {
+            const rowWidth = row.length * CARD_W + (row.length - 1) * GAP_X;
+            row.forEach((id, i) => {
+                positions.set(id, {
+                    x: (canvasW - rowWidth) / 2 + i * (CARD_W + GAP_X),
+                    y: r * (CARD_H + ROW_GAP),
+                });
+            });
+        });
+        return { canvasW, canvasH, positions };
+    }, [layout]);
+
+    if (graph.edges.length === 0) {
+        return <EntityGrid {...props} />;
+    }
+
+    const { canvasW, canvasH, positions } = geometry;
+
+    // Which edges / nodes are highlighted by the current selection.
+    const activeEdgeIds = new Set<string>();
+    const activeNodeIds = new Set<string>();
+    if (selection?.type === 'node') {
+        activeNodeIds.add(selection.id);
+        for (const e of graph.edges) {
+            if (e.fromId === selection.id || e.toId === selection.id) {
+                activeEdgeIds.add(e.id);
+                activeNodeIds.add(e.fromId);
+                activeNodeIds.add(e.toId);
+            }
+        }
+    } else if (selection?.type === 'edge') {
+        const edge = graph.edges.find(e => e.id === selection.id);
+        if (edge) {
+            activeEdgeIds.add(edge.id);
+            activeNodeIds.add(edge.fromId);
+            activeNodeIds.add(edge.toId);
+        }
+    }
+
+    // Edge path + midpoint label position, choosing connection points by the
+    // relative vertical position of the two nodes (down / up / same row).
+    const edgeRenders = graph.edges.map(edge => {
+        const from = positions.get(edge.fromId);
+        const to = positions.get(edge.toId);
+        if (!from || !to) return null;
+        const active = activeEdgeIds.has(edge.id);
+        let x1: number, y1: number, x2: number, y2: number, d: string, mx: number, my: number;
+        if (to.y > from.y) {
+            x1 = from.x + CARD_W / 2; y1 = from.y + CARD_H;
+            x2 = to.x + CARD_W / 2; y2 = to.y;
+            const midY = (y1 + y2) / 2;
+            d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
+            mx = (x1 + x2) / 2; my = midY;
+        } else if (to.y < from.y) {
+            x1 = from.x + CARD_W / 2; y1 = from.y;
+            x2 = to.x + CARD_W / 2; y2 = to.y + CARD_H;
+            const midY = (y1 + y2) / 2;
+            d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
+            mx = (x1 + x2) / 2; my = midY;
+        } else {
+            const leftToRight = to.x >= from.x;
+            x1 = from.x + (leftToRight ? CARD_W : 0); y1 = from.y + CARD_H / 2;
+            x2 = to.x + (leftToRight ? 0 : CARD_W); y2 = to.y + CARD_H / 2;
+            const midX = (x1 + x2) / 2;
+            d = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
+            mx = midX; my = (y1 + y2) / 2;
+        }
+        return { edge, active, d, mx, my };
+    }).filter((e): e is NonNullable<typeof e> => e !== null);
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500 inline-flex items-center gap-1.5">
+                    <GitBranch size={12} /> Entity relationships
+                </p>
+                <span className="text-[10px] text-neutral-400 inline-flex items-center gap-1">
+                    <MousePointerClick size={11} /> Tap an entity to open its details
+                </span>
+            </div>
+
+            <div className="bg-white rounded-xl border border-neutral-200 shadow-sm p-4 overflow-x-auto">
+                <div className="relative mx-auto" style={{ width: canvasW, height: canvasH }}>
+                    <svg
+                        className="absolute inset-0 pointer-events-none"
+                        width={canvasW}
+                        height={canvasH}
+                        aria-hidden="true"
+                    >
+                        <defs>
+                            <marker id="dm-arrow-base" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+                                <path d="M0,0 L7,3 L0,6 Z" fill={EDGE_STROKE.base} />
+                            </marker>
+                            <marker id="dm-arrow-active" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+                                <path d="M0,0 L7,3 L0,6 Z" fill={EDGE_STROKE.active} />
+                            </marker>
+                            <marker id="dm-arrow-base-start" markerWidth="9" markerHeight="9" refX="-0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+                                <path d="M7,0 L0,3 L7,6 Z" fill={EDGE_STROKE.base} />
+                            </marker>
+                            <marker id="dm-arrow-active-start" markerWidth="9" markerHeight="9" refX="-0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+                                <path d="M7,0 L0,3 L7,6 Z" fill={EDGE_STROKE.active} />
+                            </marker>
+                        </defs>
+                        {edgeRenders.map(({ edge, active, d }) => (
+                            <path
+                                key={edge.id}
+                                d={d}
+                                fill="none"
+                                stroke={active ? EDGE_STROKE.active : EDGE_STROKE.base}
+                                strokeWidth={active ? 2 : 1.5}
+                                markerEnd={`url(#dm-arrow-${active ? 'active' : 'base'})`}
+                                markerStart={edge.arrow === 'both' ? `url(#dm-arrow-${active ? 'active' : 'base'}-start)` : undefined}
+                            />
+                        ))}
+                    </svg>
+
+                    {/* Edge labels (verb + cardinality) as positioned pills. */}
+                    {edgeRenders.map(({ edge, active, mx, my }) => (
+                        <button
+                            key={`label-${edge.id}`}
+                            type="button"
+                            onClick={() => setSelection(sel =>
+                                sel?.type === 'edge' && sel.id === edge.id ? null : { type: 'edge', id: edge.id },
+                            )}
+                            style={{ left: mx, top: my, transform: 'translate(-50%, -50%)' }}
+                            className={`absolute z-10 max-w-[10rem] rounded-full border px-2 py-0.5 text-[10px] font-medium leading-tight shadow-sm transition ${
+                                active
+                                    ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
+                                    : 'border-neutral-200 bg-white text-neutral-600 hover:border-indigo-200'
+                            }`}
+                            title={edge.description || `${edge.verb}${edge.cardinality ? ` (${edge.cardinality})` : ''}`}
+                        >
+                            <span className="block truncate">{edge.verb}</span>
+                            {edge.cardinality && (
+                                <span className="block text-[9px] font-mono text-neutral-400 leading-none">{edge.cardinality}</span>
+                            )}
+                        </button>
+                    ))}
+
+                    {/* Entity nodes. */}
+                    {graph.nodes.map(node => {
+                        const pos = positions.get(node.id);
+                        if (!pos) return null;
+                        const highlighted = activeNodeIds.has(node.id);
+                        const dim = activeNodeIds.size > 0 && !highlighted;
+                        return (
+                            <button
+                                key={node.id}
+                                type="button"
+                                onClick={() => {
+                                    setSelection({ type: 'node', id: node.id });
+                                    onOpenEntity(node.id);
+                                }}
+                                style={{ left: pos.x, top: pos.y, width: CARD_W, height: CARD_H }}
+                                className={`absolute flex flex-col text-left rounded-xl border border-l-4 bg-white px-3 py-2.5 shadow-sm transition ${CATEGORY_STYLES[node.category].accent} ${
+                                    highlighted
+                                        ? 'border-indigo-500 ring-2 ring-indigo-200'
+                                        : 'border-neutral-200 hover:border-indigo-300 hover:shadow'
+                                } ${dim ? 'opacity-45' : ''}`}
+                            >
+                                <NodeCardInner node={node} />
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
+
+            {(graph.unresolved.length > 0 || graph.selfRefs.length > 0) && (
+                <p className="text-[11px] text-neutral-400">
+                    {graph.selfRefs.length > 0 && (
+                        <span>{graph.selfRefs.length} self-reference{graph.selfRefs.length === 1 ? '' : 's'}</span>
+                    )}
+                    {graph.selfRefs.length > 0 && graph.unresolved.length > 0 && ' · '}
+                    {graph.unresolved.length > 0 && (
+                        <span>
+                            {graph.unresolved.length} relationship{graph.unresolved.length === 1 ? '' : 's'} reference an entity outside this model
+                        </span>
+                    )}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/renderers/dataModel/badges.tsx
+++ b/src/components/renderers/dataModel/badges.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react';
+import {
+    Boxes, Cable, Cog, Fingerprint, KeyRound, ShieldCheck, Sparkles, User,
+} from 'lucide-react';
+import type { DataModelNode, EntityCategory, FieldTypeKind } from '../../../lib/dataModelGraph';
+import { ENTITY_CATEGORY_LABEL } from '../../../lib/dataModelGraph';
+import {
+    CATEGORY_STYLES, FIELD_TYPE_STYLES, INSPECTOR_STYLES, type InspectorCategory,
+} from './dataModelStyles';
+
+const CATEGORY_ICON: Record<EntityCategory, typeof Boxes> = {
+    core: Boxes,
+    user_config: User,
+    generated: Sparkles,
+    system: Cog,
+    external: Cable,
+};
+
+export function CategoryBadge({ category, size = 'sm' }: { category: EntityCategory; size?: 'sm' | 'xs' }) {
+    const Icon = CATEGORY_ICON[category];
+    const pad = size === 'xs' ? 'text-[10px] px-1.5 py-0.5' : 'text-[11px] px-2 py-0.5';
+    return (
+        <span className={`inline-flex items-center gap-1 rounded-full font-medium ${pad} ${CATEGORY_STYLES[category].chip}`}>
+            <Icon size={size === 'xs' ? 10 : 11} className="shrink-0" />
+            {ENTITY_CATEGORY_LABEL[category]}
+        </span>
+    );
+}
+
+/**
+ * Compact attribute badges for an entity: visibility, mutability, PII, indexed.
+ * These sit alongside the category chip and stay readable at any width.
+ */
+export function EntityAttributeBadges({ node }: { node: DataModelNode }) {
+    return (
+        <span className="inline-flex flex-wrap items-center gap-1">
+            {node.userFacing !== undefined && (
+                <Pill className={node.userFacing
+                    ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                    : 'bg-slate-100 text-slate-600 ring-1 ring-slate-200'}>
+                    {node.userFacing ? 'User-facing' : 'System'}
+                </Pill>
+            )}
+            {node.mutability && (
+                <Pill className={mutabilityClass(node.mutability)}>{node.mutability}</Pill>
+            )}
+            {node.hasPII ? (
+                <Pill className="bg-rose-50 text-rose-700 ring-1 ring-rose-200">
+                    <Fingerprint size={10} className="shrink-0" /> Contains PII
+                </Pill>
+            ) : (
+                <Pill className="bg-neutral-50 text-neutral-500 ring-1 ring-neutral-200">
+                    <ShieldCheck size={10} className="shrink-0" /> No PII
+                </Pill>
+            )}
+            {node.indexed && (
+                <Pill className="bg-slate-50 text-slate-600 ring-1 ring-slate-200">
+                    <KeyRound size={10} className="shrink-0" /> Indexed
+                </Pill>
+            )}
+        </span>
+    );
+}
+
+function mutabilityClass(mutability: string): string {
+    const m = mutability.toLowerCase();
+    if (m.includes('immutable') && !m.includes('mostly')) return 'bg-slate-50 text-slate-600 ring-1 ring-slate-200';
+    if (m.includes('mostly')) return 'bg-blue-50 text-blue-700 ring-1 ring-blue-200';
+    return 'bg-amber-50 text-amber-700 ring-1 ring-amber-200';
+}
+
+function Pill({ className, children }: { className: string; children: ReactNode }) {
+    return (
+        <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full ${className}`}>
+            {children}
+        </span>
+    );
+}
+
+export function FieldTypeChip({ kind, label }: { kind: FieldTypeKind; label: string }) {
+    return (
+        <span className={`inline-block font-mono text-[11px] px-1.5 py-0.5 rounded ${FIELD_TYPE_STYLES[kind]}`}>
+            {label}
+        </span>
+    );
+}
+
+/**
+ * A compact inspector row — a small category dot/badge, a short label, optional
+ * description, and an optional linked-entity affordance. Replaces the large
+ * stacked callout cards for relationships / constraints / privacy / indexes.
+ */
+export function InspectorRow({
+    category, label, description, linkLabel, onLink,
+}: {
+    category: InspectorCategory;
+    label: string;
+    description?: string;
+    linkLabel?: string;
+    onLink?: () => void;
+}) {
+    const style = INSPECTOR_STYLES[category];
+    return (
+        <div className="flex items-start gap-2.5 px-2.5 py-2 rounded-lg hover:bg-neutral-50 transition">
+            <span className={`mt-0.5 shrink-0 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${style.badge}`}>
+                {style.label}
+            </span>
+            <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5 flex-wrap">
+                    {label && <span className="text-[13px] font-medium text-neutral-800">{label}</span>}
+                    {linkLabel && (
+                        onLink ? (
+                            <button
+                                type="button"
+                                onClick={onLink}
+                                className="text-[11px] font-medium text-blue-600 hover:text-blue-800 hover:underline underline-offset-2"
+                            >
+                                → {linkLabel}
+                            </button>
+                        ) : (
+                            <span className="text-[11px] font-medium text-neutral-500">→ {linkLabel}</span>
+                        )
+                    )}
+                </div>
+                {description && <p className="text-xs text-neutral-600 leading-relaxed mt-0.5">{description}</p>}
+            </div>
+        </div>
+    );
+}

--- a/src/components/renderers/dataModel/dataModelStyles.ts
+++ b/src/components/renderers/dataModel/dataModelStyles.ts
@@ -1,0 +1,48 @@
+// Shared styling for the Data Model renderer (category chips, inspector-row
+// categories, field-type chips, graph node accents). Lives in its own module —
+// not a component file — so component files keep exporting only components
+// (the react-refresh/only-export-components rule).
+
+import type { EntityCategory, FieldTypeKind } from '../../../lib/dataModelGraph';
+
+/** Inspector-row categories — the compact colour language for detail rows. */
+export type InspectorCategory = 'relationship' | 'constraint' | 'privacy' | 'index' | 'warning';
+
+export const INSPECTOR_STYLES: Record<InspectorCategory, { badge: string; label: string; dot: string }> = {
+    relationship: { badge: 'bg-blue-100 text-blue-700 ring-1 ring-blue-200', label: 'Relationship', dot: 'bg-blue-500' },
+    constraint: { badge: 'bg-purple-100 text-purple-700 ring-1 ring-purple-200', label: 'Constraint', dot: 'bg-purple-500' },
+    privacy: { badge: 'bg-rose-100 text-rose-700 ring-1 ring-rose-200', label: 'Privacy', dot: 'bg-rose-500' },
+    index: { badge: 'bg-slate-100 text-slate-600 ring-1 ring-slate-200', label: 'Index', dot: 'bg-slate-400' },
+    warning: { badge: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200', label: 'Warning', dot: 'bg-amber-500' },
+};
+
+/** Category chip + graph-node accent styling, one entry per derived category. */
+export const CATEGORY_STYLES: Record<EntityCategory, {
+    chip: string;
+    /** Left border accent used on graph nodes + grouped section headers. */
+    accent: string;
+    /** Soft icon tile background. */
+    tile: string;
+}> = {
+    core: { chip: 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-200', accent: 'border-l-indigo-400', tile: 'bg-indigo-50 text-indigo-600' },
+    user_config: { chip: 'bg-violet-100 text-violet-700 ring-1 ring-violet-200', accent: 'border-l-violet-400', tile: 'bg-violet-50 text-violet-600' },
+    generated: { chip: 'bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200', accent: 'border-l-emerald-400', tile: 'bg-emerald-50 text-emerald-600' },
+    system: { chip: 'bg-slate-100 text-slate-600 ring-1 ring-slate-200', accent: 'border-l-slate-400', tile: 'bg-slate-100 text-slate-500' },
+    external: { chip: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200', accent: 'border-l-amber-400', tile: 'bg-amber-50 text-amber-600' },
+};
+
+/** Type-chip styling per coarse field-type family. */
+export const FIELD_TYPE_STYLES: Record<FieldTypeKind, string> = {
+    id: 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200',
+    reference: 'bg-blue-50 text-blue-700 ring-1 ring-blue-200',
+    text: 'bg-neutral-100 text-neutral-600 ring-1 ring-neutral-200',
+    number: 'bg-cyan-50 text-cyan-700 ring-1 ring-cyan-200',
+    boolean: 'bg-teal-50 text-teal-700 ring-1 ring-teal-200',
+    datetime: 'bg-sky-50 text-sky-700 ring-1 ring-sky-200',
+    json: 'bg-fuchsia-50 text-fuchsia-700 ring-1 ring-fuchsia-200',
+    enum: 'bg-orange-50 text-orange-700 ring-1 ring-orange-200',
+    other: 'bg-neutral-100 text-neutral-600 ring-1 ring-neutral-200',
+};
+
+/** SVG stroke colour for graph edges (default vs highlighted). */
+export const EDGE_STROKE = { base: '#cbd5e1', active: '#6366f1', label: '#64748b' } as const;

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -1,5 +1,5 @@
 import type {
-    CoreArtifactSubtype, DomainEntity, Feature, FeatureSystem, ImplementationPlan, UXPage,
+    CoreArtifactSubtype, DomainEntity, Feature, FeatureSystem, ImplementationPlan, StalenessState, UXPage,
 } from '../../types';
 import { ScreenInventoryRenderer } from './ScreenInventoryRenderer';
 import type { ScreenImageGalleryContext } from './ScreenImageGallery';
@@ -51,6 +51,10 @@ interface DispatchProps {
     generatedAt?: number;
     /** Only consumed by `prompt_pack`; current artifact version number. */
     versionNumber?: number;
+    /** Only consumed by `data_model`: source PRD version label for the overview header. */
+    prdVersionLabel?: string;
+    /** Only consumed by `data_model`: freshness state for the overview header. */
+    staleness?: StalenessState;
 }
 
 /**
@@ -96,12 +100,14 @@ export function ArtifactContentRenderer({
     onUpdatePromptEdits,
     generatedAt,
     versionNumber,
+    prdVersionLabel,
+    staleness,
 }: DispatchProps) {
     if (subtype === 'screen_inventory' && isJsonString(content)) {
         return <ScreenInventoryRenderer content={content} imageContext={screenImageContext} />;
     }
     if (subtype === 'data_model') {
-        return <DataModelRenderer content={content} />;
+        return <DataModelRenderer content={content} prdVersionLabel={prdVersionLabel} staleness={staleness} />;
     }
     if (subtype === 'component_inventory' && isJsonString(content)) {
         return <ComponentInventoryRenderer content={content} />;

--- a/src/lib/__tests__/dataModelGraph.test.ts
+++ b/src/lib/__tests__/dataModelGraph.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import { dataModelToMarkdown, parseDataModelMarkdown } from '../services/dataModelMarkdown';
+import type { ParsedEntity } from '../services/dataModelMarkdown';
+import type { DataModelContent } from '../../types';
+import {
+    analyzeDataModel,
+    buildDataModelGraph,
+    classifyFieldType,
+    computeDataModelLayout,
+    deriveEntityCategory,
+    entityAnchorId,
+    indexedFieldNames,
+    isStructuredFieldType,
+    normalizeMutability,
+    parseRelationshipCallout,
+    slugifyEntity,
+} from '../dataModelGraph';
+
+// A realistic model exercised end-to-end through the converter + parser so the
+// graph is built from the same shape the renderer sees.
+const model: DataModelContent = {
+    overview: {
+        summary: 'User input creates a MoodSnapshot which seeds a ResonancePlaylist.',
+        dataFlow: 'User → MoodSnapshot → ResonancePlaylist.',
+        productOutcome: 'A personalized, adaptive playlist.',
+    },
+    entities: [
+        {
+            name: 'MoodSnapshot',
+            description: 'Captures a single emotional state.',
+            purpose: 'Seed for playlist generation.',
+            userFacing: true,
+            mutability: 'mostly_immutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'joy_score', type: 'Float', required: true, description: 'Joy 0-1' },
+                { name: 'user_id', type: 'UUID', required: true, description: 'Owning user' },
+                { name: 'created_at', type: 'Timestamp', required: true, description: 'Creation time' },
+                { name: 'raw_input', type: 'String', required: false, description: 'Sensitive PII free-text' },
+            ],
+            relationships: [
+                { type: 'belongs_to', target: 'User' },
+                { type: 'has_many', target: 'ResonancePlaylist', description: 'Derived playlists' },
+            ],
+            indexes: ['idx_user_id_created_at on (user_id, created_at)'],
+            constraints: ['joy_score must be between 0 and 1'],
+            privacyRules: ['raw_input must be null when source = FACE_SCAN'],
+        },
+        {
+            name: 'ResonancePlaylist',
+            description: 'Adaptive playlist of tracks.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'Primary key' },
+                { name: 'mood_snapshot_id', type: 'UUID', required: true, description: 'Source snapshot' },
+            ],
+            relationships: [{ type: 'belongs_to', target: 'MoodSnapshot' }],
+        },
+        {
+            name: 'User',
+            description: 'Account holder.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [{ name: 'id', type: 'UUID', required: true, description: 'Primary key' }],
+            relationships: [{ type: 'has_many', target: 'MoodSnapshot' }],
+        },
+    ],
+    apiEndpoints: [
+        { method: 'POST', path: '/api/snapshots', description: 'Create', entity: 'MoodSnapshot' },
+    ],
+};
+
+function parse(content: DataModelContent) {
+    const parsed = parseDataModelMarkdown(dataModelToMarkdown(content));
+    if (!parsed) throw new Error('expected parseable model');
+    return parsed;
+}
+
+describe('parseRelationshipCallout', () => {
+    it('parses the converter shape with an arrow + description', () => {
+        const rel = parseRelationshipCallout('has many → ResonancePlaylist (Derived playlists)');
+        expect(rel).toEqual({
+            verb: 'has many',
+            target: 'ResonancePlaylist',
+            cardinality: '1 → many',
+            description: 'Derived playlists',
+        });
+    });
+
+    it('parses belongs to → target with many → 1 cardinality', () => {
+        const rel = parseRelationshipCallout('belongs to → User');
+        expect(rel?.verb).toBe('belongs to');
+        expect(rel?.target).toBe('User');
+        expect(rel?.cardinality).toBe('many → 1');
+    });
+
+    it('parses legacy inline shape without an arrow and strips backtick notes', () => {
+        const rel = parseRelationshipCallout('has many Visit (via foreign key `patient_id`)');
+        expect(rel?.verb).toBe('has many');
+        expect(rel?.target).toBe('Visit');
+        expect(rel?.cardinality).toBe('1 → many');
+        expect(rel?.description).toContain('patient_id');
+    });
+
+    it('maps many to many to a symmetric cardinality', () => {
+        const rel = parseRelationshipCallout('many to many → Tag');
+        expect(rel?.cardinality).toBe('many → many');
+    });
+
+    it('degrades to a references verb with no cardinality for freeform text', () => {
+        const rel = parseRelationshipCallout('associated with Session');
+        expect(rel?.verb).toBe('references');
+        expect(rel?.cardinality).toBeUndefined();
+    });
+
+    it('returns null on empty text', () => {
+        expect(parseRelationshipCallout('   ')).toBeNull();
+    });
+});
+
+describe('classifyFieldType / isStructuredFieldType', () => {
+    it('classifies scalar and structured types', () => {
+        expect(classifyFieldType('UUID', 'id')).toBe('id');
+        expect(classifyFieldType('String', 'user_id')).toBe('reference');
+        expect(classifyFieldType('jsonb', 'settings')).toBe('json');
+        expect(classifyFieldType('Object', 'payload')).toBe('json');
+        expect(classifyFieldType('Boolean', 'active')).toBe('boolean');
+        expect(classifyFieldType('Timestamp', 'created_at')).toBe('datetime');
+        expect(classifyFieldType('Float', 'joy_score')).toBe('number');
+        expect(classifyFieldType('String', 'email')).toBe('text');
+    });
+
+    it('flags json/object types as structured', () => {
+        expect(isStructuredFieldType('json', 'meta')).toBe(true);
+        expect(isStructuredFieldType('String', 'title')).toBe(false);
+    });
+});
+
+describe('deriveEntityCategory', () => {
+    const base: ParsedEntity = {
+        name: 'Thing', description: '', fieldGroups: [], callouts: [], groupsAutoDetected: false,
+    };
+
+    it('flags integration-shaped entities as external', () => {
+        expect(deriveEntityCategory({ ...base, name: 'WebhookDelivery', userFacing: true })).toBe('external');
+        expect(deriveEntityCategory({
+            ...base,
+            fieldGroups: [{ name: 'API / Integration', fields: [{ name: 'webhook_url', type: 'String', required: false, description: '' }] }],
+        })).toBe('external');
+    });
+
+    it('treats non-user-facing entities as system metadata', () => {
+        expect(deriveEntityCategory({ ...base, name: 'AuditLog', userFacing: false })).toBe('system');
+    });
+
+    it('treats immutable user-facing entities as generated outputs', () => {
+        expect(deriveEntityCategory({ ...base, name: 'Receipt', userFacing: true, mutability: 'immutable' })).toBe('generated');
+    });
+
+    it('recognizes clearly-named config entities', () => {
+        expect(deriveEntityCategory({ ...base, name: 'UserPreference', userFacing: true, mutability: 'mutable' })).toBe('user_config');
+    });
+
+    it('defaults to core product data', () => {
+        expect(deriveEntityCategory({ ...base, name: 'Order', userFacing: true, mutability: 'mutable' })).toBe('core');
+    });
+});
+
+describe('buildDataModelGraph', () => {
+    it('builds nodes with derived attributes and counts', () => {
+        const graph = buildDataModelGraph(parse(model));
+        const snapshot = graph.nodes.find(n => n.name === 'MoodSnapshot');
+        expect(snapshot).toBeTruthy();
+        expect(snapshot!.id).toBe('moodsnapshot');
+        expect(snapshot!.fieldCount).toBe(5);
+        expect(snapshot!.constraintCount).toBe(1);
+        expect(snapshot!.privacyCount).toBe(1);
+        expect(snapshot!.indexCount).toBe(1);
+        expect(snapshot!.hasPII).toBe(true);
+        expect(snapshot!.indexed).toBe(true);
+        expect(snapshot!.category).toBe('generated'); // user-facing + mostly_immutable
+    });
+
+    it('dedupes reciprocal relationships to one parent→child edge', () => {
+        const graph = buildDataModelGraph(parse(model));
+        // User has_many MoodSnapshot <-> MoodSnapshot belongs_to User → one edge.
+        const userSnapshot = graph.edges.filter(
+            e => (e.fromId === 'user' && e.toId === 'moodsnapshot') || (e.fromId === 'moodsnapshot' && e.toId === 'user'),
+        );
+        expect(userSnapshot).toHaveLength(1);
+        expect(userSnapshot[0].fromId).toBe('user');
+        expect(userSnapshot[0].toId).toBe('moodsnapshot');
+        expect(userSnapshot[0].verb).toBe('has many');
+        expect(userSnapshot[0].arrow).toBe('forward');
+        // MoodSnapshot has_many ResonancePlaylist <-> ResonancePlaylist belongs_to MoodSnapshot.
+        expect(graph.edges).toHaveLength(2);
+        expect(graph.relationshipCount).toBe(2);
+    });
+
+    it('routes many-to-many to a double-headed edge', () => {
+        const mm: DataModelContent = {
+            entities: [
+                { name: 'Post', description: '', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [{ type: 'many_to_many', target: 'Tag' }] },
+                { name: 'Tag', description: '', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [{ type: 'many_to_many', target: 'Post' }] },
+            ],
+            apiEndpoints: [],
+        };
+        const graph = buildDataModelGraph(parse(mm));
+        expect(graph.edges).toHaveLength(1);
+        expect(graph.edges[0].arrow).toBe('both');
+        expect(graph.edges[0].cardinality).toBe('many → many');
+    });
+
+    it('tracks unresolved targets as node notes, not edges', () => {
+        const content: DataModelContent = {
+            entities: [
+                { name: 'Patient', description: 'A record.', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [{ type: 'has_many', target: 'Visit' }] },
+            ],
+            apiEndpoints: [],
+        };
+        const graph = buildDataModelGraph(parse(content));
+        expect(graph.edges).toHaveLength(0);
+        expect(graph.unresolved).toHaveLength(1);
+        expect(graph.unresolved[0].targetName).toBe('Visit');
+        expect(graph.relationshipCount).toBe(1);
+    });
+
+    it('separates self-references from drawn edges', () => {
+        const content: DataModelContent = {
+            entities: [
+                { name: 'Category', description: '', userFacing: true, fields: [{ name: 'id', type: 'UUID', required: true, description: '' }], relationships: [{ type: 'belongs_to', target: 'Category' }] },
+            ],
+            apiEndpoints: [],
+        };
+        const graph = buildDataModelGraph(parse(content));
+        expect(graph.edges).toHaveLength(0);
+        expect(graph.selfRefs).toHaveLength(1);
+    });
+});
+
+describe('computeDataModelLayout', () => {
+    it('layers nodes by dependency depth', () => {
+        const graph = buildDataModelGraph(parse(model));
+        const layout = computeDataModelLayout(graph);
+        // User (root) → MoodSnapshot → ResonancePlaylist.
+        expect(layout.rows[0]).toEqual(['user']);
+        expect(layout.rows[1]).toEqual(['moodsnapshot']);
+        expect(layout.rows[2]).toEqual(['resonanceplaylist']);
+    });
+
+    it('does not infinitely recurse on cyclic graphs', () => {
+        const cyclic: DataModelContent = {
+            entities: [
+                { name: 'A', description: '', userFacing: true, fields: [], relationships: [{ type: 'has_many', target: 'B' }] },
+                { name: 'B', description: '', userFacing: true, fields: [], relationships: [{ type: 'has_many', target: 'A' }] },
+            ],
+            apiEndpoints: [],
+        };
+        const graph = buildDataModelGraph(parse(cyclic));
+        const layout = computeDataModelLayout(graph);
+        const flat = layout.rows.flat();
+        expect(flat).toContain('a');
+        expect(flat).toContain('b');
+    });
+});
+
+describe('indexedFieldNames', () => {
+    it('marks fields referenced by an index callout', () => {
+        const parsed = parse(model);
+        const snapshot = parsed.entities.find(e => e.name === 'MoodSnapshot')!;
+        const indexed = indexedFieldNames(snapshot);
+        expect(indexed.has('user_id')).toBe(true);
+        expect(indexed.has('created_at')).toBe(true);
+        expect(indexed.has('joy_score')).toBe(false);
+    });
+});
+
+describe('analyzeDataModel', () => {
+    it('summarizes counts across the model', () => {
+        const { summary } = analyzeDataModel(parse(model));
+        expect(summary.entityCount).toBe(3);
+        expect(summary.relationshipCount).toBe(2);
+        expect(summary.constraintCount).toBe(1);
+        expect(summary.indexCount).toBe(1);
+        expect(summary.piiEntityCount).toBe(1);
+        expect(summary.apiEndpointCount).toBe(1);
+        expect(summary.fieldCount).toBeGreaterThanOrEqual(8);
+    });
+});
+
+describe('helpers', () => {
+    it('slugifies and anchors entity names', () => {
+        expect(slugifyEntity('Mood Snapshot!')).toBe('mood-snapshot');
+        expect(entityAnchorId('Mood Snapshot')).toBe('data-model-entity-mood-snapshot');
+    });
+
+    it('normalizes mutability for display', () => {
+        expect(normalizeMutability('mostly_immutable')).toBe('mostly immutable');
+        expect(normalizeMutability(undefined)).toBeUndefined();
+    });
+});

--- a/src/lib/dataModelGraph.ts
+++ b/src/lib/dataModelGraph.ts
@@ -1,0 +1,541 @@
+// Data Model graph — pure, testable model that turns a parsed data-model
+// artifact into an entity-relationship graph (nodes + directional, cardinality-
+// labelled edges), derives lightweight entity categories for optional grouping,
+// and computes a deterministic layered layout for the ER-style diagram.
+//
+// It consumes the output of `parseDataModelMarkdown` (both the JSON→markdown and
+// the legacy-markdown paths flow through that parser), so a single code path
+// serves every artifact shape. Relationships are recovered from the parser's
+// `RELATIONSHIP` callouts — the same text the converter emits from the schema's
+// typed `DataRelationship[]` — so cardinality is a faithful derivation of the
+// schema's relationship `type`, never invented.
+//
+// This module must stay free of store/React/LLM imports so it is trivially
+// unit-testable (mirrors artifactDependencyGraph.ts / screenExperience.ts).
+
+import type { ParsedDataModel, ParsedEntity, ParsedCalloutKind } from './services/dataModelMarkdown';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type RelationshipCardinality = '1 → 1' | '1 → many' | 'many → 1' | 'many → many';
+
+/**
+ * Soft, derived grouping bucket for an entity. The data-model schema has no
+ * explicit domain/category field, so these are inferred from conservative,
+ * schema-backed signals (userFacing / mutability / integration-shaped fields)
+ * — deliberately simple to avoid brittle name-guessing.
+ */
+export type EntityCategory = 'core' | 'user_config' | 'generated' | 'system' | 'external';
+
+/** Coarse field-type family used to colour type chips in the field tables. */
+export type FieldTypeKind =
+    | 'id'         // UUID / primary keys
+    | 'reference'  // *_id foreign keys
+    | 'text'       // string / text
+    | 'number'     // int / float / decimal / numeric
+    | 'boolean'
+    | 'datetime'   // timestamp / date / time
+    | 'json'       // json / jsonb / object / array — structured, not a plain string
+    | 'enum'
+    | 'other';
+
+export interface DataModelNode {
+    /** Slug of the entity name — stable graph identity. */
+    id: string;
+    name: string;
+    description: string;
+    category: EntityCategory;
+    userFacing?: boolean;
+    /** Normalised for display, e.g. "mostly immutable". */
+    mutability?: string;
+    hasPII: boolean;
+    indexed: boolean;
+    fieldCount: number;
+    /** Distinct relationship count for this entity (callout count). */
+    relationshipCount: number;
+    constraintCount: number;
+    privacyCount: number;
+    indexCount: number;
+}
+
+export interface DataModelEdge {
+    id: string;
+    fromId: string;
+    toId: string;
+    /** Human verb, e.g. "has many", "belongs to". */
+    verb: string;
+    /** Present only when derivable from the schema relationship type. */
+    cardinality?: RelationshipCardinality;
+    description?: string;
+    /** 'both' → many-to-many (arrowheads at both ends). */
+    arrow: 'forward' | 'both';
+}
+
+/** A relationship whose target is not a known entity (drawn as a node note). */
+export interface UnresolvedRelationship {
+    fromId: string;
+    targetName: string;
+    verb: string;
+    cardinality?: RelationshipCardinality;
+    description?: string;
+}
+
+export interface DataModelGraph {
+    nodes: DataModelNode[];
+    edges: DataModelEdge[];
+    unresolved: UnresolvedRelationship[];
+    /** Self-references (entity → itself), surfaced as a badge rather than an edge. */
+    selfRefs: UnresolvedRelationship[];
+    /** Distinct relationship count across the whole model (deduped). */
+    relationshipCount: number;
+}
+
+export interface DataModelSummary {
+    entityCount: number;
+    relationshipCount: number;
+    fieldCount: number;
+    constraintCount: number;
+    indexCount: number;
+    /** Entities carrying at least one privacy rule / PII-flagged field group. */
+    piiEntityCount: number;
+    apiEndpointCount: number;
+}
+
+export interface DataModelAnalysis {
+    graph: DataModelGraph;
+    summary: DataModelSummary;
+}
+
+// ---------------------------------------------------------------------------
+// Slugs / anchors
+// ---------------------------------------------------------------------------
+
+export function slugifyEntity(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+/** Anchor id for an entity detail card (kept stable for scroll/outline links). */
+export function entityAnchorId(name: string): string {
+    return `data-model-entity-${slugifyEntity(name)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Relationship-callout parsing
+// ---------------------------------------------------------------------------
+
+const KNOWN_VERBS = ['many to many', 'has many', 'has one', 'belongs to'] as const;
+
+const VERB_TO_CARDINALITY: Record<string, RelationshipCardinality> = {
+    'has many': '1 → many',
+    'has one': '1 → 1',
+    'belongs to': 'many → 1',
+    'many to many': 'many → many',
+};
+
+export interface ParsedRelationshipCallout {
+    verb: string;
+    target: string;
+    cardinality?: RelationshipCardinality;
+    description?: string;
+}
+
+/**
+ * Parse a `RELATIONSHIP` callout's text back into a structured relationship.
+ * Handles both the converter shape (`"has many → Post (comments)"`) and the
+ * legacy inline shape (`"has many Visit (via foreign key \`patient_id\`)"`).
+ */
+export function parseRelationshipCallout(raw: string): ParsedRelationshipCallout | null {
+    let text = raw.trim();
+    if (!text) return null;
+
+    // Pull a trailing "(description)" off the end, if present.
+    let description: string | undefined;
+    const descMatch = text.match(/\(([^)]*)\)\s*$/);
+    if (descMatch) {
+        description = descMatch[1].trim() || undefined;
+        text = text.slice(0, descMatch.index).trim();
+    }
+
+    let verbPart = '';
+    let target = '';
+
+    const arrowIdx = text.search(/->|→/);
+    if (arrowIdx >= 0) {
+        verbPart = text.slice(0, arrowIdx).trim();
+        target = text.replace(/^[\s\S]*?(->|→)/, '').trim();
+    } else {
+        // No arrow: match a known verb prefix, remainder is the target.
+        const lower = text.toLowerCase();
+        const verb = KNOWN_VERBS.find(v => lower.startsWith(v));
+        if (verb) {
+            verbPart = verb;
+            target = text.slice(verb.length).trim();
+        } else {
+            // Freeform legacy text: treat the whole thing as the target.
+            verbPart = 'references';
+            target = text;
+        }
+    }
+
+    target = cleanTarget(target);
+    if (!target) return null;
+
+    const verb = verbPart.toLowerCase().replace(/\s+/g, ' ').trim() || 'references';
+    return { verb, target, cardinality: VERB_TO_CARDINALITY[verb], description };
+}
+
+function cleanTarget(raw: string): string {
+    return raw
+        .replace(/`/g, '')
+        .replace(/^(the|a|an)\s+/i, '')
+        .replace(/[.,;:]+$/, '')
+        .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Field-type classification
+// ---------------------------------------------------------------------------
+
+export function classifyFieldType(rawType: string, fieldName = ''): FieldTypeKind {
+    const type = rawType.toLowerCase().trim();
+    const name = fieldName.toLowerCase();
+
+    if (/\b(uuid|guid)\b/.test(type) || name === 'id') return 'id';
+    if (name.endsWith('_id') || name === 'ref' || /foreign key/.test(type)) return 'reference';
+    if (/\b(json|jsonb|object|array|map|record|struct)\b/.test(type) || type.endsWith('[]')) return 'json';
+    if (/\b(bool|boolean)\b/.test(type)) return 'boolean';
+    if (/\b(timestamp|datetime|date|time|instant)\b/.test(type)) return 'datetime';
+    if (/\b(int|integer|float|double|decimal|numeric|number|bigint|smallint|money|currency)\b/.test(type))
+        return 'number';
+    if (/\b(enum)\b/.test(type) || type.includes('|')) return 'enum';
+    if (/\b(string|text|varchar|char|uri|url|email)\b/.test(type)) return 'text';
+    return 'other';
+}
+
+/** True when a field type denotes structured/object content, not a plain scalar. */
+export function isStructuredFieldType(rawType: string, fieldName = ''): boolean {
+    return classifyFieldType(rawType, fieldName) === 'json';
+}
+
+// ---------------------------------------------------------------------------
+// Category derivation
+// ---------------------------------------------------------------------------
+
+const INTEGRATION_TOKENS = [
+    'webhook', 'integration', 'external', 'third_party', 'third-party', 'oauth',
+    'api key', 'api_key', 'apikey', 'sync', 'connector', 'provider',
+];
+const CONFIG_TOKENS = ['setting', 'preference', 'config', 'profile', 'account'];
+
+function isImmutable(mutability?: string): boolean {
+    const m = (mutability || '').toLowerCase();
+    return m.includes('immutable');
+}
+
+function hasIntegrationSignal(entity: ParsedEntity): boolean {
+    if (entity.fieldGroups.some(g => g.name === 'API / Integration')) return true;
+    const haystack = `${entity.name} ${entity.description}`.toLowerCase();
+    return INTEGRATION_TOKENS.some(t => haystack.includes(t));
+}
+
+/**
+ * Derive a conservative category for an entity. Order matters: the strongest,
+ * most explicit signal wins. Falls back to 'core' so nothing is force-fit into
+ * a speculative bucket.
+ */
+export function deriveEntityCategory(entity: ParsedEntity): EntityCategory {
+    if (hasIntegrationSignal(entity)) return 'external';
+    if (entity.userFacing === false) return 'system';
+    if (isImmutable(entity.mutability)) return 'generated';
+
+    // userFacing is true|undefined here (the `=== false` case returned above).
+    const name = entity.name.toLowerCase();
+    if (CONFIG_TOKENS.some(t => name.includes(t))) return 'user_config';
+
+    return 'core';
+}
+
+// ---------------------------------------------------------------------------
+// Node / entity attribute derivation
+// ---------------------------------------------------------------------------
+
+function countCallouts(entity: ParsedEntity, kind: ParsedCalloutKind): number {
+    return entity.callouts.filter(c => c.kind === kind).length;
+}
+
+function entityFieldCount(entity: ParsedEntity): number {
+    return entity.fieldGroups.reduce((sum, g) => sum + g.fields.length, 0);
+}
+
+function entityHasPII(entity: ParsedEntity): boolean {
+    return countCallouts(entity, 'PRIVACY') > 0
+        || entity.fieldGroups.some(g => g.name === 'Privacy / Safety' && g.fields.length > 0);
+}
+
+/** Normalise a mutability value for display ("mostly_immutable" → "mostly immutable"). */
+export function normalizeMutability(mutability?: string): string | undefined {
+    if (!mutability) return undefined;
+    return mutability.replace(/_/g, ' ').trim() || undefined;
+}
+
+/**
+ * Field names an entity indexes, derived from its `INDEX` callouts (word-level
+ * match). Conservative: only exact field-name tokens count, so an index over
+ * `(user_id, created_at)` marks both without false positives.
+ */
+export function indexedFieldNames(entity: ParsedEntity): Set<string> {
+    const indexed = new Set<string>();
+    const indexTexts = entity.callouts.filter(c => c.kind === 'INDEX').map(c => c.text.toLowerCase());
+    if (indexTexts.length === 0) return indexed;
+    for (const group of entity.fieldGroups) {
+        for (const field of group.fields) {
+            const token = field.name.toLowerCase();
+            const re = new RegExp(`(^|[^a-z0-9_])${escapeRegExp(token)}([^a-z0-9_]|$)`);
+            if (indexTexts.some(t => re.test(t))) indexed.add(field.name);
+        }
+    }
+    return indexed;
+}
+
+function escapeRegExp(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildNode(entity: ParsedEntity): DataModelNode {
+    return {
+        id: slugifyEntity(entity.name),
+        name: entity.name,
+        description: entity.description,
+        category: deriveEntityCategory(entity),
+        userFacing: entity.userFacing,
+        mutability: normalizeMutability(entity.mutability),
+        hasPII: entityHasPII(entity),
+        indexed: countCallouts(entity, 'INDEX') > 0,
+        fieldCount: entityFieldCount(entity),
+        relationshipCount: countCallouts(entity, 'RELATIONSHIP'),
+        constraintCount: countCallouts(entity, 'CONSTRAINT'),
+        privacyCount: countCallouts(entity, 'PRIVACY'),
+        indexCount: countCallouts(entity, 'INDEX'),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Graph assembly (with reciprocal-edge dedup)
+// ---------------------------------------------------------------------------
+
+type RawKind = 'container' | 'belongs' | 'many' | 'other';
+
+interface RawEdge {
+    fromId: string;
+    toId: string;
+    verb: string;
+    cardinality?: RelationshipCardinality;
+    description?: string;
+    kind: RawKind;
+}
+
+function classifyVerb(verb: string): RawKind {
+    if (verb === 'has many' || verb === 'has one') return 'container';
+    if (verb === 'belongs to') return 'belongs';
+    if (verb === 'many to many') return 'many';
+    return 'other';
+}
+
+/** Resolve a relationship target name to a known node id (tolerates plural/singular). */
+export function resolveEntityId(targetName: string, nodeIds: Set<string>): string | undefined {
+    const slug = slugifyEntity(targetName);
+    if (nodeIds.has(slug)) return slug;
+    const singular = slug.replace(/s$/, '');
+    if (nodeIds.has(singular)) return singular;
+    const plural = `${slug}s`;
+    if (nodeIds.has(plural)) return plural;
+    return undefined;
+}
+
+export function buildDataModelGraph(parsed: ParsedDataModel): DataModelGraph {
+    const nodes = parsed.entities.map(buildNode);
+    const nodeIds = new Set(nodes.map(n => n.id));
+
+    const rawEdges: RawEdge[] = [];
+    const unresolved: UnresolvedRelationship[] = [];
+    const selfRefs: UnresolvedRelationship[] = [];
+
+    parsed.entities.forEach(entity => {
+        const fromId = slugifyEntity(entity.name);
+        for (const callout of entity.callouts) {
+            if (callout.kind !== 'RELATIONSHIP') continue;
+            const rel = parseRelationshipCallout(callout.text);
+            if (!rel) continue;
+            const toId = resolveEntityId(rel.target, nodeIds);
+            if (!toId) {
+                unresolved.push({ fromId, targetName: rel.target, verb: rel.verb, cardinality: rel.cardinality, description: rel.description });
+                continue;
+            }
+            if (toId === fromId) {
+                selfRefs.push({ fromId, targetName: rel.target, verb: rel.verb, cardinality: rel.cardinality, description: rel.description });
+                continue;
+            }
+            rawEdges.push({
+                fromId,
+                toId,
+                verb: rel.verb,
+                cardinality: rel.cardinality,
+                description: rel.description,
+                kind: classifyVerb(rel.verb),
+            });
+        }
+    });
+
+    const edges = dedupeEdges(rawEdges);
+    const relationshipCount = edges.length + unresolved.length + selfRefs.length;
+
+    return { nodes, edges, unresolved, selfRefs, relationshipCount };
+}
+
+/**
+ * Collapse reciprocal relationships into a single directed, labelled edge.
+ * A `has many` A→B and its mirror `belongs to` B→A describe one relationship;
+ * we keep the container (parent→child) direction so the diagram reads top-down.
+ */
+function dedupeEdges(rawEdges: RawEdge[]): DataModelEdge[] {
+    const groups = new Map<string, RawEdge[]>();
+    for (const e of rawEdges) {
+        const key = [e.fromId, e.toId].sort().join('::');
+        const list = groups.get(key) ?? [];
+        list.push(e);
+        groups.set(key, list);
+    }
+
+    const edges: DataModelEdge[] = [];
+    for (const [key, group] of groups) {
+        const many = group.find(e => e.kind === 'many');
+        const container = group.find(e => e.kind === 'container');
+        const chosen = many ?? container ?? group[0];
+        edges.push({
+            id: `edge-${key}`,
+            fromId: chosen.fromId,
+            toId: chosen.toId,
+            verb: chosen.verb,
+            cardinality: chosen.cardinality,
+            description: chosen.description,
+            arrow: chosen.kind === 'many' ? 'both' : 'forward',
+        });
+    }
+    // Deterministic order: by source id then target id.
+    edges.sort((a, b) => (a.fromId.localeCompare(b.fromId)) || a.toId.localeCompare(b.toId));
+    return edges;
+}
+
+// ---------------------------------------------------------------------------
+// Layout (deterministic — no DOM measurement; mirrors artifactDependencyGraph)
+// ---------------------------------------------------------------------------
+
+export interface DataModelLayout {
+    rows: string[][];
+}
+
+/**
+ * Group nodes into rows by longest-path depth over the (deduped) edges, then
+ * order each row by the barycenter of its parents to reduce edge crossings.
+ * When there are no edges the caller renders a plain grid instead, so this is
+ * only meaningful for the edged case.
+ */
+export function computeDataModelLayout(graph: DataModelGraph): DataModelLayout {
+    const parentsOf = new Map<string, string[]>();
+    for (const node of graph.nodes) parentsOf.set(node.id, []);
+    for (const edge of graph.edges) {
+        parentsOf.get(edge.toId)?.push(edge.fromId);
+    }
+
+    const depth = new Map<string, number>();
+    const resolve = (id: string, trail: Set<string> = new Set()): number => {
+        const known = depth.get(id);
+        if (known !== undefined) return known;
+        if (trail.has(id)) return 0; // cycle guard (2-cycles are common in ER graphs)
+        trail.add(id);
+        const parents = parentsOf.get(id) ?? [];
+        const d = parents.length === 0 ? 0 : 1 + Math.max(...parents.map(p => resolve(p, trail)));
+        depth.set(id, d);
+        return d;
+    };
+    for (const node of graph.nodes) resolve(node.id);
+
+    const maxDepth = Math.max(0, ...Array.from(depth.values()));
+    const rows: string[][] = [];
+    for (let d = 0; d <= maxDepth; d++) {
+        rows.push(graph.nodes.filter(n => depth.get(n.id) === d).map(n => n.id));
+    }
+
+    // Barycenter pass — order each row by the mean column of its parents.
+    const col = new Map<string, number>();
+    rows[0]?.forEach((id, i) => col.set(id, i));
+    for (let r = 1; r < rows.length; r++) {
+        const scored = rows[r].map((id, i) => {
+            const parents = (parentsOf.get(id) ?? []).filter(p => col.has(p));
+            const score = parents.length > 0
+                ? parents.reduce((sum, p) => sum + (col.get(p) ?? 0), 0) / parents.length
+                : i;
+            return { id, i, score };
+        });
+        scored.sort((a, b) => (a.score - b.score) || (a.i - b.i));
+        rows[r] = scored.map(s => s.id);
+        rows[r].forEach((id, i) => col.set(id, i));
+    }
+
+    return { rows };
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+export function summarizeDataModel(parsed: ParsedDataModel, graph: DataModelGraph): DataModelSummary {
+    let fieldCount = 0;
+    let constraintCount = 0;
+    let indexCount = 0;
+    let piiEntityCount = 0;
+    for (const entity of parsed.entities) {
+        fieldCount += entityFieldCount(entity);
+        constraintCount += countCallouts(entity, 'CONSTRAINT');
+        indexCount += countCallouts(entity, 'INDEX');
+        if (entityHasPII(entity)) piiEntityCount += 1;
+    }
+    return {
+        entityCount: parsed.entities.length,
+        relationshipCount: graph.relationshipCount,
+        fieldCount,
+        constraintCount,
+        indexCount,
+        piiEntityCount,
+        apiEndpointCount: parsed.apiEndpoints.length,
+    };
+}
+
+/** Single entry point: build the graph and summary in one pass. */
+export function analyzeDataModel(parsed: ParsedDataModel): DataModelAnalysis {
+    const graph = buildDataModelGraph(parsed);
+    const summary = summarizeDataModel(parsed, graph);
+    return { graph, summary };
+}
+
+// ---------------------------------------------------------------------------
+// Display metadata for categories (labels only — colours live in the renderer)
+// ---------------------------------------------------------------------------
+
+export const ENTITY_CATEGORY_LABEL: Record<EntityCategory, string> = {
+    core: 'Core Product Data',
+    user_config: 'User Configuration',
+    generated: 'Generated Outputs',
+    system: 'System Metadata',
+    external: 'External Integrations',
+};
+
+/** Category display order for grouped views. */
+export const ENTITY_CATEGORY_ORDER: EntityCategory[] = [
+    'core', 'user_config', 'generated', 'system', 'external',
+];


### PR DESCRIPTION
## Summary

Reworks the **Data Model** artifact renderer from a long, vertically dense schema dump into an **interactive entity-relationship design surface** that speaks the same visual language as Synapse's artifact dependency graph and user-flow diagrams.

This is primarily a **renderer/design** change. The artifact schema, generation pipeline, export/render paths, staleness/dependency indicators, artifact navigation, and existing behavior are all unchanged and backward-compatible.

## What changed

**1. Compact overview header** (`DataModelOverview`) — a confidence check before diving in: artifact name, source PRD version + freshness (when available), and entity / relationship / constraint / index / PII counts as compact stat tiles.

**2. ER-style relationship diagram** (`EntityGraph`) — replaces the ASCII relationship-flow `<pre>` block with a visual node-edge diagram:
- Each entity is a rounded node card (name, category badge, description, field/relationship counts).
- Directional edges labelled with verb + cardinality (`has many · 1 → many`, `belongs to · many → 1`, `many → many` double-arrow).
- Deterministic layered SVG layout (depth + barycenter, mirrors the dependency-graph layout math) — stable between renders, no heavy graph library.
- Clicking a node opens/scrolls to its entity card; clicking an edge highlights the entities it connects.
- Graceful **empty state** (responsive grid) when a model has no relationships.

**3. Optional "Group by category" swimlanes** — conservative, schema-derived entity categories (Core Product Data / User Configuration / Generated Outputs / System Metadata / External Integrations) inferred only from `userFacing` / `mutability` / integration-shaped signals — no brittle name guessing. Offered only for larger, mixed-category models.

**4. Collapsible entity cards** (`EntityCard`) — collapsed rows show name, one-line description, key badges, and counts; expanding reveals overview, grouped field tables, relationships, constraints, privacy, indexes, and the example record. No data is removed — density is reduced by hiding detail until expanded. Single-entity models expand by default.

**5. Improved field tables** — consistent column widths, colour-coded type chips, subtle required check, indexed-field key markers, and a distinct chip + glyph for JSON/object-like types so they no longer read like a plain `string`.

**6. Compact inspector rows** (`InspectorRow`) — replaces the large stacked callout cards with tight rows using a fixed colour language: relationship = blue, constraint = purple, privacy = rose, index = slate, warning = amber. Relationship rows link to the connected entity.

## Architecture

All graph, category, layout, and summary logic lives in the **pure, unit-tested** `src/lib/dataModelGraph.ts` (`analyzeDataModel` → graph + summary), which:
- Recovers structured relationships from the parser's `RELATIONSHIP` callouts, so **cardinality is a faithful derivation of the schema's `DataRelationship.type`, never invented**.
- **Dedupes reciprocal `has_many`/`belongs_to` pairs** into one parent→child edge, resolves plural/singular targets, and tracks unresolved / self references separately.
- Handles missing relationship/cardinality data gracefully.

Provenance/freshness reach the overview via optional `prdVersionLabel`/`staleness` props threaded through `ArtifactContentRenderer` for `data_model` only.

## Backward compatibility

- Unparseable/legacy content still falls back to `ReactMarkdown`.
- The "How This Data Model Works", "How This Appears in the Product", and "API Endpoints" sections are preserved.
- Legacy markdown data models (name-only relationships, no cardinality) render without inventing data.

## Testing

- New `src/lib/__tests__/dataModelGraph.test.ts` (callout parsing, cardinality, reciprocal dedup, categories, layout, cycles, summary — 24 tests).
- New `src/components/renderers/__tests__/DataModelRenderer.test.tsx` (overview, ER edges, collapse/expand, inspector rows, categories, empty state — 8 tests).
- `npm run build` ✅, `npm run lint` ✅, full suite ✅ (137 files / 1065 tests).
- Verified visually by server-rendering the real component with the built Tailwind CSS at desktop and mobile widths (overview, ER diagram, grouped collapsible cards, expanded field tables, inspector rows all render and stack correctly).

## Notes

`CLAUDE.md` is updated with the new renderer's architecture. The `README.md`'s data-model references remain accurate (the artifact is still generated and schema-constrained — only its presentation improved), so no README edit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsi5hhq9Sakdff2sY1xh4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hsi5hhq9Sakdff2sY1xh4v)_