### PR TITLE
Fix clipped description text in data model entity-relationship nodes

### DIFF
--- a/src/components/renderers/dataModel/EntityGraph.tsx
+++ b/src/components/renderers/dataModel/EntityGraph.tsx
@@ -13,8 +13,12 @@ interface Props {
 }
 
 // Deterministic canvas geometry — no DOM measurement (mirrors DependencyGraphView).
+// CARD_H must fit the full node stack (title + category pill + 2-line
+// description + footer, incl. px-3 py-2.5 padding). Because the footer is pinned
+// with mt-auto, an under-sized height squeezes and clips the description — keep
+// this tall enough for the tallest content, or the description gets cut off.
 const CARD_W = 224;
-const CARD_H = 118;
+const CARD_H = 140;
 const GAP_X = 40;
 const ROW_GAP = 92;
 
@@ -245,7 +249,7 @@ export function EntityGraph(props: Props) {
                                     onOpenEntity(node.id);
                                 }}
                                 style={{ left: pos.x, top: pos.y, width: CARD_W, height: CARD_H }}
-                                className={`absolute flex flex-col text-left rounded-xl border border-l-4 bg-white px-3 py-2.5 shadow-sm transition ${CATEGORY_STYLES[node.category].accent} ${
+                                className={`absolute flex flex-col overflow-hidden text-left rounded-xl border border-l-4 bg-white px-3 py-2.5 shadow-sm transition ${CATEGORY_STYLES[node.category].accent} ${
                                     highlighted
                                         ? 'border-indigo-500 ring-2 ring-indigo-200'
                                         : 'border-neutral-200 hover:border-indigo-300 hover:shadow'


### PR DESCRIPTION
## Problem

The recently added **Entity Relationships** node diagram in the Data Model artifact renders node cards with text cut off — the entity description below the category pill is clipped, so cards look mis-sized.

![before](https://user-images.githubusercontent.com/placeholder)

## Root cause

`EntityGraph` uses a **deterministic canvas layout with no DOM measurement** — the fixed `CARD_H` constant drives edge routing and canvas height, so card height must be a constant. That constant was `118px`, which is too short for the full node content stack:

- title row (icon + entity name)
- category pill (e.g. "Core Product Data")
- 2-line description (`line-clamp-2`)
- footer (field count + relationship count)

Because the footer is pinned to the bottom with `mt-auto`, the under-sized height squeezed the description and it got clipped. The `EntityGrid` fallback (used when there are no relationships) was unaffected because it uses `minHeight` and grows to fit — only the fixed-height graph cards clipped.

## Fix

- Bump `CARD_H` from `118` → `140` so the full content stack fits, with a comment explaining why the constant must accommodate the tallest content.
- Add `overflow-hidden` to the node card so content clips cleanly at the rounded border instead of overlapping the footer if a font renders slightly tall.

No change to the layout algorithm, edge geometry, or any data flow — purely a sizing fix.

## Testing

- `npm run build` (tsc -b && vite build) — passes
- `npm run lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tdz66EeuSFC3pobzm1TTcZ)_