### PR TITLE
Versioning V2: change-aware staleness, Update Assets plan, export manifest (Phase A implemented)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1655,6 +1655,16 @@ PRD + build-relevant core artifacts (mockups excluded), with copy and download.
 Copy-to-clipboard (via `src/lib/utils/copyToClipboard.ts`, Clipboard API with
 an `execCommand` fallback) is available on the PRD and full bundle too.
 
+**Exports are version-aware.** `src/lib/exportManifest.ts` (pure) builds an
+**export manifest** — per asset: version number, generated-from PRD version
+label, and staleness at export time — rendered by `renderManifestMarkdown` into
+the top of the full markdown bundle, a `manifest` field in the structured JSON,
+and (via `HandoffInput.manifestMarkdown`) between the preamble and the PRD in
+the agent handoff. When any exported asset is stale, `ExportModal` shows an
+amber warning banner (same pattern as the cloud-at-risk banner) naming the
+assets; exports are never blocked — the manifest keeps the document honest.
+Keep the manifest in sync if export composition changes.
+
 ### Version history & revert (`src/components/versions/`)
 
 Shared, presentation-only components for browsing, comparing, and restoring
@@ -1678,7 +1688,60 @@ nothing extra is persisted. Wiring: `ProjectWorkspace` exposes PRD history (a
 Version X" chip + `StalenessBadge` above each generated artifact. Restores route
 to `revertSpineToVersion` / `revertArtifactToVersion`. **Revert always appends a
 new version and never deletes history.** See `docs/VERSIONING_AUDIT.md` for the
-full design (Phase 1 implemented).
+Phase 1 design and `docs/VERSIONING_V2_PLAN.md` for the change-awareness layer
+(Phase A implemented).
+
+**Change-aware staleness (`src/lib/spineChangeAnalysis.ts`, pure).** The "what
+changed" layer behind every stale flag: `diffFeatures` (by stable `Feature.id`
+— added/removed/renamed/changed), `summarizeSpineChange` (section diffs via
+`versionDiff` + a deterministic one-line headline — never an LLM call),
+`ARTIFACT_SECTION_AFFINITY`/`isLikelyUnaffected` (advisory "no changes in the
+sections this asset chiefly derives from" — identity/safety sections sit in
+every affinity set so the note only fires on genuinely narrow changes, and it
+must NEVER suppress a hard `needs_update`), `findFeatureReferences`
+(conservative removed-feature reference scan; whole-word, ≥4-char needles), and
+`makeSpineChangeResolver` (memoized "since spine X vs latest" resolver).
+`evaluateDependencyGraph` accepts an optional `spineChangeFor` input and
+attaches a `changeSummary` to `prd_changed` reasons + a node-level
+`likelyUnaffected` flag (only when the PRD change is the sole reason). Surfaced
+in the graph detail panel ("What changed: …", removed-feature still-referenced
+warnings), the `StalenessBadge` tooltip, and the artifact-header strip.
+Everything is computed at read time from stored snapshots — nothing persisted.
+
+**Provenance is complete.** Every version-creating path stamps
+`provenance.changeSource`: `ai_generation` (initial settle in
+`updateSpineStructuredPRD` when none exists; `createArtifactVersion` default
+for v1), `ai_regeneration` (`regenerateSpine`; `createArtifactVersion` default
+for v2+), `branch_merge` (`mergeBranch`), plus the existing `user_edit` /
+`ai_section_retry` / `revert` and the new **`marked_current`**. User overlay
+edits (screenEdits/promptEdits) pass `opts.historyDescription` through
+`updateArtifactVersionMetadata` to record an `Edited` history event, and the
+graph treats a non-empty overlay as manually-edited. New version-creating code
+paths must stamp a changeSource.
+
+**"Mark as up to date" (`artifactSlice.markArtifactCurrentForSpine`).** The
+escape hatch for trivial PRD changes: appends a CLONED preferred version whose
+`sourceRefs` are **rebased** — spine ref → the confirmed spine version AND
+every `core_artifact` ref → that dependency's current preferred version
+(refreshing a recorded design tokensHash `anchorInfo`). Rebasing only the spine
+ref would leave the graph still reporting `dependency_changed`; never do a
+partial rebase. Emits a `MarkedCurrent` history event. Exposed in the graph
+detail panel and the artifact-header strip when stale.
+
+**Re-finalize goes through the Update Assets plan.** When Mark-as-Final runs
+and downstream assets already exist (and no generation job is active),
+`ProjectWorkspace.finalizeAndGenerate` does NOT call `startAll` — it evaluates
+the dependency graph against the spine being finalized and opens
+`UpdateAssetsPlanModal` (`src/components/versions/`): a "what changed" header
+(vs the assets' newest baseline PRD version) and a per-asset choice —
+Regenerate / Mark up to date / Decide later — defaulted from
+`computeRecommendedUpdates`. Confirm finalizes, applies mark-current FIRST
+(healing confirmed upstreams), then regenerates the selection expanded via
+`expandSelectionWithTroubledUpstreams` (a selected dependent must never rebuild
+from a stale unselected visible input; marked-current upstreams count as
+healed) through the existing `regenerateSlots` path. Cancel aborts the finalize
+(spine stays non-final). First finalize / demo / job-active keep the direct
+`startAll` path. Do not reintroduce a blind full regeneration on re-finalize.
 
 ### PRD highlight → branch selection pipeline
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | ✍️ | **Highlight-to-refine** | Select any passage → Clarify / Expand / Specify / Alternative / Replace → a threaded branch merges back in. | Surgical edits on one span instead of regenerating the whole document. |
 | 🕓 | **Everything is versioned** | Every regenerate, edit, branch-merge, and restore appends a new version with a section-aware diff. | Non-destructive history — nothing is ever overwritten or lost. |
 | 📊 | **Orchestration metrics** | A `/metrics` dashboard records real telemetry: speedup, concurrency, critical path, token usage, cost estimates. | The concurrency is **measured, not claimed** — with per-run Gantt charts. |
-| 🔌 | **Dependency graph & staleness** | Artifacts carry source references to their inputs; a **Project Map → Dependency Graph** view shows how every asset derives from the PRD and each other, which are stale (and why), and updates all impacted artifacts in safe dependency order. | The whole workspace stays coherent as the product evolves — and drift is visible, explainable, and one click from fixed. |
+| 🔌 | **Dependency graph & change-aware staleness** | Artifacts carry source references to their inputs; a **Project Map → Dependency Graph** view shows how every asset derives from the PRD and each other, which are stale — and *what changed* ("1 feature removed · Architecture changed", including deleted features an asset still references) — and updates impacted artifacts in safe dependency order. Re-finalizing an edited PRD opens an **Update Assets plan** (regenerate / mark up to date / decide later per asset) instead of silently rebuilding everything, and exports carry a **version manifest** that flags stale content. | The whole workspace stays coherent as the product evolves — drift is visible, explainable, and surgical to fix instead of all-or-nothing. |
 | ☁️ | **Cross-device web app** | A Vercel-hosted web app: signed-in users' projects sync to a per-account server collection and follow them across machines. | Access your work from any browser — nothing is trapped on one device. |
 | 📱 | **Mobile-ready by design** | Responsive layouts, safe-area insets, touch-aware selection, swipe navigation, and reduced-motion support throughout. | The full workflow — including highlight-to-refine — works on a phone, not just desktop. |
 | 🤝 | **Coding-agent hand-off** | One-click "Copy for coding agent" bundles PRD + build artifacts for Claude Code / Cursor. | Closes the loop from idea straight to implementation. |
@@ -223,7 +223,7 @@ The backend's job is bursty and request-scoped — sync upserts, vault reads, OA
 **🔮 Future**
 - [ ] Additional LLM providers (Anthropic / Azure OpenAI) via the routing layer
 - [ ] Real-time collaborative editing on a shared spine
-- [ ] Improved versioning functionality
+- [x] Improved versioning functionality — change-aware staleness, per-asset update planning on re-finalize, export version manifest
 - [ ] Enhanced build plan features
 
 ---

--- a/docs/VERSIONING_AUDIT.md
+++ b/docs/VERSIONING_AUDIT.md
@@ -4,6 +4,9 @@
 > §10 has shipped — non-destructive edits, PRD + artifact version history,
 > compare/diff, restore-as-new-version, provenance, and downstream-staleness
 > warnings. Items under "Future enhancements" remain unbuilt.
+> **Superseded for the next increment by `docs/VERSIONING_V2_PLAN.md`** (Phase A
+> shipped: change-aware staleness, the re-finalize Update Assets plan,
+> mark-as-up-to-date, provenance completion, export version manifest).
 > Scope: PRD (spine) versioning, PRD section/inline edits, generated artifacts,
 > downstream-artifact staleness, project history/audit log, and snapshots.
 

--- a/docs/VERSIONING_V2_PLAN.md
+++ b/docs/VERSIONING_V2_PLAN.md
@@ -1,0 +1,623 @@
+# Synapse Versioning V2 — Capability Audit, Scenario Analysis & Improvement Plan
+
+> Status: **Proposal — awaiting approval. No implementation yet.**
+> Builds on `docs/VERSIONING_AUDIT.md` (Phase 1, shipped: non-destructive edits,
+> version history panels, compare/diff, restore-as-new-version, provenance,
+> staleness warnings). This document audits what shipped against ten real
+> product-revision scenarios and proposes the next increment.
+
+---
+
+## 1. Current-State Map
+
+### 1.1 Answers to the ten investigation questions
+
+**1. Where project (PRD) versions are stored.**
+`spineVersions: Record<projectId, SpineVersion[]>` in the Zustand store
+(`src/store/slices/spineSlice.ts`), append-only full snapshots. Each
+`SpineVersion` (`src/types/index.ts:652-698`) carries the full markdown
+(`responseText`) and structured object (`structuredPRD`), plus `isLatest`,
+`isFinal`, `generationMeta`, `safetyReview`, optional `provenance`
+(`VersionProvenance`), and optional `canonicalSpine` (attached on final settle,
+`spineSlice.ts:283-292`).
+
+**2. Where artifact versions are stored.**
+`artifactVersions: Record<projectId, ArtifactVersion[]>`
+(`src/store/slices/artifactSlice.ts`). `ArtifactVersion`
+(`src/types/index.ts:1121-1134`): `versionNumber` (1-based monotonic),
+`parentVersionId`, full `content`, `metadata` bag, `sourceRefs`,
+`generationPrompt`, `isPreferred`, optional `provenance`. The parent
+`Artifact.currentVersionId` points at the preferred version.
+
+**3. How PRD versions are created and selected.**
+Every creation path appends and flips prior versions' `isLatest` to false:
+`regenerateSpine` (spineSlice.ts:62-107), `mergeBranch`
+(branchSlice.ts:66-126), `editSpineStructuredPRD` (spineSlice.ts:309-366 — the
+chokepoint for all inline edits and single-section retries),
+`revertSpineToVersion` (spineSlice.ts:371-420). Ids are opaque UUIDs; display
+labels derive from **array position** (`Version ${idx + 1}`,
+`ProjectWorkspace.tsx:252-254`). Selection = `isLatest` (one per project) plus
+a read-only `viewedSpineId` for historical viewing. The only in-place mutation
+is `updateSpineStructuredPRD` (spineSlice.ts:257-301), reserved for the live
+streaming settle of an in-flight generation.
+
+**4. How artifact dependency metadata is represented.**
+`SourceRef` (`src/types/index.ts:1101-1107`): `{ sourceArtifactId,
+sourceArtifactVersionId, sourceType: ArtifactType | 'spine', anchorInfo? }`.
+`artifactJobController.runCoreArtifactSlot` stamps one `spine` ref (the exact
+`SpineVersion.id` generated from) plus one `core_artifact` ref per satisfied
+`dependsOn` input (artifactJobController.ts:326-339); `runMockupSlot` does the
+same for `MOCKUP_DEPENDENCIES`, with the design_system ref carrying the
+`tokensHash` in `anchorInfo` (artifactJobController.ts:474-497). Version
+metadata also records `dependencyStatus`, `validationBlockers`,
+`generatedFromIncompletePrd`, `spineContextUsed`, and (design_system)
+`tokens`/`tokensHash`.
+
+**5. How the dependency graph determines freshness/lineage.**
+`src/lib/artifactDependencyGraph.ts` (pure, derived from
+`CORE_ARTIFACT_PIPELINE` + `MOCKUP_DEPENDENCIES`). `evaluateDependencyGraph`
+(lines 378-534): spine-ref ≠ latest spine id → hard `needs_update`
+(`prd_changed`); recorded dependency ref ≠ that dep's current preferred version
+→ `needs_update` (`dependency_changed`); mockup tokensHash drift →
+`needs_update` (`design_tokens_changed`); legacy versions with no recorded ref
+fall back to a timestamp heuristic → advisory `update_recommended`. Upstream
+trouble propagates transitively as `impactedBy` (blue "Impacted" pill).
+`computeUpdateOrder`/`computeRecommendedUpdates` give topological batch order;
+actions route to the existing `retrySlot`/`regenerateSlots`.
+
+**6. How user edits, regenerations, and artifact updates are handled.**
+PRD edits/retries append versions via `editSpineStructuredPRD` with
+`provenance.changeSource` (`user_edit` / `ai_section_retry`) and `Edited`
+history events. Artifact regeneration appends via `createArtifactVersion`
+(artifactSlice.ts:89-169). Artifact *content* has no user-edit path; the two
+user-edit mechanisms are metadata **overlays** on the preferred version —
+`metadata.screenEdits` (screen metadata) and `metadata.promptEdits` (legacy
+prompt packs) via `updateArtifactVersionMetadata` — which create **no version
+and no history event** (artifactSlice.ts:280-303).
+
+**7. Id stability across versions.**
+- `Feature.id` — **stable and canonical**; copied verbatim into the spine
+  (`canonicalPrdSpine.ts` `buildFeatures`), protected by consistency-review
+  guards and prompt rules. The strongest identity in the system.
+- Screen ids (`ScreenItem.id`) — deterministic (`assignStableScreenIds`,
+  `screenInventoryNormalize.ts:92-109`): stored id → name slug → `-2`/`-3`
+  dedup; stable across reads and never derived from display renames.
+- Canonical-spine seed ids (`scr-`/`ent-` via `slugId`,
+  `canonicalPrdSpine.ts:96-107`) — deterministic from (name, order), but
+  **shift when names/order change**; self-flagged as interim.
+- Spine + artifact version ids — opaque random UUIDs by design; ordering comes
+  from array position / `versionNumber`.
+
+**8. Whether version metadata survives persistence, sync, export, reload.**
+**Yes, on every path.** The store `partialize` strips only transient slices
+(`projectStore.ts:39-46`); `ProjectBundle` (`projectBundle.ts:16-26`) carries
+whole `spineVersions`/`artifacts`/`artifactVersions` arrays to `/api/projects`;
+snapshots collect the same (+ per-version IndexedDB images) and remap artifact
+version ids on demo restore (`snapshotClient.ts:556-602`); the recovery
+download reuses `ProjectBundle`. No truncation anywhere; the one ceiling is the
+server's **8 MB request-body reject** (`api/projects.js:47`, HTTP 413). Old
+mockup images are **kept** per version id in IndexedDB (no GC), which is what
+makes old-vs-new visual comparison possible at all.
+
+**9. Where stale artifacts are detected.**
+Two parallel systems: (a) `stalenessSlice.getArtifactStaleness`
+(`current | possibly_outdated | outdated`, spine-ref + mockup tokensHash
+comparison) feeding `StalenessBadge`; (b) the richer dependency-graph evaluator
+(§1.1.5) feeding the Project Map. Both operate at **whole-version
+granularity** — any new latest spine flips *every* downstream artifact,
+regardless of what changed.
+
+**10. Where the UI exposes version history/comparison.**
+`src/components/versions/` (`VersionHistoryPanel`, `VersionCompareView`,
+`RevertConfirmModal`) — PRD history from the `ProjectWorkspace` overflow menu +
+historical-version banner (Compare with current / Restore); artifact history
+from the "Version history" button + "Generated from PRD Version X" chip +
+`StalenessBadge` in `ArtifactWorkspace` (:625-655, 1510-1538). `HistoryView`
+shows the event timeline but only a truncated one-line diff placeholder
+(HistoryView.tsx:96-101). Compare is hardwired to **historical ↔ current**;
+artifacts and mockups get a flat word diff of `content`.
+
+### 1.2 The load-bearing workflow finding: the re-finalize regeneration funnel
+
+This is the single most important current-behavior fact for every scenario
+below, verified end to end:
+
+1. Every appended spine version — edit, section retry, revert, merge — is
+   stamped **`isFinal: false`** (spineSlice.ts:334, 394; branchSlice.ts:100).
+2. The Assets workspace only renders when `activeSpine?.isFinal`
+   (ProjectWorkspace.tsx:905). So the moment a user edits a finalized PRD,
+   **the entire Assets workspace — including the dependency graph and all its
+   selective-update actions — disappears**, replaced by the PRD stage.
+3. To get assets back the user must **Mark Final** again →
+   `finalizeAndGenerate` → `artifactJobController.startAll` with the *new*
+   spine id (ProjectWorkspace.tsx:568-587).
+4. `startAll`'s pending-slot filter treats "done" as *done for this spine
+   version* — `isSlotDoneForSpine` requires a `spine` sourceRef equal to the
+   current spine id (artifactJobController.ts:138-154, 696). No artifact ever
+   matches a freshly appended spine, so **every artifact and mockup regenerates
+   from scratch on every re-finalize — even for a one-word typo fix**.
+5. The graph's per-artifact "Update selected" flow, staleness reasons, and
+   update ordering are all unreachable during this funnel, because the surface
+   that hosts them is hidden while `isFinal` is false.
+
+Net effect: the system quietly implements "any PRD change = regenerate the
+whole project," which is expensive, slow, discards the user's mental model of
+which assets were fine, and is precisely the trust-eroding behavior this task
+targets. (It *is* history-safe — old artifact versions and images are kept —
+but the user experiences a wall of regeneration, not a surgical update.)
+
+### 1.3 Other known gaps (evidence-backed)
+
+- **Provenance is incomplete.** `VersionChangeSource` declares
+  `ai_generation | ai_regeneration | branch_merge | consistency_review`, but no
+  production path stamps them — `regenerateSpine`, `mergeBranch`, and
+  `createArtifactVersion` leave `provenance` undefined. Only `user_edit`,
+  `ai_section_retry`, and `revert` are recorded.
+- **No change-content awareness anywhere.** `versionDiff.diffStructuredPRD`
+  computes section-level diffs, but nothing connects it to staleness: the graph
+  can say *"generated from Version 2, now on Version 4"* but never *what*
+  changed between them. Features/entities are flattened to text blobs before
+  diffing — no diff by `Feature.id` (added/removed/renamed) despite feature ids
+  being the system's most stable identity.
+- **No feature-level impact analysis.** The only feature-content check is
+  `detectStaleFeatureNames` (`artifactPromptBuilder.ts:115-129`), a prompt-
+  hygiene name-presence scan. Nothing answers "which artifacts referenced the
+  feature I just deleted?" — even though artifacts carry structured
+  traceability (`Related Features:` lines, `traceabilityMappedFeatures`
+  metadata) that makes this answerable.
+- **Exports are version-blind.** `ExportModal`/`buildAgentHandoff` always take
+  the preferred version with **no staleness check, no warning, and no version
+  manifest** — the only version metadata exported anywhere is `versionNumber`
+  in the Structured JSON path (ExportModal.tsx:120). A `possibly_outdated`
+  data model exports into the agent handoff silently.
+- **Compare limitations.** Only historical ↔ current (both `getCompareInput`
+  call sites hardwire `after` to latest/preferred); JSON-mode artifacts
+  (screen/data/component inventory) diff as one markdown blob; mockup compare
+  is a text diff even though every version's images are preserved in
+  IndexedDB (`mockupImageStore.ts:3-7`).
+- **Two staleness systems.** `stalenessSlice` (3-state) and the graph
+  evaluator (richer) implement overlapping rules that must be kept manually in
+  sync (already a documented consistency rule in CLAUDE.md).
+- **Overlay edits are invisible to versioning.** `screenEdits`/`promptEdits`
+  mutate preferred-version metadata in place — no version, no event, no
+  divergence signal ("this artifact was hand-tuned after generation").
+- **HistoryView diff placeholder** — one truncated line, no link into the real
+  compare view.
+- **Growth ceilings** — no retention cap on versions (8 MB server body limit
+  is a reject-not-truncate cliff) and no image GC across regenerations
+  (`tasks/TODO.md:131-135`).
+
+---
+
+## 2. User Scenario Gap Analysis
+
+Legend: ✅ supported · 🟡 partially supported · ❌ unsupported.
+
+### Scenario 1 — Downstream artifact reveals an underspecified feature
+
+| Capability | Status |
+| --- | --- |
+| Return to PRD and edit the feature | ✅ PRD stage, `StructuredPRDView`/`FeatureCard` edits |
+| Edit creates a new PRD version | ✅ `editSpineStructuredPRD` appends, `user_edit` provenance |
+| Downstream marked potentially stale | ✅ `prd_changed` / `possibly_outdated` (whole-version) |
+| See which artifacts came from the old version | ✅ "Generated from PRD Version X" chip; graph detail |
+| Regenerate affected artifacts | 🟡 exists in the graph — but unreachable during the funnel (§1.2); the practical path regenerates **everything** |
+| Compare old vs new artifact versions | 🟡 vs current only; text-blob diff |
+| **Understand *what* changed and what it affects** | ❌ no change summary attached to staleness anywhere |
+
+What confuses the user today: after fixing one feature, they are ejected from
+the Assets view, re-finalize, and watch all seven artifacts + mockups
+regenerate. Nothing says "you changed Features → user flows and screens are
+affected; the data model likely isn't."
+
+**Needed:** change-aware staleness (spine-version diff surfaced on every stale
+flag) + a guided, selective update flow at the re-finalize edge.
+
+### Scenario 2 — Deleting a feature after seeing UX/mockups
+
+| Capability | Status |
+| --- | --- |
+| Delete feature from canonical model | ✅ FeatureCard remove → new version |
+| New PRD version created | ✅ |
+| Identify artifacts that referenced the deleted feature | ❌ nothing scans references, despite traceability data existing |
+| Show downstream as stale/incompatible | 🟡 wholesale `prd_changed`, no reason "feature X removed" |
+| Prevent deleted features reappearing | 🟡 regeneration uses the canonical spine (deleted feature absent), so regenerated artifacts are clean; but a **stale artifact the user keeps** still shows the feature with no flag |
+| Preserve prior versions / compare pre- vs post-delete | ✅ history kept; 🟡 compare is text-only, feature deletion appears as scattered word-diff noise, not "Feature 'X' removed" |
+
+**Needed:** feature-level diff by `Feature.id` (added/removed/renamed/changed)
++ a deleted-feature reference scan across preferred artifact content and
+traceability metadata → an explicit impact list ("'Social sharing' removed —
+referenced by User Flows, Screens (2 screens), Implementation Plan (1
+milestone)").
+
+### Scenario 3 — Tech stack change after implementation planning
+
+Today the stack lives in the PRD's prose `architecture` field (plus whatever
+the implementation plan generated). A stack change is just another PRD edit:
+downstream flips wholesale, with no signal that this is an
+architecture-class change affecting `data_model`/`implementation_plan`
+specifically and not, say, `design_system`.
+
+**Needed (now):** section-level change classification — `diffStructuredPRD`
+already isolates the Architecture section; map changed sections → affected
+artifact subtypes so the stale reason reads "Architecture changed → Data
+Model, Implementation Plan need review; Design System unaffected by this
+change." **Deferred:** a structured tech-stack entity with its own version
+lineage. The PRD deliberately keeps architecture at decision level
+(CLAUDE.md: the artifacts own the detail); a structured stack object is a
+generation-pipeline change, not a versioning change, and shouldn't block this
+work.
+
+### Scenario 4 — Design system change after mockups exist
+
+This is the **best-supported scenario today**: the design system is already a
+versioned first-class dependency. `DesignDirectionControl` +
+`ChangeDirectionModal` change direction with an explicit downstream warning;
+regeneration produces a new `tokensHash`; the mockup's recorded design ref
+(`anchorInfo`) drifts → hard `design_tokens_changed`; the Mockups view shows
+the amber "Design system changed … Regenerate the mockups" banner; a
+token-identical regen correctly keeps mockups current (hash beats version id).
+
+Remaining gaps: 🟡 old-vs-new **visual** comparison doesn't exist (text diff of
+mockup specs only), even though both versions' images are preserved; 🟡 the
+design_system version doesn't record **which preset** produced it
+(`Project.designSystemPreset` is current-state only), so history can't say
+"Modern SaaS → Consumer Mobile". Both are cheap additions. **Answer to the key
+question: design system versions are already first-class dependencies — keep
+that model; don't invent a parallel one.**
+
+### Scenario 5 — User edits one artifact directly
+
+Artifact *content* editing doesn't exist; the overlay edits that do exist
+(screen metadata, prompt edits) mutate preferred-version `metadata` in place —
+no version, no event, no divergence flag. The graph shows a `manuallyEdited`
+pencil only off `provenance.changeSource === 'user_edit'`, which overlays never
+set.
+
+**Needed (now):** record overlay edits as history events + a lightweight
+"customized after generation" signal on the artifact (regeneration already
+starts overlays clean, which is correct — but the user should be warned that
+regenerating discards their customizations). **Deferred:** full artifact
+content editing and "push change upstream to PRD" — a product feature in its
+own right, out of versioning scope.
+
+### Scenario 6 — Compare two versions of the same artifact
+
+✅ PRD: section-aware + word-level, good. 🟡 Artifacts: single text blob —
+acceptable for prose artifacts, poor for JSON-mode artifacts where "screens
+added/removed" is the real question. ❌ Compare any-two (both call sites pin
+`after` = current). ❌ Mockup visual compare. ❌ Feature-level diff. Impact
+analysis attached to a diff: ❌.
+
+**Needed:** any-two selection (small UI change — the panel already lists all
+versions); structured diffs for screen_inventory (by stable screen id) and
+data_model (entities/fields by name); mockup image side-by-side; a
+`summarizeSpineChange` one-liner ("2 features changed, 1 removed ·
+Architecture edited").
+
+### Scenario 7 — Rollback to an earlier version
+
+✅ Solid (Phase 1): revert appends a new version (`revert` provenance +
+`revertedFromVersionId` + `Reverted` event), history untouched,
+`RevertConfirmModal` lists artifacts that will go stale. Two gaps: 🟡 the
+revert lands `isFinal: false` → same funnel as any edit (§1.2), so "restore
+the version everything was generated from" still regenerates everything;
+🟡 the confirm modal says *which* artifacts go stale but not *what will change*
+(the spine diff between current and the restore target is computable).
+
+### Scenario 8 — Branch / explore alternatives
+
+Branches today are text-anchored AI conversation threads that merge back into
+the single linear spine chain (branchSlice.ts, branchService.ts) — **not**
+project-level lineage. There is no project duplication either.
+
+**Recommendation: linear history is enough for now — do not build Git-like
+branching.** The append-only single-chain model is the source of the system's
+simplicity (positional labels, one `isLatest`, one staleness baseline);
+parallel lineages would fork every store slice, the dependency graph baseline,
+sync, and snapshots. The 90% use case ("try a different direction without
+losing this one") is served by a **Duplicate Project** action (copy all nine
+slices under a new project id — the snapshot `rewriteIds` machinery already
+proves the remap pattern). Propose as a later phase; explicitly defer true
+branching.
+
+### Scenario 9 — Export / share
+
+❌ The weakest area relative to effort required. No version manifest, no
+staleness warning, stale artifacts included silently, and the agent handoff —
+the export most likely to be *acted on* by a coding agent — carries no
+provenance at all.
+
+**Needed:** a generated manifest (project, PRD version label + timestamp, per
+artifact: version number, generated-from PRD version, staleness at export
+time) prepended/attached to bundle + JSON + handoff exports; an amber warning
+in `ExportModal` when any included artifact is stale (mirroring the existing
+`cloudAtRisk` banner pattern), with "export anyway / update first" choices.
+
+### Scenario 10 — Dependency graph as the version-impact interface
+
+The graph is already the right surface: derived, deterministic statuses with
+reasons, impact propagation, ordered batch updates. Three things keep it from
+being the *main* interface: (1) it's invisible exactly when needed most
+(§1.2 funnel); (2) reasons are version-granular ("PRD changed") with no
+content ("Features changed: X removed"); (3) "recommended next actions" stop
+at "update N impacted" — no notion of "this change likely doesn't affect this
+artifact" and no per-artifact "keep as-is, mark current" escape hatch.
+
+---
+
+## 3. Proposed Versioning Model
+
+**Core principle: keep the shipped model — append-only full snapshots, opaque
+UUID ids, positional labels, sourceRef lineage — and add a *change-awareness
+layer computed at read time*, not new persisted version machinery.** Every
+proposal below that matters for the MVP is derivable from data already
+persisted (spine versions are full snapshots; diffs are already computed on
+the fly). This keeps migrations at zero and honors the codebase's
+optional-fields-only compatibility rule.
+
+| Concern | Model decision |
+| --- | --- |
+| PRD versions | Unchanged (append-only `SpineVersion[]`). Complete the provenance stamping (`ai_generation`, `ai_regeneration`, `branch_merge`). |
+| Artifact versions | Unchanged (`ArtifactVersion` + `sourceRefs`). Add `marked_current` re-baselining (below) and overlay-edit history events. |
+| Feature versions | **No separate feature-version store.** `Feature.id` is stable; feature history is derivable by diffing consecutive spine snapshots (`diffFeatures` by id). Persisting per-feature version chains would duplicate the spine snapshots. |
+| Design system versions | Already first-class (artifact versions + tokensHash refs). Add `metadata.designSystemPreset` stamping at generation so direction history is legible. |
+| Tech stack / architecture versions | **Not a separate entity now.** Represent as *classified spine changes* (Architecture-section diff → architecture-class staleness reasons). Revisit only if a structured stack object enters the generation pipeline. |
+| Dependency lineage | Unchanged (`sourceRefs` chain). Legacy versions keep the timestamp heuristic. |
+| Staleness states | Keep the graph's status set; **enrich reasons with change content** (`changedSections`, `featureChanges`) and add an advisory *scoped-impact* signal ("no changes in the sections this asset derives from"). |
+| Manual edits | Overlay edits emit history events + a `customized` signal; artifact content editing deferred. |
+| Regeneration events | Unchanged mechanically; the *entry point* changes — re-finalize with existing assets routes through an update-plan dialog instead of blind `startAll`. |
+| Rollbacks | Unchanged (append-clone); enrich the confirm modal with the spine diff summary. |
+| Branching | **Deferred.** Linear history + (later) Duplicate Project. |
+
+### 3.1 The change-awareness layer (new, pure)
+
+A new pure module `src/lib/spineChangeAnalysis.ts` (or an extension of
+`versionDiff.ts` — same rules: framework-free, unit-tested, nothing persisted):
+
+- `diffFeatures(before, after): FeatureDiff` — keyed by `Feature.id`:
+  `{ added: Feature[], removed: Feature[], renamed: {id, from, to}[],
+  changed: {id, name, fields: string[]}[] }`. This is the system's first use
+  of its most stable identity for user-facing diffing.
+- `summarizeSpineChange(beforeSpine, afterSpine): SpineChangeSummary` —
+  `{ sections: SectionDiff[] (reusing diffStructuredPRD), features:
+  FeatureDiff, headline: string }` where `headline` is a deterministic
+  one-liner ("1 feature removed · Features, UX Pages changed").
+- `SECTION_ARTIFACT_AFFINITY` — a conservative, documented map from PRD section
+  keys to the artifact subtypes that *primarily* derive from them (e.g.
+  `features`/`uxPages` → screen_inventory, user_flows, mockup;
+  `domainEntities`/`architecture` → data_model, implementation_plan;
+  everything → implementation_plan). Used only for **advisory annotations**
+  ("likely unaffected by this change"), never to suppress a hard
+  `needs_update` — every artifact really is generated from the whole PRD, so
+  the honest claim is "the sections this asset chiefly derives from didn't
+  change," not "this asset is current."
+- `findFeatureReferences(feature, artifactVersions): FeatureReference[]` —
+  scans preferred versions' content (name/id token match, reusing the
+  conservative matching style of `artifactTraceabilityRepair.ts`) plus
+  structured traceability metadata, returning per-artifact hit lists for the
+  deleted/renamed-feature impact panel.
+
+`evaluateDependencyGraph` gains an optional input (the resolved before/after
+`StructuredPRD` for each stale node's spine ref → current spine) and attaches
+`changeSummary` to `prd_changed` reasons. Cost note: diffs run per stale node
+per evaluation — memoize by `(fromSpineId, toSpineId)` pair; spine pairs are
+few.
+
+### 3.2 Re-baselining: "Mark as still current"
+
+The missing escape hatch for trivial upstream changes. Per stale artifact, a
+user action that **appends a cloned `ArtifactVersion`** (same content/metadata)
+whose `sourceRefs` spine ref points at the **current** spine, with
+`provenance.changeSource: 'marked_current'` (new union member) and an
+`editSummary` ("Confirmed current for PRD Version 4"). Because it's an honest
+append — same pattern as `revertArtifactToVersion` — history stays truthful,
+`isSlotDoneForSpine` starts passing for the new spine (so re-finalize stops
+regenerating it), and the graph/staleness flip to current. Trade-off: a
+content-identical version row per confirmation; acceptable (text-only) and
+clearly labeled by its provenance badge.
+
+### 3.3 The re-finalize flow (fixing §1.2)
+
+Keep the `isFinal: false` reset (it correctly forces an explicit "this is
+final" decision after content changes). Change what finalization *does* when
+assets already exist:
+
+- In `finalizeAndGenerate`, when any artifact versions exist for the project,
+  do **not** call `startAll` blindly. Instead evaluate the dependency graph
+  against the new spine and open an **Update Assets plan dialog**: the spine
+  change summary on top ("What changed: 1 feature removed …"), then each
+  artifact with its status, reason (now change-aware), affinity annotation,
+  and a checkbox — defaults from `computeRecommendedUpdates`. Actions:
+  **Update selected** (→ `regenerateSlots`, which already handles ordering +
+  hidden closure + unhealthy-dependency expansion via `planSlotRetry`
+  semantics), **Mark selected as current** (§3.2), or **Update everything**
+  (today's behavior, one click away).
+- First finalize (no artifacts) is unchanged — `startAll` as today.
+- The Assets workspace remains gated on `isFinal` (unchanged), but the user
+  now passes through a surgical decision instead of a silent full rebuild.
+
+---
+
+## 4. Recommended User Experience
+
+- **Version history** stays where it is (PRD overflow menu; artifact header
+  button) — Phase 1 placed these well. Add: any-two compare pickers in
+  `VersionHistoryPanel`; the spine-change headline as a per-version subtitle
+  (so the list reads "Version 3 — Edited · 1 feature removed" instead of just
+  "Edited PRD").
+- **Stale labels** keep `StalenessBadge`, but the badge (and the graph node
+  detail) gains the change summary: hover/tap → "Generated from Version 2.
+  Since then: Feature 'Social sharing' removed; UX Pages changed." Advisory
+  affinity note where applicable: "No changes in the sections this asset
+  chiefly derives from."
+- **Regeneration** funnels through the Update Assets plan dialog (§3.3) at the
+  re-finalize edge; inside the workspace the existing graph actions stay, plus
+  the per-artifact **Mark as still current** action (graph detail panel +
+  artifact header next to the staleness badge).
+- **Deleted features** get an explicit impact panel: when
+  `summarizeSpineChange` detects removals, the plan dialog (and the graph's
+  Change Impact tab) lists each removed feature with the artifacts that still
+  reference it ("still shown in: User Flows, Screens (Checkout, Cart)"). A
+  stale artifact that references a removed feature upgrades its reason text to
+  "references removed feature 'X'".
+- **Dependency graph** becomes the version-impact home: node detail's
+  "Why update?" shows the change summary; the History tab links each version
+  row into the real `VersionCompareView` (also fixing the HistoryView
+  placeholder by linking, not by building a second diff renderer).
+- **Exports** show a version manifest block (PRD version + timestamp; per
+  artifact: version, generated-from PRD version, staleness) and an amber
+  banner when stale content is included — "3 assets may be out of date with
+  the current PRD" with **Review in Project Map** / **Export anyway**. The
+  manifest is included in the bundle markdown (a header section), the JSON
+  export (a `manifest` field), and the agent handoff preamble (one line per
+  artifact), so an outside reader can see exactly what they're holding.
+- **Rollback** confirm modal adds the diff summary of what restoring will
+  change, alongside the existing stale-artifact list.
+
+Clarity rule throughout: never invent VCS vocabulary — the UI says "changed /
+may be outdated / update / mark as current / restore", not
+"rebase / HEAD / branch".
+
+---
+
+## 5. Data Model and State Changes
+
+All additions are **optional fields or new pure modules** — zero migrations,
+legacy data loads unchanged (the established compatibility rule).
+
+| Change | Where | Notes |
+| --- | --- | --- |
+| `VersionChangeSource` += `'marked_current'` | `src/types/index.ts` | Union extension; display maps in `VersionHistoryPanel` gain a label. |
+| Stamp missing provenance | `spineSlice.regenerateSpine` (`ai_regeneration` on settle), `branchSlice.mergeBranch` (`branch_merge`), `artifactJobController` → `createArtifactVersion` (`ai_generation`/`ai_regeneration` by versionNumber), consistency-review apply (`consistency_review`) | Uses existing typed fields that were never written. |
+| `markArtifactCurrentForSpine(projectId, artifactId, spineVersionId)` | `artifactSlice` | Append-clone with re-pointed spine ref + provenance; mirrors `revertArtifactToVersion` (reads inside `set()` per the concurrency rule). |
+| Overlay-edit events | `updateArtifactVersionMetadata` callers (screenEdits/promptEdits paths) | Push an `Edited` `HistoryEvent` with artifact ids; no shape change. |
+| `metadata.designSystemPreset` | design_system generation (`coreArtifactService`/job controller) | Stamped at generation from the project; display-only. |
+| `SpineChangeSummary`, `FeatureDiff`, `FeatureReference` types | new `src/lib/spineChangeAnalysis.ts` | Pure module; nothing persisted. |
+| `DependencyStaleReason.changeSummary?` | `artifactDependencyGraph.ts` | Evaluation-output-only type (not persisted). |
+| Export manifest types | `src/lib/exportManifest.ts` (new, pure) | Built at export time from live state. |
+
+Deliberately **not** added: `branchId`, `isCanonical`, per-feature version
+records, a `sourceTechStackVersionId`, content hashes. The names in the task
+prompt map onto existing fields: `versionId`→`id`, `parentVersionId` exists,
+`sourcePrdVersionId`→spine `sourceRef`, `sourceArtifactVersionIds`→
+`core_artifact` refs, `createdBy`/`createdReason`/`changeSummary`→
+`provenance.changeSource`/`editSummary`, `stalenessStatus`→derived (never
+persisted), `supersedes`→`revertedFromVersionId` + `parentVersionId`.
+
+---
+
+## 6. Diff and Comparison Strategy
+
+| Diff type | Approach | When |
+| --- | --- | --- |
+| Textual (prose artifacts, PRD sections) | Existing jsdiff word-level (`diffText`) | Shipped |
+| PRD structured | Existing section-aware (`diffStructuredPRD`) | Shipped |
+| **Feature-level** | New `diffFeatures` by `Feature.id` (added/removed/renamed/changed-fields) | **Now (MVP)** — powers change-aware staleness, deletion impact, history subtitles |
+| **Human-readable change summary** | Deterministic `headline` from `summarizeSpineChange` — no LLM call (guaranteed, free, honest) | **Now (MVP)** |
+| **Dependency impact diff** | Change summary attached to graph stale reasons + affinity annotation | **Now (MVP)** |
+| Compare any-two versions | Two-picker mode in `VersionHistoryPanel`/`VersionCompareView` | Phase 2 |
+| Screen-inventory structured diff | Parse both versions (`normalizeScreenInventory` — ids are stable/deterministic), diff screens by id: added/removed/changed fields | Phase 2 |
+| Data-model structured diff | Reuse `dataModelMarkdown` parser; entities by name, fields/relationships per entity | Phase 2 |
+| Mockup visual compare | Side-by-side per-screen image gallery for two versions (images already preserved per `versionId:screenId:quality`); match screens via `sourceScreenId`/slug like `screenExperience` | Phase 2 |
+| Implementation-plan task diff | Per-milestone/task add/remove/change (backlog item exists) | Deferred |
+| Content hashing for exact drift | `contentHash` on versions | Deferred (documented graph limitation; not needed for the above) |
+
+---
+
+## 7. Phased Implementation Plan
+
+### Phase A — Change-aware staleness & guided updates (**the recommended MVP**)
+
+**Goal:** every stale flag explains *what changed*; a PRD revision after
+finalize leads to a surgical, ordered, user-controlled update instead of a
+silent full regeneration; deleted features have a visible blast radius;
+exports stop being version-blind.
+
+- **A1. Pure change analysis.** `src/lib/spineChangeAnalysis.ts`
+  (`diffFeatures`, `summarizeSpineChange`, `SECTION_ARTIFACT_AFFINITY`,
+  `findFeatureReferences`) + unit tests. No UI yet. *Risk: low (pure).*
+- **A2. Change-aware graph reasons.** Thread spine snapshots into
+  `evaluateDependencyGraph`; attach `changeSummary` + affinity annotation to
+  `prd_changed` reasons; memoize per spine pair. Update `DependencyGraphView`
+  detail panel + `StalenessBadge` tooltip + the artifact-header chip area.
+  Files: `artifactDependencyGraph.ts`, `DependencyGraphView.tsx`,
+  `StalenessBadge.tsx`, `ArtifactWorkspace.tsx`. *Risk: evaluation cost —
+  bounded by memoization; advisory annotations must not suppress hard states
+  (tested).*
+- **A3. Update Assets plan dialog at re-finalize.** New
+  `src/components/versions/UpdateAssetsPlanModal.tsx`; change
+  `ProjectWorkspace.finalizeAndGenerate` to route through it when artifact
+  versions exist (first finalize unchanged). Actions wire to existing
+  `regenerateSlots` / new `markArtifactCurrentForSpine`. *Risk: the finalize
+  edge is load-bearing (design-preset gate, incomplete-PRD gate) — the dialog
+  slots in after those gates; regression tests on the gate ordering. Rollback:
+  a flag falling back to plain `startAll`.*
+- **A4. `markArtifactCurrentForSpine`** in `artifactSlice` + graph/artifact-
+  header action + `'marked_current'` provenance label. *Risk: users
+  over-marking — mitigated by keeping it per-artifact and reversible (the
+  artifact goes stale again on the next real change; history shows the
+  confirmation).*
+- **A5. Provenance completion + overlay-edit events.** Stamp the four missing
+  change sources; emit history events from screenEdits/promptEdits saves.
+  *Risk: none (write-only additions).*
+- **A6. Export manifest + stale warning.** `src/lib/exportManifest.ts`;
+  `ExportModal` banner + manifest inclusion in bundle/JSON/handoff.
+  *Risk: none; snapshot the handoff preamble change in `promptSurfaces.test`
+  if it's covered there.*
+- **A7. Docs.** Update `CLAUDE.md` (staleness/finalize/provenance sections),
+  `VERSIONING_AUDIT.md` status note, this doc's status; README review (the
+  update-plan dialog is user-visible → README rule applies).
+
+**Migration/back-compat:** zero migrations. Legacy spines without
+`structuredPRD` on one side of a diff → change summary degrades to "content
+changed" (text-level); legacy artifacts without refs keep the timestamp
+heuristic and never get a change summary (advisory only, as today).
+**Testing:** unit tests for A1 (the bulk), graph-evaluation tests for A2,
+store tests for A4/A5, one component test for the plan dialog's
+default-selection logic, ExportModal manifest test. No broad UI snapshot
+bloat. **Validation:** `npm run build` + `npm run lint` + `npm test`
+(pre-push gate).
+
+### Phase B — Comparison depth
+
+Any-two compare; structured screen-inventory + data-model diffs; mockup visual
+before/after; `HistoryView` events link into `VersionCompareView`; revert
+modal shows the restore diff summary. Files: `versions/` components,
+`versionDiff.ts` extensions, new `mockups/MockupVersionCompare.tsx`,
+`HistoryView.tsx`. Independent of A; can ship separately.
+
+### Phase C — Consolidation & durability
+
+Unify `stalenessSlice` onto the graph evaluator (one rule set);
+`designSystemPreset` stamping; version-retention policy (cap non-preferred,
+non-latest history with pinning; respects the 8 MB sync ceiling) + image GC
+hooks (ties into the existing TODO). Duplicate Project (exploration
+affordance) lands here if wanted.
+
+### Deferred (explicitly out of scope)
+
+True project branching / parallel lineages; server-side per-version storage;
+structured tech-stack entity; artifact content editing + push-upstream;
+LLM-written change narratives (deterministic summaries only); content hashing.
+
+---
+
+## 8. Recommended MVP
+
+**Phase A, with A1–A3 as the essential core and A4–A6 as strongly recommended
+small additions.** If a cut is needed, drop A4 first (mark-as-current), then
+A6 (export manifest) — never A1–A3, which are the trust core: *what changed,
+what it affects, and a controlled way to act on it.*
+
+Why this MVP: it directly hits every success criterion — what version an
+artifact came from (shipped, now enriched), whether it's current (now with
+reasons that name the change), what changed between versions (feature-level,
+deterministic), which artifacts a PRD/feature/design change affects (change-
+aware reasons + deletion impact + existing tokensHash rule), how to regenerate
+(the plan dialog + existing graph ordering), whether old artifacts are
+preserved (already true — now visible via provenance completion), and whether
+an export contains stale content (manifest + warning). It requires **no new
+persisted version machinery, no migrations, and no backend changes**, and it
+converts the single worst current behavior (the silent full-regeneration
+funnel) into the product's most trust-building moment.

--- a/docs/VERSIONING_V2_PLAN.md
+++ b/docs/VERSIONING_V2_PLAN.md
@@ -1,6 +1,15 @@
 # Synapse Versioning V2 — Capability Audit, Scenario Analysis & Improvement Plan
 
-> Status: **Proposal — awaiting approval. No implementation yet.**
+> Status: **Phase A (the recommended MVP, §7/§8) implemented** — change-aware
+> staleness (`spineChangeAnalysis.ts`), the Update Assets plan dialog at
+> re-finalize, `markArtifactCurrentForSpine`, provenance completion,
+> overlay-edit history events, and the export version manifest. Phases B/C and
+> the deferred list remain unbuilt. Implementation notes deviating from this
+> plan: the `consistency_review` changeSource is deliberately NOT stamped as a
+> version change source (the review happens inside a single generation before
+> settle and is already recorded in `generationMeta.consistencyReview`); the
+> re-finalize dialog's per-row choices are Regenerate / Mark up to date /
+> Decide later applied atomically on confirm.
 > Builds on `docs/VERSIONING_AUDIT.md` (Phase 1, shipped: non-destructive edits,
 > version history panels, compare/diff, restore-as-new-version, provenance,
 > staleness warnings). This document audits what shipped against ten real

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -399,7 +399,11 @@ export function ArtifactWorkspace({
         const next: Record<string, ScreenMetadataEdit> = { ...current };
         if (edit) next[screenId] = edit;
         else delete next[screenId];
-        updateArtifactVersionMetadata(projectId, invArtifact.id, invPreferred.id, { screenEdits: next });
+        updateArtifactVersionMetadata(projectId, invArtifact.id, invPreferred.id, { screenEdits: next }, {
+            historyDescription: edit
+                ? `Screen details edited: ${edit.name ?? screenId}`
+                : `Screen details reset to generated: ${screenId}`,
+        });
     };
 
     // --- Mockup coverage actions --------------------------------------------
@@ -1056,7 +1060,9 @@ export function ArtifactWorkspace({
             : undefined;
         const handleUpdatePromptEdits = subtype === 'prompt_pack'
             ? (next: Record<number, string>) => {
-                updateArtifactVersionMetadata(projectId, artifact.id, preferred.id, { promptEdits: next });
+                updateArtifactVersionMetadata(projectId, artifact.id, preferred.id, { promptEdits: next }, {
+                    historyDescription: 'Developer prompt edited',
+                });
             }
             : undefined;
         const blockingIssues = readValidationBlockers(preferred.metadata);

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -45,6 +45,7 @@ import { ScreenDetailView } from './experience/ScreenDetailView';
 import type { ScreenDetailTab } from './experience/ScreenDetailTabs';
 import { DependencyGraphView } from './dependency/DependencyGraphView';
 import type { DependencyNodeId } from '../lib/artifactDependencyGraph';
+import { makeSpineChangeResolver } from '../lib/spineChangeAnalysis';
 import type {
     ArtifactSlotKey, CoreArtifactSubtype, MockupScreen, ProjectPlatform, StructuredPRD,
     GenerationStatus, ProjectTask,
@@ -247,7 +248,7 @@ export function ArtifactWorkspace({
     const {
         getArtifacts, getPreferredVersion, getArtifactStaleness, getJob, getProject,
         updateArtifactVersionMetadata, getArtifactVersions, getSpineVersions,
-        revertArtifactToVersion, setProjectDesignSystemPreset,
+        revertArtifactToVersion, setProjectDesignSystemPreset, markArtifactCurrentForSpine,
     } = useProjectStore();
     // Reactive read of the project's chosen visual direction, so the Design
     // System "Design direction" control re-renders when it changes.
@@ -630,8 +631,18 @@ export function ArtifactWorkspace({
         return idx >= 0 ? `Version ${idx + 1}` : undefined;
     };
 
+    // Change-aware staleness: "what changed since spine X" against the latest
+    // spine, memoized per spine pair for the render pass.
+    const allSpines = getSpineVersions(projectId);
+    const latestSpineId = allSpines.find(s => s.isLatest)?.id;
+    const spineChangeFor = useMemo(
+        () => makeSpineChangeResolver(allSpines, latestSpineId),
+        [allSpines, latestSpineId],
+    );
+
     // Header strip shown above a generated artifact: provenance chip ("Generated
-    // from PRD Version X"), staleness badge, and a Version history entry point.
+    // from PRD Version X"), staleness badge (+ what-changed detail), a
+    // "Mark up to date" escape hatch when stale, and a Version history entry.
     const renderVersionControls = (
         artifactId: string,
         preferred: { sourceRefs: { sourceType: string; sourceArtifactVersionId: string }[] },
@@ -639,6 +650,7 @@ export function ArtifactWorkspace({
         const staleness = getArtifactStaleness(projectId, artifactId);
         const spineRef = preferred.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId;
         const prdLabel = resolveSpineLabel(spineRef);
+        const changeSummary = staleness !== 'current' && spineRef ? spineChangeFor(spineRef) : null;
         return (
             <div className="flex items-center gap-2 flex-wrap">
                 {prdLabel && (
@@ -646,7 +658,27 @@ export function ArtifactWorkspace({
                         Generated from PRD {prdLabel}
                     </span>
                 )}
-                <StalenessBadge staleness={staleness} />
+                <StalenessBadge
+                    staleness={staleness}
+                    detail={changeSummary
+                        ? `PRD changes since ${prdLabel ?? 'this was generated'}: ${changeSummary.headline}`
+                        : undefined}
+                />
+                {changeSummary?.hasChanges && (
+                    <span className="text-[11px] text-amber-700 truncate max-w-full">
+                        Since {prdLabel ?? 'generation'}: {changeSummary.headline}
+                    </span>
+                )}
+                {staleness !== 'current' && latestSpineId && (
+                    <button
+                        type="button"
+                        onClick={() => markArtifactCurrentForSpine(projectId, artifactId, latestSpineId)}
+                        title="Confirm this artifact is still valid for the current PRD without regenerating it"
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-emerald-50 border border-emerald-200 text-emerald-700 hover:bg-emerald-100 rounded-md transition"
+                    >
+                        <ShieldCheck size={12} /> Mark up to date
+                    </button>
+                )}
                 <button
                     type="button"
                     onClick={() => setVersionHistoryArtifactId(artifactId)}

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -9,6 +9,7 @@ import { parseScreenInventory, screenInventoryToMarkdown } from '../lib/screenIn
 import { downloadFile } from '../lib/utils/downloadFile';
 import { copyToClipboard } from '../lib/utils/copyToClipboard';
 import { buildAgentHandoff } from '../lib/exportHandoff';
+import { buildExportManifest, renderManifestMarkdown, type ExportManifestEntry } from '../lib/exportManifest';
 import {
     CORE_ARTIFACT_DISPLAY_ORDER,
     getArtifactMeta,
@@ -33,7 +34,10 @@ interface ExportModalProps {
 }
 
 export function ExportModal({ projectId, onClose }: ExportModalProps) {
-    const { getProject, getLatestSpine, getArtifacts, getArtifactVersions } = useProjectStore();
+    const {
+        getProject, getLatestSpine, getArtifacts, getArtifactVersions,
+        getArtifactStaleness, getSpineVersions,
+    } = useProjectStore();
     const { addToast } = useToastStore();
     const syncInfo = useProjectSyncStore((s) => s.projects[projectId]);
     const [exporting, setExporting] = useState(false);
@@ -88,6 +92,31 @@ export function ExportModal({ projectId, onClose }: ExportModalProps) {
         .map(meta => coreArtifacts.find(a => a.subtype === meta.subtype))
         .filter((a): a is Artifact => Boolean(a));
 
+    // --- Version manifest + staleness (what exactly is being exported) ------
+    const spines = getSpineVersions(projectId);
+    const spineLabelOf = (spineId?: string): string | undefined => {
+        if (!spineId) return undefined;
+        const idx = spines.findIndex(s => s.id === spineId);
+        return idx >= 0 ? `Version ${idx + 1}` : undefined;
+    };
+    const manifestEntries: ExportManifestEntry[] = [...orderedCoreArtifacts, ...mockupArtifacts].map(a => {
+        const preferred = getArtifactVersions(projectId, a.id).find(v => v.isPreferred);
+        return {
+            title: displayTitle(a),
+            versionNumber: preferred?.versionNumber,
+            generatedFromPrdLabel: spineLabelOf(
+                preferred?.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId,
+            ),
+            staleness: getArtifactStaleness(projectId, a.id),
+        };
+    });
+    const manifest = buildExportManifest({
+        projectName: project?.name || 'project',
+        prdLabel: spineLabelOf(latestSpine?.id),
+        entries: manifestEntries,
+    });
+    const staleTitles = manifestEntries.filter(e => e.staleness !== 'current').map(e => e.title);
+
     const exportPRD = () => {
         if (!latestSpine) return;
         downloadFile(latestSpine.responseText, `${project?.name || 'project'}-prd.md`);
@@ -107,6 +136,7 @@ export function ExportModal({ projectId, onClose }: ExportModalProps) {
         if (!latestSpine?.structuredPRD) return;
         const data = {
             project: project,
+            manifest,
             structuredPRD: latestSpine.structuredPRD,
             artifacts: orderedCoreArtifacts.map(a => {
                 const versions = getArtifactVersions(projectId, a.id);
@@ -133,7 +163,7 @@ export function ExportModal({ projectId, onClose }: ExportModalProps) {
     };
 
     const buildFullBundle = (): string => {
-        const sections: string[] = [];
+        const sections: string[] = [renderManifestMarkdown(manifest), '\n---\n'];
         if (latestSpine) {
             sections.push('# Product Requirements Document\n', latestSpine.responseText, '\n---\n');
         }
@@ -155,6 +185,7 @@ export function ExportModal({ projectId, onClose }: ExportModalProps) {
         buildAgentHandoff({
             projectName: project?.name || 'This product',
             prdMarkdown: latestSpine?.responseText,
+            manifestMarkdown: renderManifestMarkdown(manifest),
             artifacts: orderedCoreArtifacts.map(a => ({
                 subtype: a.subtype ?? '',
                 title: displayTitle(a),
@@ -209,6 +240,25 @@ export function ExportModal({ projectId, onClose }: ExportModalProps) {
                                         {recoverySaved ? <Check size={12} /> : <Download size={12} />}
                                         {recoverySaved ? 'Recovery bundle saved' : 'Download recovery bundle'}
                                     </button>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {manifest.staleCount > 0 && (
+                        <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-amber-900">
+                            <div className="flex items-start gap-2">
+                                <AlertTriangle size={15} className="mt-0.5 shrink-0 text-amber-600" />
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-sm font-medium">
+                                        {manifest.staleCount} asset{manifest.staleCount === 1 ? '' : 's'} may be out of
+                                        date with the current PRD
+                                    </p>
+                                    <p className="mt-0.5 text-xs text-amber-800">
+                                        {staleTitles.join(', ')} — exports include each asset&rsquo;s latest saved
+                                        version and note this in the export manifest. Review them in Project Map →
+                                        Dependency Graph first, or export anyway.
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -17,6 +17,7 @@ const EVENT_CONFIG: Record<HistoryEventType, { icon: typeof Clock; color: string
     GenerationFailed: { icon: XCircle, color: 'text-red-600', bgColor: 'bg-red-50' },
     Edited: { icon: Pencil, color: 'text-violet-600', bgColor: 'bg-violet-50' },
     Reverted: { icon: RotateCcw, color: 'text-amber-600', bgColor: 'bg-amber-50' },
+    MarkedCurrent: { icon: CheckCircle, color: 'text-emerald-600', bgColor: 'bg-emerald-50' },
 };
 
 export function HistoryView({ projectId }: HistoryViewProps) {

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -33,7 +33,18 @@ import { FinalizationSuccessModal } from './FinalizationSuccessModal';
 import { DesignSystemPresetChoice } from './DesignSystemPresetChoice';
 import { CORE_ARTIFACT_DISPLAY_ORDER, isHiddenArtifactSubtype, isRetiredArtifactSubtype } from '../lib/coreArtifactPipeline';
 import { HistoryView } from './HistoryView';
-import { VersionHistoryPanel, VersionCompareView, RevertConfirmModal, type VersionEntry } from './versions';
+import { VersionHistoryPanel, VersionCompareView, RevertConfirmModal, UpdateAssetsPlanModal, type VersionEntry, type UpdatePlanChoice, type UpdatePlanRow } from './versions';
+import {
+    buildArtifactDependencyGraph,
+    computeRecommendedUpdates,
+    evaluateDependencyGraph,
+    expandSelectionWithTroubledUpstreams,
+    type DependencyEvaluationInput,
+    type DependencyNodeId,
+    type DependencyNodeStatus,
+} from '../lib/artifactDependencyGraph';
+import { findFeatureReferences, makeSpineChangeResolver, summarizeSpineChange } from '../lib/spineChangeAnalysis';
+import { selectPreferredDesignSystem } from '../lib/designTokens';
 import { ExportModal } from './ExportModal';
 import { SnapshotsPanel } from './SnapshotsPanel';
 import { FeedbackItemsList } from './FeedbackItemsList';
@@ -41,7 +52,7 @@ import { BranchCanvas } from './BranchCanvas';
 import { artifactJobController } from '../lib/services/artifactJobController';
 import { SECTION_TITLES } from '../lib/prompts/prdSectionPrompts';
 import type { SectionId } from '../lib/schemas/prdSchemas';
-import type { Branch, PipelineStage, FeedbackItem } from '../types';
+import type { ArtifactSlotKey, Branch, PipelineStage, FeedbackItem } from '../types';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
 import { ProjectCloudStatus, ProjectConflictBanner } from './sync/ProjectSyncStatus';
 
@@ -50,7 +61,7 @@ export function ProjectWorkspace() {
     const navigate = useNavigate();
     const authUser = useAuthStore((s) => s.user);
     const logout = useAuthStore((s) => s.logout);
-    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, editSpineStructuredPRD, revertSpineToVersion, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, getArtifactStaleness, markSpineFinal, setProjectStage, setProjectDesignSystemPreset, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, getArtifacts, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus } = useProjectStore();
+    const { getProject, getLatestSpine, regenerateSpine, updateSpineStructuredPRD, editSpineStructuredPRD, revertSpineToVersion, updateProjectProductMetadata, setSpineError, setSpineSafetyReview, getHistoryEvents, getBranchesForSpine, getSpineVersions, getArtifactStaleness, markSpineFinal, setProjectStage, setProjectDesignSystemPreset, createBranch: storCreateBranch, updateFeedbackStatus, getArtifact, getArtifactVersions, getArtifacts, appendPrdProgress, clearPrdProgress, clearSectionStatus, setSectionStatus, markArtifactCurrentForSpine } = useProjectStore();
     const prdProgress = useProjectStore((s) => (projectId ? s.prdProgress[projectId] : undefined));
     const prdSectionStatus = useProjectStore((s) => (projectId ? s.prdSectionStatus[projectId] : undefined));
     // Live asset-generation job for the post-finalize status pill.
@@ -89,6 +100,15 @@ export function ProjectWorkspace() {
     // Carries the incomplete-PRD acknowledgement across the design-preset gate
     // (which can interpose between acknowledgement and finalize).
     const pendingIncompleteAck = useRef(false);
+    // Update Assets plan — shown on the re-finalize edge when downstream
+    // assets already exist, replacing the old silent full regeneration.
+    // Cancel aborts the finalize entirely (the spine stays non-final).
+    const [updatePlan, setUpdatePlan] = useState<null | {
+        rows: UpdatePlanRow[];
+        changeHeadline?: string;
+        baselineLabel?: string;
+        ack: boolean;
+    }>(null);
     const overflowRef = useRef<HTMLDivElement>(null);
     const overflowButtonRef = useRef<HTMLButtonElement>(null);
     const overflowMenuRef = useRef<HTMLDivElement>(null);
@@ -563,10 +583,190 @@ export function ProjectWorkspace() {
         finalizeAndGenerate(ackIncomplete);
     };
 
+    // --- Update Assets plan (re-finalize with existing assets) --------------
+    // Evaluate the dependency graph against the spine being finalized, exactly
+    // like DependencyGraphView does, so the plan dialog shows the same
+    // statuses/reasons the Project Map would.
+    const buildUpdatePlanContext = () => {
+        if (!projectId || !activeSpine?.structuredPRD) return null;
+        const store = useProjectStore.getState();
+        const graph = buildArtifactDependencyGraph();
+        const spines = store.spineVersions[projectId] || [];
+        const projectArtifacts = store.artifacts[projectId] || [];
+        const mockupArtifact = projectArtifacts.find(a => a.type === 'mockup');
+
+        const snapshots: DependencyEvaluationInput['snapshots'] = {};
+        const artifactIdBySlot: Partial<Record<ArtifactSlotKey, string>> = {};
+        const contentBySlot: Partial<Record<ArtifactSlotKey, string>> = {};
+        for (const node of graph.nodes) {
+            if (node.id === 'prd') continue;
+            const slotKey = node.id as ArtifactSlotKey;
+            const artifact = slotKey === 'mockup'
+                ? mockupArtifact
+                : projectArtifacts.find(a => a.type === 'core_artifact' && a.subtype === slotKey && a.status !== 'archived');
+            const preferred = artifact ? store.getPreferredVersion(projectId, artifact.id) : undefined;
+            if (artifact && preferred) {
+                artifactIdBySlot[slotKey] = artifact.id;
+                contentBySlot[slotKey] = preferred.content;
+                snapshots[slotKey] = {
+                    artifactId: artifact.id,
+                    version: {
+                        id: preferred.id,
+                        versionNumber: preferred.versionNumber,
+                        createdAt: preferred.createdAt,
+                        sourceRefs: preferred.sourceRefs,
+                        provenance: preferred.provenance,
+                        metadata: preferred.metadata,
+                    },
+                };
+            }
+        }
+
+        const evaluations = evaluateDependencyGraph(graph, {
+            spineVersionIds: spines.map(s => s.id),
+            latestSpineId: activeSpine.id,
+            currentDesignTokensHash: selectPreferredDesignSystem(store, projectId)?.tokensHash,
+            snapshots,
+            spineChangeFor: makeSpineChangeResolver(spines, activeSpine.id),
+        });
+
+        return { graph, evaluations, snapshots, artifactIdBySlot, contentBySlot, spines };
+    };
+
+    const PLAN_STATUS_LABELS: Record<DependencyNodeStatus, string> = {
+        source: 'Source of truth',
+        up_to_date: 'Up to date',
+        needs_update: 'Needs update',
+        update_recommended: 'Update recommended',
+        generating: 'Generating…',
+        error: 'Failed',
+        missing: 'Not generated',
+    };
+
+    const openUpdatePlan = (ctx: NonNullable<ReturnType<typeof buildUpdatePlanContext>>, ack: boolean) => {
+        if (!activeSpine) return;
+        const recommended = new Set(computeRecommendedUpdates(ctx.graph, ctx.evaluations));
+        const rows: UpdatePlanRow[] = ctx.graph.nodes
+            .filter(n => n.id !== 'prd')
+            .map(node => {
+                const ev = ctx.evaluations.get(node.id);
+                const status = ev?.status ?? 'missing';
+                const summary = ev?.reasons.find(r => r.kind === 'prd_changed')?.changeSummary;
+                const content = ctx.contentBySlot[node.id as ArtifactSlotKey] ?? '';
+                const removedFeatureNames = summary && content
+                    ? summary.features.removed
+                        .filter(f => findFeatureReferences(f, [{ artifactId: node.id, title: node.title, content }]).length > 0)
+                        .map(f => f.name)
+                    : [];
+                return {
+                    id: node.id,
+                    title: node.title,
+                    statusLabel: PLAN_STATUS_LABELS[status],
+                    isStale: recommended.has(node.id),
+                    changeHeadline: summary
+                        ? `Since ${ev?.prdVersionLabel ?? 'generation'}: ${summary.headline}`
+                        : undefined,
+                    removedFeatureNames,
+                    likelyUnaffected: ev?.likelyUnaffected,
+                    defaultChoice: recommended.has(node.id) ? 'update' as const : 'skip' as const,
+                    canMarkCurrent: !!ctx.artifactIdBySlot[node.id as ArtifactSlotKey]
+                        && (status === 'needs_update' || status === 'update_recommended'),
+                };
+            });
+
+        // Header "what changed": compare against the newest spine any asset was
+        // generated from (assets can span several baselines after repeated edits).
+        let baselineIdx = -1;
+        for (const snap of Object.values(ctx.snapshots)) {
+            const refId = snap?.version.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId;
+            if (!refId) continue;
+            const idx = ctx.spines.findIndex(s => s.id === refId);
+            if (idx > baselineIdx && ctx.spines[idx]?.id !== activeSpine.id) baselineIdx = idx;
+        }
+        const baselineSpine = baselineIdx >= 0 ? ctx.spines[baselineIdx] : undefined;
+        const headerSummary = baselineSpine
+            ? summarizeSpineChange(baselineSpine.structuredPRD, activeSpine.structuredPRD)
+            : null;
+
+        setUpdatePlan({
+            rows,
+            changeHeadline: headerSummary?.headline,
+            baselineLabel: baselineSpine ? `since Version ${baselineIdx + 1}` : undefined,
+            ack,
+        });
+    };
+
+    const handleUpdatePlanConfirm = (choices: Record<string, UpdatePlanChoice>) => {
+        if (!projectId || !activeSpine?.structuredPRD || !updatePlan) return;
+        // Finalize first — the durable record every path below depends on.
+        markSpineFinal(projectId, activeSpine.id, true);
+
+        // Re-evaluate against fresh store state (the dialog may have been open
+        // a while), then apply mark-current BEFORE regeneration so a confirmed
+        // upstream is healthy when its dependents regenerate.
+        const ctx = buildUpdatePlanContext();
+        if (ctx) {
+            const marked = Object.entries(choices)
+                .filter(([, c]) => c === 'mark_current')
+                .map(([id]) => id as DependencyNodeId);
+            for (const slot of marked) {
+                const artifactId = ctx.artifactIdBySlot[slot as ArtifactSlotKey];
+                if (!artifactId) continue;
+                try {
+                    markArtifactCurrentForSpine(projectId, artifactId, activeSpine.id);
+                } catch {
+                    // No preferred version — nothing to confirm; leave as-is.
+                }
+            }
+
+            const selected = Object.entries(choices)
+                .filter(([, c]) => c === 'update')
+                .map(([id]) => id as DependencyNodeId);
+            if (selected.length > 0) {
+                // Pull in troubled visible upstreams the user left unselected —
+                // regenerating a dependent against a stale input would rebuild
+                // from stale context (marked-current upstreams count as healed).
+                const batch = expandSelectionWithTroubledUpstreams(
+                    ctx.graph, ctx.evaluations, selected, new Set(marked),
+                );
+                artifactJobController.regenerateSlots(
+                    batch.filter((id): id is ArtifactSlotKey => id !== 'prd'),
+                    {
+                        projectId,
+                        spineVersionId: activeSpine.id,
+                        prdContent: activeSpine.responseText,
+                        structuredPRD: activeSpine.structuredPRD,
+                        projectPlatform: project?.platform,
+                        acknowledgeIncomplete: updatePlan.ack,
+                    },
+                );
+            }
+        }
+        setUpdatePlan(null);
+        setShowFinalizeSuccess(true);
+    };
+
     // Performs the actual finalize + asset kickoff. Split out so it can run
     // either directly (preset already chosen / demo) or after the preset gate.
     const finalizeAndGenerate = (ackIncomplete: boolean) => {
         if (!projectId || !activeSpine) return;
+
+        // Re-finalize with existing assets: route through the Update Assets
+        // plan instead of blindly regenerating everything. First finalize (no
+        // assets yet), the demo, and mid-run finalizes keep the direct path.
+        if (activeSpine.structuredPRD && projectId !== DEMO_PROJECT_ID) {
+            const jobActive = !!assetJob && Object.values(assetJob.slots).some(
+                s => s && (s.status === 'generating' || s.status === 'queued'),
+            );
+            if (!jobActive) {
+                const ctx = buildUpdatePlanContext();
+                if (ctx && Object.keys(ctx.snapshots).length > 0) {
+                    openUpdatePlan(ctx, ackIncomplete);
+                    return; // not finalized yet — the plan dialog owns it
+                }
+            }
+        }
+
         markSpineFinal(projectId, activeSpine.id, true);
 
         // Kick off artifact generation immediately so assets are underway
@@ -816,6 +1016,16 @@ export function ProjectWorkspace() {
                 <DesignSystemPresetChoice
                     onChoose={handleChooseDesignSystemPreset}
                     onClose={() => setShowPresetChoice(false)}
+                />
+            )}
+            {updatePlan && activeSpine && (
+                <UpdateAssetsPlanModal
+                    prdLabel={getVersionLabel(activeSpine.id)}
+                    changeHeadline={updatePlan.changeHeadline}
+                    baselineLabel={updatePlan.baselineLabel}
+                    rows={updatePlan.rows}
+                    onConfirm={handleUpdatePlanConfirm}
+                    onCancel={() => setUpdatePlan(null)}
                 />
             )}
             {showFinalizeSuccess && (

--- a/src/components/StalenessBadge.tsx
+++ b/src/components/StalenessBadge.tsx
@@ -2,6 +2,8 @@ import type { StalenessState } from '../types';
 
 interface StalenessBadgeProps {
     staleness: StalenessState;
+    /** Optional "what changed" tooltip shown on hover (native title). */
+    detail?: string;
 }
 
 const config: Record<StalenessState, { label: string; className: string }> = {
@@ -19,13 +21,16 @@ const config: Record<StalenessState, { label: string; className: string }> = {
     },
 };
 
-export function StalenessBadge({ staleness }: StalenessBadgeProps) {
+export function StalenessBadge({ staleness, detail }: StalenessBadgeProps) {
     if (staleness === 'current') return null;
 
     const { label, className } = config[staleness];
 
     return (
-        <span className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${className}`}>
+        <span
+            className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${className} ${detail ? 'cursor-help' : ''}`}
+            title={detail}
+        >
             {label}
         </span>
     );

--- a/src/components/__tests__/UpdateAssetsPlanModal.test.tsx
+++ b/src/components/__tests__/UpdateAssetsPlanModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UpdateAssetsPlanModal, type UpdatePlanRow } from '../versions/UpdateAssetsPlanModal';
+
+const rows: UpdatePlanRow[] = [
+    {
+        id: 'design_system',
+        title: 'Design System',
+        statusLabel: 'Needs update',
+        isStale: true,
+        changeHeadline: 'Since Version 1: 1 feature removed',
+        likelyUnaffected: true,
+        defaultChoice: 'update',
+        canMarkCurrent: true,
+    },
+    {
+        id: 'data_model',
+        title: 'Data Model',
+        statusLabel: 'Up to date',
+        isStale: false,
+        defaultChoice: 'skip',
+        canMarkCurrent: false,
+    },
+    {
+        id: 'mockup',
+        title: 'Mockups',
+        statusLabel: 'Needs update',
+        isStale: true,
+        removedFeatureNames: ['Team Chat'],
+        defaultChoice: 'update',
+        canMarkCurrent: true,
+    },
+];
+
+const setup = () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+        <UpdateAssetsPlanModal
+            prdLabel="Version 2"
+            changeHeadline="1 feature removed · Architecture changed"
+            baselineLabel="since Version 1"
+            rows={rows}
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+        />,
+    );
+    return { onConfirm, onCancel };
+};
+
+describe('UpdateAssetsPlanModal', () => {
+    it('shows the change summary, per-row detail, and removed-feature warnings', () => {
+        setup();
+        expect(screen.getByText(/Update assets for PRD Version 2/)).toBeTruthy();
+        expect(screen.getByText(/1 feature removed · Architecture changed/)).toBeTruthy();
+        expect(screen.getByText(/Since Version 1: 1 feature removed/)).toBeTruthy();
+        expect(screen.getByText('Team Chat')).toBeTruthy();
+    });
+
+    it('confirms with the default choices (recommended rows regenerate)', () => {
+        const { onConfirm } = setup();
+        fireEvent.click(screen.getByText(/Finalize & regenerate 2/));
+        expect(onConfirm).toHaveBeenCalledWith({
+            design_system: 'update',
+            data_model: 'skip',
+            mockup: 'update',
+        });
+    });
+
+    it('lets the user switch a row to mark-current and reflects it in the confirm payload', () => {
+        const { onConfirm } = setup();
+        // First row's "Mark up to date" segment.
+        fireEvent.click(screen.getAllByText('Mark up to date')[0]);
+        fireEvent.click(screen.getByText(/Finalize & regenerate 1 · keep 1/));
+        expect(onConfirm).toHaveBeenCalledWith({
+            design_system: 'mark_current',
+            data_model: 'skip',
+            mockup: 'update',
+        });
+    });
+
+    it('disables mark-current where there is nothing to confirm and cancel aborts', () => {
+        const { onCancel, onConfirm } = setup();
+        const markButtons = screen.getAllByText('Mark up to date');
+        // data_model row (index 1) cannot be marked current.
+        expect((markButtons[1] as HTMLButtonElement).disabled).toBe(true);
+        fireEvent.click(screen.getByText('Cancel'));
+        expect(onCancel).toHaveBeenCalled();
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/dependency/DependencyGraphView.tsx
+++ b/src/components/dependency/DependencyGraphView.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import {
     AlertTriangle, AppWindow, ArrowRight, CheckCircle2, ChevronDown, ChevronUp, Circle,
     Code2, Database, ExternalLink, FileText, Image, Info, Loader2, Package, Palette,
-    PencilLine, RefreshCcw, Waypoints, X,
+    PencilLine, RefreshCcw, ShieldCheck, Waypoints, X,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { artifactJobController } from '../../lib/services/artifactJobController';
@@ -22,6 +22,7 @@ import {
     type DependencyNodeId,
     type DependencyNodeStatus,
 } from '../../lib/artifactDependencyGraph';
+import { findFeatureReferences, makeSpineChangeResolver } from '../../lib/spineChangeAnalysis';
 import type {
     ArtifactSlotKey, GenerationStatus, ProjectPlatform, StructuredPRD,
 } from '../../types';
@@ -158,12 +159,20 @@ export function DependencyGraphView({
                     createdAt: preferred.createdAt,
                     sourceRefs: preferred.sourceRefs,
                     provenance: preferred.provenance,
+                    metadata: preferred.metadata,
                 },
             };
         }
         const live = job?.slots[slotKey]?.status;
         if (live && live !== 'idle') slotStatus[slotKey] = live;
     }
+
+    // Change-aware staleness: resolves "what changed since spine X" against
+    // the latest spine (memoized per spine pair inside the resolver).
+    const spineChangeFor = useMemo(
+        () => makeSpineChangeResolver(spines, latestSpine?.id),
+        [spines, latestSpine?.id],
+    );
 
     const evaluations = evaluateDependencyGraph(graph, {
         spineVersionIds: spines.map(s => s.id),
@@ -172,6 +181,7 @@ export function DependencyGraphView({
         currentDesignTokensHash: currentDesign?.tokensHash,
         snapshots,
         slotStatus,
+        spineChangeFor,
     });
 
     const recommendedUpdates = computeRecommendedUpdates(graph, evaluations);
@@ -250,6 +260,35 @@ export function DependencyGraphView({
     }
 
     const selectedEval = selectedId ? evalOf(selectedId) : undefined;
+
+    // "Mark as up to date" — the user asserts the artifact is still valid for
+    // the current PRD; the store appends a rebased clone (honest history).
+    const canMarkCurrent = (id: DependencyNodeId): boolean => {
+        const ev = evalOf(id);
+        return !!latestSpine
+            && artifactIdByNode.has(id)
+            && (ev?.status === 'needs_update' || ev?.status === 'update_recommended');
+    };
+    const markCurrentNode = (id: DependencyNodeId) => {
+        const artifactId = artifactIdByNode.get(id);
+        if (!artifactId || !latestSpine) return;
+        useProjectStore.getState().markArtifactCurrentForSpine(projectId, artifactId, latestSpine.id);
+    };
+
+    // Removed features (per the selected node's PRD change summary) that the
+    // artifact's current content still mentions — the deletion blast radius.
+    const selectedRemovedFeatureRefs: string[] = (() => {
+        if (!selectedId || selectedId === 'prd' || !selectedEval) return [];
+        const summary = selectedEval.reasons.find(r => r.kind === 'prd_changed')?.changeSummary;
+        if (!summary || summary.features.removed.length === 0) return [];
+        const artifactId = artifactIdByNode.get(selectedId);
+        const content = artifactId ? getPreferredVersion(projectId, artifactId)?.content ?? '' : '';
+        if (!content) return [];
+        const candidate = [{ artifactId: artifactId!, title: titleOf(selectedId), content }];
+        return summary.features.removed
+            .filter(f => findFeatureReferences(f, candidate).length > 0)
+            .map(f => f.name);
+    })();
 
     return (
         <div className="max-w-5xl mx-auto space-y-4">
@@ -444,6 +483,8 @@ export function DependencyGraphView({
                     onOpenNode={onOpenNode}
                     onUpdate={() => confirmSingleUpdate(selectedId)}
                     onUpdateImpacted={() => confirmImpactedUpdate(selectedId)}
+                    onMarkCurrent={canMarkCurrent(selectedId) ? () => markCurrentNode(selectedId) : undefined}
+                    removedFeatureRefs={selectedRemovedFeatureRefs}
                     jobActive={jobActive}
                     titleOf={titleOf}
                     history={
@@ -621,9 +662,16 @@ function ImpactModePanel({ graph, evaluations, selectedId, onSelect, titleOf }: 
             {ev && ev.reasons.length > 0 && (
                 <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
                     <div className="text-sm font-semibold text-amber-900 mb-1">Why update?</div>
-                    <ul className="space-y-1">
+                    <ul className="space-y-1.5">
                         {ev.reasons.map((r, i) => (
-                            <li key={i} className="text-xs text-amber-800 leading-relaxed">{r.detail}</li>
+                            <li key={i} className="text-xs text-amber-800 leading-relaxed">
+                                {r.detail}
+                                {r.changeSummary && (
+                                    <span className="block mt-0.5 font-medium text-amber-900">
+                                        What changed: {r.changeSummary.headline}
+                                    </span>
+                                )}
+                            </li>
                         ))}
                     </ul>
                 </div>
@@ -671,6 +719,10 @@ interface DetailPanelProps {
     onOpenNode: (id: DependencyNodeId) => void;
     onUpdate: () => void;
     onUpdateImpacted: () => void;
+    /** Present only when the node is stale and can be confirmed current. */
+    onMarkCurrent?: () => void;
+    /** Removed-feature names this artifact's content still mentions. */
+    removedFeatureRefs: string[];
     jobActive: boolean;
     titleOf: (id: DependencyNodeId) => string;
     history: HistoryEntry[];
@@ -688,7 +740,8 @@ const CHANGE_SOURCE_LABELS: Record<string, string> = {
 
 function DetailPanel({
     nodeId, evaluation, graph, evaluations, tab, onTabChange, onClose, onSelect,
-    onOpenNode, onUpdate, onUpdateImpacted, jobActive, titleOf, history,
+    onOpenNode, onUpdate, onUpdateImpacted, onMarkCurrent, removedFeatureRefs,
+    jobActive, titleOf, history,
 }: DetailPanelProps) {
     const node = getDependencyNode(graph, nodeId);
     const Icon = NODE_ICONS[nodeId] ?? Package;
@@ -755,6 +808,16 @@ function DetailPanel({
                     >
                         <ExternalLink size={12} /> Open
                     </button>
+                    {onMarkCurrent && (
+                        <button
+                            type="button"
+                            onClick={onMarkCurrent}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-emerald-50 border border-emerald-200 text-emerald-700 rounded-md hover:bg-emerald-100 transition"
+                            title="Confirm this artifact is still valid for the current PRD without regenerating it"
+                        >
+                            <ShieldCheck size={12} /> Mark up to date
+                        </button>
+                    )}
                     {canUpdate && (
                         <button
                             type="button"
@@ -838,11 +901,32 @@ function DetailPanel({
                             {evaluation.reasons.length > 0 ? (
                                 <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
                                     <div className="text-sm font-semibold text-amber-900 mb-1">Why update?</div>
-                                    <ul className="space-y-1">
+                                    <ul className="space-y-1.5">
                                         {evaluation.reasons.map((r, i) => (
-                                            <li key={i} className="text-xs text-amber-800 leading-relaxed">{r.detail}</li>
+                                            <li key={i} className="text-xs text-amber-800 leading-relaxed">
+                                                {r.detail}
+                                                {r.changeSummary && (
+                                                    <span className="block mt-0.5 font-medium text-amber-900">
+                                                        What changed: {r.changeSummary.headline}
+                                                    </span>
+                                                )}
+                                            </li>
                                         ))}
                                     </ul>
+                                    {removedFeatureRefs.length > 0 && (
+                                        <p className="mt-2 pt-2 border-t border-amber-200 text-xs text-red-700 leading-relaxed">
+                                            Still references removed feature{removedFeatureRefs.length === 1 ? '' : 's'}:{' '}
+                                            <span className="font-semibold">{removedFeatureRefs.join(', ')}</span> —
+                                            regenerate this artifact so deleted features stop appearing in it.
+                                        </p>
+                                    )}
+                                    {evaluation.likelyUnaffected && removedFeatureRefs.length === 0 && (
+                                        <p className="mt-2 pt-2 border-t border-amber-200 text-xs text-neutral-600 leading-relaxed">
+                                            The PRD sections this asset chiefly derives from did not change —
+                                            if it still looks right, you can <span className="font-medium">mark it up to date</span> instead
+                                            of regenerating.
+                                        </p>
+                                    )}
                                 </div>
                             ) : nodeId !== 'prd' && evaluation.status === 'up_to_date' && !impacted ? (
                                 <div className="rounded-lg border border-green-200 bg-green-50 p-3">

--- a/src/components/versions/UpdateAssetsPlanModal.tsx
+++ b/src/components/versions/UpdateAssetsPlanModal.tsx
@@ -1,0 +1,212 @@
+// Update Assets plan — shown on the re-finalize edge when downstream assets
+// already exist. Replaces the old silent "regenerate everything" funnel with a
+// surgical, per-asset decision: Regenerate / Mark up to date / Decide later.
+// Presentational: the caller builds the rows (from the dependency-graph
+// evaluation + spine change summary) and executes the confirmed choices.
+
+import { useState } from 'react';
+import { AlertTriangle, RefreshCcw, ShieldCheck, X } from 'lucide-react';
+
+export type UpdatePlanChoice = 'update' | 'mark_current' | 'skip';
+
+export interface UpdatePlanRow {
+    /** Artifact slot key ('design_system', 'mockup', …). */
+    id: string;
+    title: string;
+    /** Human status ("Needs update", "Up to date", "Not generated", …). */
+    statusLabel: string;
+    /** True when the asset is stale/missing/errored (drives row emphasis). */
+    isStale: boolean;
+    /** What changed upstream, when known ("1 feature removed · …"). */
+    changeHeadline?: string;
+    /** Removed-feature names this asset's content still mentions. */
+    removedFeatureNames?: string[];
+    /** Advisory: the changed PRD sections aren't ones this asset derives from. */
+    likelyUnaffected?: boolean;
+    defaultChoice: UpdatePlanChoice;
+    /** False when there is nothing to confirm (missing/errored/up-to-date). */
+    canMarkCurrent: boolean;
+}
+
+interface UpdateAssetsPlanModalProps {
+    /** Positional label of the PRD version being finalized ("Version 3"). */
+    prdLabel: string;
+    /** Headline of what changed since the assets' baseline PRD version. */
+    changeHeadline?: string;
+    /** "since Version 2" — the baseline the headline compares against. */
+    baselineLabel?: string;
+    rows: UpdatePlanRow[];
+    /** Finalize + apply the choices. Keys are row ids. */
+    onConfirm: (choices: Record<string, UpdatePlanChoice>) => void;
+    /** Abort — the PRD is NOT finalized. */
+    onCancel: () => void;
+}
+
+const CHOICE_LABELS: Record<UpdatePlanChoice, string> = {
+    update: 'Regenerate',
+    mark_current: 'Mark up to date',
+    skip: 'Decide later',
+};
+
+export function UpdateAssetsPlanModal({
+    prdLabel, changeHeadline, baselineLabel, rows, onConfirm, onCancel,
+}: UpdateAssetsPlanModalProps) {
+    const [choices, setChoices] = useState<Record<string, UpdatePlanChoice>>(
+        () => Object.fromEntries(rows.map(r => [r.id, r.defaultChoice])),
+    );
+
+    const setChoice = (id: string, choice: UpdatePlanChoice) =>
+        setChoices(prev => ({ ...prev, [id]: choice }));
+
+    const updateCount = rows.filter(r => choices[r.id] === 'update').length;
+    const keepCount = rows.filter(r => choices[r.id] === 'mark_current').length;
+    const skipStaleCount = rows.filter(r => r.isStale && choices[r.id] === 'skip').length;
+
+    const confirmLabel = updateCount > 0
+        ? `Finalize & regenerate ${updateCount}${keepCount > 0 ? ` · keep ${keepCount}` : ''}`
+        : keepCount > 0
+            ? `Finalize & keep ${keepCount} current`
+            : 'Finalize only';
+
+    return (
+        <div
+            className="fixed inset-0 z-50 bg-black/40 flex items-end md:items-center justify-center p-4"
+            onClick={onCancel}
+            role="presentation"
+        >
+            <div
+                className="bg-white rounded-xl shadow-xl border border-neutral-200 w-full max-w-lg max-h-[90vh] flex flex-col overflow-hidden"
+                onClick={e => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="update-plan-title"
+            >
+                <div className="px-5 pt-5 pb-3 shrink-0">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                            <h3 id="update-plan-title" className="text-base font-bold text-neutral-900">
+                                Update assets for PRD {prdLabel}?
+                            </h3>
+                            <p className="text-sm text-neutral-600 mt-1">
+                                Your assets were generated from an earlier PRD version. Choose what to
+                                do with each — nothing is deleted, and current versions stay in history.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            aria-label="Cancel finalize"
+                            className="p-1.5 text-neutral-400 hover:text-neutral-700 transition shrink-0"
+                        >
+                            <X size={16} />
+                        </button>
+                    </div>
+                    {changeHeadline && (
+                        <div className="mt-3 rounded-lg border border-indigo-200 bg-indigo-50 p-3">
+                            <div className="text-xs font-semibold text-indigo-900">
+                                What changed{baselineLabel ? ` ${baselineLabel}` : ''}
+                            </div>
+                            <p className="text-xs text-indigo-800 mt-0.5 leading-relaxed">{changeHeadline}</p>
+                        </div>
+                    )}
+                </div>
+
+                <div className="px-5 space-y-2 overflow-y-auto min-h-0">
+                    {rows.map(row => {
+                        const choice = choices[row.id];
+                        return (
+                            <div
+                                key={row.id}
+                                className={`rounded-lg border p-3 ${row.isStale ? 'border-amber-200 bg-amber-50/50' : 'border-neutral-200'}`}
+                            >
+                                <div className="flex items-center justify-between gap-2 flex-wrap">
+                                    <span className="text-sm font-semibold text-neutral-900">{row.title}</span>
+                                    <span className={`text-[11px] px-2 py-0.5 rounded-full border font-medium ${
+                                        row.isStale
+                                            ? 'bg-amber-50 text-amber-800 border-amber-300'
+                                            : 'bg-green-50 text-green-700 border-green-200'
+                                    }`}>
+                                        {row.statusLabel}
+                                    </span>
+                                </div>
+                                {row.changeHeadline && (
+                                    <p className="text-[11px] text-neutral-600 mt-1 leading-relaxed">
+                                        {row.changeHeadline}
+                                    </p>
+                                )}
+                                {row.removedFeatureNames && row.removedFeatureNames.length > 0 && (
+                                    <p className="text-[11px] text-red-700 mt-1 leading-relaxed">
+                                        Still references removed feature{row.removedFeatureNames.length === 1 ? '' : 's'}:{' '}
+                                        <span className="font-semibold">{row.removedFeatureNames.join(', ')}</span>
+                                    </p>
+                                )}
+                                {row.likelyUnaffected && (
+                                    <p className="text-[11px] text-neutral-500 mt-1 leading-relaxed">
+                                        The changed PRD sections aren&rsquo;t ones this asset chiefly derives from.
+                                    </p>
+                                )}
+                                <div className="mt-2 inline-flex rounded-lg border border-neutral-200 p-0.5 bg-white">
+                                    {(['update', 'mark_current', 'skip'] as UpdatePlanChoice[]).map(c => {
+                                        const disabled = c === 'mark_current' && !row.canMarkCurrent;
+                                        return (
+                                            <button
+                                                key={c}
+                                                type="button"
+                                                disabled={disabled}
+                                                onClick={() => setChoice(row.id, c)}
+                                                className={`px-2.5 py-1 text-[11px] font-medium rounded-md transition ${
+                                                    choice === c
+                                                        ? c === 'update'
+                                                            ? 'bg-indigo-600 text-white'
+                                                            : c === 'mark_current'
+                                                                ? 'bg-emerald-600 text-white'
+                                                                : 'bg-neutral-600 text-white'
+                                                        : disabled
+                                                            ? 'text-neutral-300 cursor-not-allowed'
+                                                            : 'text-neutral-600 hover:text-neutral-900'
+                                                }`}
+                                            >
+                                                {CHOICE_LABELS[c]}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="px-5 py-4 shrink-0 space-y-2">
+                    {skipStaleCount > 0 && (
+                        <p className="flex items-start gap-1.5 text-[11px] text-amber-700 leading-relaxed">
+                            <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                            {skipStaleCount} asset{skipStaleCount === 1 ? '' : 's'} will stay flagged as
+                            possibly outdated — you can update them later from the Project Map.
+                        </p>
+                    )}
+                    <p className="text-[11px] text-neutral-500 leading-relaxed">
+                        Regeneration runs in dependency order; a stale input of a selected asset is
+                        included automatically so nothing rebuilds from stale context.
+                    </p>
+                    <div className="flex items-center justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            className="px-3 py-1.5 text-sm text-neutral-700 hover:bg-neutral-100 rounded-md transition"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => onConfirm(choices)}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white hover:bg-indigo-700 rounded-md transition"
+                        >
+                            {updateCount > 0 ? <RefreshCcw size={13} /> : <ShieldCheck size={13} />}
+                            {confirmLabel}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/versions/VersionHistoryPanel.tsx
+++ b/src/components/versions/VersionHistoryPanel.tsx
@@ -38,6 +38,7 @@ const SOURCE_LABEL: Record<VersionChangeSource, string> = {
     user_edit: 'Edited',
     revert: 'Restored',
     consistency_review: 'Consistency review',
+    marked_current: 'Confirmed current',
 };
 
 const SOURCE_CLASS: Record<VersionChangeSource, string> = {
@@ -48,6 +49,7 @@ const SOURCE_CLASS: Record<VersionChangeSource, string> = {
     user_edit: 'bg-violet-50 text-violet-700 border-violet-200',
     revert: 'bg-amber-50 text-amber-700 border-amber-200',
     consistency_review: 'bg-teal-50 text-teal-700 border-teal-200',
+    marked_current: 'bg-emerald-50 text-emerald-700 border-emerald-200',
 };
 
 function formatTime(ts: number): string {

--- a/src/components/versions/index.ts
+++ b/src/components/versions/index.ts
@@ -1,3 +1,4 @@
 export { VersionHistoryPanel, type VersionEntry } from './VersionHistoryPanel';
 export { VersionCompareView, type CompareInput } from './VersionCompareView';
 export { RevertConfirmModal } from './RevertConfirmModal';
+export { UpdateAssetsPlanModal, type UpdatePlanChoice, type UpdatePlanRow } from './UpdateAssetsPlanModal';

--- a/src/lib/__tests__/artifactDependencyGraph.test.ts
+++ b/src/lib/__tests__/artifactDependencyGraph.test.ts
@@ -7,6 +7,7 @@ import {
     computeRecommendedUpdates,
     computeUpdateOrder,
     evaluateDependencyGraph,
+    expandSelectionWithTroubledUpstreams,
     getDirectDependencies,
     getDirectDependents,
     type DependencyEvaluationInput,
@@ -470,5 +471,38 @@ describe('change-aware evaluation', () => {
         const evals = evaluateDependencyGraph(graph, input);
         expect(evals.get('screen_inventory')?.manuallyEdited).toBe(true);
         expect(evals.get('data_model')?.manuallyEdited).toBe(false);
+    });
+});
+
+// --- expandSelectionWithTroubledUpstreams -------------------------------------
+
+describe('expandSelectionWithTroubledUpstreams', () => {
+    it('force-includes a stale visible upstream of a selected dependent, in safe order', () => {
+        // PRD drifted: everything needs_update. Selecting only user_flows must
+        // pull in its stale screen_inventory input ahead of it.
+        const input = healthyInput();
+        input.spineVersionIds = [SPINE_V1, SPINE_V2];
+        input.latestSpineId = SPINE_V2;
+        const evals = evaluateDependencyGraph(graph, input);
+        const batch = expandSelectionWithTroubledUpstreams(graph, evals, ['user_flows']);
+        expect(batch).toContain('screen_inventory');
+        expect(batch.indexOf('screen_inventory')).toBeLessThan(batch.indexOf('user_flows'));
+    });
+
+    it('treats healed (marked-current) upstreams as healthy and leaves them out', () => {
+        const input = healthyInput();
+        input.spineVersionIds = [SPINE_V1, SPINE_V2];
+        input.latestSpineId = SPINE_V2;
+        const evals = evaluateDependencyGraph(graph, input);
+        const batch = expandSelectionWithTroubledUpstreams(
+            graph, evals, ['user_flows'], new Set<DependencyNodeId>(['screen_inventory']),
+        );
+        expect(batch).toEqual(['user_flows']);
+    });
+
+    it('leaves healthy upstreams alone and never includes the PRD', () => {
+        const evals = evaluateDependencyGraph(graph, healthyInput());
+        const batch = expandSelectionWithTroubledUpstreams(graph, evals, ['mockup', 'prd']);
+        expect(batch).toEqual(['mockup']);
     });
 });

--- a/src/lib/__tests__/artifactDependencyGraph.test.ts
+++ b/src/lib/__tests__/artifactDependencyGraph.test.ts
@@ -17,7 +17,8 @@ import {
     HIDDEN_ARTIFACT_SUBTYPES,
     RETIRED_ARTIFACT_SUBTYPES,
 } from '../coreArtifactPipeline';
-import type { SourceRef } from '../../types';
+import { summarizeSpineChange, type SpineChangeSummary } from '../spineChangeAnalysis';
+import type { SourceRef, StructuredPRD } from '../../types';
 
 const graph = buildArtifactDependencyGraph();
 
@@ -47,6 +48,7 @@ interface SnapshotOpts {
     createdAt?: number;
     sourceRefs?: SourceRef[];
     manuallyEdited?: boolean;
+    metadata?: Record<string, unknown>;
 }
 
 const snapshot = (nodeId: string, opts: SnapshotOpts = {}) => ({
@@ -57,6 +59,7 @@ const snapshot = (nodeId: string, opts: SnapshotOpts = {}) => ({
         createdAt: opts.createdAt ?? 1000,
         sourceRefs: opts.sourceRefs ?? [spineRef(SPINE_V1)],
         ...(opts.manuallyEdited ? { provenance: { changeSource: 'user_edit' as const } } : {}),
+        ...(opts.metadata ? { metadata: opts.metadata } : {}),
     },
 });
 
@@ -410,5 +413,62 @@ describe('computeRecommendedUpdates', () => {
         // data_model missing → implementation_plan is impacted and included.
         expect(order).toContain('implementation_plan');
         expect(order.indexOf('data_model')).toBeLessThan(order.indexOf('implementation_plan'));
+    });
+});
+
+// --- change-aware evaluation (spineChangeFor) --------------------------------
+
+describe('change-aware evaluation', () => {
+    const basePrd = (overrides: Partial<StructuredPRD> = {}): StructuredPRD => ({
+        vision: 'v',
+        targetUsers: ['u'],
+        coreProblem: 'p',
+        features: [{ id: 'f1', name: 'Feature One', description: 'd', userValue: 'v', complexity: 'low' }],
+        architecture: 'a',
+        risks: ['r'],
+        ...overrides,
+    });
+
+    const prdChangedInput = (summary: SpineChangeSummary): DependencyEvaluationInput => {
+        const input = healthyInput();
+        input.spineVersionIds = [SPINE_V1, SPINE_V2];
+        input.latestSpineId = SPINE_V2;
+        input.spineChangeFor = (from) => (from === SPINE_V1 ? summary : null);
+        return input;
+    };
+
+    it('attaches the change summary to prd_changed reasons; advisory never downgrades the status', () => {
+        // Risks-only change: outside screen_inventory's affinity, inside
+        // implementation_plan's.
+        const summary = summarizeSpineChange(basePrd(), basePrd({ risks: ['r', 'r2'] }));
+        const evals = evaluateDependencyGraph(graph, prdChangedInput(summary));
+
+        const screens = evals.get('screen_inventory')!;
+        expect(screens.status).toBe('needs_update');
+        expect(screens.reasons.find(r => r.kind === 'prd_changed')?.changeSummary).toBe(summary);
+        expect(screens.likelyUnaffected).toBe(true);
+
+        expect(evals.get('implementation_plan')?.likelyUnaffected).toBeUndefined();
+    });
+
+    it('never flags likelyUnaffected when other evidence exists alongside the PRD change', () => {
+        const summary = summarizeSpineChange(basePrd(), basePrd({ risks: ['r', 'r2'] }));
+        const input = prdChangedInput(summary);
+        // Mockup also has design token drift → two reasons → no advisory flag.
+        input.currentDesignTokensHash = 'hash-b';
+        const evals = evaluateDependencyGraph(graph, input);
+        const mockup = evals.get('mockup')!;
+        expect(mockup.reasons.length).toBeGreaterThan(1);
+        expect(mockup.likelyUnaffected).toBeUndefined();
+    });
+
+    it('treats overlay-edited metadata (screenEdits/promptEdits) as manually edited', () => {
+        const input = healthyInput();
+        input.snapshots.screen_inventory = snapshot('screen_inventory', {
+            metadata: { screenEdits: { 'scr-home': { name: 'Home!' } } },
+        });
+        const evals = evaluateDependencyGraph(graph, input);
+        expect(evals.get('screen_inventory')?.manuallyEdited).toBe(true);
+        expect(evals.get('data_model')?.manuallyEdited).toBe(false);
     });
 });

--- a/src/lib/__tests__/exportManifest.test.ts
+++ b/src/lib/__tests__/exportManifest.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { buildExportManifest, renderManifestMarkdown } from '../exportManifest';
+import { buildAgentHandoff } from '../exportHandoff';
+
+const entries = [
+    { title: 'Design System', versionNumber: 2, generatedFromPrdLabel: 'Version 3', staleness: 'current' as const },
+    { title: 'Data Model', versionNumber: 1, generatedFromPrdLabel: 'Version 1', staleness: 'possibly_outdated' as const },
+];
+
+describe('buildExportManifest', () => {
+    it('counts stale entries and stamps a deterministic export time', () => {
+        const manifest = buildExportManifest({
+            projectName: 'Acme',
+            prdLabel: 'Version 3',
+            entries,
+            exportedAt: new Date('2026-07-07T00:00:00Z'),
+        });
+        expect(manifest.staleCount).toBe(1);
+        expect(manifest.exportedAt).toBe('2026-07-07T00:00:00.000Z');
+    });
+});
+
+describe('renderManifestMarkdown', () => {
+    it('renders the version table and a stale warning line', () => {
+        const md = renderManifestMarkdown(buildExportManifest({
+            projectName: 'Acme', prdLabel: 'Version 3', entries,
+        }));
+        expect(md).toContain('## Export Manifest');
+        expect(md).toContain('- PRD: Version 3');
+        expect(md).toContain('| Design System | v2 | Version 3 | Current |');
+        expect(md).toContain('| Data Model | v1 | Version 1 | May be outdated |');
+        expect(md).toContain('1 asset in this export was flagged');
+    });
+
+    it('omits the warning when everything is current', () => {
+        const md = renderManifestMarkdown(buildExportManifest({
+            projectName: 'Acme',
+            entries: [{ title: 'Data Model', versionNumber: 1, staleness: 'current' }],
+        }));
+        expect(md).not.toContain('flagged');
+    });
+});
+
+describe('agent handoff manifest section', () => {
+    it('emits the manifest between the preamble and the PRD', () => {
+        const manifestMarkdown = renderManifestMarkdown(buildExportManifest({
+            projectName: 'Acme', prdLabel: 'Version 2', entries,
+        }));
+        const out = buildAgentHandoff({
+            projectName: 'Acme',
+            prdMarkdown: 'PRD body',
+            manifestMarkdown,
+            artifacts: [],
+        });
+        expect(out.indexOf('## Export Manifest')).toBeGreaterThan(out.indexOf('Build Handoff'));
+        expect(out.indexOf('## Export Manifest')).toBeLessThan(out.indexOf('## Product Requirements'));
+    });
+
+    it('is omitted when not supplied (legacy behavior unchanged)', () => {
+        const out = buildAgentHandoff({ projectName: 'Acme', prdMarkdown: 'PRD body', artifacts: [] });
+        expect(out).not.toContain('## Export Manifest');
+    });
+});

--- a/src/lib/__tests__/spineChangeAnalysis.test.ts
+++ b/src/lib/__tests__/spineChangeAnalysis.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+    diffFeatures,
+    summarizeSpineChange,
+    isLikelyUnaffected,
+    findFeatureReferences,
+    makeSpineChangeResolver,
+} from '../spineChangeAnalysis';
+import type { Feature, StructuredPRD } from '../../types';
+
+const feature = (id: string, name: string, overrides: Partial<Feature> = {}): Feature => ({
+    id,
+    name,
+    description: `${name} description`,
+    userValue: 'value',
+    complexity: 'low',
+    ...overrides,
+});
+
+const basePrd = (overrides: Partial<StructuredPRD> = {}): StructuredPRD => ({
+    vision: 'A tool for teams',
+    targetUsers: ['Managers'],
+    coreProblem: 'Coordination is hard',
+    features: [feature('feat-tasks', 'Task Boards'), feature('feat-chat', 'Team Chat')],
+    architecture: 'Local-first SPA',
+    risks: ['Adoption'],
+    ...overrides,
+});
+
+describe('diffFeatures', () => {
+    it('classifies added, removed, renamed, and changed by stable id', () => {
+        const before = [
+            feature('a', 'Alpha'),
+            feature('b', 'Beta'),
+            feature('c', 'Gamma', { complexity: 'low' }),
+        ];
+        const after = [
+            feature('a', 'Alpha Prime', { description: 'Alpha description' }), // renamed only
+            feature('c', 'Gamma', { complexity: 'high' }), // changed
+            feature('d', 'Delta'), // added
+        ];
+        const diff = diffFeatures(before, after);
+        expect(diff.added).toEqual([{ id: 'd', name: 'Delta' }]);
+        expect(diff.removed).toEqual([{ id: 'b', name: 'Beta' }]);
+        expect(diff.renamed).toEqual([{ id: 'a', from: 'Alpha', to: 'Alpha Prime' }]);
+        expect(diff.changed).toEqual([{ id: 'c', name: 'Gamma', changedFields: ['complexity'] }]);
+    });
+
+    it('reports no changes for identical lists and tolerates undefined', () => {
+        const list = [feature('a', 'Alpha')];
+        const diff = diffFeatures(list, [...list]);
+        expect(diff.added).toHaveLength(0);
+        expect(diff.removed).toHaveLength(0);
+        expect(diff.renamed).toHaveLength(0);
+        expect(diff.changed).toHaveLength(0);
+        expect(diffFeatures(undefined, undefined)).toEqual({
+            added: [], removed: [], renamed: [], changed: [],
+        });
+    });
+
+    it('compares optional array fields (acceptanceCriteria) semantically', () => {
+        const before = [feature('a', 'Alpha', { acceptanceCriteria: ['one'] })];
+        const after = [feature('a', 'Alpha', { acceptanceCriteria: ['one', 'two'] })];
+        expect(diffFeatures(before, after).changed).toEqual([
+            { id: 'a', name: 'Alpha', changedFields: ['acceptanceCriteria'] },
+        ]);
+    });
+});
+
+describe('summarizeSpineChange', () => {
+    it('produces a deterministic headline covering features and sections', () => {
+        const before = basePrd();
+        const after = basePrd({
+            features: [feature('feat-tasks', 'Task Boards')], // feat-chat removed
+            architecture: 'Server-first with Postgres',
+        });
+        const summary = summarizeSpineChange(before, after);
+        expect(summary.comparable).toBe(true);
+        expect(summary.hasChanges).toBe(true);
+        expect(summary.features.removed).toEqual([{ id: 'feat-chat', name: 'Team Chat' }]);
+        expect(summary.changedSectionKeys).toContain('architecture');
+        expect(summary.headline).toContain('1 feature removed');
+        expect(summary.headline).toContain('Architecture');
+    });
+
+    it('reports no structural changes for identical PRDs', () => {
+        const prd = basePrd();
+        const summary = summarizeSpineChange(prd, { ...prd });
+        expect(summary.hasChanges).toBe(false);
+        expect(summary.headline).toBe('No structural changes detected');
+    });
+
+    it('degrades to a generic headline when a side lacks a structured PRD', () => {
+        const summary = summarizeSpineChange(undefined, basePrd());
+        expect(summary.comparable).toBe(false);
+        expect(summary.hasChanges).toBe(true);
+        expect(summary.sections).toHaveLength(0);
+        expect(summary.headline).toContain('PRD content changed');
+    });
+});
+
+describe('isLikelyUnaffected', () => {
+    it('flags slots whose affinity sections did not change', () => {
+        // Risks-only change: screens/mockups chiefly derive from features/UX,
+        // not risks — advisory note applies. Implementation plan includes
+        // risks in its affinity — no note.
+        const summary = summarizeSpineChange(basePrd(), basePrd({ risks: ['Adoption', 'Churn'] }));
+        expect(isLikelyUnaffected('screen_inventory', summary)).toBe(true);
+        expect(isLikelyUnaffected('mockup', summary)).toBe(true);
+        expect(isLikelyUnaffected('implementation_plan', summary)).toBe(false);
+    });
+
+    it('never fires on feature changes, universal sections, or weak evidence', () => {
+        const featureChange = summarizeSpineChange(
+            basePrd(),
+            basePrd({ features: [feature('feat-tasks', 'Task Boards')] }),
+        );
+        expect(isLikelyUnaffected('data_model', featureChange)).toBe(false);
+
+        const visionChange = summarizeSpineChange(basePrd(), basePrd({ vision: 'New vision' }));
+        expect(isLikelyUnaffected('screen_inventory', visionChange)).toBe(false);
+
+        const incomparable = summarizeSpineChange(undefined, basePrd());
+        expect(isLikelyUnaffected('screen_inventory', incomparable)).toBe(false);
+
+        const unchanged = summarizeSpineChange(basePrd(), basePrd());
+        expect(isLikelyUnaffected('screen_inventory', unchanged)).toBe(false);
+    });
+});
+
+describe('findFeatureReferences', () => {
+    const candidates = [
+        { artifactId: 'a1', slot: 'user_flows', title: 'User Flows', content: 'Step 3: open Team Chat panel' },
+        { artifactId: 'a2', slot: 'data_model', title: 'Data Model', content: 'Entities: Task, Board. Related Features: feat-chat' },
+        { artifactId: 'a3', slot: 'design_system', title: 'Design System', content: 'Palette and typography only.' },
+    ];
+
+    it('matches by id first, then by whole-word name', () => {
+        const hits = findFeatureReferences({ id: 'feat-chat', name: 'Team Chat' }, candidates);
+        expect(hits).toEqual([
+            { artifactId: 'a1', slot: 'user_flows', title: 'User Flows', matchedBy: 'name' },
+            { artifactId: 'a2', slot: 'data_model', title: 'Data Model', matchedBy: 'id' },
+        ]);
+    });
+
+    it('skips short needles and partial-word matches (conservative)', () => {
+        // Short id AND short name — both below the match threshold.
+        expect(findFeatureReferences({ id: 'F1', name: 'app' }, candidates)).toHaveLength(0);
+        // "Chat" alone should not match inside "Chatter".
+        const hits = findFeatureReferences(
+            { id: 'feat-none', name: 'Chatter' },
+            [{ artifactId: 'x', title: 'X', content: 'ChatterBox is unrelated' }],
+        );
+        expect(hits).toHaveLength(0);
+    });
+});
+
+describe('makeSpineChangeResolver', () => {
+    const spines = [
+        { id: 's1', structuredPRD: basePrd() },
+        { id: 's2', structuredPRD: basePrd({ risks: ['Adoption', 'Churn'] }) },
+    ];
+
+    it('summarizes drift against the latest spine and returns null for the latest', () => {
+        const resolve = makeSpineChangeResolver(spines, 's2');
+        expect(resolve('s2')).toBeNull();
+        const summary = resolve('s1');
+        expect(summary?.hasChanges).toBe(true);
+        expect(summary?.changedSectionKeys).toEqual(['risks']);
+        // Memoized: same reference on repeat calls.
+        expect(resolve('s1')).toBe(summary);
+    });
+
+    it('returns null for unknown ids or when no latest spine exists', () => {
+        expect(makeSpineChangeResolver(spines, 's2')('nope')).toBeNull();
+        expect(makeSpineChangeResolver(spines, undefined)('s1')).toBeNull();
+    });
+});

--- a/src/lib/artifactDependencyGraph.ts
+++ b/src/lib/artifactDependencyGraph.ts
@@ -587,6 +587,45 @@ export function evaluateDependencyGraph(
  * this order never rebuilds an artifact from a stale input. Nodes currently
  * generating are excluded (they're already being handled).
  */
+/**
+ * Expand a user-selected regeneration batch with its troubled VISIBLE
+ * upstreams. `regenerateSlots` expands hidden subtypes and orders execution,
+ * but it does NOT pull in a stale/missing/errored visible input the user left
+ * unselected — regenerating a dependent against it would rebuild from stale
+ * context. Upstreams in `healed` (about to be marked current in the same
+ * action) are treated as healthy and never force-included. Returns the batch
+ * in safe update order.
+ */
+export function expandSelectionWithTroubledUpstreams(
+    graph: ArtifactDependencyGraph,
+    evaluations: Map<DependencyNodeId, DependencyNodeEvaluation>,
+    selected: DependencyNodeId[],
+    healed: ReadonlySet<DependencyNodeId> = new Set(),
+): DependencyNodeId[] {
+    const batch = new Set(selected.filter(id => id !== 'prd'));
+    const troubled = (id: DependencyNodeId): boolean => {
+        const s = evaluations.get(id)?.status;
+        return s === 'needs_update' || s === 'update_recommended' || s === 'missing' || s === 'error';
+    };
+    let grew = true;
+    while (grew) {
+        grew = false;
+        for (const id of [...batch]) {
+            const hardDeps = graph.edges
+                .filter(e => e.to === id && e.kind === 'hard')
+                .map(e => e.from);
+            for (const dep of hardDeps) {
+                if (dep === 'prd' || batch.has(dep) || healed.has(dep)) continue;
+                if (troubled(dep)) {
+                    batch.add(dep);
+                    grew = true;
+                }
+            }
+        }
+    }
+    return computeUpdateOrder(graph, [...batch]);
+}
+
 export function computeRecommendedUpdates(
     graph: ArtifactDependencyGraph,
     evaluations: Map<DependencyNodeId, DependencyNodeEvaluation>,

--- a/src/lib/artifactDependencyGraph.ts
+++ b/src/lib/artifactDependencyGraph.ts
@@ -35,6 +35,7 @@ import {
     isHiddenArtifactSubtype,
     isRetiredArtifactSubtype,
 } from './coreArtifactPipeline';
+import { isLikelyUnaffected, type SpineChangeSummary } from './spineChangeAnalysis';
 
 // ---------------------------------------------------------------------------
 // Graph shape
@@ -314,6 +315,12 @@ export interface StaleReason {
     /** The upstream node this reason points at (absent for no_provenance). */
     dependencyId?: DependencyNodeId;
     detail: string;
+    /**
+     * For prd_changed: WHAT changed between the artifact's source spine and
+     * the latest spine (feature-level + section-level, deterministic).
+     * Present only when the caller supplies `spineChangeFor`.
+     */
+    changeSummary?: SpineChangeSummary;
 }
 
 /** Minimal slice of an ArtifactVersion the evaluator needs. */
@@ -323,6 +330,8 @@ export interface DependencyVersionSnapshot {
     createdAt: number;
     sourceRefs: SourceRef[];
     provenance?: VersionProvenance;
+    /** Optional version metadata — used to detect user overlay edits. */
+    metadata?: Record<string, unknown>;
 }
 
 export interface DependencyNodeSnapshot {
@@ -341,6 +350,13 @@ export interface DependencyEvaluationInput {
     snapshots: Partial<Record<ArtifactSlotKey, DependencyNodeSnapshot>>;
     /** Live generation status per slot (transient job state). */
     slotStatus?: Partial<Record<ArtifactSlotKey, GenerationStatus>>;
+    /**
+     * Optional change-awareness hook (see spineChangeAnalysis's
+     * makeSpineChangeResolver): "what changed between spine X and the latest
+     * spine?". When present, prd_changed reasons carry a changeSummary and
+     * nodes may gain the advisory `likelyUnaffected` flag.
+     */
+    spineChangeFor?: (fromSpineVersionId: string) => SpineChangeSummary | null;
 }
 
 export interface DependencyNodeEvaluation {
@@ -359,6 +375,13 @@ export interface DependencyNodeEvaluation {
     generatedAt?: number;
     /** "Version N" label of the PRD version this artifact was generated from. */
     prdVersionLabel?: string;
+    /**
+     * ADVISORY: the PRD did change, but no changed section is one this slot
+     * chiefly derives from (ARTIFACT_SECTION_AFFINITY). Never downgrades the
+     * hard needs_update status — it is a hint for "mark as up to date", not a
+     * verdict. Only set when the sole hard evidence is prd_changed.
+     */
+    likelyUnaffected?: boolean;
 }
 
 const spineLabel = (spineVersionIds: string[], spineId: string | undefined): string | undefined => {
@@ -369,6 +392,18 @@ const spineLabel = (spineVersionIds: string[], spineId: string | undefined): str
 
 const nodeTitle = (graph: ArtifactDependencyGraph, id: DependencyNodeId): string =>
     getDependencyNode(graph, id)?.title ?? id;
+
+// User overlay edits (screenEdits / promptEdits) customize the preferred
+// version's metadata without creating a version — surface them with the same
+// "edited manually" caution flag as provenance-tracked edits.
+const hasOverlayEdits = (metadata?: Record<string, unknown>): boolean => {
+    if (!metadata) return false;
+    for (const key of ['screenEdits', 'promptEdits'] as const) {
+        const overlay = metadata[key];
+        if (overlay && typeof overlay === 'object' && Object.keys(overlay).length > 0) return true;
+    }
+    return false;
+};
 
 /**
  * Evaluate every node's local staleness, then propagate upstream trouble
@@ -429,10 +464,12 @@ export function evaluateDependencyGraph(
             advisory = true;
         } else if (input.latestSpineId && spineRef.sourceArtifactVersionId !== input.latestSpineId) {
             const latestLabel = spineLabel(input.spineVersionIds, input.latestSpineId);
+            const changeSummary = input.spineChangeFor?.(spineRef.sourceArtifactVersionId) ?? undefined;
             reasons.push({
                 kind: 'prd_changed',
                 dependencyId: 'prd',
                 detail: `The PRD changed after this was generated${refLabel && latestLabel ? ` (generated from ${refLabel}, now on ${latestLabel})` : ''}.`,
+                ...(changeSummary ? { changeSummary } : {}),
             });
         }
 
@@ -496,15 +533,26 @@ export function evaluateDependencyGraph(
                 ? 'update_recommended'
                 : 'up_to_date';
 
+        // Advisory scoping: only when the PRD change is the SOLE reason (any
+        // dependency/token drift or legacy heuristic is its own evidence) and
+        // the change avoided every section this slot chiefly derives from.
+        const prdReason = reasons.find(r => r.kind === 'prd_changed');
+        const likelyUnaffected =
+            reasons.length === 1
+            && prdReason?.changeSummary !== undefined
+            && isLikelyUnaffected(slotKey, prdReason.changeSummary);
+
         evaluations.set(node.id, {
             nodeId: node.id,
             status,
             reasons,
             impactedBy: [],
-            manuallyEdited: version.provenance?.changeSource === 'user_edit',
+            manuallyEdited: version.provenance?.changeSource === 'user_edit'
+                || hasOverlayEdits(version.metadata),
             versionNumber: version.versionNumber,
             generatedAt: version.createdAt,
             prdVersionLabel: refLabel,
+            ...(likelyUnaffected ? { likelyUnaffected: true } : {}),
         });
     }
 

--- a/src/lib/exportHandoff.ts
+++ b/src/lib/exportHandoff.ts
@@ -14,6 +14,12 @@ export interface HandoffInput {
     prdMarkdown?: string;
     /** Core artifacts in display order; mockups are intentionally excluded. */
     artifacts: HandoffArtifact[];
+    /**
+     * Pre-rendered export-manifest markdown (see exportManifest.ts). Emitted
+     * right after the preamble so the agent sees which versions it holds and
+     * whether anything was stale at export time.
+     */
+    manifestMarkdown?: string;
 }
 
 const PREAMBLE = (projectName: string) =>
@@ -34,8 +40,12 @@ How to use this document:
  * is non-empty, so a partial project still produces a coherent document.
  */
 export function buildAgentHandoff(input: HandoffInput): string {
-    const { projectName, prdMarkdown, artifacts } = input;
+    const { projectName, prdMarkdown, artifacts, manifestMarkdown } = input;
     const parts: string[] = [PREAMBLE(projectName || 'This product')];
+
+    if (manifestMarkdown && manifestMarkdown.trim()) {
+        parts.push(manifestMarkdown.trim(), '\n---\n');
+    }
 
     if (prdMarkdown && prdMarkdown.trim()) {
         parts.push('## Product Requirements\n', prdMarkdown.trim(), '\n---\n');

--- a/src/lib/exportManifest.ts
+++ b/src/lib/exportManifest.ts
@@ -1,0 +1,78 @@
+// Export manifest — the version/staleness record attached to project exports
+// so an outside reader (or coding agent) can see exactly what they're holding:
+// which PRD version, which artifact versions, which PRD version each artifact
+// was generated from, and whether anything was flagged stale AT EXPORT TIME.
+// Pure: the caller (ExportModal) prepares the entries from live store state;
+// nothing here reads the store or is persisted.
+
+import type { StalenessState } from '../types';
+
+export interface ExportManifestEntry {
+    title: string;
+    versionNumber?: number;
+    /** Positional label of the PRD version this asset was generated from. */
+    generatedFromPrdLabel?: string;
+    staleness: StalenessState;
+}
+
+export interface ExportManifest {
+    projectName: string;
+    /** ISO timestamp of the export. */
+    exportedAt: string;
+    /** Positional label of the exported PRD version ("Version 3"). */
+    prdLabel?: string;
+    entries: ExportManifestEntry[];
+    /** Entries whose staleness is not 'current'. */
+    staleCount: number;
+}
+
+export function buildExportManifest(input: {
+    projectName: string;
+    exportedAt?: Date;
+    prdLabel?: string;
+    entries: ExportManifestEntry[];
+}): ExportManifest {
+    return {
+        projectName: input.projectName,
+        exportedAt: (input.exportedAt ?? new Date()).toISOString(),
+        prdLabel: input.prdLabel,
+        entries: input.entries,
+        staleCount: input.entries.filter((e) => e.staleness !== 'current').length,
+    };
+}
+
+const STALENESS_LABELS: Record<StalenessState, string> = {
+    current: 'Current',
+    possibly_outdated: 'May be outdated',
+    outdated: 'Outdated',
+};
+
+/**
+ * Render the manifest as a markdown block for the bundle / handoff exports.
+ * Includes an explicit warning line when stale content is included, so the
+ * document is honest even after it leaves Synapse.
+ */
+export function renderManifestMarkdown(manifest: ExportManifest): string {
+    const lines: string[] = [
+        '## Export Manifest',
+        '',
+        `- Project: ${manifest.projectName}`,
+        `- Exported: ${manifest.exportedAt}`,
+    ];
+    if (manifest.prdLabel) lines.push(`- PRD: ${manifest.prdLabel}`);
+    if (manifest.entries.length > 0) {
+        lines.push('', '| Asset | Version | Generated from | Status |', '| --- | --- | --- | --- |');
+        for (const e of manifest.entries) {
+            lines.push(
+                `| ${e.title} | ${e.versionNumber !== undefined ? `v${e.versionNumber}` : '—'} | ${e.generatedFromPrdLabel ?? '—'} | ${STALENESS_LABELS[e.staleness]} |`,
+            );
+        }
+    }
+    if (manifest.staleCount > 0) {
+        lines.push(
+            '',
+            `> ⚠️ ${manifest.staleCount} asset${manifest.staleCount === 1 ? '' : 's'} in this export ${manifest.staleCount === 1 ? 'was' : 'were'} flagged as possibly out of date with the current PRD at export time. Treat the PRD as the source of truth where they disagree.`,
+        );
+    }
+    return lines.join('\n');
+}

--- a/src/lib/spineChangeAnalysis.ts
+++ b/src/lib/spineChangeAnalysis.ts
@@ -1,0 +1,301 @@
+// Pure spine-change analysis — the "what changed" layer behind change-aware
+// staleness. Given two PRD snapshots (an artifact's source spine version and
+// the current latest spine), it produces:
+//
+//   - a feature-level diff keyed by the stable `Feature.id` (added / removed /
+//     renamed / changed) — the first user-facing use of the system's most
+//     stable identity,
+//   - a section-level change list (reusing versionDiff's section model), and
+//   - a deterministic one-line headline ("1 feature removed · Architecture
+//     changed") — never an LLM call, so it is free, instant, and honest.
+//
+// It also owns the conservative ARTIFACT_SECTION_AFFINITY map used for the
+// advisory "no changes in the sections this asset chiefly derives from" note,
+// and `findFeatureReferences`, the removed-feature blast-radius scan.
+//
+// Everything here is computed at read time from stored full snapshots —
+// nothing is persisted. This module must stay free of store/React/LLM imports
+// (mirrors versionDiff.ts / artifactDependencyGraph.ts).
+
+import { diffStructuredPRD, type SectionDiff } from './versionDiff';
+import type { ArtifactSlotKey, Feature, StructuredPRD } from '../types';
+
+// ---------------------------------------------------------------------------
+// Feature-level diff (by stable Feature.id)
+// ---------------------------------------------------------------------------
+
+export type FeatureDiff = {
+    added: { id: string; name: string }[];
+    removed: { id: string; name: string }[];
+    /** Same id, different name. May ALSO appear in `changed` if other fields moved. */
+    renamed: { id: string; from: string; to: string }[];
+    /** Same id, non-name fields differ. `name` is the AFTER name. */
+    changed: { id: string; name: string; changedFields: string[] }[];
+};
+
+// Fields compared for the `changed` classification. Name is handled
+// separately (rename). Presentation-only premium fields are included where
+// they change what downstream artifacts build.
+const FEATURE_COMPARE_FIELDS = [
+    'description',
+    'userValue',
+    'complexity',
+    'priority',
+    'acceptanceCriteria',
+    'dependencies',
+    'successCriteria',
+    'edgeCases',
+    'failureModes',
+    'tier',
+] as const;
+
+const normalizeField = (value: unknown): string =>
+    value === undefined || value === null ? '' : JSON.stringify(value);
+
+/**
+ * Diff two feature lists by stable id. Features without an id are ignored
+ * (defensive — canonical PRDs always carry ids).
+ */
+export function diffFeatures(before?: Feature[], after?: Feature[]): FeatureDiff {
+    const beforeById = new Map<string, Feature>();
+    for (const f of before ?? []) if (f.id) beforeById.set(f.id, f);
+    const afterById = new Map<string, Feature>();
+    for (const f of after ?? []) if (f.id) afterById.set(f.id, f);
+
+    const diff: FeatureDiff = { added: [], removed: [], renamed: [], changed: [] };
+
+    for (const [id, f] of afterById) {
+        if (!beforeById.has(id)) diff.added.push({ id, name: f.name });
+    }
+    for (const [id, f] of beforeById) {
+        const next = afterById.get(id);
+        if (!next) {
+            diff.removed.push({ id, name: f.name });
+            continue;
+        }
+        if ((f.name ?? '').trim() !== (next.name ?? '').trim()) {
+            diff.renamed.push({ id, from: f.name, to: next.name });
+        }
+        const changedFields = FEATURE_COMPARE_FIELDS.filter(
+            (field) => normalizeField(f[field]) !== normalizeField(next[field]),
+        );
+        if (changedFields.length > 0) {
+            diff.changed.push({ id, name: next.name, changedFields: [...changedFields] });
+        }
+    }
+
+    return diff;
+}
+
+// ---------------------------------------------------------------------------
+// Spine change summary
+// ---------------------------------------------------------------------------
+
+export type SpineChangeSummary = {
+    /**
+     * False when either side lacks a structured PRD (legacy markdown-only
+     * spine) — the detail fields are then empty and only the generic headline
+     * applies. Never claim "likely unaffected" from an incomparable summary.
+     */
+    comparable: boolean;
+    hasChanges: boolean;
+    /** Per-section diffs (versionDiff SECTION_SPECS order). Empty when not comparable. */
+    sections: SectionDiff[];
+    /** Section keys with kind !== 'unchanged'. */
+    changedSectionKeys: string[];
+    /** Human labels for changedSectionKeys. */
+    changedSectionLabels: string[];
+    features: FeatureDiff;
+    /** Deterministic one-liner, e.g. "1 feature removed · Architecture changed". */
+    headline: string;
+};
+
+const EMPTY_FEATURE_DIFF: FeatureDiff = { added: [], removed: [], renamed: [], changed: [] };
+
+const plural = (n: number, noun: string): string => `${n} ${noun}${n === 1 ? '' : 's'}`;
+
+const MAX_HEADLINE_SECTION_LABELS = 3;
+
+/**
+ * Summarize what changed between two PRD snapshots. Deterministic and cheap;
+ * safe with partial/legacy PRDs (an incomparable pair degrades to a generic
+ * "PRD content changed" headline instead of a noisy everything-added diff).
+ */
+export function summarizeSpineChange(
+    before: StructuredPRD | undefined,
+    after: StructuredPRD | undefined,
+): SpineChangeSummary {
+    if (!before || !after) {
+        return {
+            comparable: false,
+            hasChanges: true,
+            sections: [],
+            changedSectionKeys: [],
+            changedSectionLabels: [],
+            features: EMPTY_FEATURE_DIFF,
+            headline: 'PRD content changed (detailed comparison unavailable for this version)',
+        };
+    }
+
+    const sections = diffStructuredPRD(before, after);
+    const changedSections = sections.filter((s) => s.kind !== 'unchanged');
+    const features = diffFeatures(before.features, after.features);
+
+    const parts: string[] = [];
+    if (features.removed.length > 0) parts.push(`${plural(features.removed.length, 'feature')} removed`);
+    if (features.added.length > 0) parts.push(`${plural(features.added.length, 'feature')} added`);
+    if (features.renamed.length > 0) parts.push(`${plural(features.renamed.length, 'feature')} renamed`);
+    if (features.changed.length > 0) parts.push(`${plural(features.changed.length, 'feature')} changed`);
+
+    // Non-feature section labels ('Features' is already covered above, and in
+    // more detail). Capped so the headline stays one line.
+    const otherLabels = changedSections.filter((s) => s.key !== 'features').map((s) => s.label);
+    if (otherLabels.length > 0) {
+        const shown = otherLabels.slice(0, MAX_HEADLINE_SECTION_LABELS);
+        const more = otherLabels.length - shown.length;
+        parts.push(`${shown.join(', ')}${more > 0 ? ` +${more} more` : ''} changed`);
+    }
+
+    const hasChanges = changedSections.length > 0
+        || features.added.length > 0
+        || features.removed.length > 0
+        || features.renamed.length > 0
+        || features.changed.length > 0;
+
+    return {
+        comparable: true,
+        hasChanges,
+        sections,
+        changedSectionKeys: changedSections.map((s) => s.key),
+        changedSectionLabels: changedSections.map((s) => s.label),
+        features,
+        headline: hasChanges ? parts.join(' · ') : 'No structural changes detected',
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Section → artifact affinity (advisory scoping)
+// ---------------------------------------------------------------------------
+
+// Identity- and safety-level sections affect every artifact — including them
+// in every affinity set keeps the "likely unaffected" note conservative:
+// it only ever appears for genuinely narrow changes (e.g. a risks-only edit
+// leaving the screens untouched).
+const UNIVERSAL_SECTIONS = ['vision', 'coreProblem', 'constraints'] as const;
+
+/**
+ * The PRD sections each artifact slot *chiefly derives from*. Used ONLY for
+ * the advisory "no changes in the sections this asset chiefly derives from"
+ * annotation — never to suppress a hard needs_update (every artifact really is
+ * generated from the whole PRD). Keys are versionDiff SECTION_SPECS keys.
+ */
+export const ARTIFACT_SECTION_AFFINITY: Record<ArtifactSlotKey, readonly string[]> = {
+    design_system: [...UNIVERSAL_SECTIONS, 'targetUsers', 'uxPages'],
+    screen_inventory: [...UNIVERSAL_SECTIONS, 'features', 'uxPages', 'targetUsers', 'primaryActions'],
+    user_flows: [...UNIVERSAL_SECTIONS, 'features', 'uxPages', 'targetUsers', 'primaryActions'],
+    component_inventory: [...UNIVERSAL_SECTIONS, 'features', 'uxPages'],
+    data_model: [...UNIVERSAL_SECTIONS, 'features', 'domainEntities', 'architecture', 'primaryActions'],
+    implementation_plan: [...UNIVERSAL_SECTIONS, 'features', 'architecture', 'domainEntities', 'nonFunctionalRequirements', 'risks'],
+    prompt_pack: [...UNIVERSAL_SECTIONS, 'features', 'architecture'], // retired — kept for type completeness
+    mockup: [...UNIVERSAL_SECTIONS, 'features', 'uxPages', 'targetUsers'],
+};
+
+/**
+ * Advisory: did this spine change avoid every section the slot chiefly
+ * derives from? False whenever the summary is incomparable or has no changes
+ * — the note must never fire on weak evidence.
+ */
+export function isLikelyUnaffected(slot: ArtifactSlotKey, summary: SpineChangeSummary): boolean {
+    if (!summary.comparable || !summary.hasChanges) return false;
+    if (summary.changedSectionKeys.length === 0) return false;
+    const affinity = ARTIFACT_SECTION_AFFINITY[slot];
+    return summary.changedSectionKeys.every((key) => !affinity.includes(key));
+}
+
+// ---------------------------------------------------------------------------
+// Removed-feature reference scan (blast radius of a deletion)
+// ---------------------------------------------------------------------------
+
+export type FeatureReferenceCandidate = {
+    artifactId: string;
+    /** Slot key when known — lets callers group hits by workspace row. */
+    slot?: string;
+    title: string;
+    /** The candidate's preferred-version content (markdown or JSON). */
+    content: string;
+};
+
+export type FeatureReferenceHit = {
+    artifactId: string;
+    slot?: string;
+    title: string;
+    matchedBy: 'id' | 'name';
+};
+
+const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Conservative match guards: short ids/names ("F1", "app") would false-positive
+// on ordinary prose, so they are skipped rather than risking a wrong
+// "still referenced" claim.
+const MIN_MATCH_LENGTH = 4;
+
+const wordBoundaryMatch = (needle: string, haystack: string): boolean => {
+    const trimmed = needle.trim();
+    if (trimmed.length < MIN_MATCH_LENGTH) return false;
+    try {
+        return new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(trimmed)}($|[^A-Za-z0-9])`, 'i').test(haystack);
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Which artifacts still reference a (removed/renamed) feature? Token match of
+ * the feature id and name against each candidate's content — the same
+ * conservative style as artifactTraceabilityRepair: it can flag likely
+ * references, it never proves absence.
+ */
+export function findFeatureReferences(
+    feature: { id: string; name: string },
+    candidates: FeatureReferenceCandidate[],
+): FeatureReferenceHit[] {
+    const hits: FeatureReferenceHit[] = [];
+    for (const c of candidates) {
+        if (!c.content) continue;
+        if (wordBoundaryMatch(feature.id, c.content)) {
+            hits.push({ artifactId: c.artifactId, slot: c.slot, title: c.title, matchedBy: 'id' });
+        } else if (wordBoundaryMatch(feature.name, c.content)) {
+            hits.push({ artifactId: c.artifactId, slot: c.slot, title: c.title, matchedBy: 'name' });
+        }
+    }
+    return hits;
+}
+
+// ---------------------------------------------------------------------------
+// Memoized resolver (per evaluation pass)
+// ---------------------------------------------------------------------------
+
+export type SpineSnapshotLike = { id: string; structuredPRD?: StructuredPRD };
+
+/**
+ * Build a memoized "what changed since spine X" resolver against the latest
+ * spine. Returns null for the latest spine itself (no drift) and for unknown
+ * ids. Summaries are cached per source id — spine pairs are few, so one
+ * resolver per render/evaluation pass is cheap.
+ */
+export function makeSpineChangeResolver(
+    spines: readonly SpineSnapshotLike[],
+    latestSpineId: string | undefined,
+): (fromSpineVersionId: string) => SpineChangeSummary | null {
+    const cache = new Map<string, SpineChangeSummary | null>();
+    const latest = latestSpineId ? spines.find((s) => s.id === latestSpineId) : undefined;
+    return (fromSpineVersionId: string) => {
+        if (!latest || fromSpineVersionId === latest.id) return null;
+        const cached = cache.get(fromSpineVersionId);
+        if (cached !== undefined) return cached;
+        const from = spines.find((s) => s.id === fromSpineVersionId);
+        const summary = from ? summarizeSpineChange(from.structuredPRD, latest.structuredPRD) : null;
+        cache.set(fromSpineVersionId, summary);
+        return summary;
+    };
+}

--- a/src/lib/versionDiff.ts
+++ b/src/lib/versionDiff.ts
@@ -5,7 +5,7 @@
 // Backed by jsdiff (`diff`), word-level. Kept framework-free and unit-tested.
 
 import { diffWordsWithSpace } from 'diff';
-import type { StructuredPRD, Feature, DomainEntity, PrimaryAction } from '../types';
+import type { StructuredPRD, Feature, DomainEntity, PrimaryAction, UXPage } from '../types';
 
 /** One contiguous run of text classified relative to the "after" version. */
 export type DiffSegment = {
@@ -87,6 +87,14 @@ const renderActions = (actions?: PrimaryAction[]): string =>
 
 const renderList = (items?: string[]): string => (items ?? []).join('\n');
 
+// Lean render — name + purpose only. The premium per-page interaction/state
+// fields are deliberately excluded (they were retired from the lean uxPages
+// shape and would make legacy-vs-new comparisons noisy).
+const renderUxPages = (pages?: UXPage[]): string =>
+    (pages ?? [])
+        .map((p) => (p.purpose ? `${p.name}\n${p.purpose}` : p.name))
+        .join('\n\n');
+
 // Known, comparable sections (core + commonly-edited grounding fields). Premium
 // nested structures beyond these are intentionally out of scope for the MVP
 // compare view.
@@ -95,6 +103,7 @@ const SECTION_SPECS: SectionSpec[] = [
     { key: 'coreProblem', label: 'Core Problem', render: (p) => p.coreProblem ?? '' },
     { key: 'targetUsers', label: 'Target Users', render: (p) => renderList(p.targetUsers) },
     { key: 'features', label: 'Features', render: (p) => renderFeatures(p.features) },
+    { key: 'uxPages', label: 'UX Pages', render: (p) => renderUxPages(p.uxPages) },
     { key: 'architecture', label: 'Architecture', render: (p) => p.architecture ?? '' },
     { key: 'risks', label: 'Risks', render: (p) => renderList(p.risks) },
     { key: 'nonFunctionalRequirements', label: 'Non-Functional Requirements', render: (p) => renderList(p.nonFunctionalRequirements) },

--- a/src/store/__tests__/artifactSlice.markCurrent.test.ts
+++ b/src/store/__tests__/artifactSlice.markCurrent.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import type { SourceRef, StructuredPRD } from '../../types';
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: {},
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+    localStorage.clear();
+});
+
+const prd = (vision: string): StructuredPRD => ({
+    vision,
+    targetUsers: [],
+    coreProblem: '',
+    features: [],
+    architecture: '',
+    risks: [],
+});
+
+const spineRef = (spineId: string): SourceRef => ({
+    id: `ref-${spineId}`,
+    sourceArtifactId: 'project',
+    sourceArtifactVersionId: spineId,
+    sourceType: 'spine',
+});
+
+describe('markArtifactCurrentForSpine', () => {
+    it('appends a cloned preferred version rebased onto the new spine and flips staleness to current', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('P', 'idea');
+        const v1 = useProjectStore.getState().spineVersions[projectId][0];
+        store.updateSpineStructuredPRD(projectId, v1.id, prd('v1'), 'md');
+
+        const { artifactId } = store.createArtifact(projectId, 'core_artifact', 'Data Model', 'data_model');
+        store.createArtifactVersion(projectId, artifactId, 'content', { k: 1 }, [spineRef(v1.id)], 'prompt');
+
+        // A PRD edit makes a newer spine latest — the artifact goes stale.
+        const { newSpineId } = store.editSpineStructuredPRD(projectId, v1.id, prd('v2'));
+        expect(useProjectStore.getState().getArtifactStaleness(projectId, artifactId)).toBe('possibly_outdated');
+
+        const { versionId } = store.markArtifactCurrentForSpine(projectId, artifactId, newSpineId);
+
+        const versions = useProjectStore.getState().artifactVersions[projectId]
+            .filter(v => v.artifactId === artifactId);
+        expect(versions).toHaveLength(2);
+        const confirmed = versions.find(v => v.id === versionId)!;
+        expect(confirmed.isPreferred).toBe(true);
+        expect(confirmed.versionNumber).toBe(2);
+        expect(confirmed.content).toBe('content'); // clone, not a rewrite
+        expect(confirmed.provenance?.changeSource).toBe('marked_current');
+        expect(confirmed.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId).toBe(newSpineId);
+
+        // History preserved + honest event recorded.
+        expect(versions.find(v => v.versionNumber === 1)?.isPreferred).toBe(false);
+        const events = useProjectStore.getState().historyEvents[projectId];
+        expect(events.some(e => e.type === 'MarkedCurrent' && e.artifactVersionId === versionId)).toBe(true);
+
+        expect(useProjectStore.getState().getArtifactStaleness(projectId, artifactId)).toBe('current');
+    });
+
+    it('rebases dependency refs onto their current preferred versions (incl. tokensHash anchor)', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('P', 'idea');
+        const v1 = useProjectStore.getState().spineVersions[projectId][0];
+        store.updateSpineStructuredPRD(projectId, v1.id, prd('v1'), 'md');
+
+        // Upstream design system with a tokensHash, regenerated once.
+        const { artifactId: designId } = store.createArtifact(projectId, 'core_artifact', 'Design System', 'design_system');
+        const { versionId: designV1 } = store.createArtifactVersion(
+            projectId, designId, 'design v1', { tokensHash: 'hash-old' }, [spineRef(v1.id)], 'p',
+        );
+        // Mockup recorded the design ref with the old hash anchor.
+        const { artifactId: mockupId } = store.createArtifact(projectId, 'mockup', 'Mockups');
+        store.createArtifactVersion(projectId, mockupId, 'mockup v1', {}, [
+            spineRef(v1.id),
+            {
+                id: 'dref', sourceArtifactId: designId, sourceArtifactVersionId: designV1,
+                sourceType: 'core_artifact', anchorInfo: 'hash-old',
+            },
+        ], 'p');
+
+        // Design system regenerates with a new hash; PRD also edits forward.
+        store.createArtifactVersion(projectId, designId, 'design v2', { tokensHash: 'hash-new' }, [spineRef(v1.id)], 'p');
+        const { newSpineId } = store.editSpineStructuredPRD(projectId, v1.id, prd('v2'));
+
+        store.markArtifactCurrentForSpine(projectId, mockupId, newSpineId);
+
+        const confirmed = useProjectStore.getState().getPreferredVersion(projectId, mockupId)!;
+        const depRef = confirmed.sourceRefs.find(r => r.sourceType === 'core_artifact')!;
+        const designPreferred = useProjectStore.getState().getPreferredVersion(projectId, designId)!;
+        expect(depRef.sourceArtifactVersionId).toBe(designPreferred.id);
+        expect(depRef.anchorInfo).toBe('hash-new');
+        // With spine + dep + hash all rebased, the mockup is fully current.
+        expect(useProjectStore.getState().getArtifactStaleness(projectId, mockupId)).toBe('current');
+    });
+
+    it('throws when the artifact has no preferred version', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('P', 'idea');
+        const { artifactId } = store.createArtifact(projectId, 'core_artifact', 'Data Model', 'data_model');
+        expect(() => store.markArtifactCurrentForSpine(projectId, artifactId, 'spine-x')).toThrow();
+    });
+});
+
+describe('provenance stamping completion', () => {
+    it('stamps ai_generation / ai_regeneration on artifact versions by default', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('P', 'idea');
+        const { artifactId } = store.createArtifact(projectId, 'core_artifact', 'Data Model', 'data_model');
+        const first = store.createArtifactVersion(projectId, artifactId, 'a', {}, [], 'p');
+        const second = store.createArtifactVersion(projectId, artifactId, 'b', {}, [], 'p');
+        const versions = useProjectStore.getState().artifactVersions[projectId];
+        expect(versions.find(v => v.id === first.versionId)?.provenance?.changeSource).toBe('ai_generation');
+        expect(versions.find(v => v.id === second.versionId)?.provenance?.changeSource).toBe('ai_regeneration');
+    });
+
+    it('stamps ai_generation on the initial spine at final settle and ai_regeneration on regenerate', () => {
+        const store = useProjectStore.getState();
+        const { projectId, spineId } = store.createProject('P', 'idea');
+        store.updateSpineStructuredPRD(projectId, spineId, prd('v1'), 'md', {
+            generationMeta: { passes: [], totalMs: 1, revised: false, schemaVersion: 2 },
+        });
+        expect(
+            useProjectStore.getState().spineVersions[projectId].find(s => s.id === spineId)?.provenance?.changeSource,
+        ).toBe('ai_generation');
+
+        const { newSpineId } = store.regenerateSpine(projectId);
+        expect(
+            useProjectStore.getState().spineVersions[projectId].find(s => s.id === newSpineId)?.provenance?.changeSource,
+        ).toBe('ai_regeneration');
+    });
+
+    it('records an Edited history event for overlay metadata edits with a description', () => {
+        const store = useProjectStore.getState();
+        const { projectId } = store.createProject('P', 'idea');
+        const { artifactId } = store.createArtifact(projectId, 'core_artifact', 'Screens', 'screen_inventory');
+        const { versionId } = store.createArtifactVersion(projectId, artifactId, 'a', {}, [], 'p');
+
+        store.updateArtifactVersionMetadata(projectId, artifactId, versionId, { screenEdits: {} });
+        const silentCount = useProjectStore.getState().historyEvents[projectId]
+            .filter(e => e.type === 'Edited').length;
+        expect(silentCount).toBe(0);
+
+        store.updateArtifactVersionMetadata(
+            projectId, artifactId, versionId, { screenEdits: {} },
+            { historyDescription: 'Screen details edited: Home' },
+        );
+        const edited = useProjectStore.getState().historyEvents[projectId].filter(e => e.type === 'Edited');
+        expect(edited).toHaveLength(1);
+        expect(edited[0].description).toContain('Home');
+    });
+});

--- a/src/store/slices/artifactSlice.ts
+++ b/src/store/slices/artifactSlice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
-import type { Artifact, ArtifactVersion, ArtifactType, CoreArtifactSubtype, SourceRef, HistoryEvent } from '../../types';
+import type { Artifact, ArtifactVersion, ArtifactType, CoreArtifactSubtype, SourceRef, HistoryEvent, VersionProvenance } from '../../types';
 import type { ProjectState } from '../types';
 import { trackActivity } from '../../lib/recruiterApi';
 
@@ -15,6 +15,7 @@ export type ArtifactSlice = {
     createArtifactVersion: ProjectState['createArtifactVersion'];
     setPreferredVersion: ProjectState['setPreferredVersion'];
     revertArtifactToVersion: ProjectState['revertArtifactToVersion'];
+    markArtifactCurrentForSpine: ProjectState['markArtifactCurrentForSpine'];
     getArtifactVersions: ProjectState['getArtifactVersions'];
     getPreferredVersion: ProjectState['getPreferredVersion'];
     getLatestArtifactVersion: ProjectState['getLatestArtifactVersion'];
@@ -93,7 +94,8 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
         metadata: Record<string, unknown>,
         sourceRefs: SourceRef[],
         generationPrompt: string,
-        parentVersionId?: string | null
+        parentVersionId?: string | null,
+        provenance?: VersionProvenance,
     ) => {
         const versionId = uuidv4();
         const now = Date.now();
@@ -124,6 +126,11 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
                 generationPrompt,
                 isPreferred: true,
                 createdAt: now,
+                // Default attribution: first version = generation, later ones =
+                // regeneration. Callers with richer context can override.
+                provenance: provenance ?? {
+                    changeSource: versionNumber === 1 ? 'ai_generation' : 'ai_regeneration',
+                },
             };
 
             const projectArtifacts = state.artifacts[projectId] || [];
@@ -238,6 +245,116 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
         return { versionId };
     },
 
+    // Versioning: "Mark as up to date" — the user asserts this artifact is
+    // still current for a NEWER spine despite not being regenerated (e.g. a
+    // typo-level PRD edit). Appends a CLONED version (same content, honest
+    // history) whose sourceRefs are REBASED onto the current state: the spine
+    // ref points at the given spine version, and every core_artifact ref is
+    // re-pointed at that dependency's current preferred version (refreshing a
+    // recorded design tokensHash anchor) — rewriting only the spine ref would
+    // leave the graph reporting dependency_changed. All reads inside set()
+    // (concurrency rule).
+    markArtifactCurrentForSpine: (projectId: string, artifactId: string, spineVersionId: string) => {
+        const preferred = (get().artifactVersions[projectId] || [])
+            .find(v => v.artifactId === artifactId && v.isPreferred);
+        if (!preferred) throw new Error('No preferred artifact version to mark current');
+
+        const versionId = uuidv4();
+        const now = Date.now();
+        const historyEventId = uuidv4();
+
+        set((state) => {
+            const versions = state.artifactVersions[projectId] || [];
+            const src = versions.find(v => v.artifactId === artifactId && v.isPreferred);
+            if (!src) return state;
+
+            const projectArtifacts = state.artifacts[projectId] || [];
+            const artifact = projectArtifacts.find(a => a.id === artifactId);
+            const versionNumber = versions.filter(v => v.artifactId === artifactId).length + 1;
+
+            // Rebase every ref. Spine ref → the confirmed spine version (added
+            // if the legacy version had none); dependency refs → each source
+            // artifact's CURRENT preferred version.
+            let sawSpineRef = false;
+            const rebasedRefs: SourceRef[] = src.sourceRefs.map((ref) => {
+                if (ref.sourceType === 'spine') {
+                    sawSpineRef = true;
+                    return { ...ref, id: uuidv4(), sourceArtifactVersionId: spineVersionId };
+                }
+                const depPreferred = versions.find(
+                    v => v.artifactId === ref.sourceArtifactId && v.isPreferred,
+                );
+                if (!depPreferred) return { ...ref, id: uuidv4() };
+                const tokensHash = depPreferred.metadata?.tokensHash;
+                return {
+                    ...ref,
+                    id: uuidv4(),
+                    sourceArtifactVersionId: depPreferred.id,
+                    // A recorded design tokensHash anchor is refreshed to the
+                    // dependency's current hash — the user is asserting
+                    // currency against today's design direction.
+                    ...(ref.anchorInfo !== undefined && typeof tokensHash === 'string'
+                        ? { anchorInfo: tokensHash }
+                        : {}),
+                };
+            });
+            if (!sawSpineRef) {
+                rebasedRefs.unshift({
+                    id: uuidv4(),
+                    sourceArtifactId: projectId,
+                    sourceArtifactVersionId: spineVersionId,
+                    sourceType: 'spine',
+                });
+            }
+
+            const spineIdx = (state.spineVersions[projectId] || []).findIndex(s => s.id === spineVersionId);
+            const spineLabel = spineIdx >= 0 ? `PRD Version ${spineIdx + 1}` : 'the current PRD';
+
+            const updatedVersions = versions.map(v =>
+                v.artifactId === artifactId ? { ...v, isPreferred: false } : v
+            );
+
+            const newVersion: ArtifactVersion = {
+                id: versionId,
+                artifactId,
+                versionNumber,
+                parentVersionId: src.id,
+                content: src.content,
+                metadata: src.metadata,
+                sourceRefs: rebasedRefs,
+                generationPrompt: src.generationPrompt,
+                isPreferred: true,
+                createdAt: now,
+                provenance: {
+                    changeSource: 'marked_current',
+                    editSummary: `Confirmed current for ${spineLabel}`,
+                },
+            };
+
+            const updatedArtifacts = projectArtifacts.map(a =>
+                a.id === artifactId ? { ...a, currentVersionId: versionId, status: 'active' as const, updatedAt: now } : a
+            );
+
+            const historyEvent: HistoryEvent = {
+                id: historyEventId,
+                projectId,
+                artifactId,
+                artifactVersionId: versionId,
+                type: 'MarkedCurrent',
+                description: `${artifact?.title || 'Artifact'} confirmed current for ${spineLabel}`,
+                createdAt: now,
+            };
+
+            return {
+                artifactVersions: { ...state.artifactVersions, [projectId]: [...updatedVersions, newVersion] },
+                artifacts: { ...state.artifacts, [projectId]: updatedArtifacts },
+                historyEvents: { ...state.historyEvents, [projectId]: [...(state.historyEvents[projectId] || []), historyEvent] },
+            };
+        });
+
+        return { versionId };
+    },
+
     setPreferredVersion: (projectId: string, artifactId: string, versionId: string) => {
         set((state) => {
             const allVersions = state.artifactVersions[projectId] || [];
@@ -282,6 +399,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
         artifactId: string,
         versionId: string,
         patch: Record<string, unknown>,
+        opts?: { historyDescription?: string },
     ) => {
         set((state) => {
             const allVersions = state.artifactVersions[projectId] || [];
@@ -295,9 +413,32 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
             const updatedArtifacts = projectArtifacts.map(a =>
                 a.id === artifactId ? { ...a, updatedAt: now } : a
             );
+            // User-authored overlay edits (screenEdits/promptEdits) pass a
+            // description so the audit timeline records them; plain metadata
+            // patches (relink/dismiss/extraScreens plumbing) stay silent.
+            const historyEvents = opts?.historyDescription
+                ? {
+                    historyEvents: {
+                        ...state.historyEvents,
+                        [projectId]: [
+                            ...(state.historyEvents[projectId] || []),
+                            {
+                                id: uuidv4(),
+                                projectId,
+                                artifactId,
+                                artifactVersionId: versionId,
+                                type: 'Edited' as const,
+                                description: opts.historyDescription,
+                                createdAt: now,
+                            },
+                        ],
+                    },
+                }
+                : {};
             return {
                 artifactVersions: { ...state.artifactVersions, [projectId]: updatedVersions },
                 artifacts: { ...state.artifacts, [projectId]: updatedArtifacts },
+                ...historyEvents,
             };
         });
     },

--- a/src/store/slices/branchSlice.ts
+++ b/src/store/slices/branchSlice.ts
@@ -98,6 +98,10 @@ export const createBranchSlice: StateCreator<ProjectState, [], [], BranchSlice> 
                 createdAt: now,
                 isLatest: true,
                 isFinal: false,
+                provenance: {
+                    changeSource: 'branch_merge',
+                    editSummary: `Merged branch: "${branch.anchorText.substring(0, 40)}${branch.anchorText.length > 40 ? '…' : ''}"`,
+                },
             };
 
             const mergeEvent: HistoryEvent = {

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -86,6 +86,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
                 createdAt: now,
                 isLatest: true,
                 isFinal: false,
+                provenance: { changeSource: 'ai_regeneration' },
             };
 
             const regenEvent: HistoryEvent = {
@@ -275,6 +276,12 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
                 // (onPartial) updates leave the run marked as still running.
                 if (meta?.generationMeta !== undefined) {
                     next.generationPhase = 'complete';
+                    // Attribution: a settling run whose spine carries no
+                    // provenance yet is the initial generation (regenerate /
+                    // merge stamp theirs at creation and are preserved here).
+                    if (!next.provenance) {
+                        next.provenance = { changeSource: 'ai_generation' };
+                    }
                     // Attach the canonical PRD spine on final settle only. It is
                     // rebuilt deterministically at artifact-generation time too,
                     // so this persisted copy is a diagnostic/diffing convenience

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -7,7 +7,7 @@ import type {
     QualityScores, GenerationMeta, SpineSafetyReview,
     PreflightMode, PreflightQuestion,
     ProjectTask, TaskStatus, TaskExternalRef,
-    WorkflowRun,
+    WorkflowRun, VersionProvenance,
 } from '../types';
 import type { ImplementationTask } from '../types/tasks';
 import type { SectionId } from '../lib/schemas/prdSchemas';
@@ -152,13 +152,20 @@ export interface ProjectState {
         metadata: Record<string, unknown>,
         sourceRefs: SourceRef[],
         generationPrompt: string,
-        parentVersionId?: string | null
+        parentVersionId?: string | null,
+        // Optional attribution override; defaults to ai_generation /
+        // ai_regeneration by version number.
+        provenance?: VersionProvenance,
     ) => { versionId: string };
     setPreferredVersion: (projectId: string, artifactId: string, versionId: string) => void;
     // Versioning: restore a historical artifact version by appending a cloned
     // ArtifactVersion (increments versionNumber, becomes preferred) rather than
     // only re-pointing isPreferred — keeps the audit log honest.
     revertArtifactToVersion: (projectId: string, artifactId: string, sourceVersionId: string) => { versionId: string };
+    // Versioning: user asserts the preferred version is still current for a
+    // newer spine — appends a cloned version whose sourceRefs are rebased onto
+    // the given spine version and each dependency's current preferred version.
+    markArtifactCurrentForSpine: (projectId: string, artifactId: string, spineVersionId: string) => { versionId: string };
     getArtifactVersions: (projectId: string, artifactId: string) => ArtifactVersion[];
     getPreferredVersion: (projectId: string, artifactId: string) => ArtifactVersion | undefined;
     getLatestArtifactVersion: (projectId: string, artifactId: string) => ArtifactVersion | undefined;
@@ -167,6 +174,10 @@ export interface ProjectState {
         artifactId: string,
         versionId: string,
         patch: Record<string, unknown>,
+        // When the patch is a user-authored overlay edit (screenEdits /
+        // promptEdits), pass a description so an 'Edited' history event is
+        // recorded; plumbing patches omit it and stay silent.
+        opts?: { historyDescription?: string },
     ) => void;
 
     // Feedback actions

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1319,7 +1319,8 @@ export type HistoryEventType =
     | 'FeedbackApplied'
     | 'GenerationFailed'
     | 'Edited'
-    | 'Reverted';
+    | 'Reverted'
+    | 'MarkedCurrent';
 
 // --- Version provenance ----------------------------------------------------
 // Attribution for "who/what produced this version". Attached to both
@@ -1332,7 +1333,8 @@ export type VersionChangeSource =
     | 'branch_merge'        // consolidation back into the spine
     | 'user_edit'           // inline edit in the workspace
     | 'revert'              // restore of an earlier version
-    | 'consistency_review'; // optional final reconciliation pass
+    | 'consistency_review'  // optional final reconciliation pass
+    | 'marked_current';     // user confirmed an artifact is still current for a newer PRD
 
 export type VersionProvenance = {
     changeSource?: VersionChangeSource;


### PR DESCRIPTION
## What this is

Originally the approved planning doc (`docs/VERSIONING_V2_PLAN.md`); now also the **Phase A implementation** of that plan. Six commits: the plan, then five implementation checkpoints.

## What shipped (Phase A — the recommended MVP)

1. **Pure change-analysis layer** (`src/lib/spineChangeAnalysis.ts`): feature-level diffs by stable `Feature.id` (added/removed/renamed/changed), deterministic spine-change headlines (no LLM calls), a conservative section→artifact affinity map for the advisory "likely unaffected" note, and a removed-feature reference scan. `versionDiff` gains a UX Pages section.
2. **Change-aware staleness**: `evaluateDependencyGraph` attaches a "what changed" summary to `prd_changed` reasons and a node-level `likelyUnaffected` advisory (never downgrades the hard status). Surfaced in the Project Map detail panel (incl. "still references removed feature X" warnings), the `StalenessBadge` tooltip, and the artifact header.
3. **Update Assets plan dialog**: re-finalizing a PRD with existing assets no longer silently regenerates everything. A per-asset plan (Regenerate / Mark up to date / Decide later, defaults from `computeRecommendedUpdates`) shows what changed since the assets' baseline PRD version; confirm applies mark-current first, then regenerates in safe dependency order. Cancel aborts the finalize.
4. **Mark as up to date** (`markArtifactCurrentForSpine`): appends a cloned preferred version with **all** sourceRefs rebased (spine ref + dependency refs + design tokensHash anchor) so staleness genuinely flips to current — per the Codex review comment on partial-ref rebasing.
5. **Selection expansion** (`expandSelectionWithTroubledUpstreams`): a selected dependent pulls in its troubled visible upstreams (marked-current upstreams count as healed) — per the Codex review comment on `regenerateSlots` not applying the unhealthy-dependency closure to batches.
6. **Provenance completion**: `ai_generation` / `ai_regeneration` / `branch_merge` are now stamped; overlay edits (screenEdits/promptEdits) record `Edited` history events and surface the manually-edited flag in the graph.
7. **Export version manifest**: full bundle, structured JSON, and the agent handoff carry a per-asset version/staleness manifest; `ExportModal` warns when stale content is included (never blocks).

## Deliberate deviations from the plan

- `consistency_review` is **not** stamped as a version changeSource — the review runs inside a single generation before settle and is already recorded in `generationMeta.consistencyReview`; a version has one changeSource.
- The plan dialog uses per-row three-way choices applied atomically on confirm (cleaner than the checkbox + separate actions sketched in the plan).

## Compatibility & testing

Zero migrations — every new field is optional or computed at read time; legacy projects degrade gracefully (incomparable spine pairs → generic "PRD content changed" headline; no advisory notes on weak evidence). `npm run build`, `npm run lint`, and the full suite (**143 files / 1108 tests**) pass; ~40 new focused tests cover the pure layer, the store action (incl. ref rebasing + staleness flip), graph evaluation, the modal, and the manifest.

## Deferred (per plan)

Phase B (any-two compare, structured screen/data-model diffs, mockup visual before/after), Phase C (staleness-system consolidation, retention, design-preset stamping), and the explicit deferrals (branching, server-side history, structured tech-stack entity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVc5ZVaFdg578tuLKh1heC