### PR TITLE
Reframe mockup gaps as Mockup Coverage (separate true issues)

### DIFF
--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -372,7 +372,7 @@ export function ArtifactWorkspace({
     // Validation issues minus the user's persisted dismissals.
     const visibleScreenIssues = useMemo(() => {
         const dismissed = readDismissedScreenIssues(invPreferred?.metadata);
-        return screenIndex.issues.filter(i => !dismissed.has(i.key));
+        return screenIndex.issues.filter(i => i.kind !== 'legacy_name_match' && !dismissed.has(i.key));
     }, [screenIndex, invPreferred]);
 
     // Repair: pin/relink a mockup screen to a canonical screen (persisted on

--- a/src/components/experience/ReferenceWarningsPanel.tsx
+++ b/src/components/experience/ReferenceWarningsPanel.tsx
@@ -11,7 +11,7 @@ import { AlertTriangle, Check, ChevronDown, ChevronRight, EyeOff, Link2 } from '
 import type { ScreenReferenceIssue, ScreenReferenceIssueKind } from '../../lib/screenExperience';
 
 const KIND_META: Record<ScreenReferenceIssueKind, { label: string; chip: string }> = {
-    unmatched_flow_step: { label: 'Flow', chip: 'bg-amber-100 text-amber-800' },
+    unmatched_flow_step: { label: 'Unknown screen', chip: 'bg-amber-100 text-amber-800' },
     unmatched_mockup_screen: { label: 'Mockup', chip: 'bg-red-50 text-red-700' },
     slug_collision: { label: 'Naming', chip: 'bg-amber-100 text-amber-800' },
     legacy_name_match: { label: 'Legacy match', chip: 'bg-neutral-100 text-neutral-600' },
@@ -39,14 +39,19 @@ export function ReferenceWarningsPanel({ issues, screenOptions, onRelink, onDism
             >
                 <span className="inline-flex items-center gap-2 text-xs font-medium text-amber-900">
                     <AlertTriangle size={13} className="text-amber-600 shrink-0" />
-                    {issues.length} {issues.length === 1 ? 'reference needs' : 'references need'} review
+                    Needs Review
+                    <span className="font-normal text-amber-700">
+                        {issues.length} {issues.length === 1 ? 'reference could' : 'references could'} not be resolved
+                    </span>
                 </span>
                 {open
                     ? <ChevronDown size={14} className="text-amber-500 shrink-0" />
                     : <ChevronRight size={14} className="text-amber-500 shrink-0" />}
             </button>
             {open && (
-                <ul className="px-4 pb-3 space-y-2">
+                <div className="px-4 pb-3">
+                    <p className="mb-2 text-xs text-amber-800">These may affect artifact consistency.</p>
+                    <ul className="space-y-2">
                     {issues.map(issue => (
                         <IssueRow
                             key={issue.key}
@@ -56,7 +61,8 @@ export function ReferenceWarningsPanel({ issues, screenOptions, onRelink, onDism
                             onDismiss={onDismiss}
                         />
                     ))}
-                </ul>
+                    </ul>
+                </div>
             )}
         </div>
     );

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -5,6 +5,7 @@
 // mockup coverage) and click through to the Screen Detail view.
 
 import { AppWindow, ChevronRight, Image as ImageIcon, Workflow } from 'lucide-react';
+import { useState } from 'react';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 
@@ -13,7 +14,7 @@ interface Props {
     /** Opens the Screen Detail view — keyed by the stable canonical id. */
     onSelectScreen: (screenId: string) => void;
     /**
-     * Opens the confirmed "Generate missing mockups" flow. Absent (no mockup
+     * Opens the confirmed "Generate remaining mockups" flow. Absent (no mockup
      * artifact yet / unparseable payload) the button is hidden. Nothing is
      * generated without this explicit confirmation.
      */
@@ -21,6 +22,7 @@ interface Props {
 }
 
 export function ScreenListView({ index, onSelectScreen, onGenerateMissingMockups }: Props) {
+    const [showAllCoverage, setShowAllCoverage] = useState(false);
     if (index.items.length === 0) {
         return (
             <div className="max-w-xl mx-auto bg-white rounded-xl border border-dashed border-neutral-300 p-10 text-center">
@@ -35,31 +37,70 @@ export function ScreenListView({ index, onSelectScreen, onGenerateMissingMockups
         );
     }
 
-    const coveredCount = index.items.filter(i => i.mockupScreen).length;
-    const missingCount = index.items.length - coveredCount;
+    const { summary, unmockedScreens } = index.mockupCoverage;
+    const shownUnmocked = showAllCoverage ? unmockedScreens : unmockedScreens.slice(0, 3);
+    const uncoveredLabel = summary.notMockedYetScreens === 1 ? '1 supporting screen available to generate' : `${summary.notMockedYetScreens} supporting screens available to generate`;
 
     return (
         <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-8">
-            {/* Mockup coverage summary — makes partial coverage explicit
-                instead of leaving users to discover empty Mockups tabs. */}
-            <div className="flex items-center justify-between gap-2 flex-wrap rounded-lg border border-neutral-200 bg-white px-4 py-2.5">
-                <span className="inline-flex items-center gap-2 text-xs text-neutral-600">
-                    <ImageIcon size={13} className={coveredCount > 0 ? 'text-emerald-500' : 'text-neutral-300'} />
-                    <span>
-                        Mockups: <span className="font-semibold text-neutral-800">{coveredCount} of {index.items.length}</span> screens covered
-                    </span>
-                </span>
-                {onGenerateMissingMockups && missingCount > 0 && (
-                    <button
-                        type="button"
-                        onClick={onGenerateMissingMockups}
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
-                    >
-                        <ImageIcon size={12} /> Generate missing mockups ({missingCount})
-                    </button>
+            <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+                <div className="flex items-start gap-3">
+                    <div className="mt-0.5 h-8 w-8 shrink-0 rounded-lg bg-indigo-50 flex items-center justify-center">
+                        <ImageIcon size={16} className="text-indigo-600" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        <h3 className="text-sm font-semibold text-neutral-900">Mockup Coverage</h3>
+                        <p className="mt-1 text-xs leading-relaxed text-neutral-600">
+                            <span className="font-medium text-neutral-800">Mockups prioritize the most important screens.</span>{' '}
+                            We created mockups for the core user-facing screens. Some supporting screens from the Screens artifact don’t have mockups yet, but they can be generated anytime.
+                        </p>
+                        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+                            <div className="rounded-lg bg-neutral-50 border border-neutral-200 px-3 py-2">
+                                <span className="font-semibold text-neutral-900">{summary.mockedScreens} of {summary.totalScreens}</span> screens have mockups
+                            </div>
+                            <div className="rounded-lg bg-indigo-50 border border-indigo-100 px-3 py-2 text-indigo-800">
+                                <span className="font-semibold">{summary.notMockedYetScreens}</span> {summary.notMockedYetScreens === 1 ? 'supporting screen' : 'supporting screens'} available to generate
+                            </div>
+                        </div>
+                        {summary.notMockedYetScreens > 0 && onGenerateMissingMockups && (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                                <button type="button" onClick={onGenerateMissingMockups} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition">
+                                    <ImageIcon size={12} /> {summary.notMockedYetScreens === 1 ? 'Generate mockup' : 'Generate remaining mockups'}
+                                </button>
+                                <button type="button" onClick={onGenerateMissingMockups} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition">
+                                    Choose screens to mock up
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                </div>
+                {summary.notMockedYetScreens > 0 && (
+                    <div className="mt-4 border-t border-neutral-100 pt-3">
+                        <div className="text-xs font-semibold text-neutral-700 mb-2">Not mocked yet</div>
+                        <ul className="space-y-2">
+                            {shownUnmocked.map(item => (
+                                <li key={item.screenId} className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-xs">
+                                    <div className="flex items-start justify-between gap-2">
+                                        <div className="min-w-0">
+                                            <p className="font-medium text-neutral-900">Not mocked yet — {item.screenName}</p>
+                                            <p className="mt-0.5 text-neutral-600">This supporting screen is defined in the Screens artifact but wasn’t included in the initial mockup set.</p>
+                                        </div>
+                                        {onGenerateMissingMockups && (
+                                            <button type="button" onClick={onGenerateMissingMockups} className="shrink-0 text-indigo-700 hover:text-indigo-900 font-medium">Generate mockup</button>
+                                        )}
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                        {unmockedScreens.length > 3 && (
+                            <button type="button" onClick={() => setShowAllCoverage(v => !v)} className="mt-2 text-xs font-medium text-indigo-700 hover:text-indigo-900">
+                                {showAllCoverage ? 'Hide' : `Show all ${unmockedScreens.length}`}
+                            </button>
+                        )}
+                        <p className="sr-only">{uncoveredLabel}</p>
+                    </div>
                 )}
             </div>
-
             {/* Slug collisions and other reference problems surface in the
                 ReferenceWarningsPanel rendered above this list (with repair
                 and dismiss actions), not as a separate banner here. */}

--- a/src/lib/__tests__/screenExperience.test.ts
+++ b/src/lib/__tests__/screenExperience.test.ts
@@ -419,6 +419,47 @@ describe('reference validation issues', () => {
     });
 });
 
+
+describe('mockup coverage classification', () => {
+    it('treats partial mockup coverage as coverage, not a warning', () => {
+        const inv: ScreenInventoryContent = { sections: [{ title: 'All', screens: Array.from({ length: 10 }, (_, i) => ({ id: `scr-${i + 1}`, name: `Screen ${i + 1}`, priority: i < 6 ? 'P0' : 'P2', purpose: 'Test.' })) }] };
+        const payload: MockupPayload = { version: 'mockup_spec_v1', title: 'T', summary: 'S', screens: Array.from({ length: 6 }, (_, i) => ({ id: `mock-${i + 1}`, name: `Screen ${i + 1}`, purpose: 'Test.', sourceScreenId: `scr-${i + 1}` })) };
+        const index = buildScreenIndex(inv, [], payload);
+        expect(index.mockupCoverage.summary).toMatchObject({ totalScreens: 10, mockedScreens: 6, notMockedYetScreens: 4, trueIssues: 0 });
+        expect(index.issues.filter(i => i.kind !== 'legacy_name_match')).toEqual([]);
+    });
+
+    it('classifies a flow step referencing a known screen without a mockup as not mocked yet', () => {
+        const inv: ScreenInventoryContent = { sections: [{ title: 'All', screens: [{ id: 'scr-study-summary', name: 'Study Summary', priority: 'P2', purpose: 'Summarize.' }] }] };
+        const flows = parseFlows(`### Flow: Study\n**Goal:** Test.\n**Steps:**\n1. [Study Summary] — User reviews → System displays summary\n**Success Outcome:** Done.`);
+        const index = buildScreenIndex(inv, flows, { version: 'mockup_spec_v1', title: 'T', summary: 'S', screens: [] });
+        expect(index.byId.get('scr-study-summary')?.relatedFlows).toHaveLength(1);
+        expect(index.mockupCoverage.unmockedScreens).toEqual([{ screenId: 'scr-study-summary', screenName: 'Study Summary', reason: 'supporting_screen' }]);
+        expect(index.issues.filter(i => i.kind !== 'legacy_name_match')).toEqual([]);
+    });
+
+    it('classifies a flow step referencing an unknown screen as a missing reference', () => {
+        const flows = parseFlows(`### Flow: Broken\n**Goal:** Test.\n**Steps:**\n1. [Does Not Exist] — User taps → System opens it\n**Success Outcome:** Done.`);
+        const index = buildScreenIndex(INVENTORY, flows, null);
+        expect(index.issues.some(i => i.kind === 'unmatched_flow_step' && i.key === 'flowstep:does-not-exist')).toBe(true);
+        expect(index.mockupCoverage.summary.trueIssues).toBe(1);
+    });
+
+    it('classifies a mockup referencing an unknown screen as a missing reference', () => {
+        const payload: MockupPayload = { version: 'mockup_spec_v1', title: 'T', summary: 'S', screens: [{ id: 'mock-unknown', name: 'Unknown', purpose: 'No source.', sourceScreenId: 'scr-unknown' }] };
+        const index = buildScreenIndex(INVENTORY, [], payload);
+        expect(index.issues.some(i => i.kind === 'unmatched_mockup_screen' && i.mockupScreenId === 'mock-unknown')).toBe(true);
+        expect(index.mockupCoverage.summary.trueIssues).toBe(1);
+    });
+
+    it('handles empty mockups as all screens available to generate without warnings', () => {
+        const index = buildScreenIndex(INVENTORY, [], { version: 'mockup_spec_v1', title: 'T', summary: 'S', screens: [] });
+        expect(index.mockupCoverage.summary).toMatchObject({ totalScreens: 5, mockedScreens: 0, notMockedYetScreens: 5, trueIssues: 0, coveragePercent: 0 });
+        expect(index.mockupCoverage.unmockedScreens).toHaveLength(5);
+        expect(index.issues.filter(i => i.kind !== 'legacy_name_match')).toEqual([]);
+    });
+});
+
 describe('screen links (relink repairs)', () => {
     it('an explicit link outranks sourceScreenId and name matching', () => {
         const payload: MockupPayload = {

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -181,6 +181,40 @@ export function readScreenLinks(metadata: Record<string, unknown> | undefined): 
 
 export const EMPTY_SCREEN_LINKS: Record<string, string> = {};
 
+export function formatScreenLabel(screenId: string): string {
+    const cleaned = screenId
+        .replace(/^(scr|mod|flow|screen)[-_]/i, '')
+        .replace(/[-_]+/g, ' ')
+        .trim();
+    if (!cleaned) return screenId;
+    return cleaned.replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export function buildMockupCoverage(
+    items: readonly ScreenExperienceItem[],
+    trueIssueCount = 0,
+): MockupCoverageModel {
+    const mockedScreens = items.filter(i => i.mockupScreen).length;
+    const totalScreens = items.length;
+    const unmockedScreens = items
+        .filter(i => !i.mockupScreen)
+        .map((item): UnmockedScreenCoverageItem => ({
+            screenId: item.id,
+            screenName: item.screen.name || formatScreenLabel(item.id),
+            reason: item.screen.priority === 'P0' ? 'not_generated_yet' : 'supporting_screen',
+        }));
+    return {
+        summary: {
+            totalScreens,
+            mockedScreens,
+            notMockedYetScreens: unmockedScreens.length,
+            trueIssues: trueIssueCount,
+            coveragePercent: totalScreens > 0 ? Math.round((mockedScreens / totalScreens) * 100) : 0,
+        },
+        unmockedScreens,
+    };
+}
+
 /**
  * Dismissed validation-issue keys, stored on the screen_inventory
  * ArtifactVersion as `metadata.dismissedScreenIssues` (the Screens view's
@@ -195,6 +229,32 @@ export function readDismissedScreenIssues(metadata: Record<string, unknown> | un
 
 export const EMPTY_DISMISSED_ISSUES: ReadonlySet<string> = new Set();
 
+export type MockupCoverageStatus =
+    | 'mocked'
+    | 'not_mocked_yet'
+    | 'missing_reference'
+    | 'invalid_mockup'
+    | 'ambiguous_reference';
+
+export interface UnmockedScreenCoverageItem {
+    screenId: string;
+    screenName: string;
+    reason: 'not_prioritized' | 'supporting_screen' | 'not_generated_yet';
+}
+
+export interface MockupCoverageSummary {
+    totalScreens: number;
+    mockedScreens: number;
+    notMockedYetScreens: number;
+    trueIssues: number;
+    coveragePercent: number;
+}
+
+export interface MockupCoverageModel {
+    summary: MockupCoverageSummary;
+    unmockedScreens: UnmockedScreenCoverageItem[];
+}
+
 export interface ScreenExperienceIndex {
     items: ScreenExperienceItem[];
     /** Canonical lookup — id is the stable, rename-safe key. */
@@ -206,6 +266,8 @@ export interface ScreenExperienceIndex {
     collisions: ScreenSlugCollision[];
     /** Slugs with a canonical screen — used to gate flow-node navigation. */
     availableSlugs: ReadonlySet<string>;
+    /** Expected partial mockup coverage, separated from true reference issues. */
+    mockupCoverage: MockupCoverageModel;
     /** Non-blocking reference-validation findings (see kinds above). Full,
      * undismissed set — callers filter against readDismissedScreenIssues. */
     issues: ScreenReferenceIssue[];
@@ -221,6 +283,10 @@ export const EMPTY_SCREEN_EXPERIENCE_INDEX: ScreenExperienceIndex = {
     sections: [],
     collisions: [],
     availableSlugs: new Set(),
+    mockupCoverage: {
+        summary: { totalScreens: 0, mockedScreens: 0, notMockedYetScreens: 0, trueIssues: 0, coveragePercent: 0 },
+        unmockedScreens: [],
+    },
     issues: [],
 };
 
@@ -344,7 +410,7 @@ export function buildScreenIndex(
         issues.push({
             key: `flowstep:${slug}`,
             kind: 'unmatched_flow_step',
-            message: `Flow step "${name}" could not be matched to a screen.`,
+            message: `Unknown screen reference: ${formatScreenLabel(name)}.`,
         });
     }
 
@@ -391,7 +457,7 @@ export function buildScreenIndex(
             issues.push({
                 key: `mockup:${mockupScreen.id}`,
                 kind: 'unmatched_mockup_screen',
-                message: `Mockup "${mockupScreen.name}" could not be matched to a screen.`,
+                message: `Mockup references missing screen: ${formatScreenLabel(mockupScreen.name)}.`,
                 mockupScreenId: mockupScreen.id,
             });
         }
@@ -417,6 +483,7 @@ export function buildScreenIndex(
         sections,
         collisions,
         availableSlugs: new Set(bySlug.keys()),
+        mockupCoverage: buildMockupCoverage(items, issues.filter(i => i.kind !== 'legacy_name_match').length),
         issues,
     };
 }


### PR DESCRIPTION
### Motivation
- The current UI treated every missing mockup reference as a warning, which creates user distrust even when mockups are intentionally prioritized and partial coverage is expected.  
- The goal is to present expected partial mockup coverage as a calm, actionable summary while still surfacing real unresolved reference issues as warnings.  
- Preserve internal validation metadata but change user-facing grouping and copy to reflect "Mockup Coverage" vs true "Needs Review" problems.

### Description
- Added a normalized Mockup Coverage data model and helpers in `src/lib/screenExperience.ts` (`MockupCoverageModel`, `buildMockupCoverage`, `formatScreenLabel`) and wired it into `buildScreenIndex` so coverage is computed separately from reference `issues`.  
- Reclassified missing-but-known screens as coverage gaps (not warnings) and left unknown references / unmatched mockups as `issues`; updated wording for unresolved references to clearer phrasing.  
- Replaced the warning-style summary with a calm `Mockup Coverage` panel in `src/components/experience/ScreenListView.tsx` that shows counts, explanatory copy, a compact list of unmocked supporting screens with progressive disclosure, and buttons that route to the existing generation flow.  
- Kept true validation UI in `ReferenceWarningsPanel.tsx` but improved language/labels and left repair/dismiss actions intact.  
- Filtered legacy name-only matches out of the user-facing warning count in `ArtifactWorkspace.tsx` while preserving them internally.  
- Added unit tests in `src/lib/__tests__/screenExperience.test.ts` covering partial coverage, known-but-unmocked flow refs, unknown flow refs, mockups referencing unknown screens, and empty mockup payload behavior.

### Testing
- Ran the focused tests with `npm test -- --run src/lib/__tests__/screenExperience.test.ts` and all tests passed (`34 passed`).  
- Ran the build with `npm run build`; the production build completed successfully (CSS syntax warning reported but build succeeded).  
- Ran linter with `npm run lint`; lint completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6c13b02c8321a489339825f6eb37)