### PR TITLE
Screens Phase 3A: mockup variant gallery + derived coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1514,14 +1514,19 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   steps highlighted (`highlightedStepIndices`) plus a per-flow "This screen
   appears in" context block (repeated appearances labeled "— Step N
   (appearance i of k)"; decision steps flag unspecified branch outcomes);
-  Mockups = `MockupScreenImage` (which internally routes to the manual
-  upload sheet) plus a metadata line (platform · fidelity · generated-from
-  PRD version · mockup version, threaded via `ScreenDetailMockupContext`), the
-  **Mockup variants card** (`MockupVariantsCard` — per-state/per-platform
-  variant rows from `buildMockupVariantRows`, replacing the old
-  states-represented panel; see the Phase 2 bullet below), and a
-  `buildMockupSpecCoverage` spec-mapping
-  panel. Shared priority-chip styles live in
+  Mockups = the **Phase 3A `MockupVariantsPanel`**
+  (`src/components/experience/MockupVariantsPanel.tsx`): a viewport × state
+  **variant gallery** driven by `buildScreenMockupVariants`
+  (`src/lib/mockupVariants.ts`, pure), with a derived summary row
+  ("N of M recommended variants generated · K missing · coverage unknown for
+  legacy mockup"), selectable variant cards (generated vs. missing, visually
+  distinct), and a **selected-variant detail panel**. The primary generated
+  Default variant renders the existing `MockupScreenImage` (its
+  generate/upload/regenerate actions are untouched); missing variants are
+  honest placeholders (NO per-variant generation in Phase 3A — no dead
+  "Generate variant" button); a `buildMockupSpecCoverage` panel shows spec
+  coverage or an honest "Coverage unknown" for legacy mockups. See the
+  "Mockup variants (Phase 3A)" bullet below. Shared priority-chip styles live in
   `src/components/renderers/screenPriority.ts`
   (own module — the react-refresh/only-export-components rule forbids constant
   exports from component files).
@@ -1593,23 +1598,43 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   rendering through the Phase 1 derived layer — never require contract
   fields.
 - **Per-state mockup variant tracking is metadata-based, never visual.**
-  `buildMockupVariantRows(item, platform?)` derives one row for the default
-  view (status `generated` iff the screen joins a mockup screen) plus one per
-  documented non-default state (`required` iff `state.needsMockup`); a
-  default-`type` state folds into the default row. Rows carry a
-  deterministic id (`default` / `state:<slug>`), the overlay key for the
-  user-set **`mockupVariantStatus`** map (`'accepted' | 'not_needed'`) on
-  `ScreenMetadataEdit`. Per-variant image generation is NOT wired — the
-  Mockups-tab `MockupVariantsCard` offers only the real actions (mark
-  accepted / not needed / undo) and says "tracked from generated mockup
+  Two layers build on the same `mockupVariantStatus` overlay keys and must stay
+  compatible:
+  - **Readiness layer** — `buildMockupVariantRows(item, platform?)`
+    (`screenReadiness.ts`) derives one row for the default view (status
+    `generated` iff the screen joins a mockup screen) plus one per documented
+    non-default state (`required` iff `state.needsMockup`); a default-`type`
+    state folds into the default row. Rows carry a deterministic id
+    (`default` / `state:<slug>`) — the overlay key for the user-set
+    **`mockupVariantStatus`** map (`'accepted' | 'not_needed'`) on
+    `ScreenMetadataEdit`. A missing **state** row (never the default row —
+    that's `missing_mockup_p0`'s job, and counting it would downgrade legacy
+    mockup-less P2/P3 screens) left `missing` while `required` is the
+    `missing_state_variants` readiness gap; `accepted`/`not_needed` resolve it.
+    This layer alone drives review status.
+  - **Phase 3A discovery layer (`src/lib/mockupVariants.ts`, pure,
+    unit-tested)** — `buildScreenMockupVariants(item, {platform, mobileRelevant})`
+    adds a **viewport dimension** (desktop / mobile / tablet) on top of states,
+    for the Mockups-tab gallery + screen-card summary + coverage-panel rollup.
+    A legacy single-image mockup normalizes to **`Desktop · Default`**
+    (`source: 'legacy'`, `coverageStatus: 'unknown'` — no per-variant coverage
+    metadata was ever captured). Recommendations are DERIVED estimates:
+    `Desktop · Default` for every primary screen, `Mobile · Default` for P0
+    (and P1/supporting when `mobileRelevant`), and important documented states.
+    **Overlay-key compatibility**: the primary-viewport Default reuses `default`
+    and primary-viewport states reuse `state:<slug>` (shared with the readiness
+    layer); only the secondary-viewport default introduces `${viewport}:default`.
+    `summarizeScreenVariants` (per-screen card) and
+    `buildMockupVariantCoverageSummary` (artifact rollup: recommended
+    generated/total, P0 mobile coverage, legacy-unknown count) drive the UI.
+    This layer is **display/discovery only — it never changes review status.**
+  Per-variant image generation is NOT wired (Phase 3B) — the Mockups-tab
+  `MockupVariantsPanel` offers only the real actions (mark accepted / not
+  needed / undo) and says coverage is "tracked from generated mockup
   metadata"; never add a dead "generate variant" button or wording that
-  implies Synapse inspected the rendered image. A missing row offers BOTH
-  "Mark accepted" (the user verified/uploaded the variant externally) and
-  "Not needed". A **state** row (never the default row — that's
-  `missing_mockup_p0`'s job, and counting it would downgrade legacy
-  mockup-less P2/P3 screens) left `missing` while `required` is the
-  `missing_state_variants` readiness gap; `accepted`/`not_needed` resolve it
-  deliberately. `parseDecisionBranches` (arrow-form +
+  implies Synapse inspected the rendered image, and never claim visual
+  alignment / show "covered" without structured metadata (legacy → "unknown").
+  `parseDecisionBranches` (arrow-form +
   if/otherwise) powers both the branch-aware Flow-tab rendering
   (`DecisionBranches`) and the `decision_missing_branches` gap — an
   unparseable decision renders the raw text with an honest "branch outcomes

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -37,6 +37,7 @@ import {
     type ScreenMetadataEdit,
 } from '../lib/screenExperience';
 import { buildReadinessIndex, buildScreenCoverageSummary } from '../lib/screenReadiness';
+import { buildMockupVariantCoverageSummary } from '../lib/mockupVariants';
 import { ReferenceWarningsPanel } from './experience/ReferenceWarningsPanel';
 import { parseScreenInventory } from '../lib/screenInventoryNormalize';
 import { parseFlows } from './renderers/userFlows/parseFlow';
@@ -392,6 +393,17 @@ export function ArtifactWorkspace({
             structuredPRD.features,
         ),
         [screenIndex, screenReadiness, flowsPreferred, parsedFlows, structuredPRD.features],
+    );
+
+    // Phase 3A: derived mockup-variant coverage (viewport × state). Platform
+    // comes from the current mockup settings (drives the primary viewport);
+    // mobile-relevance broadens recommended Mobile variants beyond P0.
+    const mockupPlatform = mockupPreferred ? extractMockupSettings(mockupPreferred).platform : undefined;
+    const mobileRelevant = projectPlatform === 'app'
+        || mockupPlatform === 'mobile' || mockupPlatform === 'responsive';
+    const variantCoverage = useMemo(
+        () => buildMockupVariantCoverageSummary(screenIndex, { platform: mockupPlatform, mobileRelevant }),
+        [screenIndex, mockupPlatform, mobileRelevant],
     );
 
     // Validation issues minus the user's persisted dismissals.
@@ -836,6 +848,7 @@ export function ArtifactWorkspace({
                         availableScreenSlugs={screenIndex.availableSlugs}
                         screenImageContext={invScreenImageContext}
                         mockupContext={mockupDetailContext}
+                        mobileRelevant={mobileRelevant}
                         mockupStatus={slotStatusFor('mockup')}
                         onRetryMockup={() => handleRetrySlot('mockup')}
                         features={structuredPRD.features}
@@ -938,6 +951,9 @@ export function ArtifactWorkspace({
                         index={screenIndex}
                         readiness={screenReadiness}
                         coverage={screenCoverage}
+                        variantCoverage={variantCoverage}
+                        mockupPlatform={mockupPlatform}
+                        mobileRelevant={mobileRelevant}
                         onSelectScreen={handleOpenScreen}
                         onGenerateMissingMockups={
                             mockupDetailContext

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -299,24 +299,34 @@ describe('Phase 2 contract rendering', () => {
         expect(getAllByText('Empty state appears when no evaluations exist').length).toBeGreaterThan(0);
     });
 
-    it('Mockups tab lists variant rows from metadata with honest statuses', () => {
+    it('Mockups tab presents a viewport × state variant gallery with honest statuses', () => {
         const { getByText, getAllByText } = renderContractDetail('mockups');
-        expect(getByText('Mockup variants')).toBeTruthy();
-        expect(getByText('Tracked from generated mockup metadata')).toBeTruthy();
-        expect(getByText('Default view')).toBeTruthy();
-        expect(getByText('Generated')).toBeTruthy();
-        expect(getAllByText(/Generated from/).length).toBeGreaterThan(0);
-        expect(getByText(/PRD Version 3 · mockup v2/)).toBeTruthy();
-        expect(getByText('Empty history')).toBeTruthy();
-        expect(getAllByText('Missing').length).toBe(2);
-        // Only real actions are offered; per-variant generation is not claimed.
-        expect(getByText(/Per-variant generation isn’t wired yet/)).toBeTruthy();
+        // Header + derived summary.
+        expect(getByText(/recommended .*variants.* generated/)).toBeTruthy();
+        // Variant cards (viewport × state). The default is generated; mobile /
+        // states are recommended-but-missing.
+        expect(getAllByText('Desktop · Default').length).toBeGreaterThan(0);
+        expect(getByText('Mobile · Default')).toBeTruthy();
+        expect(getByText('Desktop · Empty history')).toBeTruthy();
+        expect(getByText('Desktop · Upload error')).toBeTruthy();
+        // Legacy mockup with no coverage metadata → unknown, never fabricated.
+        expect(getByText('Coverage unknown')).toBeTruthy();
+        expect(getByText(/Generated from PRD Version 3/)).toBeTruthy();
+        // Missing variants are visually distinct (Missing pills + "Not generated yet").
+        expect(getAllByText('Missing').length).toBe(3);
+        expect(getAllByText('Not generated yet').length).toBe(3);
+        // Selecting a missing variant explains generation isn't in this phase —
+        // and offers no dead "Generate variant" button.
+        fireEvent.click(getByText('Mobile · Default'));
+        expect(getByText(/Per-variant generation lands in Phase 3B/)).toBeTruthy();
     });
 
     it('marking a variant not needed persists through the edit overlay', () => {
         const onSave = vi.fn();
-        const { getAllByText } = renderContractDetail('mockups', { onSaveScreenEdit: onSave });
-        fireEvent.click(getAllByText('Not needed')[0]);
+        const { getByText } = renderContractDetail('mockups', { onSaveScreenEdit: onSave });
+        // Select the missing Empty-history variant, then mark it not needed.
+        fireEvent.click(getByText('Desktop · Empty history'));
+        fireEvent.click(getByText('Not needed'));
         expect(onSave).toHaveBeenCalledTimes(1);
         const [id, edit] = onSave.mock.calls[0] as [string, Record<string, unknown>];
         expect(id).toBe('scr-submission');
@@ -358,11 +368,10 @@ describe('Phase 2 contract rendering', () => {
 describe('missing variant acceptance (review-feedback regression)', () => {
     it('a missing variant row can be marked accepted (e.g. verified via upload), not just not-needed', () => {
         const onSave = vi.fn();
-        const { getAllByText } = renderContractDetail('mockups', { onSaveScreenEdit: onSave });
-        // Row order: default (generated) → Empty history (missing) → Upload
-        // error (missing); the first "Mark accepted" after the default row's
-        // belongs to the missing Empty history row.
-        fireEvent.click(getAllByText('Mark accepted')[1]);
+        const { getByText } = renderContractDetail('mockups', { onSaveScreenEdit: onSave });
+        // Select the missing Empty-history variant, then mark it accepted.
+        fireEvent.click(getByText('Desktop · Empty history'));
+        fireEvent.click(getByText('Mark accepted'));
         expect(onSave).toHaveBeenCalledTimes(1);
         const [, edit] = onSave.mock.calls[0] as [string, Record<string, unknown>];
         expect(edit.mockupVariantStatus).toEqual({ 'state:empty-history': 'accepted' });

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -1,0 +1,380 @@
+// Phase 3A: the redesigned Mockups tab for a single screen. Presents the
+// screen's mockups as a viewport × state VARIANT grid (see
+// src/lib/mockupVariants.ts) instead of a lone image preview:
+//   - a summary row (generated / missing / coverage),
+//   - a selectable variant gallery (generated vs. missing, visually distinct),
+//   - a selected-variant detail panel (preview, status, metadata, coverage),
+//   - a spec-coverage panel for the generated mockup.
+//
+// Everything is derived + read-time. The single generated image still renders
+// through the existing MockupScreenImage (its generate / upload / regenerate
+// actions are untouched). Missing variants are honest placeholders — Phase 3A
+// introduces NO per-variant generation, so no dead "Generate variant" button
+// is shown. Status is tracked from generated metadata + the user's overlay,
+// never from inspecting pixels, and the copy says so.
+
+import { useMemo, useState } from 'react';
+import {
+    CheckCircle2, ImageOff, Info, Layers, Monitor, Smartphone, Tablet,
+} from 'lucide-react';
+import type { MockupPlatform } from '../../types';
+import {
+    COVERAGE_STATUS_LABELS,
+    VARIANT_STATUS_LABELS,
+    formatVariantLabel,
+    type DerivedMockupVariant,
+    type MockupVariantStatus,
+    type MockupViewport,
+    type ScreenMockupVariantSummary,
+} from '../../lib/mockupVariants';
+import { buildMockupSpecCoverage } from '../../lib/screenReadiness';
+import type { ScreenExperienceItem } from '../../lib/screenExperience';
+import { MockupScreenImage } from '../mockups/MockupScreenImage';
+import type { ScreenDetailMockupContext } from './ScreenDetailView';
+
+const VIEWPORT_ICON: Record<MockupViewport, typeof Monitor> = {
+    desktop: Monitor,
+    mobile: Smartphone,
+    tablet: Tablet,
+};
+
+const STATUS_PILL: Record<MockupVariantStatus, string> = {
+    generated: 'text-emerald-700 bg-emerald-50 ring-emerald-200',
+    missing: 'text-amber-700 bg-amber-50 ring-amber-200',
+    accepted: 'text-sky-700 bg-sky-50 ring-sky-200',
+    not_needed: 'text-neutral-500 bg-neutral-100 ring-neutral-200',
+};
+
+const COVERAGE_TONE: Record<DerivedMockupVariant['coverageStatus'], string> = {
+    aligned: 'text-emerald-700',
+    partial: 'text-amber-700',
+    missing_items: 'text-amber-700',
+    unknown: 'text-neutral-500',
+};
+
+const PLATFORM_LABELS: Record<MockupPlatform, string> = {
+    mobile: 'Mobile',
+    desktop: 'Desktop',
+    responsive: 'Responsive',
+};
+
+interface Props {
+    item: ScreenExperienceItem;
+    variants: DerivedMockupVariant[];
+    summary: ScreenMockupVariantSummary;
+    mockupContext: ScreenDetailMockupContext;
+    /** Persists a per-variant status onto the screen edit overlay (null clears
+     * it back to the tracked/derived status). */
+    onSetVariantStatus?: (variantId: string, status: 'accepted' | 'not_needed' | null) => void;
+}
+
+/** The variant that holds the single generated image (primary Default). The
+ * image renders whenever a mockup exists for this screen — even after the user
+ * marks the default "accepted" (which flips status off 'generated'). */
+const holdsGeneratedImage = (v: DerivedMockupVariant, hasMockup: boolean): boolean =>
+    v.id === 'default' && hasMockup;
+
+export function MockupVariantsPanel({
+    item, variants, summary, mockupContext, onSetVariantStatus,
+}: Props) {
+    const [selectedId, setSelectedId] = useState<string>(() => {
+        const generated = variants.find(v => v.status === 'generated');
+        return (generated ?? variants[0])?.id ?? 'default';
+    });
+    const selected = variants.find(v => v.id === selectedId) ?? variants[0];
+
+    const specCoverage = useMemo(
+        () => buildMockupSpecCoverage(item.baseScreen, item.mockupScreen?.coreUIElements),
+        [item.baseScreen, item.mockupScreen],
+    );
+
+    const summaryParts: string[] = [
+        `${summary.generated} of ${summary.recommended} recommended ${summary.recommended === 1 ? 'variant' : 'variants'} generated`,
+    ];
+    if (summary.missing > 0) summaryParts.push(`${summary.missing} missing`);
+    if (summary.coverageUnknown) summaryParts.push('coverage unknown for legacy mockup');
+
+    return (
+        <div className="space-y-3">
+            {/* Header + summary */}
+            <div>
+                <h3 className="text-sm font-semibold text-neutral-900">Mockups</h3>
+                <p className="text-xs text-neutral-500 mt-0.5">
+                    Generated product screen previews mapped to this screen&rsquo;s states and viewports.
+                </p>
+                <p className="mt-1.5 text-[11px] text-neutral-500">{summaryParts.join(' · ')}</p>
+            </div>
+
+            {/* Variant gallery — pills, selectable */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {variants.map(v => (
+                    <VariantCard
+                        key={v.id}
+                        variant={v}
+                        selected={v.id === selected?.id}
+                        onSelect={() => setSelectedId(v.id)}
+                    />
+                ))}
+            </div>
+
+            {/* Selected variant detail */}
+            {selected && (
+                <VariantDetail
+                    variant={selected}
+                    item={item}
+                    mockupContext={mockupContext}
+                    specCoverage={specCoverage}
+                    onSetVariantStatus={onSetVariantStatus}
+                />
+            )}
+        </div>
+    );
+}
+
+function VariantCard({
+    variant, selected, onSelect,
+}: {
+    variant: DerivedMockupVariant;
+    selected: boolean;
+    onSelect: () => void;
+}) {
+    const Icon = VIEWPORT_ICON[variant.viewport];
+    const generated = variant.status === 'generated' || variant.status === 'accepted';
+    return (
+        <button
+            type="button"
+            onClick={onSelect}
+            aria-pressed={selected}
+            className={`text-left rounded-lg border p-3 transition ${
+                selected
+                    ? 'border-indigo-400 ring-1 ring-indigo-200 bg-indigo-50/40'
+                    : 'border-neutral-200 bg-white hover:border-indigo-300'
+            }`}
+        >
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1.5 min-w-0">
+                    <Icon size={13} className={generated ? 'text-emerald-500' : 'text-neutral-400'} aria-hidden />
+                    <span className="text-xs font-medium text-neutral-800 truncate">
+                        {formatVariantLabel(variant)}
+                    </span>
+                </div>
+                <span className={`shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full ring-1 ${STATUS_PILL[variant.status]}`}>
+                    {VARIANT_STATUS_LABELS[variant.status]}
+                </span>
+            </div>
+            <div className="mt-1.5 flex items-center gap-2 flex-wrap text-[10px]">
+                {variant.required && variant.status === 'missing' && variant.id !== 'default' && (
+                    <span className="uppercase tracking-wide text-violet-700 bg-violet-50 ring-1 ring-violet-100 px-1.5 py-px rounded">
+                        Recommended
+                    </span>
+                )}
+                {variant.status === 'generated' && (
+                    <span className={COVERAGE_TONE[variant.coverageStatus]}>
+                        Coverage: {COVERAGE_STATUS_LABELS[variant.coverageStatus].toLowerCase()}
+                    </span>
+                )}
+                {variant.status === 'missing' && (
+                    <span className="text-neutral-400">Not generated yet</span>
+                )}
+            </div>
+        </button>
+    );
+}
+
+function VariantDetail({
+    variant, item, mockupContext, specCoverage, onSetVariantStatus,
+}: {
+    variant: DerivedMockupVariant;
+    item: ScreenExperienceItem;
+    mockupContext: ScreenDetailMockupContext;
+    specCoverage: ReturnType<typeof buildMockupSpecCoverage>;
+    onSetVariantStatus?: (variantId: string, status: 'accepted' | 'not_needed' | null) => void;
+}) {
+    const primaryGenerated = holdsGeneratedImage(variant, Boolean(item.mockupScreen));
+    const metaParts = [
+        PLATFORM_LABELS[mockupContext.settings.platform],
+        mockupContext.prdVersionLabel ? `Generated from PRD ${mockupContext.prdVersionLabel}` : null,
+        mockupContext.versionNumber ? `Mockup v${mockupContext.versionNumber}` : null,
+    ].filter(Boolean);
+
+    return (
+        <div className="bg-white rounded-xl border border-neutral-200 p-4 space-y-3">
+            <div className="flex items-start justify-between gap-2 flex-wrap">
+                <div className="min-w-0">
+                    <h4 className="text-sm font-semibold text-neutral-900">{formatVariantLabel(variant)}</h4>
+                    <p className="text-[11px] text-neutral-500 mt-0.5">
+                        Status: {VARIANT_STATUS_LABELS[variant.status]}
+                        {variant.userSet && ' (set by you)'}
+                        {variant.status === 'generated' && variant.source === 'legacy' && ' · Source: existing mockup'}
+                    </p>
+                </div>
+                <VariantActions variant={variant} onSetVariantStatus={onSetVariantStatus} />
+            </div>
+
+            {/* Preview */}
+            {primaryGenerated ? (
+                <div className="space-y-2">
+                    <div className="rounded-lg border border-neutral-200 overflow-hidden">
+                        <MockupScreenImage
+                            projectId={mockupContext.projectId}
+                            artifactId={mockupContext.artifactId}
+                            versionId={mockupContext.versionId}
+                            screen={item.mockupScreen!}
+                            payload={mockupContext.payload}
+                            settings={mockupContext.settings}
+                        />
+                    </div>
+                    {metaParts.length > 0 && (
+                        <p className="text-[11px] text-neutral-400">{metaParts.join(' · ')}</p>
+                    )}
+                </div>
+            ) : variant.status === 'missing' ? (
+                <div className="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/60 p-6 text-center">
+                    <ImageOff size={18} className="text-neutral-300 mx-auto mb-2" aria-hidden />
+                    <p className="text-xs font-medium text-neutral-700">
+                        No mockup for {formatVariantLabel(variant)} yet.
+                    </p>
+                    <p className="text-[11px] text-neutral-500 mt-1 max-w-sm mx-auto">
+                        {variant.notes[0] ?? 'Recommended for this screen.'}
+                    </p>
+                    <p className="text-[11px] text-neutral-400 mt-2">
+                        Per-variant generation lands in Phase 3B. For now, regenerate the full mockup
+                        or upload an image and mark this variant accepted.
+                    </p>
+                </div>
+            ) : (
+                <div className="rounded-lg border border-neutral-200 bg-neutral-50/60 p-4 text-center">
+                    <p className="text-xs text-neutral-600">
+                        {variant.status === 'accepted'
+                            ? 'You marked this variant accepted — no generated preview is stored in Synapse for it.'
+                            : 'This variant is marked not needed.'}
+                    </p>
+                </div>
+            )}
+
+            {/* Spec coverage — only for the variant that holds the real image. */}
+            <SpecCoverageSection show={primaryGenerated} specCoverage={specCoverage} />
+
+            {/* Notes */}
+            {variant.notes.length > 0 && variant.status !== 'missing' && (
+                <ul className="space-y-1">
+                    {variant.notes.map((note, i) => (
+                        <li key={i} className="flex items-start gap-1.5 text-[11px] text-neutral-500">
+                            <Info size={11} className="mt-0.5 shrink-0 text-neutral-400" aria-hidden />
+                            <span>{note}</span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+function SpecCoverageSection({
+    show, specCoverage,
+}: {
+    show: boolean;
+    specCoverage: ReturnType<typeof buildMockupSpecCoverage>;
+}) {
+    // Coverage is only meaningful for the variant that holds the real image;
+    // other variants show the honest "unknown" state rather than a fabricated grid.
+    if (!show) return null;
+    return (
+        <div className="rounded-lg border border-neutral-200 p-3">
+            <div className="flex items-center gap-1.5 mb-2">
+                <Layers size={12} className="text-neutral-400" aria-hidden />
+                <h5 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                    Spec coverage
+                </h5>
+            </div>
+            {specCoverage.length === 0 ? (
+                <div className="text-[11px] text-neutral-500 space-y-1">
+                    <p className="font-medium text-neutral-600">Coverage unknown</p>
+                    <p>
+                        This mockup was generated before coverage metadata was recorded. It may still
+                        be useful visually, but Synapse cannot confirm which screen-spec items are
+                        represented.
+                    </p>
+                    <p className="text-neutral-400">
+                        UI Regions · Required States · User Actions · Acceptance Criteria — Not checked.
+                    </p>
+                </div>
+            ) : (
+                <>
+                    <ul className="space-y-1 text-xs">
+                        {specCoverage.map((row, i) => (
+                            <li key={i} className="flex items-center justify-between gap-2">
+                                <span className="text-neutral-700">{row.element}</span>
+                                {row.status === 'in_spec' ? (
+                                    <span className="text-emerald-700 font-medium">In mockup spec</span>
+                                ) : (
+                                    <span className="text-amber-700">Not in mockup spec</span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="text-[11px] text-neutral-400 mt-2">
+                        Compared against the mockup&rsquo;s generation spec, not the rendered image —
+                        treat &ldquo;Not in mockup spec&rdquo; as a prompt to double-check the visual.
+                    </p>
+                </>
+            )}
+        </div>
+    );
+}
+
+function VariantActions({
+    variant, onSetVariantStatus,
+}: {
+    variant: DerivedMockupVariant;
+    onSetVariantStatus?: (variantId: string, status: 'accepted' | 'not_needed' | null) => void;
+}) {
+    if (!onSetVariantStatus) return null;
+    const btn = 'text-[10px] px-2 py-0.5 rounded bg-neutral-100 hover:bg-neutral-200 text-neutral-700 transition';
+    if (variant.userSet) {
+        return (
+            <button
+                type="button"
+                onClick={() => onSetVariantStatus(variant.id, null)}
+                className="text-[10px] text-neutral-500 hover:text-neutral-700 underline decoration-dotted shrink-0"
+            >
+                Undo
+            </button>
+        );
+    }
+    if (variant.status === 'generated') {
+        return (
+            <button
+                type="button"
+                onClick={() => onSetVariantStatus(variant.id, 'accepted')}
+                className={`${btn} shrink-0 inline-flex items-center gap-1`}
+                title="Confirm this variant looks good"
+            >
+                <CheckCircle2 size={11} aria-hidden /> Mark accepted
+            </button>
+        );
+    }
+    if (variant.status === 'missing') {
+        return (
+            <div className="flex items-center gap-1.5 shrink-0">
+                <button
+                    type="button"
+                    onClick={() => onSetVariantStatus(variant.id, 'accepted')}
+                    className={btn}
+                    title="Confirm this variant is covered — e.g. you uploaded or verified it outside the generated set"
+                >
+                    Mark accepted
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onSetVariantStatus(variant.id, 'not_needed')}
+                    className={btn}
+                    title="Skip this recommended variant"
+                >
+                    Not needed
+                </button>
+            </div>
+        );
+    }
+    return null;
+}

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -11,9 +11,13 @@ import {
     AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, Gauge, Image as ImageIcon,
 } from 'lucide-react';
 import type { ScreenCoverageSummary } from '../../lib/screenReadiness';
+import type { MockupVariantCoverageSummary } from '../../lib/mockupVariants';
 
 interface Props {
     summary: ScreenCoverageSummary;
+    /** Artifact-level mockup-variant rollup (Phase 3A). Absent/null → the
+     * variant rows are hidden (e.g. no screens). */
+    variantCoverage?: MockupVariantCoverageSummary | null;
     /** Opens the confirmed "Generate remaining mockups" flow (absent → no
      * mockup artifact yet; the action row is hidden). */
     onGenerateMissingMockups?: () => void;
@@ -40,7 +44,7 @@ function MetricRow({
     );
 }
 
-export function ScreenCoveragePanel({ summary, onGenerateMissingMockups }: Props) {
+export function ScreenCoveragePanel({ summary, variantCoverage, onGenerateMissingMockups }: Props) {
     const [showUncovered, setShowUncovered] = useState(false);
     const {
         totalScreens, prdFeatures, stateVariants, flows, p0, states, mockups, openRisks,
@@ -111,6 +115,30 @@ export function ScreenCoveragePanel({ summary, onGenerateMissingMockups }: Props
                                 value={`${mockups.covered} / ${mockups.total} screens`}
                                 tone={missingMockups > 0 ? 'neutral' : 'good'}
                             />
+                            {variantCoverage && variantCoverage.recommendedTotal > 0 && (
+                                <MetricRow
+                                    label="Mockup variants"
+                                    value={`${variantCoverage.recommendedGenerated} / ${variantCoverage.recommendedTotal} recommended`}
+                                    hint="Recommended viewport × state variants generated or accepted across all screens — tracked from mockup metadata and your marks, never from inspecting images"
+                                    tone={variantCoverage.recommendedGenerated < variantCoverage.recommendedTotal ? 'warn' : 'good'}
+                                />
+                            )}
+                            {variantCoverage && variantCoverage.p0Total > 0 && (
+                                <MetricRow
+                                    label="Mobile coverage (P0)"
+                                    value={`${variantCoverage.p0WithMobile} / ${variantCoverage.p0Total} P0 screens`}
+                                    hint="P0 screens with a generated or accepted Mobile default variant"
+                                    tone={variantCoverage.p0WithMobile < variantCoverage.p0Total ? 'warn' : 'good'}
+                                />
+                            )}
+                            {variantCoverage && variantCoverage.legacyUnknownMockups > 0 && (
+                                <MetricRow
+                                    label="Legacy mockups (coverage unknown)"
+                                    value={`${variantCoverage.legacyUnknownMockups}`}
+                                    hint="Mockups generated before coverage metadata was captured — visually useful, but Synapse can't confirm which spec items they represent"
+                                    tone="neutral"
+                                />
+                            )}
                             {stateVariants && (
                                 <MetricRow
                                     label="Recommended state variants"

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -127,7 +127,7 @@ export function ScreenCoveragePanel({ summary, variantCoverage, onGenerateMissin
                                 <MetricRow
                                     label="Mobile coverage (P0)"
                                     value={`${variantCoverage.p0WithMobile} / ${variantCoverage.p0Total} P0 screens`}
-                                    hint="P0 screens with a generated or accepted Mobile default variant"
+                                    hint="P0 screens whose Mobile default variant is generated, accepted, or marked not needed"
                                     tone={variantCoverage.p0WithMobile < variantCoverage.p0Total ? 'warn' : 'good'}
                                 />
                             )}

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -18,7 +18,7 @@ import {
     RefreshCcw, RotateCcw, Workflow,
 } from 'lucide-react';
 import type {
-    Feature, GenerationStatus, MockupFidelity, MockupPayload, MockupPlatform,
+    Feature, GenerationStatus, MockupPayload,
     MockupSettings, ScreenPriority,
 } from '../../types';
 import {
@@ -28,10 +28,15 @@ import {
     type ScreenMetadataEdit,
 } from '../../lib/screenExperience';
 import {
-    buildMockupSpecCoverage, buildMockupVariantRows, parseDecisionBranches,
+    parseDecisionBranches,
     REVIEW_STATUS_LABELS,
-    type MockupVariantRow, type ScreenReadiness, type ScreenReviewStatus,
+    type ScreenReadiness, type ScreenReviewStatus,
 } from '../../lib/screenReadiness';
+import {
+    buildScreenMockupVariants, formatVariantLabel, summarizeScreenVariants,
+    VARIANT_STATUS_LABELS,
+} from '../../lib/mockupVariants';
+import { MockupVariantsPanel } from './MockupVariantsPanel';
 import { ScreenOverviewPanel } from './ScreenOverviewPanel';
 import { ReadinessBadge } from './ReadinessBadge';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
@@ -41,7 +46,6 @@ import { FlowJourney } from '../renderers/userFlows/FlowJourney';
 import { StepCard } from '../renderers/userFlows/StepCard';
 import { FeatureDetailDrawer } from '../renderers/userFlows/FeatureDetailDrawer';
 import type { FeatureRef, FlowIssue } from '../renderers/userFlows/types';
-import { MockupScreenImage } from '../mockups/MockupScreenImage';
 import { ScreenDetailTabs, type ScreenDetailTab } from './ScreenDetailTabs';
 
 /** Everything the Mockups tab needs to render the reused mockup components. */
@@ -71,6 +75,9 @@ interface Props {
     screenImageContext?: ScreenImageGalleryContext;
     /** Mockups tab context — absent when no parseable mockup artifact exists. */
     mockupContext?: ScreenDetailMockupContext;
+    /** True when the project is mobile-relevant (mobile-first / responsive) —
+     * enables recommended Mobile variants on P1/supporting screens. */
+    mobileRelevant?: boolean;
     /** Mockup generation slot status, for honest Mockups-tab empty states. */
     mockupStatus?: GenerationStatus;
     onRetryMockup?: () => void;
@@ -98,7 +105,7 @@ interface Props {
 export function ScreenDetailView({
     item, readiness, activeTab, onTabChange, onBack,
     onNavigateToScreen, availableScreenSlugs,
-    screenImageContext, mockupContext, mockupStatus, onRetryMockup,
+    screenImageContext, mockupContext, mobileRelevant, mockupStatus, onRetryMockup,
     features, onSaveScreenEdit, onAddToMockups, unmatchedMockups, onLinkMockup,
 }: Props) {
     const { screen } = item;
@@ -246,6 +253,7 @@ export function ScreenDetailView({
                 <MockupsTab
                     item={item}
                     mockupContext={mockupContext}
+                    mobileRelevant={mobileRelevant}
                     mockupStatus={mockupStatus}
                     onRetryMockup={onRetryMockup}
                     onAddToMockups={onAddToMockups}
@@ -586,24 +594,13 @@ function DecisionBranches({ decision }: { decision: string }) {
 
 // --- Mockups tab ------------------------------------------------------------
 
-const PLATFORM_LABELS: Record<MockupPlatform, string> = {
-    mobile: 'Mobile',
-    desktop: 'Desktop',
-    responsive: 'Responsive',
-};
-
-const FIDELITY_LABELS: Record<MockupFidelity, string> = {
-    low: 'Low fidelity',
-    mid: 'Mid fidelity',
-    high: 'High fidelity',
-};
-
 function MockupsTab({
-    item, mockupContext, mockupStatus, onRetryMockup, onAddToMockups,
+    item, mockupContext, mobileRelevant, mockupStatus, onRetryMockup, onAddToMockups,
     unmatchedMockups, onLinkMockup, onSaveScreenEdit,
 }: {
     item: ScreenExperienceItem;
     mockupContext?: ScreenDetailMockupContext;
+    mobileRelevant?: boolean;
     mockupStatus?: GenerationStatus;
     onRetryMockup?: () => void;
     onAddToMockups?: () => void;
@@ -612,6 +609,13 @@ function MockupsTab({
     onSaveScreenEdit?: (screenId: string, edit: ScreenMetadataEdit | null) => void;
 }) {
     const [linkTarget, setLinkTarget] = useState('');
+
+    // Derived viewport × state variant grid (see src/lib/mockupVariants.ts).
+    const variants = buildScreenMockupVariants(item, {
+        platform: mockupContext?.settings.platform,
+        mobileRelevant,
+    });
+    const variantSummary = summarizeScreenVariants(variants);
 
     // Persist a per-variant status into the screen's edit overlay (null
     // clears the override back to the tracked/derived status). Merges into
@@ -630,65 +634,14 @@ function MockupsTab({
         : undefined;
 
     if (mockupContext && item.mockupScreen) {
-        const specCoverage = buildMockupSpecCoverage(
-            item.baseScreen,
-            item.mockupScreen.coreUIElements,
-        );
-        const variantRows = buildMockupVariantRows(item, mockupContext.settings.platform);
-        const metaParts = [
-            'Generated product screen preview',
-            PLATFORM_LABELS[mockupContext.settings.platform],
-            FIDELITY_LABELS[mockupContext.settings.fidelity],
-        ];
-        if (mockupContext.prdVersionLabel) metaParts.push(`Generated from PRD ${mockupContext.prdVersionLabel}`);
-        if (mockupContext.versionNumber) metaParts.push(`Mockup v${mockupContext.versionNumber}`);
         return (
-            <div className="space-y-3">
-                <p className="text-[11px] text-neutral-500">
-                    {metaParts.join(' · ')}
-                </p>
-                <div className="bg-white rounded-xl border border-neutral-200 overflow-hidden">
-                    <MockupScreenImage
-                        projectId={mockupContext.projectId}
-                        artifactId={mockupContext.artifactId}
-                        versionId={mockupContext.versionId}
-                        screen={item.mockupScreen}
-                        payload={mockupContext.payload}
-                        settings={mockupContext.settings}
-                    />
-                </div>
-
-                <MockupVariantsCard
-                    rows={variantRows}
-                    prdVersionLabel={mockupContext.prdVersionLabel}
-                    mockupVersionNumber={mockupContext.versionNumber}
-                    onSetVariantStatus={setVariantStatus}
-                />
-
-                {specCoverage.length > 0 && (
-                    <div className="bg-white rounded-lg border border-neutral-200 p-4">
-                        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500 mb-2">
-                            Spec coverage in mockup
-                        </h4>
-                        <ul className="space-y-1 text-xs">
-                            {specCoverage.map((row, i) => (
-                                <li key={i} className="flex items-center justify-between gap-2">
-                                    <span className="text-neutral-700">{row.element}</span>
-                                    {row.status === 'in_spec' ? (
-                                        <span className="text-emerald-700 font-medium">In mockup spec</span>
-                                    ) : (
-                                        <span className="text-amber-700">Not in mockup spec</span>
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-                        <p className="text-[11px] text-neutral-400 mt-2">
-                            Compared against the mockup&rsquo;s generation spec, not the rendered image —
-                            treat &ldquo;Not in mockup spec&rdquo; as a prompt to double-check the visual.
-                        </p>
-                    </div>
-                )}
-            </div>
+            <MockupVariantsPanel
+                item={item}
+                variants={variants}
+                summary={variantSummary}
+                mockupContext={mockupContext}
+                onSetVariantStatus={setVariantStatus}
+            />
         );
     }
 
@@ -723,6 +676,7 @@ function MockupsTab({
     }
 
     return (
+        <div className="space-y-3">
         <div className="bg-white rounded-xl border border-dashed border-neutral-300 p-8 text-center">
             <ImageIcon size={20} className="text-neutral-300 mx-auto mb-2" />
             <p className="text-sm font-medium text-neutral-700">
@@ -772,134 +726,40 @@ function MockupsTab({
                 </div>
             )}
         </div>
-    );
-}
 
-// --- Mockup variants card -----------------------------------------------------
-
-const VARIANT_STATUS_META: Record<MockupVariantRow['status'], { label: string; className: string }> = {
-    generated: { label: 'Generated', className: 'text-emerald-700 bg-emerald-50 ring-emerald-200' },
-    missing: { label: 'Missing', className: 'text-amber-700 bg-amber-50 ring-amber-200' },
-    accepted: { label: 'Accepted', className: 'text-sky-700 bg-sky-50 ring-sky-200' },
-    not_needed: { label: 'Not needed', className: 'text-neutral-500 bg-neutral-100 ring-neutral-200' },
-};
-
-/**
- * Per-state / per-platform mockup variant tracking. Status comes from
- * generated mockup METADATA (the spec-to-spec join) plus the user's overlay —
- * never from inspecting the rendered image, and the copy says so. Per-variant
- * image generation isn't wired yet, so the only actions offered are the two
- * that really work: mark a variant accepted, or mark a recommended variant
- * not needed (both persist to the screen's edit overlay).
- */
-function MockupVariantsCard({
-    rows, prdVersionLabel, mockupVersionNumber, onSetVariantStatus,
-}: {
-    rows: MockupVariantRow[];
-    prdVersionLabel?: string;
-    mockupVersionNumber?: number;
-    onSetVariantStatus?: (variantId: string, status: 'accepted' | 'not_needed' | null) => void;
-}) {
-    if (rows.length === 0) return null;
-    const missingRequired = rows.filter(r => r.required && r.status === 'missing').length;
-    const generatedFrom = [
-        prdVersionLabel ? `PRD ${prdVersionLabel}` : null,
-        mockupVersionNumber ? `mockup v${mockupVersionNumber}` : null,
-    ].filter(Boolean).join(' · ');
-    return (
-        <div className="bg-white rounded-lg border border-neutral-200 p-4">
-            <header className="flex items-center justify-between gap-2 flex-wrap mb-2">
-                <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
-                    Mockup variants
-                </h4>
-                <span className="text-[9px] uppercase tracking-wide text-indigo-500 bg-indigo-50 ring-1 ring-indigo-100 px-1.5 py-0.5 rounded">
-                    Tracked from generated mockup metadata
-                </span>
-            </header>
-            <ul className="divide-y divide-neutral-100">
-                {rows.map(row => {
-                    const meta = VARIANT_STATUS_META[row.status];
-                    return (
-                        <li key={row.id} className="py-2 flex items-center justify-between gap-3 text-xs">
-                            <div className="min-w-0">
-                                <div className="flex items-center gap-1.5 flex-wrap">
-                                    <span className="font-medium text-neutral-800">{row.label}</span>
-                                    {row.platform && (
-                                        <span className="text-[10px] text-neutral-500 bg-neutral-100 px-1.5 py-px rounded">
-                                            {PLATFORM_LABELS[row.platform]}
-                                        </span>
-                                    )}
-                                    {row.stateType && row.stateType !== 'default' && (
-                                        <span className="text-[9px] uppercase tracking-wide text-sky-700 bg-sky-50 ring-1 ring-sky-100 px-1.5 py-px rounded">
-                                            {row.stateType}
-                                        </span>
-                                    )}
-                                    {row.required && row.id !== 'default' && (
-                                        <span className="text-[9px] uppercase tracking-wide text-violet-700 bg-violet-50 ring-1 ring-violet-100 px-1.5 py-px rounded">
-                                            Recommended
-                                        </span>
-                                    )}
-                                </div>
-                                {row.status === 'generated' && generatedFrom && (
-                                    <div className="text-[10px] text-neutral-400 mt-0.5">
-                                        Generated from {generatedFrom}
-                                    </div>
-                                )}
-                            </div>
-                            <div className="flex items-center gap-1.5 shrink-0">
-                                <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ring-1 ${meta.className}`}>
-                                    {meta.label}
-                                </span>
-                                {onSetVariantStatus && (
-                                    row.userSet ? (
-                                        <button
-                                            type="button"
-                                            onClick={() => onSetVariantStatus(row.id, null)}
-                                            className="text-[10px] text-neutral-500 hover:text-neutral-700 underline decoration-dotted"
-                                        >
-                                            Undo
-                                        </button>
-                                    ) : row.status === 'generated' ? (
-                                        <button
-                                            type="button"
-                                            onClick={() => onSetVariantStatus(row.id, 'accepted')}
-                                            className="text-[10px] px-2 py-0.5 rounded bg-neutral-100 hover:bg-neutral-200 text-neutral-700 transition"
-                                        >
-                                            Mark accepted
-                                        </button>
-                                    ) : row.status === 'missing' ? (
-                                        <>
-                                            <button
-                                                type="button"
-                                                onClick={() => onSetVariantStatus(row.id, 'accepted')}
-                                                className="text-[10px] px-2 py-0.5 rounded bg-neutral-100 hover:bg-neutral-200 text-neutral-700 transition"
-                                                title="Confirm this variant is covered — e.g. you uploaded or verified it outside the generated set"
-                                            >
-                                                Mark accepted
-                                            </button>
-                                            <button
-                                                type="button"
-                                                onClick={() => onSetVariantStatus(row.id, 'not_needed')}
-                                                className="text-[10px] px-2 py-0.5 rounded bg-neutral-100 hover:bg-neutral-200 text-neutral-700 transition"
-                                                title="Skip this recommended variant — it stops counting as a readiness gap"
-                                            >
-                                                Not needed
-                                            </button>
-                                        </>
-                                    ) : null
-                                )}
-                            </div>
+        {/* Recommended variants discovery — even without a mockup, show what
+            this screen probably wants so missing viewports/states are visible. */}
+        {variantSummary.recommended > 0 && (
+            <div className="bg-white rounded-lg border border-neutral-200 p-4">
+                <div className="flex items-center justify-between gap-2 flex-wrap mb-2">
+                    <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                        Recommended variants
+                    </h4>
+                    <span className="text-[10px] text-neutral-400">
+                        {variantSummary.generated} of {variantSummary.recommended} generated
+                    </span>
+                </div>
+                <ul className="space-y-1 text-xs">
+                    {variants.filter(v => v.required).map(v => (
+                        <li key={v.id} className="flex items-center justify-between gap-2">
+                            <span className="text-neutral-700">{formatVariantLabel(v)}</span>
+                            <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ring-1 ${
+                                v.status === 'missing'
+                                    ? 'text-amber-700 bg-amber-50 ring-amber-200'
+                                    : 'text-emerald-700 bg-emerald-50 ring-emerald-200'
+                            }`}>
+                                {VARIANT_STATUS_LABELS[v.status]}
+                            </span>
                         </li>
-                    );
-                })}
-            </ul>
-            <p className="text-[11px] text-neutral-400 mt-2">
-                {missingRequired > 0
-                    ? `${missingRequired} recommended ${missingRequired === 1 ? 'variant has' : 'variants have'} no mockup yet. `
-                    : ''}
-                Per-variant generation isn&rsquo;t wired yet — regenerate the full mockup from the
-                artifact actions, or upload a variant image and mark it accepted here.
-            </p>
+                    ))}
+                </ul>
+                <p className="text-[11px] text-neutral-400 mt-2">
+                    Derived from this screen&rsquo;s priority and documented states — tracked from
+                    generated metadata, never from inspecting images. Single-variant generation lands
+                    in Phase 3B.
+                </p>
+            </div>
+        )}
         </div>
     );
 }

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -9,11 +9,16 @@
 
 import { AlertTriangle, AppWindow, ChevronRight, Image as ImageIcon, Layers, Workflow } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import type { MockupPlatform } from '../../types';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
 import {
     SCREEN_LIST_FILTERS, screenMatchesFilter,
     type ScreenCoverageSummary, type ScreenListFilter, type ScreenReadiness,
 } from '../../lib/screenReadiness';
+import {
+    buildScreenMockupVariants, summarizeScreenVariants,
+    type MockupVariantCoverageSummary,
+} from '../../lib/mockupVariants';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 import { ScreenCoveragePanel } from './ScreenCoveragePanel';
 import { ReadinessBadge } from './ReadinessBadge';
@@ -24,6 +29,13 @@ interface Props {
     readiness: ReadonlyMap<string, ScreenReadiness>;
     /** Artifact-level coverage rollup for the top panel. */
     coverage: ScreenCoverageSummary;
+    /** Artifact-level mockup-variant rollup for the coverage panel (Phase 3A). */
+    variantCoverage?: MockupVariantCoverageSummary | null;
+    /** Generation platform of the mockup set — drives per-screen variant
+     * derivation (viewport). */
+    mockupPlatform?: MockupPlatform;
+    /** True when the project is mobile-relevant (mobile-first / responsive). */
+    mobileRelevant?: boolean;
     /** Opens the Screen Detail view — keyed by the stable canonical id. */
     onSelectScreen: (screenId: string) => void;
     /**
@@ -35,7 +47,8 @@ interface Props {
 }
 
 export function ScreenListView({
-    index, readiness, coverage, onSelectScreen, onGenerateMissingMockups,
+    index, readiness, coverage, variantCoverage, mockupPlatform, mobileRelevant,
+    onSelectScreen, onGenerateMissingMockups,
 }: Props) {
     const [filter, setFilter] = useState<ScreenListFilter>('all');
 
@@ -75,6 +88,7 @@ export function ScreenListView({
         <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-6">
             <ScreenCoveragePanel
                 summary={coverage}
+                variantCoverage={variantCoverage}
                 onGenerateMissingMockups={onGenerateMissingMockups}
             />
 
@@ -134,6 +148,8 @@ export function ScreenListView({
                                 <ScreenRow
                                     item={item}
                                     readiness={readiness.get(item.id)}
+                                    mockupPlatform={mockupPlatform}
+                                    mobileRelevant={mobileRelevant}
                                     onSelect={() => onSelectScreen(item.id)}
                                 />
                             </li>
@@ -146,10 +162,12 @@ export function ScreenListView({
 }
 
 function ScreenRow({
-    item, readiness, onSelect,
+    item, readiness, mockupPlatform, mobileRelevant, onSelect,
 }: {
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
+    mockupPlatform?: MockupPlatform;
+    mobileRelevant?: boolean;
     onSelect: () => void;
 }) {
     const { screen } = item;
@@ -160,6 +178,9 @@ function ScreenRow({
     const stateCount = screen.states?.length ?? 0;
     const riskCount = screen.risks?.length ?? 0;
     const featureRefs = screen.featureRefs ?? [];
+    const variantSummary = summarizeScreenVariants(
+        buildScreenMockupVariants(item, { platform: mockupPlatform, mobileRelevant }),
+    );
 
     return (
         <button
@@ -217,6 +238,22 @@ function ScreenRow({
                         {riskCount} {riskCount === 1 ? 'risk' : 'risks'} to review
                     </span>
                 )}
+                {variantSummary.mobileMissing && (
+                    <span
+                        className="text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full"
+                        title="No mobile mockup variant yet"
+                    >
+                        Mobile: missing
+                    </span>
+                )}
+                {variantSummary.coverageUnknown && (
+                    <span
+                        className="text-[10px] text-neutral-500 bg-neutral-50 ring-1 ring-neutral-200 px-1.5 py-0.5 rounded-full"
+                        title="This mockup was generated before coverage metadata was captured"
+                    >
+                        Coverage: unknown
+                    </span>
+                )}
             </div>
 
             <div className="mt-auto pt-3 flex items-center gap-3 flex-wrap text-[11px] text-neutral-500">
@@ -227,9 +264,14 @@ function ScreenRow({
                     <Layers size={11} className={stateCount > 0 ? 'text-sky-500' : 'text-neutral-300'} />
                     {stateCount > 0 ? `${stateCount} ${stateCount === 1 ? 'state' : 'states'}` : 'No states'}
                 </span>
-                <span className="inline-flex items-center gap-1" title="Mockup coverage">
-                    <ImageIcon size={11} className={item.mockupScreen ? 'text-emerald-500' : 'text-neutral-300'} />
-                    {item.mockupScreen ? 'Mockup' : 'No mockup'}
+                <span
+                    className="inline-flex items-center gap-1"
+                    title="Mockup variant coverage — generated vs. recommended (viewport × state), tracked from mockup metadata"
+                >
+                    <ImageIcon size={11} className={variantSummary.hasMockup ? 'text-emerald-500' : 'text-neutral-300'} />
+                    {variantSummary.hasMockup
+                        ? `Mockups: ${variantSummary.label}`
+                        : 'No mockup'}
                 </span>
                 <span
                     className="inline-flex items-center gap-1"

--- a/src/lib/__tests__/mockupVariants.test.ts
+++ b/src/lib/__tests__/mockupVariants.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import type { MockupPayload, ScreenInventoryContent, ScreenItem } from '../../types';
+import { buildScreenIndex } from '../screenExperience';
+import {
+    buildMockupVariantCoverageSummary,
+    buildScreenMockupVariants,
+    formatVariantLabel,
+    normalizeScreenPriority,
+    summarizeScreenVariants,
+    viewportFromPlatform,
+} from '../mockupVariants';
+
+// --- Fixtures -----------------------------------------------------------------
+
+const p0Screen: ScreenItem = {
+    id: 'scr-home',
+    name: 'Home Dashboard',
+    priority: 'P0',
+    purpose: 'Landing surface.',
+    states: [
+        { name: 'Default', description: 'Shows the feed', type: 'default' },
+        { name: 'Empty History', description: 'No activity yet', type: 'empty', needsMockup: true },
+        { name: 'Loading', description: 'Fetching', type: 'loading' },
+    ],
+};
+
+const supportingScreen: ScreenItem = {
+    id: 'scr-settings',
+    name: 'Settings',
+    priority: 'P2',
+    purpose: 'Adjust preferences.',
+};
+
+function makeInventory(screens: ScreenItem[]): ScreenInventoryContent {
+    return { sections: [{ title: 'Main', screens }] };
+}
+
+function makeMockupPayload(
+    screens: Array<{ id: string; name: string; sourceScreenId?: string; coreUIElements?: string[] }>,
+): MockupPayload {
+    return {
+        version: 'mockup_spec_v1',
+        title: 'Mockups',
+        summary: 'Test payload',
+        screens: screens.map(s => ({ purpose: 'p', ...s })),
+    };
+}
+
+// --- viewportFromPlatform -----------------------------------------------------
+
+describe('viewportFromPlatform', () => {
+    it('maps platforms, defaulting responsive/undefined to desktop', () => {
+        expect(viewportFromPlatform('mobile')).toBe('mobile');
+        expect(viewportFromPlatform('desktop')).toBe('desktop');
+        expect(viewportFromPlatform('responsive')).toBe('desktop');
+        expect(viewportFromPlatform(undefined)).toBe('desktop');
+    });
+});
+
+describe('normalizeScreenPriority', () => {
+    it('preserves the P0 distinction for legacy priorities', () => {
+        expect(normalizeScreenPriority('core')).toBe('P0');
+        expect(normalizeScreenPriority('secondary')).toBe('P1');
+        expect(normalizeScreenPriority('supporting')).toBe('P2');
+        expect(normalizeScreenPriority('P0')).toBe('P0');
+    });
+});
+
+describe('formatVariantLabel', () => {
+    it('renders "Viewport · State"', () => {
+        expect(formatVariantLabel({ viewport: 'desktop', stateName: 'Default' })).toBe('Desktop · Default');
+        expect(formatVariantLabel({ viewport: 'mobile', stateName: 'Empty History' })).toBe('Mobile · Empty History');
+    });
+});
+
+// --- buildScreenMockupVariants ------------------------------------------------
+
+describe('buildScreenMockupVariants', () => {
+    it('normalizes a legacy single mockup to Desktop · Default · Generated with unknown coverage', () => {
+        const index = buildScreenIndex(
+            makeInventory([{ id: 'scr-x', name: 'Screen X', priority: 'P0', purpose: 'p' }]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Screen X', sourceScreenId: 'scr-x' }]),
+        );
+        const variants = buildScreenMockupVariants(index.items[0]);
+        const dflt = variants.find(v => v.id === 'default')!;
+        expect(dflt.viewport).toBe('desktop');
+        expect(dflt.stateName).toBe('Default');
+        expect(dflt.status).toBe('generated');
+        expect(dflt.source).toBe('legacy');
+        expect(dflt.coverageStatus).toBe('unknown');
+        expect(dflt.coverageEstimated).toBe(true);
+        expect(formatVariantLabel(dflt)).toBe('Desktop · Default');
+    });
+
+    it('produces a missing Desktop · Default when the screen has no mockup', () => {
+        const index = buildScreenIndex(makeInventory([supportingScreen]), [], null);
+        const variants = buildScreenMockupVariants(index.items[0]);
+        const dflt = variants.find(v => v.id === 'default')!;
+        expect(dflt.status).toBe('missing');
+        expect(dflt.viewport).toBe('desktop');
+        expect(dflt.source).toBe('derived_missing');
+    });
+
+    it('recommends a Mobile · Default for P0 screens', () => {
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null);
+        const variants = buildScreenMockupVariants(index.items[0]);
+        const mobile = variants.find(v => v.id === 'mobile:default');
+        expect(mobile).toBeDefined();
+        expect(mobile!.viewport).toBe('mobile');
+        expect(mobile!.required).toBe(true);
+        expect(mobile!.status).toBe('missing');
+    });
+
+    it('does NOT recommend Mobile default for a supporting screen unless mobile-relevant', () => {
+        const index = buildScreenIndex(makeInventory([supportingScreen]), [], null);
+        const noMobile = buildScreenMockupVariants(index.items[0]);
+        expect(noMobile.find(v => v.viewport === 'mobile')).toBeUndefined();
+
+        const withMobile = buildScreenMockupVariants(index.items[0], { mobileRelevant: true });
+        expect(withMobile.find(v => v.viewport === 'mobile')).toBeDefined();
+    });
+
+    it('turns documented important states into recommended state variants', () => {
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null);
+        const variants = buildScreenMockupVariants(index.items[0]);
+        const stateVariants = variants.filter(v => v.stateType && v.stateType !== 'default');
+        const names = stateVariants.map(v => v.stateName).sort();
+        expect(names).toEqual(['Empty History', 'Loading']);
+        // The explicit default-type state folds into the desktop Default row
+        // (not duplicated as a state variant).
+        expect(variants.filter(v => v.viewport === 'desktop' && v.stateType === 'default')).toHaveLength(1);
+    });
+
+    it('an existing generated variant prevents a duplicate missing placeholder for that slot', () => {
+        const index = buildScreenIndex(
+            makeInventory([p0Screen]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
+        );
+        const variants = buildScreenMockupVariants(index.items[0]);
+        const defaults = variants.filter(v => v.stateType === 'default' && v.viewport === 'desktop');
+        expect(defaults).toHaveLength(1);
+        expect(defaults[0].status).toBe('generated');
+    });
+
+    it('honors the user overlay (accepted / not_needed)', () => {
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null, {
+            'scr-home': { mockupVariantStatus: { 'mobile:default': 'accepted', 'state:loading': 'not_needed' } },
+        });
+        const variants = buildScreenMockupVariants(index.items[0]);
+        expect(variants.find(v => v.id === 'mobile:default')!.status).toBe('accepted');
+        expect(variants.find(v => v.id === 'mobile:default')!.userSet).toBe(true);
+        expect(variants.find(v => v.id === 'state:loading')!.status).toBe('not_needed');
+    });
+
+    it('marks generated mockup coverage from spec-to-spec token overlap when metadata exists', () => {
+        const inv = makeInventory([{
+            id: 'scr-x', name: 'Screen X', priority: 'P0', purpose: 'p',
+            coreUIElements: ['Activity feed', 'Header bar'],
+        }]);
+        const index = buildScreenIndex(inv, [], makeMockupPayload([
+            { id: 'm1', name: 'Screen X', sourceScreenId: 'scr-x', coreUIElements: ['Activity feed', 'Header bar'] },
+        ]));
+        const variants = buildScreenMockupVariants(index.items[0]);
+        expect(variants.find(v => v.id === 'default')!.coverageStatus).toBe('aligned');
+    });
+
+    it('does not throw on a screen with no priority / states / spec data', () => {
+        const index = buildScreenIndex(
+            // deliberately sparse — priority coerced, no states, no purpose
+            { sections: [{ title: 'X', screens: [{ name: 'Sparse' } as ScreenItem] }] },
+            [],
+            null,
+        );
+        expect(() => buildScreenMockupVariants(index.items[0])).not.toThrow();
+        const variants = buildScreenMockupVariants(index.items[0]);
+        expect(variants.find(v => v.id === 'default')).toBeDefined();
+    });
+});
+
+// --- summarizeScreenVariants --------------------------------------------------
+
+describe('summarizeScreenVariants', () => {
+    it('counts generated vs missing among recommended variants', () => {
+        const index = buildScreenIndex(
+            makeInventory([p0Screen]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
+        );
+        const summary = summarizeScreenVariants(buildScreenMockupVariants(index.items[0]));
+        // recommended: desktop default (generated) + mobile default + Empty History + Loading = 4
+        expect(summary.recommended).toBe(4);
+        expect(summary.generated).toBe(1);
+        expect(summary.missing).toBe(3);
+        expect(summary.mobileMissing).toBe(true);
+        expect(summary.hasMockup).toBe(true);
+        expect(summary.coverageUnknown).toBe(true);
+    });
+
+    it('reports "No mockup yet" when nothing is generated', () => {
+        const index = buildScreenIndex(makeInventory([supportingScreen]), [], null);
+        const summary = summarizeScreenVariants(buildScreenMockupVariants(index.items[0]));
+        expect(summary.hasMockup).toBe(false);
+        expect(summary.label).toBe('No mockup yet');
+    });
+});
+
+// --- buildMockupVariantCoverageSummary ----------------------------------------
+
+describe('buildMockupVariantCoverageSummary', () => {
+    it('rolls up recommended coverage, P0 mobile coverage and legacy-unknown mockups', () => {
+        const index = buildScreenIndex(
+            makeInventory([p0Screen, supportingScreen]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
+        );
+        const rollup = buildMockupVariantCoverageSummary(index)!;
+        expect(rollup.p0Total).toBe(1);
+        expect(rollup.p0WithMobile).toBe(0); // no mobile mockup for the P0 screen
+        expect(rollup.legacyUnknownMockups).toBe(1);
+        expect(rollup.recommendedGenerated).toBe(1);
+        expect(rollup.recommendedTotal).toBeGreaterThan(1);
+    });
+
+    it('returns null for an empty index', () => {
+        const index = buildScreenIndex(null, [], null);
+        expect(buildMockupVariantCoverageSummary(index)).toBeNull();
+    });
+});

--- a/src/lib/__tests__/mockupVariants.test.ts
+++ b/src/lib/__tests__/mockupVariants.test.ts
@@ -204,6 +204,38 @@ describe('summarizeScreenVariants', () => {
         expect(summary.hasMockup).toBe(false);
         expect(summary.label).toBe('No mockup yet');
     });
+
+    it('excludes not_needed variants from the recommended total (resolved gap)', () => {
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null, {
+            'scr-home': {
+                mockupVariantStatus: {
+                    'mobile:default': 'not_needed',
+                    'state:empty-history': 'not_needed',
+                    'state:loading': 'not_needed',
+                },
+            },
+        });
+        const summary = summarizeScreenVariants(buildScreenMockupVariants(index.items[0]));
+        // Only the desktop default remains recommended; not-needed rows drop out
+        // of both the denominator and the missing count.
+        expect(summary.recommended).toBe(1);
+        expect(summary.missing).toBe(1); // desktop default has no mockup
+        expect(summary.mobileMissing).toBe(false);
+    });
+
+    it('keeps hasMockup/coverageUnknown true after the generated default is accepted', () => {
+        const index = buildScreenIndex(
+            makeInventory([{ id: 'scr-x', name: 'Screen X', priority: 'P0', purpose: 'p' }]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Screen X', sourceScreenId: 'scr-x' }]),
+            { 'scr-x': { mockupVariantStatus: { 'default': 'accepted' } } },
+        );
+        const summary = summarizeScreenVariants(buildScreenMockupVariants(index.items[0]));
+        // Marking the default accepted flips its status off 'generated', but the
+        // image still exists — presence must survive.
+        expect(summary.hasMockup).toBe(true);
+        expect(summary.coverageUnknown).toBe(true);
+    });
 });
 
 // --- buildMockupVariantCoverageSummary ----------------------------------------
@@ -226,5 +258,24 @@ describe('buildMockupVariantCoverageSummary', () => {
     it('returns null for an empty index', () => {
         const index = buildScreenIndex(null, [], null);
         expect(buildMockupVariantCoverageSummary(index)).toBeNull();
+    });
+
+    it('drops not_needed variants from the recommended total and treats not_needed mobile as handled', () => {
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null, {
+            'scr-home': {
+                mockupVariantStatus: {
+                    'mobile:default': 'not_needed',
+                    'state:empty-history': 'not_needed',
+                    'state:loading': 'not_needed',
+                },
+            },
+        });
+        const rollup = buildMockupVariantCoverageSummary(index)!;
+        // Only desktop default counts toward the denominator now.
+        expect(rollup.recommendedTotal).toBe(1);
+        expect(rollup.recommendedGenerated).toBe(0);
+        // A deliberately-skipped mobile default is "handled", not a gap.
+        expect(rollup.p0WithMobile).toBe(1);
+        expect(rollup.p0Total).toBe(1);
     });
 });

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -1,0 +1,445 @@
+// Phase 3A: derived mockup-variant model for the Screens experience view.
+//
+// A "mockup variant" is one (viewport × screen state) cell of the visual
+// coverage grid for a screen — e.g. "Desktop · Default", "Mobile · Default",
+// "Desktop · Empty History", "Desktop · Loading". Today the mockup pipeline
+// still generates a SINGLE image per screen, so at most one variant is ever
+// actually generated; every other variant is a *derived recommendation* that
+// currently has no persisted data. This module makes that grid visible so a
+// reviewer can see, at a glance, what exists vs. what a screen probably wants.
+//
+// Everything here is PURE and read-time only (no store, no IDB, no React, no
+// LLM). It is layered ON TOP of the existing readiness model
+// (src/lib/screenReadiness.ts) — it never changes review-status logic. The
+// only persisted input is the optional user overlay
+// (ScreenMetadataEdit.mockupVariantStatus), keyed by variant id.
+//
+// Honesty rules (mirroring screenReadiness):
+//   - Status is tracked from generated mockup METADATA + the user's overlay,
+//     never from inspecting rendered pixels.
+//   - Recommendations are DERIVED estimates from the screen priority + spec —
+//     label them as such, never as authoritative.
+//   - Legacy single-image mockups carry no per-variant coverage metadata, so
+//     their coverage is 'unknown' — never claim visual alignment.
+//
+// Overlay-key compatibility: the primary-viewport Default row reuses the
+// existing overlay key `default` and primary-viewport state rows reuse
+// `state:<slug>` (the same keys buildMockupVariantRows already persists), so a
+// user's earlier accepted/not-needed marks survive. Only the *secondary*
+// viewport default (e.g. Mobile when the mockup is Desktop) introduces a new
+// `${viewport}:default` key.
+
+import type {
+    LegacyScreenPriority, MockupPlatform, ScreenItem, ScreenPriority, ScreenStateType,
+} from '../types';
+import { slugifyScreenName } from './screenInventoryImageStore';
+import type { ScreenExperienceIndex, ScreenExperienceItem } from './screenExperience';
+import { buildMockupSpecCoverage, type MockupVariantRowStatus } from './screenReadiness';
+
+export type MockupViewport = 'desktop' | 'mobile' | 'tablet';
+
+/** Variant fulfilment status. Aligns with MockupVariantRowStatus in
+ * screenReadiness so overlay values stay interchangeable. */
+export type MockupVariantStatus = MockupVariantRowStatus; // generated | missing | accepted | not_needed
+
+/** Spec-coverage confidence for a variant. 'unknown' is the honest default
+ * for legacy single-image mockups (no coverage metadata was captured). */
+export type MockupVariantCoverage = 'aligned' | 'partial' | 'missing_items' | 'unknown';
+
+/** Where the variant record came from:
+ *   'legacy'          — an existing single-image mockup with no per-variant metadata;
+ *   'variant'         — a mockup carrying explicit variant metadata (future);
+ *   'derived_missing' — a recommended variant with no mockup yet. */
+export type MockupVariantSource = 'legacy' | 'variant' | 'derived_missing';
+
+export interface DerivedMockupVariant {
+    /** Deterministic id — also the ScreenMetadataEdit.mockupVariantStatus key. */
+    id: string;
+    screenId: string;
+    viewport: MockupViewport;
+    stateName: string;
+    stateType?: ScreenStateType;
+    status: MockupVariantStatus;
+    /** Recommended for this screen (counts toward recommended-coverage totals).
+     * A missing required variant is what the "N missing" summary reports. */
+    required: boolean;
+    /** True when status came from the user's overlay (accepted / not_needed). */
+    userSet: boolean;
+    source: MockupVariantSource;
+    coverageStatus: MockupVariantCoverage;
+    /** True when the coverage figure is an estimate (spec-to-spec token overlap
+     * or "not captured"), never a visual inspection. Always true today. */
+    coverageEstimated: boolean;
+    /** Short human notes explaining status / recommendation / coverage. */
+    notes: string[];
+}
+
+export const VIEWPORT_LABELS: Record<MockupViewport, string> = {
+    desktop: 'Desktop',
+    mobile: 'Mobile',
+    tablet: 'Tablet',
+};
+
+/** `Desktop · Default`, `Mobile · Empty History`, … */
+export function formatVariantLabel(variant: Pick<DerivedMockupVariant, 'viewport' | 'stateName'>): string {
+    return `${VIEWPORT_LABELS[variant.viewport]} · ${variant.stateName}`;
+}
+
+/** The viewport a mockup image occupies, from its generation platform. A
+ * 'responsive' mockup is treated as Desktop-primary (its default breakpoint);
+ * missing platform falls back to Desktop — the conservative common case and
+ * the legacy normalization the Phase 3A spec calls for. */
+export function viewportFromPlatform(platform?: MockupPlatform): MockupViewport {
+    if (platform === 'mobile') return 'mobile';
+    return 'desktop';
+}
+
+/** Coerce a possibly-legacy priority to a P-scale value for the recommendation
+ * rules. Unlike stylablePriority (which flattens everything unknown to P1),
+ * this preserves the P0 distinction legacy 'core' screens carry. */
+export function normalizeScreenPriority(priority: ScreenPriority | LegacyScreenPriority): ScreenPriority {
+    switch (priority) {
+        case 'P0':
+        case 'core':
+            return 'P0';
+        case 'P1':
+        case 'secondary':
+            return 'P1';
+        case 'P2':
+        case 'supporting':
+            return 'P2';
+        case 'P3':
+            return 'P3';
+        default:
+            return 'P1';
+    }
+}
+
+const DEFAULT_VARIANT_ID = 'default';
+
+/** State types that warrant their own mockup variant when documented. */
+const IMPORTANT_STATE_TYPES: ReadonlySet<ScreenStateType> = new Set<ScreenStateType>([
+    'empty', 'loading', 'error', 'success', 'permission', 'disabled',
+]);
+
+/** Name keywords that mark a state as visually important even when its `type`
+ * is missing/other (legacy specs rarely set `type`). */
+const IMPORTANT_STATE_KEYWORDS = [
+    'empty', 'loading', 'error', 'success', 'permission', 'disabled', 'selected',
+];
+
+function isImportantState(name: string, type?: ScreenStateType): boolean {
+    if (type && IMPORTANT_STATE_TYPES.has(type)) return true;
+    const lower = name.toLowerCase();
+    return IMPORTANT_STATE_KEYWORDS.some(k => lower.includes(k));
+}
+
+export interface BuildVariantOptions {
+    /** Generation platform of the current mockup set (mockup settings). */
+    platform?: MockupPlatform;
+    /** True when the project is mobile-relevant (mobile-first / responsive) —
+     * enables a recommended Mobile default on P1 / supporting screens. P0
+     * always recommends mobile regardless. */
+    mobileRelevant?: boolean;
+}
+
+interface VariantSeed {
+    viewport: MockupViewport;
+    stateName: string;
+    stateType?: ScreenStateType;
+    overlayKey: string;
+    required: boolean;
+    /** This seed holds the single generated image (the primary default row). */
+    generatedSlot: boolean;
+    /** Explicit generation-contract signal (state.needsMockup / typed state). */
+    fromContract: boolean;
+}
+
+/**
+ * Derive the full variant grid for one screen: the generated primary Default
+ * row, any recommended secondary-viewport default, and one row per documented
+ * important state. Existing single-image mockups normalize to the primary
+ * Default row with `source: 'legacy'` and `coverageStatus: 'unknown'`.
+ */
+export function buildScreenMockupVariants(
+    item: Pick<ScreenExperienceItem, 'screen' | 'baseScreen' | 'mockupScreen' | 'edit' | 'id'>,
+    options: BuildVariantOptions = {},
+): DerivedMockupVariant[] {
+    const { screen } = item;
+    const overlay = item.edit?.mockupVariantStatus ?? {};
+    const priority = normalizeScreenPriority(screen.priority);
+    const primary = viewportFromPlatform(options.platform);
+    const mobileRelevant = options.mobileRelevant ?? (primary !== 'desktop');
+
+    const seeds: VariantSeed[] = [];
+
+    // 1. Primary-viewport Default — the slot the single generated image fills.
+    seeds.push({
+        viewport: primary,
+        stateName: 'Default',
+        stateType: 'default',
+        overlayKey: DEFAULT_VARIANT_ID,
+        required: true,
+        generatedSlot: true,
+        fromContract: false,
+    });
+
+    // 2. Secondary-viewport Default recommendation.
+    //    - Desktop is the baseline default for P0/P1 screens.
+    //    - Mobile default is recommended for P0 always, P1/supporting when the
+    //      project is mobile-relevant.
+    const wantDesktopDefault = priority === 'P0' || priority === 'P1';
+    const wantMobileDefault = priority === 'P0' || mobileRelevant;
+    if (primary !== 'desktop' && wantDesktopDefault) {
+        seeds.push({
+            viewport: 'desktop',
+            stateName: 'Default',
+            stateType: 'default',
+            overlayKey: 'desktop:default',
+            required: true,
+            generatedSlot: false,
+            fromContract: false,
+        });
+    }
+    if (primary === 'desktop' && wantMobileDefault) {
+        seeds.push({
+            viewport: 'mobile',
+            stateName: 'Default',
+            stateType: 'default',
+            overlayKey: 'mobile:default',
+            required: true,
+            generatedSlot: false,
+            fromContract: false,
+        });
+    }
+
+    // 3. Important state variants on the primary viewport. State overlay keys
+    //    match the existing readiness rows (`state:<slug>`, deduped) so marks
+    //    stay shared.
+    const usedStateSlugs = new Set<string>();
+    for (const state of screen.states ?? []) {
+        if (!state.name?.trim()) continue;
+        if (state.type === 'default') continue; // folds into the Default row
+        const recommended = state.needsMockup === true || isImportantState(state.name, state.type);
+        if (!recommended) continue;
+        const base = slugifyScreenName(state.name);
+        let slug = base;
+        let n = 2;
+        while (usedStateSlugs.has(slug)) {
+            slug = `${base}-${n}`;
+            n += 1;
+        }
+        usedStateSlugs.add(slug);
+        seeds.push({
+            viewport: primary,
+            stateName: state.name,
+            stateType: state.type,
+            overlayKey: `state:${slug}`,
+            required: true,
+            generatedSlot: false,
+            fromContract: state.needsMockup !== undefined || state.type !== undefined,
+        });
+    }
+
+    return seeds.map(seed => buildVariant(item, seed, overlay));
+}
+
+function buildVariant(
+    item: Pick<ScreenExperienceItem, 'screen' | 'baseScreen' | 'mockupScreen' | 'id'>,
+    seed: VariantSeed,
+    overlay: Record<string, 'accepted' | 'not_needed'>,
+): DerivedMockupVariant {
+    const override: 'accepted' | 'not_needed' | undefined = overlay[seed.overlayKey];
+    const generated = seed.generatedSlot && Boolean(item.mockupScreen);
+    const status: MockupVariantStatus = override ?? (generated ? 'generated' : 'missing');
+    const source: MockupVariantSource = generated ? 'legacy' : 'derived_missing';
+
+    let coverageStatus: MockupVariantCoverage = 'unknown';
+    const notes: string[] = [];
+    if (generated) {
+        const rows = buildMockupSpecCoverage(item.baseScreen, item.mockupScreen?.coreUIElements);
+        if (rows.length === 0) {
+            coverageStatus = 'unknown';
+            notes.push('Coverage metadata was not captured for this mockup — Synapse cannot confirm which spec items it represents.');
+        } else {
+            const inSpec = rows.filter(r => r.status === 'in_spec').length;
+            coverageStatus = inSpec === rows.length ? 'aligned' : inSpec === 0 ? 'missing_items' : 'partial';
+            notes.push(`${inSpec} of ${rows.length} spec UI items appear in the mockup spec (spec-to-spec, not a visual check).`);
+        }
+    } else if (override === 'not_needed') {
+        notes.push('Marked not needed — excluded from recommended coverage.');
+    } else if (override === 'accepted') {
+        notes.push('Marked accepted by you — e.g. verified or uploaded outside the generated set.');
+    } else if (seed.required) {
+        // Not generated, not user-marked → a recommended-but-missing variant.
+        notes.push(recommendationReason(item.screen, seed));
+        notes.push('Single-variant generation lands in Phase 3B — for now, regenerate the full mockup or upload and mark this variant accepted.');
+    }
+
+    return {
+        id: seed.overlayKey,
+        screenId: item.id,
+        viewport: seed.viewport,
+        stateName: seed.stateName,
+        stateType: seed.stateType,
+        status,
+        required: seed.required,
+        userSet: Boolean(override),
+        source,
+        coverageStatus,
+        coverageEstimated: true,
+        notes,
+    };
+}
+
+function recommendationReason(screen: ScreenItem, seed: VariantSeed): string {
+    const priority = normalizeScreenPriority(screen.priority);
+    if (seed.stateType === 'default') {
+        if (seed.viewport === 'mobile') {
+            return priority === 'P0'
+                ? 'Recommended for P0 screen mobile coverage.'
+                : 'Recommended because the project appears mobile-relevant.';
+        }
+        return 'Recommended baseline coverage for a primary screen.';
+    }
+    return `Recommended because this screen documents a "${seed.stateName}" state that usually warrants its own mockup.`;
+}
+
+// --- Per-screen summary (screen cards) -------------------------------------------
+
+export interface ScreenMockupVariantSummary {
+    /** Recommended variants for this screen (required rows). */
+    recommended: number;
+    /** Recommended variants that are generated or user-accepted. */
+    generated: number;
+    /** Recommended variants still missing (not generated / accepted / skipped). */
+    missing: number;
+    /** True when a required Mobile default is missing. */
+    mobileMissing: boolean;
+    /** True when the screen joins a generated mockup. */
+    hasMockup: boolean;
+    /** True when the generated mockup carries no coverage metadata (legacy). */
+    coverageUnknown: boolean;
+    /** Compact primary line for the card, e.g. "1 / 4 recommended" or
+     * "No mockup yet". */
+    label: string;
+    /** Optional secondary line, e.g. "Mobile + 1 state variant recommended". */
+    detail?: string;
+}
+
+const isGeneratedOrAccepted = (s: MockupVariantStatus): boolean =>
+    s === 'generated' || s === 'accepted';
+
+export function summarizeScreenVariants(variants: readonly DerivedMockupVariant[]): ScreenMockupVariantSummary {
+    const recommendedRows = variants.filter(v => v.required);
+    const recommended = recommendedRows.length;
+    const generated = recommendedRows.filter(v => isGeneratedOrAccepted(v.status)).length;
+    // A "not_needed" recommended variant is deliberately skipped — it is not a
+    // gap, so exclude it from the missing count.
+    const missing = recommendedRows.filter(v => v.status === 'missing').length;
+    const mobileMissing = recommendedRows.some(
+        v => v.viewport === 'mobile' && v.stateType === 'default' && v.status === 'missing',
+    );
+    const hasMockup = variants.some(v => v.status === 'generated');
+    const coverageUnknown = variants.some(v => v.status === 'generated' && v.coverageStatus === 'unknown');
+
+    const missingRows = recommendedRows.filter(v => v.status === 'missing');
+    const missingDefaults = missingRows.filter(v => v.stateType === 'default');
+    const missingStates = missingRows.filter(v => v.stateType !== 'default');
+    const detailParts: string[] = [];
+    for (const d of missingDefaults) detailParts.push(`${VIEWPORT_LABELS[d.viewport]} default`);
+    if (missingStates.length === 1) detailParts.push('1 state variant');
+    else if (missingStates.length > 1) detailParts.push(`${missingStates.length} state variants`);
+
+    let label: string;
+    if (!hasMockup && generated === 0) {
+        label = 'No mockup yet';
+    } else if (missing === 0) {
+        label = recommended === 1 ? 'Default covered' : `${generated} / ${recommended} recommended`;
+    } else {
+        label = `${generated} / ${recommended} recommended`;
+    }
+
+    return {
+        recommended,
+        generated,
+        missing,
+        mobileMissing,
+        hasMockup,
+        coverageUnknown,
+        label,
+        detail: detailParts.length > 0 ? `${detailParts.join(' + ')} recommended` : undefined,
+    };
+}
+
+// --- Artifact-level rollup (coverage panel) -------------------------------------
+
+export interface MockupVariantCoverageSummary {
+    /** Recommended variants generated/accepted across all screens. */
+    recommendedGenerated: number;
+    /** Recommended variants across all screens. */
+    recommendedTotal: number;
+    /** P0 screens whose Mobile default is generated/accepted. */
+    p0WithMobile: number;
+    /** Total P0 screens. */
+    p0Total: number;
+    /** Generated mockups with no captured coverage metadata (legacy). */
+    legacyUnknownMockups: number;
+}
+
+/** Roll up variant coverage across the whole screen index for the Screen
+ * Coverage & Readiness panel. Returns null when there are no screens. */
+export function buildMockupVariantCoverageSummary(
+    index: ScreenExperienceIndex,
+    options: BuildVariantOptions = {},
+): MockupVariantCoverageSummary | null {
+    if (index.items.length === 0) return null;
+    let recommendedGenerated = 0;
+    let recommendedTotal = 0;
+    let p0WithMobile = 0;
+    let p0Total = 0;
+    let legacyUnknownMockups = 0;
+
+    for (const item of index.items) {
+        const variants = buildScreenMockupVariants(item, options);
+        const isP0 = normalizeScreenPriority(item.screen.priority) === 'P0';
+        if (isP0) p0Total += 1;
+        for (const v of variants) {
+            if (v.required) {
+                recommendedTotal += 1;
+                if (isGeneratedOrAccepted(v.status)) recommendedGenerated += 1;
+            }
+            if (isP0 && v.viewport === 'mobile' && v.stateType === 'default'
+                && isGeneratedOrAccepted(v.status)) {
+                p0WithMobile += 1;
+            }
+            if (v.status === 'generated' && v.coverageStatus === 'unknown') {
+                legacyUnknownMockups += 1;
+            }
+        }
+    }
+
+    return {
+        recommendedGenerated,
+        recommendedTotal,
+        p0WithMobile,
+        p0Total,
+        legacyUnknownMockups,
+    };
+}
+
+// --- Variant status presentation ------------------------------------------------
+
+export const VARIANT_STATUS_LABELS: Record<MockupVariantStatus, string> = {
+    generated: 'Generated',
+    missing: 'Missing',
+    accepted: 'Accepted',
+    not_needed: 'Not needed',
+};
+
+export const COVERAGE_STATUS_LABELS: Record<MockupVariantCoverage, string> = {
+    aligned: 'Aligned with spec',
+    partial: 'Partial',
+    missing_items: 'Spec items missing',
+    unknown: 'Unknown',
+};

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -330,18 +330,27 @@ export interface ScreenMockupVariantSummary {
 const isGeneratedOrAccepted = (s: MockupVariantStatus): boolean =>
     s === 'generated' || s === 'accepted';
 
+/** True when the variant holds (or is derived from) a real generated mockup
+ * image — independent of the mutable status. A user marking the generated
+ * default "accepted" flips status off 'generated' but the image still exists,
+ * so presence must key off the mockup join (source), not the status. */
+const hasGeneratedImage = (v: DerivedMockupVariant): boolean =>
+    v.source === 'legacy' || v.source === 'variant';
+
 export function summarizeScreenVariants(variants: readonly DerivedMockupVariant[]): ScreenMockupVariantSummary {
-    const recommendedRows = variants.filter(v => v.required);
+    // A "not_needed" recommended variant is deliberately skipped — it is not a
+    // gap, so it must drop out of BOTH the denominator and the missing count
+    // (consistent with the readiness layer, where not_needed resolves the gap);
+    // otherwise the coverage line would warn "1 / 2 recommended" forever.
+    const recommendedRows = variants.filter(v => v.required && v.status !== 'not_needed');
     const recommended = recommendedRows.length;
     const generated = recommendedRows.filter(v => isGeneratedOrAccepted(v.status)).length;
-    // A "not_needed" recommended variant is deliberately skipped — it is not a
-    // gap, so exclude it from the missing count.
     const missing = recommendedRows.filter(v => v.status === 'missing').length;
     const mobileMissing = recommendedRows.some(
         v => v.viewport === 'mobile' && v.stateType === 'default' && v.status === 'missing',
     );
-    const hasMockup = variants.some(v => v.status === 'generated');
-    const coverageUnknown = variants.some(v => v.status === 'generated' && v.coverageStatus === 'unknown');
+    const hasMockup = variants.some(hasGeneratedImage);
+    const coverageUnknown = variants.some(v => hasGeneratedImage(v) && v.coverageStatus === 'unknown');
 
     const missingRows = recommendedRows.filter(v => v.status === 'missing');
     const missingDefaults = missingRows.filter(v => v.stateType === 'default');
@@ -405,15 +414,19 @@ export function buildMockupVariantCoverageSummary(
         const isP0 = normalizeScreenPriority(item.screen.priority) === 'P0';
         if (isP0) p0Total += 1;
         for (const v of variants) {
-            if (v.required) {
+            // A not_needed variant is deliberately skipped — drop it from the
+            // denominator so a resolved gap never keeps the panel warning.
+            if (v.required && v.status !== 'not_needed') {
                 recommendedTotal += 1;
                 if (isGeneratedOrAccepted(v.status)) recommendedGenerated += 1;
             }
+            // "Handled" = generated, accepted, or explicitly not needed, so a
+            // deliberately-skipped mobile default doesn't read as a gap.
             if (isP0 && v.viewport === 'mobile' && v.stateType === 'default'
-                && isGeneratedOrAccepted(v.status)) {
+                && (isGeneratedOrAccepted(v.status) || v.status === 'not_needed')) {
                 p0WithMobile += 1;
             }
-            if (v.status === 'generated' && v.coverageStatus === 'unknown') {
+            if (hasGeneratedImage(v) && v.coverageStatus === 'unknown') {
                 legacyUnknownMockups += 1;
             }
         }


### PR DESCRIPTION
## Summary

Phase 3A of the Screens artifact upgrade — a **safe, read-side vertical slice**. It presents existing mockups as viewport × state **variants** (`Desktop · Default`, `Mobile · Default`, `Desktop · Empty`, …) so reviewers can see, at a glance, what exists vs. what a screen probably wants. **No change to mockup generation, prompts, schema, sync, or snapshots** — everything is derived at read time.

## What changed

**New pure module — `src/lib/mockupVariants.ts`** (unit-tested)
- Backward-compatible variant normalization: a legacy single-image mockup becomes `Desktop · Default · Generated` with spec coverage `unknown` (no per-variant metadata was ever captured).
- Derives recommended/missing variants from screen priority + documented states (`Desktop · Default` baseline; `Mobile · Default` for P0, and P1/supporting when mobile-relevant; important documented states). Recommendations are labeled **estimates**, never authoritative.
- Per-screen summary (`summarizeScreenVariants`) and artifact-level rollup (`buildMockupVariantCoverageSummary`).
- Reuses the existing `mockupVariantStatus` overlay keys (`default` / `state:<slug>`) so prior accepted/not-needed marks survive; only the secondary-viewport default introduces a new `${viewport}:default` key.

**Redesigned Mockups tab — `MockupVariantsPanel`**
- Summary row, selectable variant gallery (generated vs. missing, visually distinct), and a selected-variant detail panel (preview, status, metadata, spec coverage, notes).
- The generated image still renders through the existing `MockupScreenImage` — its generate / upload / regenerate actions are untouched.
- Missing variants are honest placeholders — **no per-variant generation in Phase 3A, no dead buttons.** Coverage is shown as `unknown` for legacy mockups; the UI never claims visual alignment without structured metadata.

**Screen cards + coverage panel**
- Cards show a compact variant summary (`N / M recommended`, `Mobile: missing`, `Coverage: unknown`).
- Screen Coverage & Readiness panel gains mockup-variant / P0-mobile-coverage / legacy-unknown rows.

**Readiness status logic is unchanged** — this layer is display/discovery only and never downgrades a screen's review status.

## Backward compatibility

- Legacy single-image mockups render as `Desktop · Default`; no migration required.
- Screens with no mockup / no states / no priority / no spec data degrade gracefully (missing `Desktop · Default`, conservative defaults, `Coverage unknown`), never crash.
- Existing regenerate / open / link-mockup / add-to-mockups actions are preserved.
- Demo project behavior is unchanged (it still carries legacy mockups; they render as `Desktop · Default` with unknown coverage).

## Tests

- 16 new pure tests in `src/lib/__tests__/mockupVariants.test.ts` (legacy normalization, missing-variant derivation, P0 mobile recommendation, important states, overlay honoring, coverage, no-throw on sparse data, summaries/rollups).
- Updated the Mockups-tab component tests in `ScreenExperienceViews.test.tsx` for the new gallery UI (variant labels, statuses, coverage-unknown, mark accepted / not needed via the selected-variant detail).
- Full suite green: **1211 passed**. `npm run build` and `npm run lint` both pass.

## Recommended Phase 3B notes

- Wire single-variant generation from the missing-variant placeholder (the overlay keys and recommendation model are already in place).
- Capture a structured coverage manifest at generation time so legacy `unknown` coverage becomes real per-variant `aligned/partial/missing_items`.
- Key per-variant images by `versionId:screenId:variantId:quality` (mirrors the existing mockup image keying) so multiple viewports/states can coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUo8GAzQ5jJht4fyjFPqLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUo8GAzQ5jJht4fyjFPqLB)_