### PR TITLE
Screens Phase 3B: single-variant mockup generation + coverage manifests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1628,12 +1628,40 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     `buildMockupVariantCoverageSummary` (artifact rollup: recommended
     generated/total, P0 mobile coverage, legacy-unknown count) drive the UI.
     This layer is **display/discovery only — it never changes review status.**
-  Per-variant image generation is NOT wired (Phase 3B) — the Mockups-tab
-  `MockupVariantsPanel` offers only the real actions (mark accepted / not
-  needed / undo) and says coverage is "tracked from generated mockup
-  metadata"; never add a dead "generate variant" button or wording that
-  implies Synapse inspected the rendered image, and never claim visual
-  alignment / show "covered" without structured metadata (legacy → "unknown").
+  - **Phase 3B single-variant generation (`src/lib/mockupVariantRequest.ts`
+    pure + `src/lib/mockupVariantImageStore.ts` IDB +
+    `src/store/mockupVariantImageStore.ts` Zustand +
+    `src/components/experience/MockupVariantImage.tsx`)** — the Mockups tab can
+    now GENERATE / regenerate / retry ONE specific non-default variant
+    (`Mobile · Default`, `Desktop · Empty History`, …). The **default variant
+    (`id === 'default'`) is deliberately left on the legacy `MockupScreenImage`
+    path unchanged** (keys `versionId:screenId:quality`, coverage stays
+    "unknown"); every OTHER variant uses a **dedicated, independent** per-variant
+    IDB store keyed **`versionId:screenId:variantId:quality`** so generating one
+    variant never overwrites another. `buildVariantGenerationRequest` assembles a
+    variant-scoped request (viewport + state + core regions/actions/criteria/
+    risks, derived only from existing screen-contract fields);
+    `buildVariantImagePrompt` scopes the gpt-image-2 prompt to that exact viewport
+    + state (forbids other states / a generic default; realistic mobile viewport;
+    explicit empty/loading/error/permission/success guidance);
+    `buildVariantCoverageManifest` captures a **generation-time coverage
+    manifest** (`MockupCoverageManifest` in `src/types`) — a deterministic,
+    structured self-report of what the render was ASKED to include (`estimated:
+    true`), **never a visual inspection**. The manifest is stored WITH the variant
+    image and threaded back into the derived model
+    (`buildScreenMockupVariants`'s optional `generatedVariants` map →
+    `source: 'variant'`, real `coverageStatus`), the screen cards, and the
+    artifact rollup (`buildMockupVariantCoverageSummary`'s
+    `generatedVariantsByScreen` → `manifestBackedGenerated`, counted separately
+    from `legacyUnknownMockups`). **Honesty rules stand:** legacy mockups without
+    a manifest stay "unknown"; UI copy says "Coverage manifest captured during
+    generation … not a visual inspection", never "visually verified"; never show
+    "covered" without structured metadata. Generation is gated on an OpenAI key
+    (`hasOpenAIKey`) + `gpt_image` image mode — demo / keyless users see a
+    disabled action with a clear explanation, never a silent failure. The
+    per-variant store is **independent of snapshots & cross-device sync** (a
+    documented Phase 3C gap, mirroring the screen-inventory-image sync gap) — do
+    not entangle it with `snapshotClient` / `imageRefsStore`.
   `parseDecisionBranches` (arrow-form +
   if/otherwise) powers both the branch-aware Flow-tab rendering
   (`DecisionBranches`) and the `decision_missing_branches` gap — an

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -37,7 +37,8 @@ import {
     type ScreenMetadataEdit,
 } from '../lib/screenExperience';
 import { buildReadinessIndex, buildScreenCoverageSummary } from '../lib/screenReadiness';
-import { buildMockupVariantCoverageSummary } from '../lib/mockupVariants';
+import { buildMockupVariantCoverageSummary, type GeneratedVariantMap } from '../lib/mockupVariants';
+import { useMockupVariantImageStore } from '../store/mockupVariantImageStore';
 import { ReferenceWarningsPanel } from './experience/ReferenceWarningsPanel';
 import { parseScreenInventory } from '../lib/screenInventoryNormalize';
 import { parseFlows } from './renderers/userFlows/parseFlow';
@@ -401,9 +402,37 @@ export function ArtifactWorkspace({
     const mockupPlatform = mockupPreferred ? extractMockupSettings(mockupPreferred).platform : undefined;
     const mobileRelevant = projectPlatform === 'app'
         || mockupPlatform === 'mobile' || mockupPlatform === 'responsive';
+
+    // Phase 3B: manifest-backed generated variants across all screens (from the
+    // per-variant image store), keyed by screenId → variantId → coverage. Loaded
+    // lazily; feeds both the artifact-level rollup and the per-screen cards so
+    // they reflect real generated variants, not just derived recommendations.
+    const mockupVersionId = mockupPreferred?.id;
+    const loadVariantImagesForVersion = useMockupVariantImageStore(s => s.loadForVersion);
+    const variantImagesMap = useMockupVariantImageStore(s => s.images);
+    useEffect(() => {
+        if (mockupVersionId) void loadVariantImagesForVersion(mockupVersionId);
+    }, [mockupVersionId, loadVariantImagesForVersion]);
+    const generatedVariantsByScreen = useMemo(() => {
+        const map = new Map<string, GeneratedVariantMap>();
+        if (!mockupVersionId) return map;
+        for (const key of Object.keys(variantImagesMap)) {
+            const r = variantImagesMap[key];
+            if (r.versionId !== mockupVersionId) continue;
+            const existing = map.get(r.screenId) ?? {};
+            existing[r.variantId] = { coverage: r.coverageManifest?.overallStatus ?? 'unknown' };
+            map.set(r.screenId, existing);
+        }
+        return map;
+    }, [variantImagesMap, mockupVersionId]);
+
     const variantCoverage = useMemo(
-        () => buildMockupVariantCoverageSummary(screenIndex, { platform: mockupPlatform, mobileRelevant }),
-        [screenIndex, mockupPlatform, mobileRelevant],
+        () => buildMockupVariantCoverageSummary(screenIndex, {
+            platform: mockupPlatform,
+            mobileRelevant,
+            generatedVariantsByScreen: (id) => generatedVariantsByScreen.get(id),
+        }),
+        [screenIndex, mockupPlatform, mobileRelevant, generatedVariantsByScreen],
     );
 
     // Validation issues minus the user's persisted dismissals.
@@ -954,6 +983,7 @@ export function ArtifactWorkspace({
                         variantCoverage={variantCoverage}
                         mockupPlatform={mockupPlatform}
                         mobileRelevant={mobileRelevant}
+                        generatedVariantsByScreen={(id) => generatedVariantsByScreen.get(id)}
                         onSelectScreen={handleOpenScreen}
                         onGenerateMissingMockups={
                             mockupDetailContext

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -315,10 +315,14 @@ describe('Phase 2 contract rendering', () => {
         // Missing variants are visually distinct (Missing pills + "Not generated yet").
         expect(getAllByText('Missing').length).toBe(3);
         expect(getAllByText('Not generated yet').length).toBe(3);
-        // Selecting a missing variant explains generation isn't in this phase —
-        // and offers no dead "Generate variant" button.
+        // Selecting a missing variant offers a Phase 3B "Generate variant"
+        // action — disabled here because the test env has no OpenAI key — with
+        // a clear, non-alarming explanation rather than a silent failure.
         fireEvent.click(getByText('Mobile · Default'));
-        expect(getByText(/Per-variant generation lands in Phase 3B/)).toBeTruthy();
+        const generateBtn = getByText('Generate variant').closest('button');
+        expect(generateBtn).toBeTruthy();
+        expect(generateBtn?.disabled).toBe(true);
+        expect(getAllByText(/requires your own OpenAI API key/).length).toBeGreaterThan(0);
     });
 
     it('marking a variant not needed persists through the edit overlay', () => {

--- a/src/components/experience/MockupVariantImage.tsx
+++ b/src/components/experience/MockupVariantImage.tsx
@@ -1,0 +1,166 @@
+// Phase 3B: renders ONE non-default mockup variant's image with generation
+// actions (generate / regenerate / retry), backed by the dedicated per-variant
+// image store. The legacy "Desktop · Default" variant is NOT rendered here — it
+// keeps using MockupScreenImage. Each variant is keyed independently, so
+// generating one never overwrites another.
+//
+// Demo / API-key behavior mirrors MockupScreenImage: generation requires an
+// OpenAI key (the demo project has none), so the action is disabled with a
+// clear, non-alarming explanation rather than a silent failure.
+
+import { useEffect } from 'react';
+import {
+    AlertTriangle, ImageOff, Loader2, RefreshCw, Settings as SettingsIcon, Sparkles, X,
+} from 'lucide-react';
+import type { MockupImageQuality, MockupPlatform } from '../../types';
+import { hasOpenAIKey } from '../../lib/openaiClient';
+import { getMockupImageMode } from '../../lib/artifactModelSettings';
+import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
+import type { MockupVariantGenerationRequest } from '../../lib/mockupVariantRequest';
+import { formatVariantLabel, type DerivedMockupVariant } from '../../lib/mockupVariants';
+
+interface Props {
+    projectId: string;
+    artifactId: string;
+    versionId: string;
+    platform: MockupPlatform;
+    variant: DerivedMockupVariant;
+    request: MockupVariantGenerationRequest;
+}
+
+const DEMO_KEYLESS_MESSAGE =
+    'Generating custom mockup variants requires your own OpenAI API key. Add one in Settings to customize this project.';
+const UPLOAD_MODE_MESSAGE =
+    'Mockup image source is set to “upload your own” in Settings. Switch it to AI generation to generate variants here.';
+
+export function MockupVariantImage({
+    projectId, artifactId, versionId, platform, variant, request,
+}: Props) {
+    const scope = `${versionId}:${request.screenId}:${request.variantId}`;
+    const record = useMockupVariantImageStore(s => s.getBestRecord(versionId, request.screenId, request.variantId));
+    // Subscribe to the images map so a freshly-stored record re-renders us.
+    useMockupVariantImageStore(s => s.images);
+    const inFlight = useMockupVariantImageStore(s => s.inFlight[scope]);
+    const error = useMockupVariantImageStore(s => s.errors[scope]);
+    const generate = useMockupVariantImageStore(s => s.generate);
+    const cancel = useMockupVariantImageStore(s => s.cancel);
+    const clearError = useMockupVariantImageStore(s => s.clearError);
+    const loadForVersion = useMockupVariantImageStore(s => s.loadForVersion);
+
+    // Hydrate this version's variant images from IDB (reload / tab switch).
+    useEffect(() => {
+        void loadForVersion(versionId);
+    }, [versionId, loadForVersion]);
+
+    const keyPresent = hasOpenAIKey();
+    const uploadMode = getMockupImageMode() === 'user_uploaded';
+    const canGenerate = keyPresent && !uploadMode;
+    const gateReason = uploadMode ? UPLOAD_MODE_MESSAGE : DEMO_KEYLESS_MESSAGE;
+
+    const handleGenerate = (quality: MockupImageQuality) => {
+        if (!canGenerate) return;
+        clearError(versionId, request.screenId, request.variantId);
+        void generate({ projectId, artifactId, versionId, platform, request, quality });
+    };
+
+    const label = formatVariantLabel(variant);
+
+    if (inFlight) {
+        return (
+            <div className="bg-white rounded-lg border border-neutral-200 p-8 flex flex-col items-center justify-center text-center min-h-[320px]">
+                <Loader2 size={26} className="text-indigo-500 animate-spin mb-3" />
+                <div className="text-sm font-medium text-neutral-800">Generating {label}…</div>
+                <div className="text-xs text-neutral-500 mt-1">
+                    OpenAI gpt-image-2 · usually 5–15s
+                </div>
+                <button
+                    type="button"
+                    onClick={() => cancel(versionId, request.screenId, request.variantId)}
+                    className="mt-4 inline-flex items-center gap-1.5 text-xs text-neutral-500 hover:text-neutral-800 px-2 py-1 rounded-md hover:bg-neutral-50 transition"
+                >
+                    <X size={12} /> Cancel
+                </button>
+            </div>
+        );
+    }
+
+    if (record) {
+        return (
+            <div className="overflow-hidden">
+                <div className="relative bg-neutral-50 flex items-center justify-center rounded-lg border border-neutral-200 overflow-hidden">
+                    <img
+                        src={record.dataUrl}
+                        alt={`AI mockup of ${request.screenName} — ${label}`}
+                        className="max-w-full max-h-[560px] object-contain"
+                    />
+                </div>
+                <div className="mt-2 flex items-center justify-end">
+                    <button
+                        type="button"
+                        disabled={!canGenerate}
+                        onClick={() => handleGenerate(record.quality)}
+                        className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        title={canGenerate ? 'Regenerate this variant (replaces this render)' : gateReason}
+                    >
+                        <RefreshCw size={12} /> Regenerate variant
+                    </button>
+                </div>
+                {!canGenerate && (
+                    <p className="mt-1 text-[11px] text-neutral-400 text-right">{gateReason}</p>
+                )}
+            </div>
+        );
+    }
+
+    // Failed (no record + error) — honest failure state with retry.
+    if (error) {
+        return (
+            <div className="bg-white rounded-lg border border-amber-200 bg-amber-50/40 p-6 flex flex-col items-center justify-center text-center min-h-[240px]">
+                <AlertTriangle size={20} className="text-amber-500 mb-2" />
+                <div className="text-sm font-medium text-neutral-800">{label} — generation failed</div>
+                <p className="text-[11px] text-neutral-600 mt-1 max-w-sm">
+                    We couldn&rsquo;t generate this variant. You can retry, or review your API key in Settings.
+                </p>
+                <p className="text-[11px] text-amber-700 mt-2 max-w-md break-words">{error}</p>
+                <button
+                    type="button"
+                    disabled={!canGenerate}
+                    onClick={() => handleGenerate('low')}
+                    className="mt-3 inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
+                >
+                    <RefreshCw size={13} /> Retry generation
+                </button>
+            </div>
+        );
+    }
+
+    // Missing — no image yet. Offer generation (gated).
+    return (
+        <div className="bg-white rounded-lg border border-dashed border-neutral-300 p-6 flex flex-col items-center justify-center text-center min-h-[240px]">
+            <ImageOff size={20} className="text-neutral-300 mb-2" />
+            <div className="text-sm font-medium text-neutral-800">No {label} mockup yet</div>
+            <p className="text-[11px] text-neutral-500 mt-1 max-w-sm">
+                {variant.notes[0] ?? 'Recommended for this screen.'} Generate just this variant — it
+                won&rsquo;t change any other mockup.
+            </p>
+            <button
+                type="button"
+                disabled={!canGenerate}
+                onClick={() => handleGenerate('low')}
+                className="mt-4 inline-flex items-center gap-1.5 text-sm px-4 py-2 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
+                title={canGenerate ? 'Generate this variant (low-quality draft, 5–15s)' : gateReason}
+            >
+                <Sparkles size={14} /> Generate variant
+            </button>
+            {canGenerate ? (
+                <p className="mt-2 text-[11px] text-amber-700 max-w-sm">
+                    Paid OpenAI operation — billed to your account via your key (usually a few cents).
+                </p>
+            ) : (
+                <p className="mt-3 inline-flex items-center gap-1.5 text-[11px] text-neutral-500 max-w-sm">
+                    <SettingsIcon size={11} className="shrink-0" /> {gateReason}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -15,9 +15,11 @@
 
 import { useMemo, useState } from 'react';
 import {
-    CheckCircle2, ImageOff, Info, Layers, Monitor, Smartphone, Tablet,
+    CheckCircle2, Info, Layers, Monitor, ShieldQuestion, Smartphone, Tablet,
 } from 'lucide-react';
-import type { MockupPlatform } from '../../types';
+import type {
+    MockupCoverageItem, MockupCoverageItemStatus, MockupCoverageManifest, MockupPlatform,
+} from '../../types';
 import {
     COVERAGE_STATUS_LABELS,
     VARIANT_STATUS_LABELS,
@@ -28,8 +30,11 @@ import {
     type ScreenMockupVariantSummary,
 } from '../../lib/mockupVariants';
 import { buildMockupSpecCoverage } from '../../lib/screenReadiness';
+import { buildVariantGenerationRequest, type VariantRequestContext } from '../../lib/mockupVariantRequest';
+import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import type { ScreenExperienceItem } from '../../lib/screenExperience';
 import { MockupScreenImage } from '../mockups/MockupScreenImage';
+import { MockupVariantImage } from './MockupVariantImage';
 import type { ScreenDetailMockupContext } from './ScreenDetailView';
 
 const VIEWPORT_ICON: Record<MockupViewport, typeof Monitor> = {
@@ -191,11 +196,40 @@ function VariantDetail({
     onSetVariantStatus?: (variantId: string, status: 'accepted' | 'not_needed' | null) => void;
 }) {
     const primaryGenerated = holdsGeneratedImage(variant, Boolean(item.mockupScreen));
+    // The default variant keeps the legacy MockupScreenImage; every other
+    // variant (mobile/desktop default, state variants) uses the Phase 3B
+    // per-variant generation path.
+    const isVariantPath = variant.id !== 'default';
+
     const metaParts = [
         PLATFORM_LABELS[mockupContext.settings.platform],
         mockupContext.prdVersionLabel ? `Generated from PRD ${mockupContext.prdVersionLabel}` : null,
         mockupContext.versionNumber ? `Mockup v${mockupContext.versionNumber}` : null,
     ].filter(Boolean);
+
+    // Variant-specific generation request (Phase 3B). Derived from the effective
+    // screen + this variant + the mockup context (product title/summary,
+    // fidelity, sibling default mockup for visual consistency).
+    const requestContext: VariantRequestContext = {
+        projectName: mockupContext.payload.title,
+        productSummary: mockupContext.payload.summary,
+        fidelity: mockupContext.settings.fidelity,
+        siblingMockup: item.mockupScreen,
+    };
+    const variantRequest = useMemo(
+        () => (isVariantPath
+            ? buildVariantGenerationRequest(item.screen, item.id, variant, requestContext)
+            : null),
+        // requestContext is derived from stable mockupContext fields.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [isVariantPath, item.screen, item.id, variant, mockupContext.payload.title,
+            mockupContext.payload.summary, mockupContext.settings.fidelity, item.mockupScreen],
+    );
+
+    // Manifest-backed coverage for this variant (from the per-variant image store).
+    const variantRecord = useMockupVariantImageStore(
+        s => (isVariantPath ? s.getBestRecord(mockupContext.versionId, item.id, variant.id) : undefined),
+    );
 
     return (
         <div className="bg-white rounded-xl border border-neutral-200 p-4 space-y-3">
@@ -206,6 +240,7 @@ function VariantDetail({
                         Status: {VARIANT_STATUS_LABELS[variant.status]}
                         {variant.userSet && ' (set by you)'}
                         {variant.status === 'generated' && variant.source === 'legacy' && ' · Source: existing mockup'}
+                        {variant.status === 'generated' && variant.source === 'variant' && ' · Source: generated variant'}
                     </p>
                 </div>
                 <VariantActions variant={variant} onSetVariantStatus={onSetVariantStatus} />
@@ -228,20 +263,15 @@ function VariantDetail({
                         <p className="text-[11px] text-neutral-400">{metaParts.join(' · ')}</p>
                     )}
                 </div>
-            ) : variant.status === 'missing' ? (
-                <div className="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/60 p-6 text-center">
-                    <ImageOff size={18} className="text-neutral-300 mx-auto mb-2" aria-hidden />
-                    <p className="text-xs font-medium text-neutral-700">
-                        No mockup for {formatVariantLabel(variant)} yet.
-                    </p>
-                    <p className="text-[11px] text-neutral-500 mt-1 max-w-sm mx-auto">
-                        {variant.notes[0] ?? 'Recommended for this screen.'}
-                    </p>
-                    <p className="text-[11px] text-neutral-400 mt-2">
-                        Per-variant generation lands in Phase 3B. For now, regenerate the full mockup
-                        or upload an image and mark this variant accepted.
-                    </p>
-                </div>
+            ) : isVariantPath && variantRequest && variant.status !== 'not_needed' ? (
+                <MockupVariantImage
+                    projectId={mockupContext.projectId}
+                    artifactId={mockupContext.artifactId}
+                    versionId={mockupContext.versionId}
+                    platform={mockupContext.settings.platform}
+                    variant={variant}
+                    request={variantRequest}
+                />
             ) : (
                 <div className="rounded-lg border border-neutral-200 bg-neutral-50/60 p-4 text-center">
                     <p className="text-xs text-neutral-600">
@@ -252,8 +282,13 @@ function VariantDetail({
                 </div>
             )}
 
-            {/* Spec coverage — only for the variant that holds the real image. */}
-            <SpecCoverageSection show={primaryGenerated} specCoverage={specCoverage} />
+            {/* Coverage — manifest-backed for generated variants, spec-to-spec
+                for the legacy default, honest "unknown" otherwise. */}
+            {variantRecord?.coverageManifest ? (
+                <VariantManifestCoverage manifest={variantRecord.coverageManifest} />
+            ) : (
+                <SpecCoverageSection show={primaryGenerated} specCoverage={specCoverage} />
+            )}
 
             {/* Notes */}
             {variant.notes.length > 0 && variant.status !== 'missing' && (
@@ -266,6 +301,79 @@ function VariantDetail({
                     ))}
                 </ul>
             )}
+        </div>
+    );
+}
+
+const MANIFEST_ITEM_TONE: Record<MockupCoverageItemStatus, string> = {
+    covered: 'text-emerald-700',
+    partial: 'text-amber-700',
+    missing: 'text-amber-700',
+    unknown: 'text-neutral-500',
+    not_applicable: 'text-neutral-400',
+};
+
+const MANIFEST_ITEM_LABEL: Record<MockupCoverageItemStatus, string> = {
+    covered: 'In spec',
+    partial: 'Partial',
+    missing: 'Missing',
+    unknown: 'Unknown',
+    not_applicable: 'N/A',
+};
+
+/** Renders the generation-time coverage manifest for a generated variant. This
+ * is a self-report of the generation spec, NOT a visual inspection — the copy
+ * says so explicitly. */
+function VariantManifestCoverage({ manifest }: { manifest: MockupCoverageManifest }) {
+    const groups: Array<{ label: string; items: MockupCoverageItem[] }> = [
+        { label: 'UI regions', items: manifest.uiRegions },
+        { label: 'User actions', items: manifest.userActions },
+        { label: 'Acceptance criteria', items: manifest.acceptanceCriteria },
+    ].filter(g => g.items.length > 0);
+
+    return (
+        <div className="rounded-lg border border-neutral-200 p-3">
+            <div className="flex items-center gap-1.5 mb-2">
+                <ShieldQuestion size={12} className="text-neutral-400" aria-hidden />
+                <h5 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                    Coverage manifest
+                </h5>
+                <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full ring-1 bg-neutral-50 text-neutral-600 ring-neutral-200">
+                    {COVERAGE_STATUS_LABELS[manifest.overallStatus]}
+                </span>
+            </div>
+            {groups.length === 0 ? (
+                <p className="text-[11px] text-neutral-500">
+                    No spec items were documented for this screen — coverage is a best-effort estimate.
+                </p>
+            ) : (
+                <div className="space-y-2">
+                    {groups.map(group => (
+                        <div key={group.label}>
+                            <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-0.5">
+                                {group.label}
+                            </div>
+                            <ul className="space-y-0.5 text-xs">
+                                {group.items.map((item, i) => (
+                                    <li key={i} className="flex items-center justify-between gap-2">
+                                        <span className="text-neutral-700 truncate">{item.label}</span>
+                                        <span className={`shrink-0 ${MANIFEST_ITEM_TONE[item.status]}`}>
+                                            {MANIFEST_ITEM_LABEL[item.status]}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {manifest.warnings.map((w, i) => (
+                <p key={i} className="text-[11px] text-amber-700 mt-2">{w}</p>
+            ))}
+            <p className="text-[11px] text-neutral-400 mt-2">
+                Coverage manifest captured during generation — a structured self-report of what the
+                render was asked to include, not a visual inspection of the image.
+            </p>
         </div>
     );
 }

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -34,8 +34,9 @@ import {
 } from '../../lib/screenReadiness';
 import {
     buildScreenMockupVariants, formatVariantLabel, summarizeScreenVariants,
-    VARIANT_STATUS_LABELS,
+    VARIANT_STATUS_LABELS, type GeneratedVariantMap,
 } from '../../lib/mockupVariants';
+import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import { MockupVariantsPanel } from './MockupVariantsPanel';
 import { ScreenOverviewPanel } from './ScreenOverviewPanel';
 import { ReadinessBadge } from './ReadinessBadge';
@@ -610,10 +611,31 @@ function MockupsTab({
 }) {
     const [linkTarget, setLinkTarget] = useState('');
 
+    // Phase 3B: manifest-backed generated variants for this screen (viewport ×
+    // state), from the per-variant image store. Loaded lazily on view; a
+    // generated variant flips the derived model from missing → generated.
+    const versionId = mockupContext?.versionId;
+    const loadVariantImages = useMockupVariantImageStore(s => s.loadForVersion);
+    const variantImages = useMockupVariantImageStore(s => s.images);
+    useEffect(() => {
+        if (versionId) void loadVariantImages(versionId);
+    }, [versionId, loadVariantImages]);
+    const generatedVariants = useMemo<GeneratedVariantMap>(() => {
+        if (!versionId) return {};
+        const out: GeneratedVariantMap = {};
+        for (const key of Object.keys(variantImages)) {
+            const r = variantImages[key];
+            if (r.versionId !== versionId || r.screenId !== item.id) continue;
+            out[r.variantId] = { coverage: r.coverageManifest?.overallStatus ?? 'unknown' };
+        }
+        return out;
+    }, [variantImages, versionId, item.id]);
+
     // Derived viewport × state variant grid (see src/lib/mockupVariants.ts).
     const variants = buildScreenMockupVariants(item, {
         platform: mockupContext?.settings.platform,
         mobileRelevant,
+        generatedVariants,
     });
     const variantSummary = summarizeScreenVariants(variants);
 
@@ -755,8 +777,8 @@ function MockupsTab({
                 </ul>
                 <p className="text-[11px] text-neutral-400 mt-2">
                     Derived from this screen&rsquo;s priority and documented states — tracked from
-                    generated metadata, never from inspecting images. Single-variant generation lands
-                    in Phase 3B.
+                    generated metadata, never from inspecting images. Add this screen to the mockups to
+                    generate individual variants.
                 </p>
             </div>
         )}

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../lib/screenReadiness';
 import {
     buildScreenMockupVariants, summarizeScreenVariants,
-    type MockupVariantCoverageSummary,
+    type GeneratedVariantMap, type MockupVariantCoverageSummary,
 } from '../../lib/mockupVariants';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 import { ScreenCoveragePanel } from './ScreenCoveragePanel';
@@ -36,6 +36,9 @@ interface Props {
     mockupPlatform?: MockupPlatform;
     /** True when the project is mobile-relevant (mobile-first / responsive). */
     mobileRelevant?: boolean;
+    /** Phase 3B: resolves a screen's manifest-backed generated variants so the
+     * card reflects real generation (e.g. "Mobile: generated"). */
+    generatedVariantsByScreen?: (screenId: string) => GeneratedVariantMap | undefined;
     /** Opens the Screen Detail view — keyed by the stable canonical id. */
     onSelectScreen: (screenId: string) => void;
     /**
@@ -48,7 +51,7 @@ interface Props {
 
 export function ScreenListView({
     index, readiness, coverage, variantCoverage, mockupPlatform, mobileRelevant,
-    onSelectScreen, onGenerateMissingMockups,
+    generatedVariantsByScreen, onSelectScreen, onGenerateMissingMockups,
 }: Props) {
     const [filter, setFilter] = useState<ScreenListFilter>('all');
 
@@ -150,6 +153,7 @@ export function ScreenListView({
                                     readiness={readiness.get(item.id)}
                                     mockupPlatform={mockupPlatform}
                                     mobileRelevant={mobileRelevant}
+                                    generatedVariants={generatedVariantsByScreen?.(item.id)}
                                     onSelect={() => onSelectScreen(item.id)}
                                 />
                             </li>
@@ -162,12 +166,13 @@ export function ScreenListView({
 }
 
 function ScreenRow({
-    item, readiness, mockupPlatform, mobileRelevant, onSelect,
+    item, readiness, mockupPlatform, mobileRelevant, generatedVariants, onSelect,
 }: {
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
     mockupPlatform?: MockupPlatform;
     mobileRelevant?: boolean;
+    generatedVariants?: GeneratedVariantMap;
     onSelect: () => void;
 }) {
     const { screen } = item;
@@ -179,7 +184,7 @@ function ScreenRow({
     const riskCount = screen.risks?.length ?? 0;
     const featureRefs = screen.featureRefs ?? [];
     const variantSummary = summarizeScreenVariants(
-        buildScreenMockupVariants(item, { platform: mockupPlatform, mobileRelevant }),
+        buildScreenMockupVariants(item, { platform: mockupPlatform, mobileRelevant, generatedVariants }),
     );
 
     return (

--- a/src/lib/__tests__/mockupVariantRequest.test.ts
+++ b/src/lib/__tests__/mockupVariantRequest.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { ScreenItem } from '../../types';
+import { buildScreenIndex } from '../screenExperience';
+import { buildScreenMockupVariants } from '../mockupVariants';
+import {
+    buildVariantCoverageManifest,
+    buildVariantGenerationRequest,
+    buildVariantImagePrompt,
+    type VariantRequestContext,
+} from '../mockupVariantRequest';
+
+const CTX: VariantRequestContext = {
+    projectName: 'Acme',
+    productSummary: 'A product for teams.',
+    fidelity: 'high',
+};
+
+const richScreen: ScreenItem = {
+    id: 'scr-home',
+    name: 'Home Dashboard',
+    priority: 'P0',
+    purpose: 'Landing surface.',
+    userIntent: 'See recent activity.',
+    coreUIElements: ['Activity feed', 'Header bar'],
+    exitPaths: [{ label: 'Open settings', target: 'Settings' }],
+    handoff: { events: [{ name: 'Refresh feed' }] },
+    acceptanceCriteria: ['Feed loads within 2s'],
+    risks: ['Empty first-run experience'],
+    states: [
+        { name: 'Default', description: 'Shows the feed', type: 'default' },
+        {
+            name: 'Empty History', description: 'No activity yet', type: 'empty',
+            needsMockup: true, trigger: 'User has no events', systemBehavior: 'Show onboarding CTA',
+            acceptanceCriteria: ['Shows a "Get started" button'],
+        },
+    ],
+};
+
+function variantsFor(screen: ScreenItem) {
+    const index = buildScreenIndex(
+        { sections: [{ title: 'Main', screens: [screen] }] }, [], null,
+    );
+    return { item: index.items[0], variants: buildScreenMockupVariants(index.items[0]) };
+}
+
+describe('buildVariantGenerationRequest', () => {
+    it('includes viewport and state and derives spec fields', () => {
+        const { item, variants } = variantsFor(richScreen);
+        const mobile = variants.find(v => v.id === 'mobile:default')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, mobile, CTX);
+        expect(req.viewport).toBe('mobile');
+        expect(req.stateName).toBe('Default');
+        expect(req.priority).toBe('P0');
+        expect(req.coreUIRegions).toEqual(['Activity feed', 'Header bar']);
+        expect(req.userActions).toEqual(['Refresh feed', 'Open settings']);
+        expect(req.acceptanceCriteria).toEqual(['Feed loads within 2s']);
+        expect(req.risks).toEqual(['Empty first-run experience']);
+    });
+
+    it('pulls state-specific trigger/behavior/criteria for a state variant', () => {
+        const { item, variants } = variantsFor(richScreen);
+        const empty = variants.find(v => v.stateName === 'Empty History')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, empty, CTX);
+        expect(req.stateType).toBe('empty');
+        expect(req.stateTrigger).toBe('User has no events');
+        expect(req.stateBehavior).toBe('Show onboarding CTA');
+        // State-level acceptance criteria win over screen-level.
+        expect(req.acceptanceCriteria).toEqual(['Shows a "Get started" button']);
+    });
+
+    it('produces a valid request for a sparse screen (no states/spec)', () => {
+        const { item, variants } = variantsFor({ name: 'Sparse' } as ScreenItem);
+        const dflt = variants.find(v => v.id === 'default')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, dflt, CTX);
+        expect(req.coreUIRegions).toEqual([]);
+        expect(req.userActions).toEqual([]);
+        expect(req.acceptanceCriteria).toEqual([]);
+        expect(req.viewport).toBe('desktop');
+        expect(req.stateName).toBe('Default');
+    });
+});
+
+describe('buildVariantImagePrompt', () => {
+    it('scopes the prompt to the exact viewport + state and forbids other states', () => {
+        const { item, variants } = variantsFor(richScreen);
+        const empty = variants.find(v => v.stateName === 'Empty History')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, empty, CTX);
+        const prompt = buildVariantImagePrompt(req);
+        expect(prompt).toContain('Viewport: desktop. State: Empty History.');
+        expect(prompt).toContain('EMPTY state');
+        expect(prompt).toContain('Do not create a generic default screen');
+    });
+
+    it('emphasizes a realistic mobile viewport for mobile variants', () => {
+        const { item, variants } = variantsFor(richScreen);
+        const mobile = variants.find(v => v.id === 'mobile:default')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, mobile, CTX);
+        const prompt = buildVariantImagePrompt(req);
+        expect(prompt).toContain('mobile app screen');
+        expect(prompt).toContain('do not simply shrink a desktop layout');
+    });
+});
+
+describe('buildVariantCoverageManifest', () => {
+    it('marks requested spec items covered and reports aligned when content exists', () => {
+        const { item, variants } = variantsFor(richScreen);
+        const mobile = variants.find(v => v.id === 'mobile:default')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, mobile, CTX);
+        const manifest = buildVariantCoverageManifest(req);
+        expect(manifest.estimated).toBe(true);
+        expect(manifest.overallStatus).toBe('aligned');
+        expect(manifest.uiRegions.every(r => r.status === 'covered')).toBe(true);
+        expect(manifest.states[0]).toMatchObject({ label: 'Default', status: 'covered' });
+        expect(manifest.variant).toEqual({ viewport: 'mobile', stateName: 'Default' });
+    });
+
+    it('reports unknown with a warning for a sparse screen', () => {
+        const { item, variants } = variantsFor({ name: 'Sparse' } as ScreenItem);
+        const dflt = variants.find(v => v.id === 'default')!;
+        const req = buildVariantGenerationRequest(item.screen, item.id, dflt, CTX);
+        const manifest = buildVariantCoverageManifest(req);
+        expect(manifest.overallStatus).toBe('unknown');
+        expect(manifest.warnings.length).toBeGreaterThan(0);
+    });
+});

--- a/src/lib/__tests__/mockupVariants.test.ts
+++ b/src/lib/__tests__/mockupVariants.test.ts
@@ -260,6 +260,54 @@ describe('buildMockupVariantCoverageSummary', () => {
         expect(buildMockupVariantCoverageSummary(index)).toBeNull();
     });
 
+    it('counts manifest-backed generated variants separately from legacy-unknown coverage', () => {
+        const index = buildScreenIndex(
+            makeInventory([p0Screen]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
+        );
+        // The Mobile · Default variant is generated with an "aligned" manifest.
+        const rollup = buildMockupVariantCoverageSummary(index, {
+            generatedVariantsByScreen: (id) =>
+                id === 'scr-home' ? { 'mobile:default': { coverage: 'aligned' } } : undefined,
+        })!;
+        expect(rollup.manifestBackedGenerated).toBe(1);
+        // Legacy default mockup still has no manifest → unknown.
+        expect(rollup.legacyUnknownMockups).toBe(1);
+        // Mobile default now counts as generated + P0 mobile covered.
+        expect(rollup.p0WithMobile).toBe(1);
+        expect(rollup.recommendedGenerated).toBe(2); // desktop default (legacy) + mobile default
+    });
+});
+
+// --- Phase 3B: generated-variant threading ------------------------------------
+
+describe('buildScreenMockupVariants with generatedVariants (Phase 3B)', () => {
+    it('flips a missing non-default variant to generated with manifest coverage', () => {
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null);
+        const variants = buildScreenMockupVariants(index.items[0], {
+            generatedVariants: { 'mobile:default': { coverage: 'aligned' } },
+        });
+        const mobile = variants.find(v => v.id === 'mobile:default')!;
+        expect(mobile.status).toBe('generated');
+        expect(mobile.source).toBe('variant');
+        expect(mobile.coverageStatus).toBe('aligned');
+        // Other variants stay missing.
+        expect(variants.find(v => v.id === 'state:loading')!.status).toBe('missing');
+    });
+
+    it('never applies generatedVariants to the legacy default slot', () => {
+        const index = buildScreenIndex(makeInventory([supportingScreen]), [], null);
+        // Even if a stray "default" entry exists, the default slot reads the
+        // legacy mockup join, not this map.
+        const variants = buildScreenMockupVariants(index.items[0], {
+            generatedVariants: { 'default': { coverage: 'aligned' } },
+        });
+        const dflt = variants.find(v => v.id === 'default')!;
+        expect(dflt.status).toBe('missing');
+        expect(dflt.source).toBe('derived_missing');
+    });
+
     it('drops not_needed variants from the recommended total and treats not_needed mobile as handled', () => {
         const index = buildScreenIndex(makeInventory([p0Screen]), [], null, {
             'scr-home': {

--- a/src/lib/mockupVariantImageStore.ts
+++ b/src/lib/mockupVariantImageStore.ts
@@ -1,0 +1,136 @@
+// Phase 3B: IndexedDB persistence for per-variant mockup images + coverage
+// manifests. Deliberately a SEPARATE object store from the legacy single-image
+// mockup store (src/lib/mockupImageStore.ts) so:
+//   - generating one variant (e.g. Mobile · Default) never touches another
+//     (Desktop · Default), and
+//   - the legacy default-variant rendering path is completely unaffected.
+//
+// Records are keyed by the composite `${versionId}:${screenId}:${variantId}:${quality}`.
+// Because a variantId itself contains colons (`mobile:default`, `state:<slug>`),
+// callers never PARSE the key — enumeration is done via the `versionId` index
+// and structured record fields. Falls back to an in-memory Map when IndexedDB
+// is unavailable (private browsing), matching mockupImageStore's behavior.
+
+import type { MockupImageQuality, MockupVariantImageRecord } from '../types';
+
+const DB_NAME = 'synapse-mockup-variant-images';
+const DB_VERSION = 1;
+const STORE_NAME = 'variant-images';
+const VERSION_INDEX = 'versionId';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+const memoryFallback: Map<string, MockupVariantImageRecord> = new Map();
+let memoryFallbackWarned = false;
+
+const noteFallback = (reason: string) => {
+    if (!memoryFallbackWarned) {
+        memoryFallbackWarned = true;
+        console.warn(`[mockup-variant-image-store] IndexedDB unavailable (${reason}); using in-memory fallback. Variant images will be lost on reload.`);
+    }
+};
+
+const openDb = (): Promise<IDBDatabase> => {
+    if (dbPromise) return dbPromise;
+    if (typeof indexedDB === 'undefined') {
+        noteFallback('indexedDB undefined');
+        return Promise.reject(new Error('IndexedDB unavailable'));
+    }
+
+    dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                const store = db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+                store.createIndex(VERSION_INDEX, 'versionId', { unique: false });
+            }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('Failed to open IndexedDB'));
+        req.onblocked = () => reject(new Error('IndexedDB open blocked'));
+    }).catch((err) => {
+        dbPromise = null;
+        noteFallback(String(err?.message ?? err));
+        throw err;
+    });
+
+    return dbPromise;
+};
+
+/** Composite primary key for a variant image record. */
+export const buildVariantImageKey = (
+    versionId: string,
+    screenId: string,
+    variantId: string,
+    quality: MockupImageQuality,
+): string => `${versionId}:${screenId}:${variantId}:${quality}`;
+
+export const putVariantImage = async (record: MockupVariantImageRecord): Promise<void> => {
+    try {
+        const db = await openDb();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            tx.objectStore(STORE_NAME).put(record);
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error ?? new Error('IDB put failed'));
+            tx.onabort = () => reject(tx.error ?? new Error('IDB put aborted'));
+        });
+    } catch {
+        memoryFallback.set(record.key, record);
+    }
+};
+
+export const getVariantImage = async (key: string): Promise<MockupVariantImageRecord | undefined> => {
+    try {
+        const db = await openDb();
+        return await new Promise<MockupVariantImageRecord | undefined>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly');
+            const req = tx.objectStore(STORE_NAME).get(key);
+            req.onsuccess = () => resolve(req.result as MockupVariantImageRecord | undefined);
+            req.onerror = () => reject(req.error ?? new Error('IDB get failed'));
+        });
+    } catch {
+        return memoryFallback.get(key);
+    }
+};
+
+export const listVariantImagesForVersion = async (
+    versionId: string,
+): Promise<MockupVariantImageRecord[]> => {
+    try {
+        const db = await openDb();
+        return await new Promise<MockupVariantImageRecord[]>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly');
+            const idx = tx.objectStore(STORE_NAME).index(VERSION_INDEX);
+            const req = idx.getAll(versionId);
+            req.onsuccess = () => resolve((req.result as MockupVariantImageRecord[]) ?? []);
+            req.onerror = () => reject(req.error ?? new Error('IDB index getAll failed'));
+        });
+    } catch {
+        return Array.from(memoryFallback.values()).filter(r => r.versionId === versionId);
+    }
+};
+
+export const deleteVariantImagesForVersion = async (versionId: string): Promise<void> => {
+    try {
+        const db = await openDb();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const idx = tx.objectStore(STORE_NAME).index(VERSION_INDEX);
+            const req = idx.openCursor(IDBKeyRange.only(versionId));
+            req.onsuccess = () => {
+                const cursor = req.result;
+                if (cursor) {
+                    cursor.delete();
+                    cursor.continue();
+                }
+            };
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error ?? new Error('IDB delete failed'));
+        });
+    } catch {
+        for (const [k, r] of memoryFallback.entries()) {
+            if (r.versionId === versionId) memoryFallback.delete(k);
+        }
+    }
+};

--- a/src/lib/mockupVariantRequest.ts
+++ b/src/lib/mockupVariantRequest.ts
@@ -1,0 +1,257 @@
+// Phase 3B: pure builders for single-variant mockup generation.
+//
+// Given one screen + one derived variant (viewport × state), assemble:
+//   - a MockupVariantGenerationRequest (the structured generation input),
+//   - a variant-specific image prompt (buildVariantImagePrompt), and
+//   - a generation-time coverage manifest (buildVariantCoverageManifest).
+//
+// Everything here is PURE (no React / store / IDB / network). The manifest is
+// a GENERATION-TIME self-report of what the request asked the image to render,
+// derived deterministically from the request spec — never a visual inspection
+// of the rendered pixels (estimated: true, and the UI labels it as such).
+
+import type {
+    DesignTokens, MockupCoverageItem, MockupCoverageManifest,
+    MockupCoverageOverallStatus, MockupScreen, ScreenItem, ScreenPriority,
+    ScreenStateType,
+} from '../types';
+import { buildDesignSystemBrief } from './designTokens';
+import { IMAGE_CLOSING_RULES, fidelityStyleHint } from './prompts/imagePromptFragments';
+import { slugifyScreenName } from './screenInventoryImageStore';
+import { normalizeScreenPriority, type DerivedMockupVariant, type MockupViewport } from './mockupVariants';
+
+/** Structured input for generating one mockup variant (viewport × state). */
+export interface MockupVariantGenerationRequest {
+    projectName: string;
+    productSummary: string;
+    screenId: string;
+    screenName: string;
+    screenPurpose: string;
+    userIntent?: string;
+    priority: ScreenPriority;
+    /** Overlay-compatible variant id (`mobile:default`, `state:<slug>`, …). */
+    variantId: string;
+    viewport: MockupViewport;
+    stateName: string;
+    /** Semantic state category, when known (drives the state visual guidance). */
+    stateType?: ScreenStateType;
+    stateTrigger?: string;
+    stateBehavior?: string;
+    coreUIRegions: string[];
+    userActions: string[];
+    acceptanceCriteria: string[];
+    /** Known risks / edge cases affecting this visual state. */
+    risks: string[];
+    /** Context about the screen's existing default mockup, when available. */
+    siblingContext?: string;
+    /** Mockup fidelity ('low' | 'mid' | 'high'), from mockup settings. */
+    fidelity: string;
+}
+
+/** Fields the caller supplies from the project / mockup settings. */
+export interface VariantRequestContext {
+    projectName: string;
+    productSummary: string;
+    fidelity: string;
+    /** The screen's existing default mockup screen spec (for sibling context). */
+    siblingMockup?: MockupScreen;
+}
+
+const uniqueNonEmpty = (values: Array<string | undefined | null>): string[] => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const v of values) {
+        const t = v?.trim();
+        if (!t) continue;
+        const k = t.toLowerCase();
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push(t);
+    }
+    return out;
+};
+
+/** Find the documented screen state that a variant renders (by name slug). */
+const matchState = (screen: ScreenItem, variant: DerivedMockupVariant) => {
+    const targetSlug = slugifyScreenName(variant.stateName);
+    return (screen.states ?? []).find(s => slugifyScreenName(s.name ?? '') === targetSlug);
+};
+
+/**
+ * Assemble the structured generation request for one variant. Every field is
+ * derived from existing screen-contract data (states / handoff / exitPaths /
+ * risks) — nothing is invented. Sparse screens still produce a valid request
+ * (empty arrays, no state detail).
+ */
+export function buildVariantGenerationRequest(
+    screen: ScreenItem,
+    screenId: string,
+    variant: DerivedMockupVariant,
+    ctx: VariantRequestContext,
+): MockupVariantGenerationRequest {
+    const state = variant.stateType && variant.stateType !== 'default'
+        ? matchState(screen, variant)
+        : undefined;
+
+    const coreUIRegions = uniqueNonEmpty([
+        ...(screen.coreUIElements ?? []),
+        ...(screen.coreUIElements?.length ? [] : (screen.components ?? [])),
+    ]);
+    const userActions = uniqueNonEmpty([
+        ...((screen.handoff?.events ?? []).map(e => e.name)),
+        ...((screen.exitPaths ?? []).map(p => p.label)),
+    ]);
+    const acceptanceCriteria = uniqueNonEmpty([
+        ...(state?.acceptanceCriteria ?? []),
+        ...(state ? [] : (screen.acceptanceCriteria ?? [])),
+    ]);
+    const risks = uniqueNonEmpty([
+        ...((screen.riskDetails ?? []).map(r => r.description)),
+        ...(screen.riskDetails?.length ? [] : (screen.risks ?? [])),
+    ]);
+
+    const siblingContext = ctx.siblingMockup?.coreUIElements?.length
+        ? `The screen's existing default mockup includes: ${ctx.siblingMockup.coreUIElements.join('; ')}. Keep this variant visually consistent with it.`
+        : undefined;
+
+    return {
+        projectName: ctx.projectName,
+        productSummary: ctx.productSummary,
+        screenId,
+        screenName: screen.name,
+        screenPurpose: screen.purpose ?? '',
+        userIntent: screen.userIntent,
+        priority: normalizeScreenPriority(screen.priority),
+        variantId: variant.id,
+        viewport: variant.viewport,
+        stateName: variant.stateName,
+        stateType: variant.stateType,
+        stateTrigger: state?.trigger,
+        stateBehavior: state?.systemBehavior ?? state?.description,
+        coreUIRegions,
+        userActions,
+        acceptanceCriteria,
+        risks,
+        siblingContext,
+        fidelity: ctx.fidelity,
+    };
+}
+
+const VIEWPORT_PROMPT_HINTS: Record<MockupViewport, string> = {
+    desktop: 'desktop web app screen, landscape orientation',
+    mobile: 'realistic mobile app screen, portrait orientation with a touch-friendly hierarchy — do not simply shrink a desktop layout',
+    tablet: 'tablet app screen, landscape orientation',
+};
+
+// Explicit visual guidance per state category so the requested state is
+// unmistakably represented in the render (not a generic default screen).
+const STATE_VISUAL_GUIDANCE: Partial<Record<ScreenStateType, string>> = {
+    empty: 'This is an EMPTY state — the UI must visibly show no items/content, with an appropriate empty-state message or primary call to action.',
+    loading: 'This is a LOADING state — show skeleton placeholders, spinners, or progress indicators instead of loaded content.',
+    error: 'This is an ERROR state — show a clear, recoverable error message with a way to retry or recover.',
+    permission: 'This is a PERMISSION state — show access guidance or a request-access affordance rather than the full content.',
+    success: 'This is a SUCCESS state — show a completion/confirmation message.',
+    disabled: 'This is a DISABLED state — render controls in a visibly disabled/inactive treatment.',
+};
+
+/** Build the state-specific instruction block (empty for default states). */
+function buildStateInstruction(request: MockupVariantGenerationRequest): string {
+    const isDefault = !request.stateType || request.stateType === 'default'
+        || request.stateName.trim().toLowerCase() === 'default';
+    if (isDefault) return '';
+    const parts: string[] = [
+        `The visible UI must clearly represent the "${request.stateName}" state.`,
+    ];
+    const guidance = request.stateType ? STATE_VISUAL_GUIDANCE[request.stateType] : undefined;
+    if (guidance) parts.push(guidance);
+    if (request.stateTrigger) parts.push(`Triggered when: ${request.stateTrigger}.`);
+    if (request.stateBehavior) parts.push(`Expected behavior: ${request.stateBehavior}.`);
+    return parts.join(' ');
+}
+
+/**
+ * Build the natural-language prompt for a single variant. Scoped to one
+ * viewport + state; instructs the model NOT to render other states or a
+ * generic default, and appends the Design System Brief when tokens exist so
+ * the variant follows the same visual language as the default mockup.
+ */
+export function buildVariantImagePrompt(
+    request: MockupVariantGenerationRequest,
+    designTokens?: DesignTokens,
+): string {
+    const hasDs = Boolean(designTokens);
+    const styleHint = fidelityStyleHint(request.fidelity, hasDs);
+    const tokenBrief = designTokens ? ` ${buildDesignSystemBrief(designTokens)}` : '';
+    const priorityLine = request.priority === 'P0'
+        ? 'This is a P0 screen (essential to the main product loop) — give it a polished, central treatment.'
+        : '';
+
+    return [
+        'Generate a mockup for this exact screen variant only:',
+        `Viewport: ${request.viewport}. State: ${request.stateName}.`,
+        `Screen: "${request.screenName}" for the product "${request.projectName}".`,
+        request.screenPurpose ? `Screen purpose: ${request.screenPurpose}` : '',
+        request.userIntent ? `User intent: ${request.userIntent}.` : '',
+        request.coreUIRegions.length ? `Core UI regions to include: ${request.coreUIRegions.join('; ')}.` : '',
+        request.userActions.length ? `Primary user actions: ${request.userActions.join('; ')}.` : '',
+        buildStateInstruction(request),
+        request.risks.length ? `Design carefully around these known edge cases: ${request.risks.join('; ')}.` : '',
+        priorityLine,
+        request.siblingContext ?? '',
+        request.productSummary ? `Product context: ${request.productSummary}` : '',
+        `Render as a ${VIEWPORT_PROMPT_HINTS[request.viewport]}.`,
+        'Do not show other states unless they are necessary as background context. Do not create a generic default screen when a specific state was requested. Preserve the project’s design system and visual language, and keep the layout coherent with sibling variants.',
+        `Style: ${styleHint}.${tokenBrief}`,
+        ...IMAGE_CLOSING_RULES,
+    ].filter(Boolean).join(' ');
+}
+
+/**
+ * Build the generation-time coverage manifest for a variant. This is a
+ * deterministic, structured restatement of what the request ASKED the image to
+ * render — not a visual check. Every requested spec item is marked `covered`
+ * (evidence: it was in the request); the rendered state is `covered` and other
+ * states are `not_applicable` to this variant. `estimated` is always true.
+ */
+export function buildVariantCoverageManifest(
+    request: MockupVariantGenerationRequest,
+): MockupCoverageManifest {
+    const covered = (label: string): MockupCoverageItem => ({
+        label,
+        status: 'covered',
+        evidence: 'Requested in the generation spec for this variant.',
+    });
+
+    const uiRegions = request.coreUIRegions.map(covered);
+    const userActions = request.userActions.map(covered);
+    const acceptanceCriteria = request.acceptanceCriteria.map(covered);
+    const states: MockupCoverageItem[] = [{
+        label: request.stateName,
+        status: 'covered',
+        evidence: 'This variant renders this state.',
+    }];
+
+    const warnings: string[] = [];
+    if (uiRegions.length === 0) {
+        warnings.push('No core UI regions were documented for this screen — coverage is inferred from the screen purpose only.');
+    }
+    if (acceptanceCriteria.length === 0) {
+        warnings.push('No acceptance criteria were documented for this variant — visual completeness is a best-effort estimate.');
+    }
+
+    // "aligned" once there is any concrete spec content the render was asked to
+    // include; "unknown" for a sparse screen with nothing to align against.
+    const hasContent = uiRegions.length + userActions.length + acceptanceCriteria.length > 0;
+    const overallStatus: MockupCoverageOverallStatus = hasContent ? 'aligned' : 'unknown';
+
+    return {
+        variant: { viewport: request.viewport, stateName: request.stateName },
+        overallStatus,
+        estimated: true,
+        uiRegions,
+        states,
+        userActions,
+        acceptanceCriteria,
+        warnings,
+    };
+}

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -134,6 +134,17 @@ function isImportantState(name: string, type?: ScreenStateType): boolean {
     return IMPORTANT_STATE_KEYWORDS.some(k => lower.includes(k));
 }
 
+/** Phase 3B: real generation state for one variant, keyed by variant id.
+ * Threaded in from the per-variant image store so a derived-missing variant
+ * flips to 'generated' once its image + coverage manifest exist. */
+export interface GeneratedVariantInfo {
+    /** Coverage from the stored manifest's overallStatus. */
+    coverage: MockupVariantCoverage;
+}
+
+/** Per-screen map of variantId -> generation info (from the variant image store). */
+export type GeneratedVariantMap = Record<string, GeneratedVariantInfo>;
+
 export interface BuildVariantOptions {
     /** Generation platform of the current mockup set (mockup settings). */
     platform?: MockupPlatform;
@@ -141,6 +152,12 @@ export interface BuildVariantOptions {
      * enables a recommended Mobile default on P1 / supporting screens. P0
      * always recommends mobile regardless. */
     mobileRelevant?: boolean;
+    /** Phase 3B: manifest-backed generated variants for THIS screen, keyed by
+     * variant id. A non-default variant present here renders as 'generated'
+     * with its manifest coverage. Absent → the Phase 3A derived-missing model.
+     * The default variant's generation state still comes from the legacy
+     * mockup join (item.mockupScreen), never this map. */
+    generatedVariants?: GeneratedVariantMap;
 }
 
 interface VariantSeed {
@@ -241,22 +258,36 @@ export function buildScreenMockupVariants(
         });
     }
 
-    return seeds.map(seed => buildVariant(item, seed, overlay));
+    const generatedVariants = options.generatedVariants ?? {};
+    return seeds.map(seed => buildVariant(item, seed, overlay, generatedVariants));
 }
 
 function buildVariant(
     item: Pick<ScreenExperienceItem, 'screen' | 'baseScreen' | 'mockupScreen' | 'id'>,
     seed: VariantSeed,
     overlay: Record<string, 'accepted' | 'not_needed'>,
+    generatedVariants: GeneratedVariantMap,
 ): DerivedMockupVariant {
     const override: 'accepted' | 'not_needed' | undefined = overlay[seed.overlayKey];
-    const generated = seed.generatedSlot && Boolean(item.mockupScreen);
+    // The legacy default variant is generated iff the screen joins a mockup.
+    const legacyGenerated = seed.generatedSlot && Boolean(item.mockupScreen);
+    // A non-default variant is generated iff the per-variant image store has a
+    // record for it (Phase 3B). The default slot never reads this map — its
+    // image lives in the legacy store.
+    const variantImage = !seed.generatedSlot ? generatedVariants[seed.overlayKey] : undefined;
+    const generated = legacyGenerated || Boolean(variantImage);
     const status: MockupVariantStatus = override ?? (generated ? 'generated' : 'missing');
-    const source: MockupVariantSource = generated ? 'legacy' : 'derived_missing';
+    const source: MockupVariantSource = variantImage
+        ? 'variant'
+        : legacyGenerated ? 'legacy' : 'derived_missing';
 
     let coverageStatus: MockupVariantCoverage = 'unknown';
     const notes: string[] = [];
-    if (generated) {
+    if (variantImage) {
+        // Manifest-backed coverage captured during this variant's generation.
+        coverageStatus = variantImage.coverage;
+        notes.push('Coverage manifest captured during generation — a self-report of the generation spec, not a visual inspection of the image.');
+    } else if (legacyGenerated) {
         const rows = buildMockupSpecCoverage(item.baseScreen, item.mockupScreen?.coreUIElements);
         if (rows.length === 0) {
             coverageStatus = 'unknown';
@@ -273,7 +304,6 @@ function buildVariant(
     } else if (seed.required) {
         // Not generated, not user-marked → a recommended-but-missing variant.
         notes.push(recommendationReason(item.screen, seed));
-        notes.push('Single-variant generation lands in Phase 3B — for now, regenerate the full mockup or upload and mark this variant accepted.');
     }
 
     return {
@@ -394,13 +424,24 @@ export interface MockupVariantCoverageSummary {
     p0Total: number;
     /** Generated mockups with no captured coverage metadata (legacy). */
     legacyUnknownMockups: number;
+    /** Phase 3B: generated variants backed by a captured coverage manifest —
+     * counted separately from legacy "unknown" coverage. */
+    manifestBackedGenerated: number;
+}
+
+/** Options for the artifact-level rollup. Extends BuildVariantOptions with a
+ * per-screen generated-variant lookup so manifest-backed coverage is counted. */
+export interface CoverageSummaryOptions extends Omit<BuildVariantOptions, 'generatedVariants'> {
+    /** Resolve THIS screen's manifest-backed generated variants (variant image
+     * store), keyed by variant id. Absent → the derived-only rollup. */
+    generatedVariantsByScreen?: (screenId: string) => GeneratedVariantMap | undefined;
 }
 
 /** Roll up variant coverage across the whole screen index for the Screen
  * Coverage & Readiness panel. Returns null when there are no screens. */
 export function buildMockupVariantCoverageSummary(
     index: ScreenExperienceIndex,
-    options: BuildVariantOptions = {},
+    options: CoverageSummaryOptions = {},
 ): MockupVariantCoverageSummary | null {
     if (index.items.length === 0) return null;
     let recommendedGenerated = 0;
@@ -408,9 +449,13 @@ export function buildMockupVariantCoverageSummary(
     let p0WithMobile = 0;
     let p0Total = 0;
     let legacyUnknownMockups = 0;
+    let manifestBackedGenerated = 0;
+
+    const { generatedVariantsByScreen, ...variantOptions } = options;
 
     for (const item of index.items) {
-        const variants = buildScreenMockupVariants(item, options);
+        const generatedVariants = generatedVariantsByScreen?.(item.id);
+        const variants = buildScreenMockupVariants(item, { ...variantOptions, generatedVariants });
         const isP0 = normalizeScreenPriority(item.screen.priority) === 'P0';
         if (isP0) p0Total += 1;
         for (const v of variants) {
@@ -429,6 +474,9 @@ export function buildMockupVariantCoverageSummary(
             if (hasGeneratedImage(v) && v.coverageStatus === 'unknown') {
                 legacyUnknownMockups += 1;
             }
+            if (v.source === 'variant' && isGeneratedOrAccepted(v.status)) {
+                manifestBackedGenerated += 1;
+            }
         }
     }
 
@@ -438,6 +486,7 @@ export function buildMockupVariantCoverageSummary(
         p0WithMobile,
         p0Total,
         legacyUnknownMockups,
+        manifestBackedGenerated,
     };
 }
 

--- a/src/store/__tests__/mockupVariantImageStore.test.ts
+++ b/src/store/__tests__/mockupVariantImageStore.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MockupVariantImageRecord } from '../../types';
+import type { MockupVariantGenerationRequest } from '../../lib/mockupVariantRequest';
+
+// In-memory fake of the variant-image IndexedDB layer + a stub OpenAI image
+// call so we can exercise generation without a real IDB or network.
+vi.mock('../../lib/mockupVariantImageStore', () => {
+    const db = new Map<string, MockupVariantImageRecord>();
+    return {
+        buildVariantImageKey: (v: string, s: string, variant: string, q: string) =>
+            `${v}:${s}:${variant}:${q}`,
+        putVariantImage: async (record: MockupVariantImageRecord) => { db.set(record.key, record); },
+        getVariantImage: async (key: string) => db.get(key),
+        listVariantImagesForVersion: async (versionId: string) =>
+            [...db.values()].filter(r => r.versionId === versionId),
+        deleteVariantImagesForVersion: async (versionId: string) => {
+            for (const [k, r] of db.entries()) if (r.versionId === versionId) db.delete(k);
+        },
+        __db: db,
+    };
+});
+
+let shouldFail = false;
+vi.mock('../../lib/openaiClient', () => ({
+    callOpenAIImage: async () => {
+        if (shouldFail) throw new Error('boom');
+        return 'BASE64DATA';
+    },
+    hasOpenAIKey: () => true,
+}));
+
+// Design tokens selector reads the project store — stub it out.
+vi.mock('../../lib/designTokens', () => ({ selectPreferredDesignTokens: () => undefined }));
+
+import { useMockupVariantImageStore } from '../mockupVariantImageStore';
+
+const makeRequest = (
+    overrides: Partial<MockupVariantGenerationRequest> = {},
+): MockupVariantGenerationRequest => ({
+    projectName: 'Acme',
+    productSummary: 'A product.',
+    screenId: 'scr-home',
+    screenName: 'Home',
+    screenPurpose: 'Landing.',
+    priority: 'P0',
+    variantId: 'mobile:default',
+    viewport: 'mobile',
+    stateName: 'Default',
+    coreUIRegions: ['Feed'],
+    userActions: ['Refresh'],
+    acceptanceCriteria: ['Loads fast'],
+    risks: [],
+    fidelity: 'high',
+    ...overrides,
+});
+
+const genArgs = (request: MockupVariantGenerationRequest) => ({
+    projectId: 'p1', artifactId: 'a1', versionId: 'v1',
+    platform: 'desktop' as const, request, quality: 'low' as const,
+});
+
+describe('mockupVariantImageStore.generate', () => {
+    beforeEach(() => {
+        shouldFail = false;
+        useMockupVariantImageStore.setState({ images: {}, inFlight: {}, errors: {} });
+    });
+
+    it('stores a generated variant under a per-variant key with its manifest', async () => {
+        const req = makeRequest();
+        await useMockupVariantImageStore.getState().generate(genArgs(req));
+
+        const record = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        expect(record).toBeDefined();
+        expect(record?.key).toBe('v1:scr-home:mobile:default:low');
+        expect(record?.dataUrl).toBe('data:image/png;base64,BASE64DATA');
+        expect(record?.coverageManifest?.overallStatus).toBe('aligned');
+        expect(record?.viewport).toBe('mobile');
+    });
+
+    it('generating Mobile · Default does not overwrite Desktop · Default', async () => {
+        const store = useMockupVariantImageStore.getState();
+        await store.generate(genArgs(makeRequest({ variantId: 'desktop:default', viewport: 'desktop' })));
+        await store.generate(genArgs(makeRequest({ variantId: 'mobile:default', viewport: 'mobile' })));
+
+        const desktop = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'desktop:default');
+        const mobile = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        expect(desktop?.viewport).toBe('desktop');
+        expect(mobile?.viewport).toBe('mobile');
+        // Distinct keys — neither clobbered the other.
+        expect(desktop?.key).not.toBe(mobile?.key);
+        expect(Object.keys(useMockupVariantImageStore.getState().images)).toHaveLength(2);
+    });
+
+    it('a failed generation records an error without losing existing variants', async () => {
+        const store = useMockupVariantImageStore.getState();
+        // First succeed for the desktop variant.
+        await store.generate(genArgs(makeRequest({ variantId: 'desktop:default', viewport: 'desktop' })));
+        // Then fail generating the mobile variant.
+        shouldFail = true;
+        await useMockupVariantImageStore.getState()
+            .generate(genArgs(makeRequest({ variantId: 'mobile:default', viewport: 'mobile' })));
+
+        const state = useMockupVariantImageStore.getState();
+        // Existing desktop variant survives.
+        expect(state.getBestRecord('v1', 'scr-home', 'desktop:default')).toBeDefined();
+        // Mobile variant is absent and its scope carries an error.
+        expect(state.getBestRecord('v1', 'scr-home', 'mobile:default')).toBeUndefined();
+        expect(state.errors['v1:scr-home:mobile:default']).toBe('boom');
+    });
+});

--- a/src/store/mockupVariantImageStore.ts
+++ b/src/store/mockupVariantImageStore.ts
@@ -112,7 +112,14 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
         const designTokens = selectPreferredDesignTokens(useProjectStore.getState(), projectId);
         const prompt = buildVariantImagePrompt(request, designTokens);
         const manifest = buildVariantCoverageManifest(request);
-        const size = pickImageSize(request.viewport === 'mobile' ? 'mobile' : platform);
+        // Size follows the variant's own viewport (a desktop variant stays
+        // landscape even if the mockup set's platform is mobile, and vice versa);
+        // 'tablet' falls back to the responsive/square crop via the platform.
+        const sizePlatform: MockupPlatform =
+            request.viewport === 'mobile' ? 'mobile'
+            : request.viewport === 'desktop' ? 'desktop'
+            : platform;
+        const size = pickImageSize(sizePlatform);
 
         try {
             const b64 = await callOpenAIImage(prompt, { quality, size, signal: abort.signal });

--- a/src/store/mockupVariantImageStore.ts
+++ b/src/store/mockupVariantImageStore.ts
@@ -1,0 +1,180 @@
+/**
+ * Session-scoped Zustand store for per-variant mockup images (Phase 3B). Holds
+ * an in-memory reactive cache of MockupVariantImageRecord rows hydrated from
+ * IndexedDB (src/lib/mockupVariantImageStore.ts, the source of truth) plus the
+ * generation orchestration (in-flight / error state keyed per variant).
+ *
+ * This is the NEW per-variant path. It is independent of the legacy
+ * mockupImageStore (which still owns the default variant's single image), so
+ * generating one variant never overwrites another. Each record carries its
+ * coverage manifest so the Mockups tab can show manifest-backed coverage
+ * instead of "unknown".
+ */
+
+import { create } from 'zustand';
+import type {
+    MockupImageQuality, MockupVariantImageRecord,
+} from '../types';
+import { callOpenAIImage } from '../lib/openaiClient';
+import { pickImageSize } from '../lib/services/mockupImageService';
+import {
+    buildVariantCoverageManifest, buildVariantImagePrompt,
+    type MockupVariantGenerationRequest,
+} from '../lib/mockupVariantRequest';
+import type { MockupPlatform } from '../types';
+import { selectPreferredDesignTokens } from '../lib/designTokens';
+import { useProjectStore } from './projectStore';
+import {
+    buildVariantImageKey,
+    getVariantImage as idbGetVariantImage,
+    listVariantImagesForVersion as idbListVariantImages,
+    putVariantImage as idbPutVariantImage,
+} from '../lib/mockupVariantImageStore';
+
+interface InFlight {
+    quality: MockupImageQuality;
+    startedAt: number;
+    abort: AbortController;
+}
+
+/** Per-(version, screen, variant) scope key for in-flight / error tracking. */
+const variantScope = (versionId: string, screenId: string, variantId: string): string =>
+    `${versionId}:${screenId}:${variantId}`;
+
+interface VariantImageStoreState {
+    /** Map of composite key -> record. */
+    images: Record<string, MockupVariantImageRecord>;
+    /** Map of variant scope -> in-flight info. */
+    inFlight: Record<string, InFlight>;
+    /** Map of variant scope -> error message. */
+    errors: Record<string, string>;
+
+    /** Hydrate a version's variant images from IndexedDB into the cache. */
+    loadForVersion: (versionId: string) => Promise<void>;
+
+    /** Synchronous lookup of the best cached record for one variant. */
+    getBestRecord: (
+        versionId: string, screenId: string, variantId: string,
+    ) => MockupVariantImageRecord | undefined;
+
+    /** Generate (or regenerate) the image for one variant. */
+    generate: (args: {
+        projectId: string;
+        artifactId: string;
+        versionId: string;
+        platform: MockupPlatform;
+        request: MockupVariantGenerationRequest;
+        quality: MockupImageQuality;
+    }) => Promise<void>;
+
+    cancel: (versionId: string, screenId: string, variantId: string) => void;
+    clearError: (versionId: string, screenId: string, variantId: string) => void;
+}
+
+const QUALITY_RANK: Record<MockupImageQuality, number> = { low: 0, medium: 1, high: 2 };
+
+export const useMockupVariantImageStore = create<VariantImageStoreState>((set, get) => ({
+    images: {},
+    inFlight: {},
+    errors: {},
+
+    loadForVersion: async (versionId) => {
+        const records = await idbListVariantImages(versionId);
+        if (records.length === 0) return;
+        set((state) => {
+            const next = { ...state.images };
+            for (const r of records) next[r.key] = r;
+            return { images: next };
+        });
+    },
+
+    getBestRecord: (versionId, screenId, variantId) => {
+        const images = get().images;
+        let best: MockupVariantImageRecord | undefined;
+        for (const k of Object.keys(images)) {
+            const r = images[k];
+            if (r.versionId !== versionId || r.screenId !== screenId || r.variantId !== variantId) continue;
+            if (!best || QUALITY_RANK[r.quality] > QUALITY_RANK[best.quality]) best = r;
+        }
+        return best;
+    },
+
+    generate: async ({ projectId, artifactId, versionId, platform, request, quality }) => {
+        const scope = variantScope(versionId, request.screenId, request.variantId);
+        if (get().inFlight[scope]) return; // one generation per variant at a time
+
+        const abort = new AbortController();
+        set((state) => ({
+            inFlight: { ...state.inFlight, [scope]: { quality, startedAt: Date.now(), abort } },
+            errors: { ...state.errors, [scope]: '' },
+        }));
+
+        const designTokens = selectPreferredDesignTokens(useProjectStore.getState(), projectId);
+        const prompt = buildVariantImagePrompt(request, designTokens);
+        const manifest = buildVariantCoverageManifest(request);
+        const size = pickImageSize(request.viewport === 'mobile' ? 'mobile' : platform);
+
+        try {
+            const b64 = await callOpenAIImage(prompt, { quality, size, signal: abort.signal });
+            const key = buildVariantImageKey(versionId, request.screenId, request.variantId, quality);
+            const record: MockupVariantImageRecord = {
+                key,
+                projectId,
+                artifactId,
+                versionId,
+                screenId: request.screenId,
+                variantId: request.variantId,
+                viewport: request.viewport,
+                stateName: request.stateName,
+                dataUrl: `data:image/png;base64,${b64}`,
+                quality,
+                prompt,
+                coverageManifest: manifest,
+                generatedAt: Date.now(),
+            };
+            await idbPutVariantImage(record);
+            set((state) => {
+                const nextInFlight = { ...state.inFlight };
+                delete nextInFlight[scope];
+                return {
+                    images: { ...state.images, [key]: record },
+                    inFlight: nextInFlight,
+                };
+            });
+        } catch (err) {
+            const aborted = (err as { name?: string })?.name === 'AbortError' || abort.signal.aborted;
+            const message = aborted
+                ? ''
+                : err instanceof Error ? err.message : 'OpenAI image generation failed.';
+            set((state) => {
+                const nextInFlight = { ...state.inFlight };
+                delete nextInFlight[scope];
+                const nextErrors = { ...state.errors };
+                if (message) nextErrors[scope] = message; else delete nextErrors[scope];
+                return { inFlight: nextInFlight, errors: nextErrors };
+            });
+        }
+    },
+
+    cancel: (versionId, screenId, variantId) => {
+        const scope = variantScope(versionId, screenId, variantId);
+        get().inFlight[scope]?.abort.abort();
+    },
+
+    clearError: (versionId, screenId, variantId) => {
+        const scope = variantScope(versionId, screenId, variantId);
+        set((state) => {
+            if (!state.errors[scope]) return state;
+            const next = { ...state.errors };
+            delete next[scope];
+            return { errors: next };
+        });
+    },
+}));
+
+// Re-export a helper so callers can compute the scope key without duplicating.
+export const variantImageScope = variantScope;
+
+// Re-export helper for reading a single record from IDB (used by tests / rare
+// cache-miss paths).
+export { idbGetVariantImage as getVariantImageFromIdb };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1335,6 +1335,67 @@ export type MockupImageRecord = {
     generatedAt: number;
 };
 
+// --- Mockup variant coverage manifest (Phase 3B) ---
+//
+// A structured, GENERATION-TIME self-report of what a single mockup variant
+// (viewport × state) was asked to render. This is NOT computer vision — it is
+// derived deterministically from the generation-request spec and is always
+// labeled as an estimate (`estimated: true`). Legacy mockups have no manifest
+// and stay "unknown"; the UI never claims visual verification.
+export type MockupCoverageItemStatus =
+    | 'covered' | 'partial' | 'missing' | 'unknown' | 'not_applicable';
+
+export type MockupCoverageOverallStatus =
+    | 'aligned' | 'partial' | 'missing_items' | 'unknown';
+
+export interface MockupCoverageItem {
+    label: string;
+    status: MockupCoverageItemStatus;
+    /** Short note on why the item carries its status (e.g. "requested in the
+     * generation spec"). Never a claim about the rendered pixels. */
+    evidence?: string;
+}
+
+export interface MockupCoverageManifest {
+    variant: {
+        viewport: 'desktop' | 'mobile' | 'tablet';
+        stateName: string;
+    };
+    overallStatus: MockupCoverageOverallStatus;
+    /** Always true today — the manifest is a generation-time self-report,
+     * never a visual inspection of the rendered image. */
+    estimated: boolean;
+    uiRegions: MockupCoverageItem[];
+    states: MockupCoverageItem[];
+    userActions: MockupCoverageItem[];
+    acceptanceCriteria: MockupCoverageItem[];
+    warnings: string[];
+}
+
+// --- Mockup variant image records (Phase 3B) ---
+//
+// Per-variant AI image + coverage manifest, stored in a DEDICATED IndexedDB
+// store (src/lib/mockupVariantImageStore.ts) keyed by
+// `${versionId}:${screenId}:${variantId}:${quality}` so generating one variant
+// never overwrites another (e.g. Mobile · Default vs Desktop · Default). This
+// is intentionally independent of the legacy single-image MockupImageRecord
+// path, which keeps rendering the "Desktop · Default" variant untouched.
+export type MockupVariantImageRecord = {
+    key: string;              // `${versionId}:${screenId}:${variantId}:${quality}`
+    projectId: string;
+    artifactId: string;
+    versionId: string;
+    screenId: string;
+    variantId: string;        // overlay-compatible id: `mobile:default`, `state:<slug>`, …
+    viewport: 'desktop' | 'mobile' | 'tablet';
+    stateName: string;
+    dataUrl: string;          // `data:image/png;base64,...`
+    quality: MockupImageQuality;
+    prompt: string;           // prompt sent to gpt-image-2 (for traceability)
+    coverageManifest?: MockupCoverageManifest;
+    generatedAt: number;
+};
+
 // --- Screen Inventory user-uploaded images ---
 //
 // Per-screen image history attached to a Screen Inventory artifact. Users


### PR DESCRIPTION
## Summary

Phase 3B of the Screens artifact upgrade, building on the Phase 3A viewport × state variant gallery. Users can now **generate / regenerate / retry one specific mockup variant** (e.g. `Mobile · Default`, `Desktop · Empty History`) from the Mockups tab, and each generation captures a **structured coverage manifest** so the gallery shows known coverage instead of "unknown".

This is a narrow, additive vertical slice — the legacy default-mockup path, existing regenerate/open/add-to-mockups behavior, and demo/API-key gating are all preserved.

## How single-variant generation works

- The **default variant** (`id === 'default'`) is deliberately left on the existing `MockupScreenImage` path (unchanged keys, coverage stays "unknown").
- Every **non-default variant** (mobile/desktop default, state variants) uses a new per-variant path: `buildVariantGenerationRequest` assembles a viewport+state-scoped request from existing screen-contract fields, `buildVariantImagePrompt` scopes the gpt-image-2 prompt to that exact viewport + state (forbids other states / a generic default; realistic mobile viewport; explicit empty/loading/error/permission/success guidance), and the image + manifest are stored independently.
- Generation is scoped to the selected screen + viewport + state and never touches other variants.

## Variant identity / storage

- Dedicated IndexedDB store (`mockupVariantImageStore.ts`) keyed **`versionId:screenId:variantId:quality`** — generating `Mobile · Default` never overwrites `Desktop · Default`; regenerating one state variant never overwrites another. Variant ids reuse the Phase 3A overlay scheme (`default`, `state:<slug>`, `${viewport}:default`), so accepted/not-needed marks stay compatible.
- Records persist across reloads (IDB); a session-scoped Zustand store is the reactive cache + generation orchestrator.

## Coverage manifest behavior + limitations

- `buildVariantCoverageManifest` produces a **deterministic, generation-time self-report** of what the render was asked to include (`estimated: true`) — **not computer vision**. UI copy says "Coverage manifest captured during generation … not a visual inspection", never "visually verified".
- Legacy mockups without a manifest stay **Coverage unknown**. Manifest-backed generated variants are counted separately from legacy-unknown coverage in the artifact rollup (`manifestBackedGenerated`).

## Demo / API-key behavior

- Generation requires an OpenAI key + `gpt_image` image mode (mirrors `MockupScreenImage`). Demo / keyless users can still view existing mockups and missing-variant placeholders, but the Generate/Regenerate action is **disabled with a clear, non-alarming explanation** — never a silent failure or a raw API error.

## Backward compatibility

- No artifact schema migration. Legacy mockups render unchanged. The new store is separate from `mockupImageStore` and independent of snapshots / cross-device sync (a documented Phase 3C gap, mirroring the screen-inventory-image sync gap). Old projects with no variant images fall through to the Phase 3A derived-recommendation model.

## Tests

- `mockupVariantRequest.test.ts` — request payload includes viewport/state, state-specific fields, sparse-screen safety, prompt scoping, manifest aligned/unknown.
- `mockupVariantImageStore.test.ts` — per-variant key isolation (Mobile·Default vs Desktop·Default), missing→generated, failure preserves existing variants.
- `mockupVariants.test.ts` — generated-variant threading flips missing→generated with manifest coverage; default slot never reads the map; rollup counts manifest-backed separately from legacy-unknown.
- Updated the Phase 3A component test for the now-live generation action.
- Full suite green (1227 tests), `npm run build` + `npm run lint` clean.

## Manual verification

Drove the real `MockupVariantsPanel` in a browser (Vite + Playwright harness): a manifest-backed generated variant renders "Source: generated variant" + the Coverage manifest with the "not a visual inspection" disclaimer; a missing variant offers a "Generate variant" action that is correctly disabled with the keyless explanation. The live OpenAI generation call itself requires a key + backend proxy not available in this environment.

## Known limitations / Phase 3C follow-up

- Default-variant manifest capture (default stays on the legacy path → "unknown").
- Variant images don't yet travel in snapshots or cross-device sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015HpS3U1fhHkqizNroLeoBC)_