### PR TITLE
Fix duplicate numbering in PRD Example Flows steps

### DIFF
--- a/src/components/prd/PremiumSections.tsx
+++ b/src/components/prd/PremiumSections.tsx
@@ -5,6 +5,7 @@ import type {
 } from '../../types';
 import { coerceToBulletList, looksDegenerate } from '../../lib/textCleanup';
 import { sanitizeRolePermissions } from '../../lib/prdRolesSanitizer';
+import { stripLeadingListNumber } from '../../lib/utils/stripLeadingListNumber';
 
 // Shared section wrapper. Mirrors the heading style used in StructuredPRDView
 // for visual consistency.
@@ -445,7 +446,7 @@ export function ArchFlowsSection({ flows }: { flows: ArchFlow[] }) {
                     <div key={i} className="p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
                         <p className="text-sm font-bold text-neutral-900 mb-2">{f.name}</p>
                         <ol className="list-decimal pl-5 text-sm text-neutral-700 space-y-1">
-                            {f.steps.map((s, k) => <li key={k}>{s}</li>)}
+                            {f.steps.map((s, k) => <li key={k}>{stripLeadingListNumber(s)}</li>)}
                         </ol>
                     </div>
                 ))}

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -30,6 +30,7 @@ import {
     isImplementationSummaryEmpty,
 } from '../derive/implementationSummary';
 import { sanitizeRolePermissions } from '../prdRolesSanitizer';
+import { stripLeadingListNumber } from '../utils/stripLeadingListNumber';
 
 const tierTag = (tier?: string): string => {
     if (!tier) return '';
@@ -220,7 +221,7 @@ const renderArchFlows = (flows: ArchFlow[]): string[] => {
     const lines: string[] = [];
     flows.forEach(f => {
         lines.push(`### ${f.name}`);
-        f.steps.forEach((step, idx) => lines.push(`${idx + 1}. ${step}`));
+        f.steps.forEach((step, idx) => lines.push(`${idx + 1}. ${stripLeadingListNumber(step)}`));
         lines.push('');
     });
     return lines;

--- a/src/lib/utils/__tests__/stripLeadingListNumber.test.ts
+++ b/src/lib/utils/__tests__/stripLeadingListNumber.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { stripLeadingListNumber } from '../stripLeadingListNumber';
+
+describe('stripLeadingListNumber', () => {
+    it('strips a leading "N. " ordinal', () => {
+        expect(stripLeadingListNumber('1. User completes the form.')).toBe('User completes the form.');
+        expect(stripLeadingListNumber('12. Something else.')).toBe('Something else.');
+    });
+
+    it('strips a leading "N) " ordinal', () => {
+        expect(stripLeadingListNumber('3) Do the thing.')).toBe('Do the thing.');
+    });
+
+    it('leaves text with no leading ordinal untouched', () => {
+        expect(stripLeadingListNumber('User completes the form.')).toBe('User completes the form.');
+    });
+
+    it('does not strip a number that is not a leading ordinal', () => {
+        expect(stripLeadingListNumber('Retry after 3. seconds pass.')).toBe('Retry after 3. seconds pass.');
+    });
+});

--- a/src/lib/utils/stripLeadingListNumber.ts
+++ b/src/lib/utils/stripLeadingListNumber.ts
@@ -1,0 +1,7 @@
+// Some legacy generations embedded a step's own ordinal ("1. Do the thing")
+// even though callers render steps into an already-numbered list, producing
+// visible double numbering ("1.  1. Do the thing"). Strip it defensively at
+// render time so both new and legacy PRDs display a single number.
+export function stripLeadingListNumber(text: string): string {
+    return text.replace(/^\s*\d+[.)]\s+/, '');
+}


### PR DESCRIPTION
## Summary
- The PRD's "Example Flows" section (under Architecture) was rendering steps like "1.  1. User completes the form…" — a duplicate leading number.
- Root cause: `architectureFlows[].steps` text sometimes carries its own leading `"1. "` ordinal, and it's rendered a second time by an auto-numbered `<ol>` (`ArchFlowsSection` in `PremiumSections.tsx`) or a manually-numbered markdown list (`renderArchFlows` in `prdMarkdownRenderer.ts`).
- Added a small pure helper, `stripLeadingListNumber`, and applied it at render time in both places so any redundant leading ordinal is stripped before display — this fixes both new generations and already-persisted/legacy PRDs (including the demo project) without requiring regeneration.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (added `src/lib/utils/__tests__/stripLeadingListNumber.test.ts`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M1so3t74Y1AJXvZdvsd2iH)_