### PR TITLE
Phase 3C: mockup variant trust — freshness, history, default sidecar, local-only clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1660,8 +1660,52 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     (`hasOpenAIKey`) + `gpt_image` image mode — demo / keyless users see a
     disabled action with a clear explanation, never a silent failure. The
     per-variant store is **independent of snapshots & cross-device sync** (a
-    documented Phase 3C gap, mirroring the screen-inventory-image sync gap) — do
+    documented Phase 3D gap, mirroring the screen-inventory-image sync gap) — do
     not entangle it with `snapshotClient` / `imageRefsStore`.
+  - **Phase 3C variant trust — freshness, history, default sidecar
+    (`src/lib/mockupVariantTrust.ts`, pure).** A generated variant is captured
+    with a **`MockupVariantSourceSignature`** — a deterministic snapshot of the
+    inputs that materially affect its image: a **screen-contract hash**
+    (`computeScreenContractHash`, keyed off the SAME screen-spec fields
+    `buildVariantGenerationRequest` uses — viewport + state + core UI regions +
+    user actions + acceptance criteria + risks; **excludes** overlay-only UI
+    metadata like notes/reviewStatus/variant marks so cosmetic edits never trip a
+    false stale warning) plus the **design-system tokens hash** and the
+    **PRD/spine + screen-inventory + design-system version ids** at generation
+    time. `buildVariantSourceSignature` (used at BOTH storage and comparison so
+    they can't drift) is stored on `MockupVariantImageRecord.sourceSignature` +
+    `generatedFrom`. `compareVariantFreshness(stored, current)` →
+    **`current` | `possibly_stale` | `stale` | `unknown`**: contract-hash or
+    design/PRD **hash** mismatch → `stale`; version-id changed but no hash to
+    confirm → `possibly_stale`; **no stored signature → `unknown` (legacy /
+    pre-3C records are NEVER falsely stale)**. Freshness is threaded into the
+    derived model (`DerivedMockupVariant.freshness`) via a
+    **`VariantTrustContext`** (current versions/hash) passed from
+    `ArtifactWorkspace` → Screen views; a rollup
+    (`summarizeVariantFreshness` → `MockupVariantCoverageSummary.freshness`
+    `{current, review, unknown}`) feeds the coverage panel. UI: freshness badges
+    + a calm explanation + a metadata-only **Source comparison** section (never a
+    visual diff) in `MockupVariantsPanel`; a compact "Freshness: N to review"
+    chip on screen cards.
+    **Variant history:** the store's `generate` preserves the previous
+    successful record as the newest **`history`** entry on regeneration (capped,
+    newest-first); a **failed regeneration never appends history and never erases
+    the current record**. Shown in a collapsible, local-only history section
+    (view-only — no restore).
+    **Default coverage sidecar:** the default variant KEEPS the legacy
+    `MockupScreenImage` image path; on a NEW default (re)generation the panel
+    captures a metadata-only sidecar record (`variantId: 'default'`, empty
+    `dataUrl`, coverage manifest + source signature) keyed
+    `versionId:screenId:default:quality` via `putSidecar` — wired through an
+    optional `onGenerated` callback on the legacy image store/component (other
+    callers unaffected). **Old defaults with no sidecar stay coverage-unknown; no
+    fabricated coverage, and the legacy default image is never moved into the
+    variant store.**
+    **Local-only clarity:** the Mockups tab and per-variant detail state that
+    generated variant images are saved on this device only until snapshot/sync
+    lands. **Snapshot/sync of variant images remains a documented gap →
+    Phase 3D: Portable variant image snapshots / cross-device sync.** Do not
+    entangle the variant store with `snapshotClient` / `imageRefsStore`.
   `parseDecisionBranches` (arrow-form +
   if/otherwise) powers both the branch-aware Flow-tab rendering
   (`DecisionBranches`) and the `decision_missing_branches` gap — an

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -38,6 +38,7 @@ import {
 } from '../lib/screenExperience';
 import { buildReadinessIndex, buildScreenCoverageSummary } from '../lib/screenReadiness';
 import { buildMockupVariantCoverageSummary, type GeneratedVariantMap } from '../lib/mockupVariants';
+import type { MockupVariantSourceSignature, VariantTrustContext } from '../lib/mockupVariantTrust';
 import { useMockupVariantImageStore } from '../store/mockupVariantImageStore';
 import { ReferenceWarningsPanel } from './experience/ReferenceWarningsPanel';
 import { parseScreenInventory } from '../lib/screenInventoryNormalize';
@@ -420,19 +421,34 @@ export function ArtifactWorkspace({
             const r = variantImagesMap[key];
             if (r.versionId !== mockupVersionId) continue;
             const existing = map.get(r.screenId) ?? {};
-            existing[r.variantId] = { coverage: r.coverageManifest?.overallStatus ?? 'unknown' };
+            existing[r.variantId] = {
+                coverage: r.coverageManifest?.overallStatus ?? 'unknown',
+                sourceSignature: r.sourceSignature as MockupVariantSourceSignature | undefined,
+            };
             map.set(r.screenId, existing);
         }
         return map;
     }, [variantImagesMap, mockupVersionId]);
 
+    // Phase 3C: current screen/design/PRD context for variant freshness. Primitive
+    // selects (not the wrapper object) keep the selector output reference-stable.
+    const designSystemVersionId = useProjectStore(s => selectPreferredDesignSystem(s, projectId)?.versionId);
+    const designSystemHash = useProjectStore(s => selectPreferredDesignSystem(s, projectId)?.tokensHash);
+    const trustContext = useMemo<VariantTrustContext>(() => ({
+        prdVersionId: spineVersionId,
+        screenVersionId: invPreferred?.id,
+        designSystemVersionId,
+        designSystemHash,
+    }), [spineVersionId, invPreferred?.id, designSystemVersionId, designSystemHash]);
+
     const variantCoverage = useMemo(
         () => buildMockupVariantCoverageSummary(screenIndex, {
             platform: mockupPlatform,
             mobileRelevant,
+            trustContext,
             generatedVariantsByScreen: (id) => generatedVariantsByScreen.get(id),
         }),
-        [screenIndex, mockupPlatform, mobileRelevant, generatedVariantsByScreen],
+        [screenIndex, mockupPlatform, mobileRelevant, trustContext, generatedVariantsByScreen],
     );
 
     // Validation issues minus the user's persisted dismissals.
@@ -568,6 +584,9 @@ export function ArtifactWorkspace({
             settings: extractMockupSettings(mockupPreferred),
             versionNumber: mockupPreferred.versionNumber,
             prdVersionLabel: mockupSpineIdx >= 0 ? `Version ${mockupSpineIdx + 1}` : undefined,
+            // Phase 3C: current trust context so the Mockups tab can capture
+            // source signatures on generation and derive per-variant freshness.
+            trustContext,
         }
         : undefined;
 
@@ -983,6 +1002,7 @@ export function ArtifactWorkspace({
                         variantCoverage={variantCoverage}
                         mockupPlatform={mockupPlatform}
                         mobileRelevant={mobileRelevant}
+                        trustContext={trustContext}
                         generatedVariantsByScreen={(id) => generatedVariantsByScreen.get(id)}
                         onSelectScreen={handleOpenScreen}
                         onGenerateMissingMockups={

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -247,6 +247,7 @@ function renderContractDetail(
         edits?: Parameters<typeof buildScreenIndex>[3];
         onSaveScreenEdit?: (id: string, edit: ScreenMetadataEdit | null) => void;
         withMockupContext?: boolean;
+        trustContext?: import('../../lib/mockupVariantTrust').VariantTrustContext;
     } = {},
 ) {
     const index = buildScreenIndex(contractInventory, [], contractPayload, opts.edits);
@@ -271,6 +272,7 @@ function renderContractDetail(
                 settings: { platform: 'desktop', fidelity: 'mid', scope: 'multi_screen' },
                 versionNumber: 2,
                 prdVersionLabel: 'Version 3',
+                trustContext: opts.trustContext,
             }}
         />,
     );
@@ -379,5 +381,106 @@ describe('missing variant acceptance (review-feedback regression)', () => {
         expect(onSave).toHaveBeenCalledTimes(1);
         const [, edit] = onSave.mock.calls[0] as [string, Record<string, unknown>];
         expect(edit.mockupVariantStatus).toEqual({ 'state:empty-history': 'accepted' });
+    });
+});
+
+// --- Phase 3C: variant freshness / staleness / history / local-only ----------
+
+import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
+import { buildVariantSourceSignature } from '../../lib/mockupVariantTrust';
+import type { MockupVariantImageRecord } from '../../types';
+
+const TRUST = {
+    prdVersionId: 'prd-1',
+    screenVersionId: 'inv-1',
+    designSystemVersionId: 'ds-1',
+    designSystemHash: 'dshash1',
+};
+
+/** Seed a per-variant image record into the store (jsdom has no IndexedDB, so
+ * loadForVersion is a no-op and the seeded cache persists). */
+function seedVariant(record: Partial<MockupVariantImageRecord> & { variantId: string }) {
+    const full: MockupVariantImageRecord = {
+        key: `v1:scr-submission:${record.variantId}:low`,
+        projectId: 'p1', artifactId: 'a1', versionId: 'v1', screenId: 'scr-submission',
+        viewport: 'desktop', stateName: 'Empty history', dataUrl: 'data:image/png;base64,ZZZ',
+        quality: 'low', prompt: '', generatedAt: 1, ...record,
+    };
+    useMockupVariantImageStore.setState({ images: { [full.key]: full } });
+}
+
+describe('Phase 3C variant freshness & history UI', () => {
+    beforeEach(() => {
+        useMockupVariantImageStore.setState({ images: {}, inFlight: {}, errors: {} });
+    });
+
+    it('shows the local-only storage note in the Mockups tab', () => {
+        const { getByText } = renderContractDetail('mockups');
+        expect(getByText(/saved on this device for now/)).toBeTruthy();
+    });
+
+    it('a legacy default with no source metadata reads Freshness unknown', () => {
+        const { getAllByText, getByText } = renderContractDetail('mockups', { trustContext: TRUST });
+        // Default variant is generated via the legacy join but carries no
+        // signature → unknown, never falsely stale.
+        expect(getAllByText('Freshness unknown').length).toBeGreaterThan(0);
+        expect(getByText(/Source comparison unavailable for this older mockup/)).toBeTruthy();
+    });
+
+    it('renders a Stale badge + reason when the stored contract hash differs', () => {
+        seedVariant({
+            variantId: 'state:empty-history',
+            coverageManifest: {
+                variant: { viewport: 'desktop', stateName: 'Empty history' },
+                overallStatus: 'aligned', estimated: true,
+                uiRegions: [], states: [], userActions: [], acceptanceCriteria: [], warnings: [],
+            },
+            sourceSignature: {
+                screenId: 'scr-submission', viewport: 'desktop', stateName: 'Empty history',
+                variantId: 'state:empty-history', screenContractHash: 'DEFINITELY_DIFFERENT',
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+            generatedFrom: { prdVersionId: 'prd-1', screenVersionId: 'inv-1', designSystemVersionId: 'ds-1' },
+        });
+        const { getByText, getAllByText } = renderContractDetail('mockups', { trustContext: TRUST });
+        fireEvent.click(getByText('Desktop · Empty history'));
+        expect(getAllByText('Stale').length).toBeGreaterThan(0);
+        expect(getAllByText(/Screen spec changed after this mockup was generated/).length).toBeGreaterThan(0);
+    });
+
+    it('renders a Current badge when the stored signature matches the current one', () => {
+        // Compute the signature the component will compute for this variant.
+        const sig = buildVariantSourceSignature(
+            { screen: contractScreen, viewport: 'desktop', stateName: 'Empty history',
+              stateType: 'empty', variantId: 'state:empty-history' },
+            TRUST,
+            '2026-01-01T00:00:00.000Z',
+        );
+        seedVariant({
+            variantId: 'state:empty-history',
+            sourceSignature: sig,
+            generatedFrom: { prdVersionId: 'prd-1', screenVersionId: 'inv-1', designSystemVersionId: 'ds-1' },
+        });
+        const { getByText, getAllByText } = renderContractDetail('mockups', { trustContext: TRUST });
+        fireEvent.click(getByText('Desktop · Empty history'));
+        expect(getAllByText('Current').length).toBeGreaterThan(0);
+    });
+
+    it('renders the variant history section when history exists', () => {
+        seedVariant({
+            variantId: 'state:empty-history',
+            history: [{
+                dataUrl: 'data:image/png;base64,OLD',
+                quality: 'low',
+                generatedAt: 1,
+                reason: 'regenerated',
+            }],
+        });
+        const { getByText } = renderContractDetail('mockups', { trustContext: TRUST });
+        fireEvent.click(getByText('Desktop · Empty history'));
+        const historyToggle = getByText(/Variant history \(1 previous\)/);
+        expect(historyToggle).toBeTruthy();
+        fireEvent.click(historyToggle);
+        expect(getByText('Previous render 1')).toBeTruthy();
     });
 });

--- a/src/components/experience/MockupVariantImage.tsx
+++ b/src/components/experience/MockupVariantImage.tsx
@@ -12,11 +12,12 @@ import { useEffect } from 'react';
 import {
     AlertTriangle, ImageOff, Loader2, RefreshCw, Settings as SettingsIcon, Sparkles, X,
 } from 'lucide-react';
-import type { MockupImageQuality, MockupPlatform } from '../../types';
+import type { MockupImageQuality, MockupPlatform, MockupVariantImageRecord } from '../../types';
 import { hasOpenAIKey } from '../../lib/openaiClient';
 import { getMockupImageMode } from '../../lib/artifactModelSettings';
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import type { MockupVariantGenerationRequest } from '../../lib/mockupVariantRequest';
+import type { MockupVariantSourceSignature } from '../../lib/mockupVariantTrust';
 import { formatVariantLabel, type DerivedMockupVariant } from '../../lib/mockupVariants';
 
 interface Props {
@@ -26,6 +27,10 @@ interface Props {
     platform: MockupPlatform;
     variant: DerivedMockupVariant;
     request: MockupVariantGenerationRequest;
+    /** Phase 3C: source signature to store with this render (freshness). The
+     * createdAt is re-stamped at generation time. */
+    sourceSignature?: MockupVariantSourceSignature;
+    generatedFrom?: MockupVariantImageRecord['generatedFrom'];
 }
 
 const DEMO_KEYLESS_MESSAGE =
@@ -35,6 +40,7 @@ const UPLOAD_MODE_MESSAGE =
 
 export function MockupVariantImage({
     projectId, artifactId, versionId, platform, variant, request,
+    sourceSignature, generatedFrom,
 }: Props) {
     const scope = `${versionId}:${request.screenId}:${request.variantId}`;
     const record = useMockupVariantImageStore(s => s.getBestRecord(versionId, request.screenId, request.variantId));
@@ -60,7 +66,15 @@ export function MockupVariantImage({
     const handleGenerate = (quality: MockupImageQuality) => {
         if (!canGenerate) return;
         clearError(versionId, request.screenId, request.variantId);
-        void generate({ projectId, artifactId, versionId, platform, request, quality });
+        // Re-stamp createdAt so the stored signature's timestamp reflects the
+        // actual generation moment (the hash itself is unchanged).
+        const signature = sourceSignature
+            ? { ...sourceSignature, createdAt: new Date().toISOString() }
+            : undefined;
+        void generate({
+            projectId, artifactId, versionId, platform, request, quality,
+            sourceSignature: signature, generatedFrom,
+        });
     };
 
     const label = formatVariantLabel(variant);

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -136,6 +136,11 @@ export function MockupVariantsPanel({
                     Generated product screen previews mapped to this screen&rsquo;s states and viewports.
                 </p>
                 <p className="mt-1.5 text-[11px] text-neutral-500">{summaryParts.join(' · ')}</p>
+                <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-neutral-400">
+                    <Info size={10} className="shrink-0" aria-hidden />
+                    Generated variant images are saved on this device for now — they may not appear on
+                    another browser until snapshot/sync support is added.
+                </p>
             </div>
 
             {/* Variant gallery — pills, selectable */}

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -36,9 +36,7 @@ import {
     type MockupVariantFreshnessStatus, type MockupVariantSourceSignature,
 } from '../../lib/mockupVariantTrust';
 import { buildMockupSpecCoverage } from '../../lib/screenReadiness';
-import {
-    buildVariantCoverageManifest, buildVariantGenerationRequest, type VariantRequestContext,
-} from '../../lib/mockupVariantRequest';
+import { buildVariantGenerationRequest, type VariantRequestContext } from '../../lib/mockupVariantRequest';
 import { buildVariantImageKey } from '../../lib/mockupVariantImageStore';
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import type { ScreenExperienceItem } from '../../lib/screenExperience';
@@ -106,6 +104,37 @@ interface Props {
  * marks the default "accepted" (which flips status off 'generated'). */
 const holdsGeneratedImage = (v: DerivedMockupVariant, hasMockup: boolean): boolean =>
     v.id === 'default' && hasMockup;
+
+/**
+ * Build the default variant's coverage manifest from the ACTUAL legacy prompt
+ * inputs — the mockup screen's `coreUIElements` (what `buildScreenImagePrompt`
+ * requests). User actions and acceptance criteria are deliberately left empty:
+ * the legacy default prompt never requests them, so claiming them "covered"
+ * would over-state coverage. Honest and legacy-faithful.
+ */
+function buildDefaultSidecarManifest(
+    uiElements: string[] | undefined,
+    viewport: MockupViewport,
+): MockupCoverageManifest {
+    const uiRegions: MockupCoverageItem[] = (uiElements ?? []).map(label => ({
+        label,
+        status: 'covered' as const,
+        evidence: 'Requested in the default mockup generation prompt.',
+    }));
+    const warnings = uiRegions.length === 0
+        ? ['No UI elements were recorded for this mockup — coverage is inferred from the screen purpose only.']
+        : [];
+    return {
+        variant: { viewport, stateName: 'Default' },
+        overallStatus: uiRegions.length > 0 ? 'aligned' : 'unknown',
+        estimated: true,
+        uiRegions,
+        states: [{ label: 'Default', status: 'covered', evidence: 'The default mockup renders this screen.' }],
+        userActions: [],
+        acceptanceCriteria: [],
+        warnings,
+    };
+}
 
 export function MockupVariantsPanel({
     item, variants, summary, mockupContext, onSetVariantStatus,
@@ -262,7 +291,11 @@ function VariantDetail({
             mockupContext.payload.summary, mockupContext.settings.fidelity, item.mockupScreen],
     );
 
-    // Phase 3C: source signature to capture with a new render (freshness).
+    // Phase 3C: source signature to capture with a new render (freshness). The
+    // default variant renders via the legacy prompt (buildScreenImagePrompt),
+    // which requests only the mockup screen's UI elements — so its signature is
+    // built in `legacyDefault` mode from those inputs, never the full variant
+    // request (which would invent user-action / acceptance-criteria coverage).
     const trustContext = mockupContext.trustContext;
     const variantSourceSignature = useMemo<MockupVariantSourceSignature | undefined>(
         () => (trustContext
@@ -273,12 +306,15 @@ function VariantDetail({
                     stateName: variant.stateName,
                     stateType: variant.stateType,
                     variantId: variant.id,
+                    legacyDefault: !isVariantPath,
+                    legacyUIRegions: !isVariantPath ? item.mockupScreen?.coreUIElements : undefined,
                 },
                 trustContext,
                 new Date().toISOString(),
             )
             : undefined),
-        [trustContext, item.screen, variant.viewport, variant.stateName, variant.stateType, variant.id],
+        [trustContext, isVariantPath, item.screen, item.mockupScreen,
+            variant.viewport, variant.stateName, variant.stateType, variant.id],
     );
     const generatedFrom = useMemo(
         () => (trustContext
@@ -305,12 +341,6 @@ function VariantDetail({
     // fires on new generation, so old defaults stay coverage-unknown.
     const handleDefaultGenerated = useCallback((record: MockupImageRecord) => {
         if (isVariantPath || !variantSourceSignature) return;
-        const request = buildVariantGenerationRequest(item.screen, item.id, variant, {
-            projectName: mockupContext.payload.title,
-            productSummary: mockupContext.payload.summary,
-            fidelity: mockupContext.settings.fidelity,
-            siblingMockup: item.mockupScreen,
-        });
         const sidecar: MockupVariantImageRecord = {
             key: buildVariantImageKey(mockupContext.versionId, item.id, 'default', record.quality),
             projectId: mockupContext.projectId,
@@ -324,13 +354,17 @@ function VariantDetail({
             dataUrl: '',
             quality: record.quality,
             prompt: '',
-            coverageManifest: buildVariantCoverageManifest(request),
+            // Manifest reflects ONLY what the legacy default prompt requested (the
+            // mockup screen's UI elements) — never the inventory screen's user
+            // actions / acceptance criteria, which the legacy render never used.
+            coverageManifest: buildDefaultSidecarManifest(item.mockupScreen?.coreUIElements, variant.viewport),
             sourceSignature: { ...variantSourceSignature, createdAt: new Date().toISOString() },
             generatedFrom,
             generatedAt: Date.now(),
         };
         void putSidecar(sidecar);
-    }, [isVariantPath, variantSourceSignature, generatedFrom, item, variant, mockupContext, putSidecar]);
+    }, [isVariantPath, variantSourceSignature, generatedFrom, item.mockupScreen, item.id,
+        variant.viewport, mockupContext, putSidecar]);
 
     return (
         <div className="bg-white rounded-xl border border-neutral-200 p-4 space-y-3">

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -15,10 +15,12 @@
 
 import { useMemo, useState } from 'react';
 import {
-    CheckCircle2, Info, Layers, Monitor, ShieldQuestion, Smartphone, Tablet,
+    CheckCircle2, Clock, History as HistoryIcon, Info, Layers, Monitor, ShieldQuestion,
+    Smartphone, Tablet,
 } from 'lucide-react';
 import type {
     MockupCoverageItem, MockupCoverageItemStatus, MockupCoverageManifest, MockupPlatform,
+    MockupVariantImageRecord,
 } from '../../types';
 import {
     COVERAGE_STATUS_LABELS,
@@ -29,6 +31,10 @@ import {
     type MockupViewport,
     type ScreenMockupVariantSummary,
 } from '../../lib/mockupVariants';
+import {
+    FRESHNESS_LABELS, buildVariantSourceSignature,
+    type MockupVariantFreshnessStatus, type MockupVariantSourceSignature,
+} from '../../lib/mockupVariantTrust';
 import { buildMockupSpecCoverage } from '../../lib/screenReadiness';
 import { buildVariantGenerationRequest, type VariantRequestContext } from '../../lib/mockupVariantRequest';
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
@@ -62,6 +68,25 @@ const PLATFORM_LABELS: Record<MockupPlatform, string> = {
     desktop: 'Desktop',
     responsive: 'Responsive',
 };
+
+const FRESHNESS_PILL: Record<MockupVariantFreshnessStatus, string> = {
+    current: 'text-emerald-700 bg-emerald-50 ring-emerald-200',
+    possibly_stale: 'text-amber-700 bg-amber-50 ring-amber-200',
+    stale: 'text-amber-800 bg-amber-100 ring-amber-300',
+    unknown: 'text-neutral-500 bg-neutral-100 ring-neutral-200',
+};
+
+/** Compact freshness badge for a generated variant (nothing shown for a
+ * variant that holds no generated image). */
+function FreshnessBadge({ status }: { status: MockupVariantFreshnessStatus }) {
+    const Icon = status === 'current' ? CheckCircle2 : status === 'unknown' ? ShieldQuestion : Clock;
+    return (
+        <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full ring-1 ${FRESHNESS_PILL[status]}`}>
+            <Icon size={10} aria-hidden />
+            {FRESHNESS_LABELS[status]}
+        </span>
+    );
+}
 
 interface Props {
     item: ScreenExperienceItem;
@@ -178,6 +203,9 @@ function VariantCard({
                         Coverage: {COVERAGE_STATUS_LABELS[variant.coverageStatus].toLowerCase()}
                     </span>
                 )}
+                {variant.freshness && (variant.status === 'generated' || variant.status === 'accepted') && (
+                    <FreshnessBadge status={variant.freshness.status} />
+                )}
                 {variant.status === 'missing' && (
                     <span className="text-neutral-400">Not generated yet</span>
                 )}
@@ -226,9 +254,37 @@ function VariantDetail({
             mockupContext.payload.summary, mockupContext.settings.fidelity, item.mockupScreen],
     );
 
-    // Manifest-backed coverage for this variant (from the per-variant image store).
+    // Phase 3C: source signature to capture with a new render (freshness).
+    const trustContext = mockupContext.trustContext;
+    const variantSourceSignature = useMemo<MockupVariantSourceSignature | undefined>(
+        () => (trustContext
+            ? buildVariantSourceSignature(
+                {
+                    screen: item.screen,
+                    viewport: variant.viewport,
+                    stateName: variant.stateName,
+                    stateType: variant.stateType,
+                    variantId: variant.id,
+                },
+                trustContext,
+                new Date().toISOString(),
+            )
+            : undefined),
+        [trustContext, item.screen, variant.viewport, variant.stateName, variant.stateType, variant.id],
+    );
+    const generatedFrom = trustContext
+        ? {
+            prdVersionId: trustContext.prdVersionId,
+            screenVersionId: trustContext.screenVersionId,
+            designSystemVersionId: trustContext.designSystemVersionId,
+        }
+        : undefined;
+
+    // Manifest-backed coverage + stored metadata for this variant (from the
+    // per-variant image store). Fetched for EVERY variant — for the default it
+    // returns the Phase 3C coverage sidecar when one exists.
     const variantRecord = useMockupVariantImageStore(
-        s => (isVariantPath ? s.getBestRecord(mockupContext.versionId, item.id, variant.id) : undefined),
+        s => s.getBestRecord(mockupContext.versionId, item.id, variant.id),
     );
 
     return (
@@ -243,8 +299,19 @@ function VariantDetail({
                         {variant.status === 'generated' && variant.source === 'variant' && ' · Source: generated variant'}
                     </p>
                 </div>
-                <VariantActions variant={variant} onSetVariantStatus={onSetVariantStatus} />
+                <div className="flex items-center gap-1.5 shrink-0">
+                    {variant.freshness && (variant.status === 'generated' || variant.status === 'accepted') && (
+                        <FreshnessBadge status={variant.freshness.status} />
+                    )}
+                    <VariantActions variant={variant} onSetVariantStatus={onSetVariantStatus} />
+                </div>
             </div>
+
+            {/* Freshness explanation — calm, specific, never blocking. */}
+            {variant.freshness && (variant.status === 'generated' || variant.status === 'accepted')
+                && variant.freshness.status !== 'current' && (
+                <FreshnessExplanation status={variant.freshness.status} reasons={variant.freshness.reasons} />
+            )}
 
             {/* Preview */}
             {primaryGenerated ? (
@@ -271,6 +338,8 @@ function VariantDetail({
                     platform={mockupContext.settings.platform}
                     variant={variant}
                     request={variantRequest}
+                    sourceSignature={variantSourceSignature}
+                    generatedFrom={generatedFrom}
                 />
             ) : (
                 <div className="rounded-lg border border-neutral-200 bg-neutral-50/60 p-4 text-center">
@@ -290,6 +359,42 @@ function VariantDetail({
                 <SpecCoverageSection show={primaryGenerated} specCoverage={specCoverage} />
             )}
 
+            {/* Source comparison — why review is (or isn't) recommended. Only
+                meaningful when a stored signature exists for this render. */}
+            {variantRecord?.sourceSignature != null && trustContext && (
+                <SourceComparison
+                    stored={variantRecord.sourceSignature as MockupVariantSourceSignature}
+                    generatedFrom={variantRecord.generatedFrom}
+                    current={trustContext}
+                    reasons={variant.freshness?.status && variant.freshness.status !== 'current'
+                        ? variant.freshness.reasons : []}
+                />
+            )}
+            {/* An older generated image with no source metadata. */}
+            {(variant.source === 'legacy' || variant.source === 'variant')
+                && variantRecord?.sourceSignature == null && (
+                <p className="text-[11px] text-neutral-400">
+                    Source comparison unavailable for this older mockup — it was generated before Synapse
+                    captured source metadata.
+                </p>
+            )}
+
+            {/* Variant history — preserved prior renders (local-only). */}
+            {variantRecord?.history && variantRecord.history.length > 0 && (
+                <VariantHistory
+                    current={variantRecord}
+                    history={variantRecord.history}
+                />
+            )}
+
+            {/* Storage clarity — variant images are local to this device. */}
+            {(variant.source === 'variant' || variantRecord) && (
+                <p className="text-[11px] text-neutral-400 flex items-center gap-1">
+                    <Info size={10} className="shrink-0" aria-hidden />
+                    Storage: Local browser cache — saved on this device until snapshot/sync support is added.
+                </p>
+            )}
+
             {/* Notes */}
             {variant.notes.length > 0 && variant.status !== 'missing' && (
                 <ul className="space-y-1">
@@ -300,6 +405,157 @@ function VariantDetail({
                         </li>
                     ))}
                 </ul>
+            )}
+        </div>
+    );
+}
+
+/** Calm, specific explanation of why a variant may be stale (or unconfirmed). */
+function FreshnessExplanation({
+    status, reasons,
+}: {
+    status: MockupVariantFreshnessStatus;
+    reasons: string[];
+}) {
+    const tone = status === 'unknown'
+        ? 'border-neutral-200 bg-neutral-50 text-neutral-600'
+        : 'border-amber-200 bg-amber-50 text-amber-800';
+    const Icon = status === 'unknown' ? ShieldQuestion : Clock;
+    return (
+        <div className={`rounded-lg border p-3 text-[11px] ${tone}`}>
+            <div className="flex items-center gap-1.5 font-medium">
+                <Icon size={12} aria-hidden />
+                {FRESHNESS_LABELS[status]}
+            </div>
+            {reasons.length > 0 && (
+                <ul className="mt-1 space-y-0.5 list-disc list-inside">
+                    {reasons.map((r, i) => <li key={i}>{r}</li>)}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+/** Compact metadata comparison — generated-from vs current (spec/design/PRD).
+ * Metadata only; never a visual diff. */
+function SourceComparison({
+    stored, generatedFrom, current, reasons,
+}: {
+    stored: MockupVariantSourceSignature;
+    generatedFrom?: { prdVersionId?: string; screenVersionId?: string; designSystemVersionId?: string };
+    current: {
+        prdVersionId?: string; screenVersionId?: string;
+        designSystemVersionId?: string; designSystemHash?: string;
+    };
+    reasons: string[];
+}) {
+    const rows: Array<{ label: string; changed: boolean; note?: string }> = [];
+    // Screen spec — compare the contract hash when both sides have one.
+    const screenChanged = Boolean(stored.screenContractHash);
+    rows.push({
+        label: 'Screen spec',
+        changed: reasons.some(r => /screen spec/i.test(r)),
+        note: reasons.some(r => /screen spec/i.test(r)) ? 'changed' : screenChanged ? 'unchanged' : 'unknown',
+    });
+    const dsFrom = generatedFrom?.designSystemVersionId ?? stored.designSystemVersionId;
+    rows.push({
+        label: 'Design system',
+        changed: reasons.some(r => /design system/i.test(r)),
+        note: dsFrom && current.designSystemVersionId
+            ? (dsFrom === current.designSystemVersionId ? 'unchanged' : 'changed')
+            : 'unknown',
+    });
+    const prdFrom = generatedFrom?.prdVersionId ?? stored.prdVersionId;
+    rows.push({
+        label: 'PRD context',
+        changed: reasons.some(r => /PRD/i.test(r)),
+        note: prdFrom && current.prdVersionId
+            ? (prdFrom === current.prdVersionId ? 'unchanged' : 'changed')
+            : 'unknown',
+    });
+
+    return (
+        <div className="rounded-lg border border-neutral-200 p-3">
+            <div className="flex items-center gap-1.5 mb-2">
+                <Layers size={12} className="text-neutral-400" aria-hidden />
+                <h5 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                    Source comparison
+                </h5>
+            </div>
+            <ul className="space-y-1 text-xs">
+                {rows.map(row => (
+                    <li key={row.label} className="flex items-center justify-between gap-2">
+                        <span className="text-neutral-700">{row.label}</span>
+                        <span className={row.changed
+                            ? 'text-amber-700 font-medium'
+                            : row.note === 'unknown' ? 'text-neutral-400' : 'text-emerald-700'}>
+                            {row.note === 'unknown' ? 'Not comparable' : row.changed ? 'Changed' : 'Unchanged'}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+            {reasons.length > 0 && (
+                <div className="mt-2 text-[11px] text-neutral-500">
+                    <div className="font-medium text-neutral-600">Why review is recommended</div>
+                    <ul className="mt-0.5 space-y-0.5 list-disc list-inside">
+                        {reasons.map((r, i) => <li key={i}>{r}</li>)}
+                    </ul>
+                </div>
+            )}
+            <p className="text-[11px] text-neutral-400 mt-2">
+                Compared from stored generation metadata, not the rendered image.
+            </p>
+        </div>
+    );
+}
+
+/** Minimal, local-only history of prior renders for one variant. */
+function VariantHistory({
+    current, history,
+}: {
+    current: { dataUrl: string; coverageManifest?: MockupCoverageManifest; generatedAt: number };
+    history: NonNullable<MockupVariantImageRecord['history']>;
+}) {
+    const [open, setOpen] = useState(false);
+    return (
+        <div className="rounded-lg border border-neutral-200 p-3">
+            <button
+                type="button"
+                onClick={() => setOpen(o => !o)}
+                className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-neutral-500 hover:text-neutral-700"
+            >
+                <HistoryIcon size={12} aria-hidden />
+                Variant history ({history.length} previous)
+            </button>
+            {open && (
+                <div className="mt-2 space-y-2">
+                    <div className="text-[11px] text-neutral-500">
+                        Current — coverage {current.coverageManifest
+                            ? COVERAGE_STATUS_LABELS[current.coverageManifest.overallStatus].toLowerCase()
+                            : 'unknown'}
+                    </div>
+                    {history.map((entry, i) => (
+                        <div key={i} className="flex items-center gap-2 rounded border border-neutral-100 p-1.5">
+                            <img
+                                src={entry.dataUrl}
+                                alt={`Previous render ${i + 1}`}
+                                className="h-12 w-12 rounded object-cover border border-neutral-200 bg-neutral-50"
+                            />
+                            <div className="min-w-0 text-[11px] text-neutral-500">
+                                <div className="text-neutral-700">Previous render {i + 1}</div>
+                                <div>
+                                    Coverage {entry.coverageManifest
+                                        ? COVERAGE_STATUS_LABELS[entry.coverageManifest.overallStatus].toLowerCase()
+                                        : 'unknown'}
+                                    {entry.reason ? ` · ${entry.reason}` : ''}
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                    <p className="text-[11px] text-neutral-400">
+                        Previous renders are kept on this device only.
+                    </p>
+                </div>
             )}
         </div>
     );

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -13,14 +13,14 @@
 // is shown. Status is tracked from generated metadata + the user's overlay,
 // never from inspecting pixels, and the copy says so.
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
     CheckCircle2, Clock, History as HistoryIcon, Info, Layers, Monitor, ShieldQuestion,
     Smartphone, Tablet,
 } from 'lucide-react';
 import type {
-    MockupCoverageItem, MockupCoverageItemStatus, MockupCoverageManifest, MockupPlatform,
-    MockupVariantImageRecord,
+    MockupCoverageItem, MockupCoverageItemStatus, MockupCoverageManifest, MockupImageRecord,
+    MockupPlatform, MockupVariantImageRecord,
 } from '../../types';
 import {
     COVERAGE_STATUS_LABELS,
@@ -36,7 +36,10 @@ import {
     type MockupVariantFreshnessStatus, type MockupVariantSourceSignature,
 } from '../../lib/mockupVariantTrust';
 import { buildMockupSpecCoverage } from '../../lib/screenReadiness';
-import { buildVariantGenerationRequest, type VariantRequestContext } from '../../lib/mockupVariantRequest';
+import {
+    buildVariantCoverageManifest, buildVariantGenerationRequest, type VariantRequestContext,
+} from '../../lib/mockupVariantRequest';
+import { buildVariantImageKey } from '../../lib/mockupVariantImageStore';
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import type { ScreenExperienceItem } from '../../lib/screenExperience';
 import { MockupScreenImage } from '../mockups/MockupScreenImage';
@@ -272,13 +275,16 @@ function VariantDetail({
             : undefined),
         [trustContext, item.screen, variant.viewport, variant.stateName, variant.stateType, variant.id],
     );
-    const generatedFrom = trustContext
-        ? {
-            prdVersionId: trustContext.prdVersionId,
-            screenVersionId: trustContext.screenVersionId,
-            designSystemVersionId: trustContext.designSystemVersionId,
-        }
-        : undefined;
+    const generatedFrom = useMemo(
+        () => (trustContext
+            ? {
+                prdVersionId: trustContext.prdVersionId,
+                screenVersionId: trustContext.screenVersionId,
+                designSystemVersionId: trustContext.designSystemVersionId,
+            }
+            : undefined),
+        [trustContext],
+    );
 
     // Manifest-backed coverage + stored metadata for this variant (from the
     // per-variant image store). Fetched for EVERY variant — for the default it
@@ -286,6 +292,40 @@ function VariantDetail({
     const variantRecord = useMockupVariantImageStore(
         s => s.getBestRecord(mockupContext.versionId, item.id, variant.id),
     );
+    const putSidecar = useMockupVariantImageStore(s => s.putSidecar);
+
+    // Phase 3C: when the DEFAULT variant is (re)generated through the legacy
+    // MockupScreenImage path, capture a coverage/source sidecar keyed
+    // `versionId:screenId:default:quality` WITHOUT moving the legacy image. Only
+    // fires on new generation, so old defaults stay coverage-unknown.
+    const handleDefaultGenerated = useCallback((record: MockupImageRecord) => {
+        if (isVariantPath || !variantSourceSignature) return;
+        const request = buildVariantGenerationRequest(item.screen, item.id, variant, {
+            projectName: mockupContext.payload.title,
+            productSummary: mockupContext.payload.summary,
+            fidelity: mockupContext.settings.fidelity,
+            siblingMockup: item.mockupScreen,
+        });
+        const sidecar: MockupVariantImageRecord = {
+            key: buildVariantImageKey(mockupContext.versionId, item.id, 'default', record.quality),
+            projectId: mockupContext.projectId,
+            artifactId: mockupContext.artifactId,
+            versionId: mockupContext.versionId,
+            screenId: item.id,
+            variantId: 'default',
+            viewport: variant.viewport,
+            stateName: 'Default',
+            // Sidecar carries no owned image — the legacy store still renders it.
+            dataUrl: '',
+            quality: record.quality,
+            prompt: '',
+            coverageManifest: buildVariantCoverageManifest(request),
+            sourceSignature: { ...variantSourceSignature, createdAt: new Date().toISOString() },
+            generatedFrom,
+            generatedAt: Date.now(),
+        };
+        void putSidecar(sidecar);
+    }, [isVariantPath, variantSourceSignature, generatedFrom, item, variant, mockupContext, putSidecar]);
 
     return (
         <div className="bg-white rounded-xl border border-neutral-200 p-4 space-y-3">
@@ -324,6 +364,7 @@ function VariantDetail({
                             screen={item.mockupScreen!}
                             payload={mockupContext.payload}
                             settings={mockupContext.settings}
+                            onGenerated={handleDefaultGenerated}
                         />
                     </div>
                     {metaParts.length > 0 && (
@@ -387,8 +428,10 @@ function VariantDetail({
                 />
             )}
 
-            {/* Storage clarity — variant images are local to this device. */}
-            {(variant.source === 'variant' || variantRecord) && (
+            {/* Storage clarity — per-variant images are local to this device
+                (the legacy default image itself still syncs, so its note is
+                omitted; only the genuinely local-only variant images carry it). */}
+            {variant.source === 'variant' && (
                 <p className="text-[11px] text-neutral-400 flex items-center gap-1">
                     <Info size={10} className="shrink-0" aria-hidden />
                     Storage: Local browser cache — saved on this device until snapshot/sync support is added.

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -12,6 +12,16 @@ import {
 } from 'lucide-react';
 import type { ScreenCoverageSummary } from '../../lib/screenReadiness';
 import type { MockupVariantCoverageSummary } from '../../lib/mockupVariants';
+import type { VariantFreshnessRollup } from '../../lib/mockupVariantTrust';
+
+/** "8 current · 2 review · 3 unknown" (omits zero segments). */
+function freshnessLabel(f: VariantFreshnessRollup): string {
+    const parts: string[] = [];
+    if (f.current > 0) parts.push(`${f.current} current`);
+    if (f.review > 0) parts.push(`${f.review} review`);
+    if (f.unknown > 0) parts.push(`${f.unknown} unknown`);
+    return parts.length ? parts.join(' · ') : 'None generated';
+}
 
 interface Props {
     summary: ScreenCoverageSummary;
@@ -129,6 +139,14 @@ export function ScreenCoveragePanel({ summary, variantCoverage, onGenerateMissin
                                     value={`${variantCoverage.p0WithMobile} / ${variantCoverage.p0Total} P0 screens`}
                                     hint="P0 screens whose Mobile default variant is generated, accepted, or marked not needed"
                                     tone={variantCoverage.p0WithMobile < variantCoverage.p0Total ? 'warn' : 'good'}
+                                />
+                            )}
+                            {variantCoverage && variantCoverage.freshness.total > 0 && (
+                                <MetricRow
+                                    label="Mockup freshness"
+                                    value={freshnessLabel(variantCoverage.freshness)}
+                                    hint="Generated mockup variants compared to the current screen spec, design system, and PRD — from stored generation metadata, never a visual check. Unknown = an older mockup with no source metadata."
+                                    tone={variantCoverage.freshness.review > 0 ? 'warn' : 'good'}
                                 />
                             )}
                             {variantCoverage && variantCoverage.legacyUnknownMockups > 0 && (

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -36,6 +36,7 @@ import {
     buildScreenMockupVariants, formatVariantLabel, summarizeScreenVariants,
     VARIANT_STATUS_LABELS, type GeneratedVariantMap,
 } from '../../lib/mockupVariants';
+import type { MockupVariantSourceSignature, VariantTrustContext } from '../../lib/mockupVariantTrust';
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import { MockupVariantsPanel } from './MockupVariantsPanel';
 import { ScreenOverviewPanel } from './ScreenOverviewPanel';
@@ -60,6 +61,9 @@ export interface ScreenDetailMockupContext {
     versionNumber?: number;
     /** "Version N" label of the PRD the mockup was generated from. */
     prdVersionLabel?: string;
+    /** Phase 3C: current screen/design/PRD context — captured into new variant
+     * source signatures and used to derive freshness. */
+    trustContext?: VariantTrustContext;
 }
 
 interface Props {
@@ -626,7 +630,10 @@ function MockupsTab({
         for (const key of Object.keys(variantImages)) {
             const r = variantImages[key];
             if (r.versionId !== versionId || r.screenId !== item.id) continue;
-            out[r.variantId] = { coverage: r.coverageManifest?.overallStatus ?? 'unknown' };
+            out[r.variantId] = {
+                coverage: r.coverageManifest?.overallStatus ?? 'unknown',
+                sourceSignature: r.sourceSignature as MockupVariantSourceSignature | undefined,
+            };
         }
         return out;
     }, [variantImages, versionId, item.id]);
@@ -635,6 +642,7 @@ function MockupsTab({
     const variants = buildScreenMockupVariants(item, {
         platform: mockupContext?.settings.platform,
         mobileRelevant,
+        trustContext: mockupContext?.trustContext,
         generatedVariants,
     });
     const variantSummary = summarizeScreenVariants(variants);

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -19,6 +19,7 @@ import {
     buildScreenMockupVariants, summarizeScreenVariants,
     type GeneratedVariantMap, type MockupVariantCoverageSummary,
 } from '../../lib/mockupVariants';
+import type { VariantTrustContext } from '../../lib/mockupVariantTrust';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 import { ScreenCoveragePanel } from './ScreenCoveragePanel';
 import { ReadinessBadge } from './ReadinessBadge';
@@ -39,6 +40,8 @@ interface Props {
     /** Phase 3B: resolves a screen's manifest-backed generated variants so the
      * card reflects real generation (e.g. "Mobile: generated"). */
     generatedVariantsByScreen?: (screenId: string) => GeneratedVariantMap | undefined;
+    /** Phase 3C: current trust context for per-screen variant freshness. */
+    trustContext?: VariantTrustContext;
     /** Opens the Screen Detail view — keyed by the stable canonical id. */
     onSelectScreen: (screenId: string) => void;
     /**
@@ -51,7 +54,7 @@ interface Props {
 
 export function ScreenListView({
     index, readiness, coverage, variantCoverage, mockupPlatform, mobileRelevant,
-    generatedVariantsByScreen, onSelectScreen, onGenerateMissingMockups,
+    generatedVariantsByScreen, trustContext, onSelectScreen, onGenerateMissingMockups,
 }: Props) {
     const [filter, setFilter] = useState<ScreenListFilter>('all');
 
@@ -154,6 +157,7 @@ export function ScreenListView({
                                     mockupPlatform={mockupPlatform}
                                     mobileRelevant={mobileRelevant}
                                     generatedVariants={generatedVariantsByScreen?.(item.id)}
+                                    trustContext={trustContext}
                                     onSelect={() => onSelectScreen(item.id)}
                                 />
                             </li>
@@ -166,13 +170,14 @@ export function ScreenListView({
 }
 
 function ScreenRow({
-    item, readiness, mockupPlatform, mobileRelevant, generatedVariants, onSelect,
+    item, readiness, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
 }: {
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
     mockupPlatform?: MockupPlatform;
     mobileRelevant?: boolean;
     generatedVariants?: GeneratedVariantMap;
+    trustContext?: VariantTrustContext;
     onSelect: () => void;
 }) {
     const { screen } = item;
@@ -183,9 +188,14 @@ function ScreenRow({
     const stateCount = screen.states?.length ?? 0;
     const riskCount = screen.risks?.length ?? 0;
     const featureRefs = screen.featureRefs ?? [];
-    const variantSummary = summarizeScreenVariants(
-        buildScreenMockupVariants(item, { platform: mockupPlatform, mobileRelevant, generatedVariants }),
-    );
+    const variants = buildScreenMockupVariants(item, {
+        platform: mockupPlatform, mobileRelevant, generatedVariants, trustContext,
+    });
+    const variantSummary = summarizeScreenVariants(variants);
+    // Compact freshness signal — count generated variants worth a review.
+    const freshReview = variants.filter(
+        v => v.freshness && (v.freshness.status === 'stale' || v.freshness.status === 'possibly_stale'),
+    ).length;
 
     return (
         <button
@@ -249,6 +259,14 @@ function ScreenRow({
                         title="No mobile mockup variant yet"
                     >
                         Mobile: missing
+                    </span>
+                )}
+                {freshReview > 0 && (
+                    <span
+                        className="text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full"
+                        title="One or more generated mockup variants may be stale — the screen spec, design system, or PRD changed after generation"
+                    >
+                        Freshness: {freshReview} to review
                     </span>
                 )}
                 {variantSummary.coverageUnknown && (

--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -28,6 +28,10 @@ interface Props {
     screen: MockupScreen;
     payload: MockupPayload;
     settings: MockupSettings;
+    /** Phase 3C: fired after a successful render so a caller (the variant panel)
+     * can capture a default-variant coverage sidecar. Optional — other callers
+     * of this component pass nothing and behave exactly as before. */
+    onGenerated?: (record: MockupImageRecord) => void;
 }
 
 const QUALITY_RANK: Record<MockupImageQuality, number> = { low: 0, medium: 1, high: 2 };
@@ -46,7 +50,7 @@ const pickInitialQuality = (records: MockupImageRecord[]): MockupImageQuality | 
     ).quality;
 };
 
-export function MockupScreenImage({ projectId, artifactId, versionId, screen, payload, settings }: Props) {
+export function MockupScreenImage({ projectId, artifactId, versionId, screen, payload, settings, onGenerated }: Props) {
     const scope = buildScreenScopeKey(versionId, screen.id);
     // Subscribe to the whole image map; filtered records are derived below.
     // The previous implementation subscribed only to a single keyed entry,
@@ -152,7 +156,7 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
             if (!ok) return;
         }
         clearError(versionId, screen.id);
-        void generate({ projectId, artifactId, versionId, screen, payload, settings, quality });
+        void generate({ projectId, artifactId, versionId, screen, payload, settings, quality, onGenerated });
     };
 
     if (inFlight) {

--- a/src/lib/__tests__/mockupVariantTrust.test.ts
+++ b/src/lib/__tests__/mockupVariantTrust.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import type { ScreenItem } from '../../types';
+import {
+    computeScreenContractHash,
+    buildVariantSourceSignature,
+    compareVariantFreshness,
+    summarizeVariantFreshness,
+    type VariantContractInput,
+    type MockupVariantSourceSignature,
+    type MockupVariantFreshness,
+} from '../mockupVariantTrust';
+
+const baseScreen = (overrides: Partial<ScreenItem> = {}): ScreenItem => ({
+    id: 'scr-home',
+    name: 'Home',
+    priority: 'P0',
+    purpose: 'The landing screen.',
+    userIntent: 'See a summary.',
+    coreUIElements: ['Feed', 'Header'],
+    exitPaths: [{ label: 'Open settings', target: 'Settings' }],
+    acceptanceCriteria: ['Loads under 2s'],
+    states: [
+        {
+            name: 'Empty',
+            description: 'No items yet.',
+            type: 'empty',
+            systemBehavior: 'Show an empty-state CTA.',
+            needsMockup: true,
+            acceptanceCriteria: ['Empty CTA visible'],
+        },
+    ],
+    ...overrides,
+});
+
+const defaultInput = (screen: ScreenItem): VariantContractInput => ({
+    screen,
+    viewport: 'desktop',
+    stateName: 'Default',
+    stateType: 'default',
+    variantId: 'default',
+});
+
+const emptyStateInput = (screen: ScreenItem): VariantContractInput => ({
+    screen,
+    viewport: 'desktop',
+    stateName: 'Empty',
+    stateType: 'empty',
+    variantId: 'state:empty',
+});
+
+describe('computeScreenContractHash', () => {
+    it('is deterministic for identical inputs', () => {
+        const a = computeScreenContractHash(defaultInput(baseScreen()));
+        const b = computeScreenContractHash(defaultInput(baseScreen()));
+        expect(a).toBe(b);
+    });
+
+    it('changes when a relevant screen-state behavior changes', () => {
+        const before = computeScreenContractHash(emptyStateInput(baseScreen()));
+        const after = computeScreenContractHash(emptyStateInput(baseScreen({
+            states: [{
+                name: 'Empty',
+                description: 'No items yet.',
+                type: 'empty',
+                systemBehavior: 'Show a different empty-state layout with onboarding tips.',
+                needsMockup: true,
+                acceptanceCriteria: ['Empty CTA visible'],
+            }],
+        })));
+        expect(before).not.toBe(after);
+    });
+
+    it('changes when acceptance criteria change', () => {
+        const before = computeScreenContractHash(defaultInput(baseScreen()));
+        const after = computeScreenContractHash(defaultInput(baseScreen({
+            acceptanceCriteria: ['Loads under 2s', 'Shows a welcome banner'],
+        })));
+        expect(before).not.toBe(after);
+    });
+
+    it('does not change for unrelated UI-only metadata', () => {
+        // notes / reviewStatus / mockupVariantStatus live on the overlay, never
+        // on the ScreenItem the hash reads — so cosmetic fields can't move it.
+        const before = computeScreenContractHash(defaultInput(baseScreen()));
+        // navigationFrom is a legacy display-only field not in the contract.
+        const after = computeScreenContractHash(defaultInput(baseScreen({
+            navigationFrom: ['Somewhere'],
+            navigationTo: ['Elsewhere'],
+        })));
+        expect(before).toBe(after);
+    });
+});
+
+const ctx = {
+    prdVersionId: 'prd-1',
+    screenVersionId: 'inv-1',
+    designSystemVersionId: 'ds-1',
+    designSystemHash: 'dshash1',
+};
+
+describe('compareVariantFreshness', () => {
+    it('is current when stored and current signatures match', () => {
+        const screen = baseScreen();
+        const sig = buildVariantSourceSignature(defaultInput(screen), ctx, '2026-01-01T00:00:00.000Z');
+        const current = buildVariantSourceSignature(defaultInput(screen), ctx, '2026-02-01T00:00:00.000Z');
+        const result = compareVariantFreshness(sig, current);
+        expect(result.status).toBe('current');
+    });
+
+    it('is stale when the screen-contract hash changes', () => {
+        const stored = buildVariantSourceSignature(defaultInput(baseScreen()), ctx, '2026-01-01T00:00:00.000Z');
+        const current = buildVariantSourceSignature(
+            defaultInput(baseScreen({ purpose: 'A completely rewritten purpose.' })),
+            ctx,
+            '2026-02-01T00:00:00.000Z',
+        );
+        const result = compareVariantFreshness(stored, current);
+        expect(result.status).toBe('stale');
+        expect(result.reasons.some(r => /screen spec/i.test(r))).toBe(true);
+    });
+
+    it('is stale when the design system hash changes', () => {
+        const screen = baseScreen();
+        const stored = buildVariantSourceSignature(defaultInput(screen), ctx, '2026-01-01T00:00:00.000Z');
+        const current = buildVariantSourceSignature(
+            defaultInput(screen),
+            { ...ctx, designSystemHash: 'dshash2', designSystemVersionId: 'ds-2' },
+            '2026-02-01T00:00:00.000Z',
+        );
+        const result = compareVariantFreshness(stored, current);
+        expect(result.status).toBe('stale');
+        expect(result.reasons.some(r => /design system/i.test(r))).toBe(true);
+    });
+
+    it('is possibly_stale when version metadata changes but hashes are missing', () => {
+        const screen = baseScreen();
+        // Neither side carries a design-system hash — only version ids differ.
+        const noHashCtx = { prdVersionId: 'prd-1', screenVersionId: 'inv-1', designSystemVersionId: 'ds-1' };
+        const stored = buildVariantSourceSignature(defaultInput(screen), noHashCtx, '2026-01-01T00:00:00.000Z');
+        const current = buildVariantSourceSignature(
+            defaultInput(screen),
+            { ...noHashCtx, designSystemVersionId: 'ds-2' },
+            '2026-02-01T00:00:00.000Z',
+        );
+        const result = compareVariantFreshness(stored, current);
+        expect(result.status).toBe('possibly_stale');
+    });
+
+    it('is unknown for a legacy variant without a source signature', () => {
+        const current = buildVariantSourceSignature(defaultInput(baseScreen()), ctx, '2026-02-01T00:00:00.000Z');
+        const result = compareVariantFreshness(undefined, current);
+        expect(result.status).toBe('unknown');
+    });
+});
+
+describe('summarizeVariantFreshness', () => {
+    it('counts current / review / unknown correctly and never treats unknown as stale', () => {
+        const mk = (status: MockupVariantFreshness['status']): MockupVariantFreshness => ({
+            status, reasons: [], severity: 'info', estimated: true,
+        });
+        const rollup = summarizeVariantFreshness([
+            mk('current'), mk('current'),
+            mk('stale'), mk('possibly_stale'),
+            mk('unknown'), mk('unknown'), mk('unknown'),
+        ]);
+        expect(rollup.current).toBe(2);
+        expect(rollup.review).toBe(2);
+        expect(rollup.unknown).toBe(3);
+        expect(rollup.total).toBe(7);
+    });
+});
+
+describe('signature provenance', () => {
+    it('captures the version context and screen identity', () => {
+        const sig: MockupVariantSourceSignature = buildVariantSourceSignature(
+            emptyStateInput(baseScreen()), ctx, '2026-01-01T00:00:00.000Z',
+        );
+        expect(sig.screenId).toBe('scr-home');
+        expect(sig.variantId).toBe('state:empty');
+        expect(sig.viewport).toBe('desktop');
+        expect(sig.designSystemHash).toBe('dshash1');
+        expect(sig.prdVersionId).toBe('prd-1');
+        expect(sig.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+});

--- a/src/lib/__tests__/mockupVariantTrust.test.ts
+++ b/src/lib/__tests__/mockupVariantTrust.test.ts
@@ -78,6 +78,27 @@ describe('computeScreenContractHash', () => {
         expect(before).not.toBe(after);
     });
 
+    it('legacy-default mode ignores user actions / acceptance criteria the legacy prompt never used', () => {
+        const input = (screen: ScreenItem): VariantContractInput => ({
+            screen, viewport: 'desktop', stateName: 'Default', stateType: 'default',
+            variantId: 'default', legacyDefault: true, legacyUIRegions: ['Feed', 'Header'],
+        });
+        const before = computeScreenContractHash(input(baseScreen()));
+        // Changing acceptance criteria / exit paths must NOT move the legacy
+        // default hash — the legacy prompt never requested those fields.
+        const after = computeScreenContractHash(input(baseScreen({
+            acceptanceCriteria: ['Totally different criteria'],
+            exitPaths: [{ label: 'A brand new action', target: 'Elsewhere' }],
+        })));
+        expect(before).toBe(after);
+        // But changing the legacy UI regions DOES move it.
+        const changedUI = computeScreenContractHash({
+            screen: baseScreen(), viewport: 'desktop', stateName: 'Default', stateType: 'default',
+            variantId: 'default', legacyDefault: true, legacyUIRegions: ['Feed', 'New Panel'],
+        });
+        expect(changedUI).not.toBe(before);
+    });
+
     it('does not change for unrelated UI-only metadata', () => {
         // notes / reviewStatus / mockupVariantStatus live on the overlay, never
         // on the ScreenItem the hash reads — so cosmetic fields can't move it.

--- a/src/lib/mockupVariantTrust.ts
+++ b/src/lib/mockupVariantTrust.ts
@@ -241,7 +241,7 @@ const REASON = {
     current: 'Matches the current screen spec, design system, and PRD context.',
 } as const;
 
-const unknownFreshness = (reason = REASON.noMetadata): MockupVariantFreshness => ({
+const unknownFreshness = (reason: string = REASON.noMetadata): MockupVariantFreshness => ({
     status: 'unknown',
     reasons: [reason],
     severity: 'info',

--- a/src/lib/mockupVariantTrust.ts
+++ b/src/lib/mockupVariantTrust.ts
@@ -128,6 +128,17 @@ export interface VariantContractInput {
     stateName: string;
     stateType?: string;
     variantId: string;
+    /** True for the legacy DEFAULT variant, whose image is produced by the
+     * legacy `buildScreenImagePrompt` path — which requests ONLY the mockup
+     * screen's UI elements, never the inventory screen's user actions /
+     * acceptance criteria / risks. In this mode the contract hash (and any
+     * sidecar manifest) is built from those actual legacy inputs so it never
+     * over-claims coverage or over-flags freshness on fields the render never
+     * used. */
+    legacyDefault?: boolean;
+    /** The UI regions the legacy default prompt actually requested (the mockup
+     * screen's `coreUIElements`). Used only when `legacyDefault` is set. */
+    legacyUIRegions?: string[];
 }
 
 /** Find the documented screen state a non-default variant renders (by slug). */
@@ -146,6 +157,25 @@ function matchState(screen: ScreenItem, input: VariantContractInput): ScreenStat
  */
 export function computeScreenContractHash(input: VariantContractInput): string {
     const { screen } = input;
+
+    // Legacy default: hash only what the legacy prompt actually requested — the
+    // mockup screen's UI regions plus screen identity fields. Omits user actions
+    // / acceptance criteria / risks / per-state detail the legacy render never
+    // consumed, so it can't over-flag freshness on unused fields.
+    if (input.legacyDefault) {
+        const contract = {
+            legacyDefault: true,
+            name: screen.name ?? '',
+            purpose: screen.purpose ?? '',
+            userIntent: screen.userIntent ?? '',
+            priority: normalizePriority(screen.priority),
+            viewport: input.viewport,
+            stateName: input.stateName,
+            coreUIRegions: clean(input.legacyUIRegions ?? []),
+        };
+        return stableHash(contract);
+    }
+
     const state = matchState(screen, input);
     const coreUIRegions = clean([
         ...(screen.coreUIElements ?? []),

--- a/src/lib/mockupVariantTrust.ts
+++ b/src/lib/mockupVariantTrust.ts
@@ -1,0 +1,372 @@
+// Phase 3C: source signatures + freshness (staleness) for generated mockup
+// variants. This is the TRUST layer on top of the Phase 3A/3B variant model.
+//
+// A generated variant is captured with a MockupVariantSourceSignature — a
+// deterministic snapshot of the screen-contract inputs that materially affect
+// how the image renders (viewport + state + the same screen-spec fields the
+// generation request uses) plus the PRD / design-system / screen version
+// context at generation time. Later, we recompute the signature from the
+// CURRENT screen/design/PRD context and compare: if the screen-contract hash
+// moved, or the design-system / PRD context changed, the variant is stale.
+//
+// Everything here is PURE and read-time only (no store, no IDB, no React, no
+// LLM). Honesty rules mirror the rest of the Screens layer:
+//   - Freshness is derived from stored METADATA vs. current metadata, never
+//     from inspecting rendered pixels.
+//   - Legacy / pre-signature records are `unknown`, NEVER falsely `stale`.
+//   - The screen-contract hash covers only fields that change the visual;
+//     volatile UI-only overlay fields (notes, review status, variant marks)
+//     are excluded so freshness warnings stay quiet unless the spec truly moved.
+
+import type { ScreenItem, ScreenState, LegacyScreenPriority, ScreenPriority } from '../types';
+
+export type MockupVariantTrustViewport = 'desktop' | 'mobile' | 'tablet';
+
+/** A deterministic snapshot of the inputs that materially affect one variant's
+ * rendered image, captured at generation time and stored with the record. */
+export interface MockupVariantSourceSignature {
+    /** Current PRD/spine version id at generation time (context provenance). */
+    prdVersionId?: string;
+    /** screen_inventory artifact version id at generation time. */
+    screenVersionId?: string;
+    /** design_system artifact version id at generation time. */
+    designSystemVersionId?: string;
+    screenId: string;
+    screenTitle?: string;
+    viewport: MockupVariantTrustViewport;
+    stateName: string;
+    variantId: string;
+    /** Hash of the screen-contract fields this variant's image depends on. */
+    screenContractHash: string;
+    /** Design-system tokens hash (mirrors the mockup design-drift signal). */
+    designSystemHash?: string;
+    /** Optional PRD-content hash (proxy: absent today, we compare version ids). */
+    prdContextHash?: string;
+    /** ISO timestamp captured at generation. */
+    createdAt: string;
+}
+
+export type MockupVariantFreshnessStatus =
+    | 'current'
+    | 'possibly_stale'
+    | 'stale'
+    | 'unknown';
+
+export interface MockupVariantFreshness {
+    status: MockupVariantFreshnessStatus;
+    /** Calm, human-readable explanations of the status. */
+    reasons: string[];
+    /** UI weight — nothing here ever blocks rendering or generation. */
+    severity: 'info' | 'review' | 'blocking';
+    /** Always true — freshness is a metadata estimate, never a visual check. */
+    estimated: boolean;
+}
+
+// --- Deterministic hashing (self-contained; mirrors designTokens/hash.ts) ----
+
+function canonicalStringify(value: unknown): string {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return JSON.stringify(value ?? null);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalStringify).join(',')}]`;
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const entries = keys.map(k => `${JSON.stringify(k)}:${canonicalStringify(obj[k])}`);
+    return `{${entries.join(',')}}`;
+}
+
+function fnv1a(input: string): string {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+        h ^= input.charCodeAt(i);
+        h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+    }
+    return h.toString(16).padStart(8, '0');
+}
+
+function stableHash(value: unknown): string {
+    const canonical = canonicalStringify(value);
+    return `${fnv1a(canonical)}${fnv1a(canonical + ':v1')}`;
+}
+
+// --- Screen-contract hashing -------------------------------------------------
+
+function normalizePriority(priority: ScreenPriority | LegacyScreenPriority): ScreenPriority {
+    switch (priority) {
+        case 'P0': case 'core': return 'P0';
+        case 'P1': case 'secondary': return 'P1';
+        case 'P2': case 'supporting': return 'P2';
+        case 'P3': return 'P3';
+        default: return 'P1';
+    }
+}
+
+const clean = (values: Array<string | undefined | null>): string[] => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const v of values) {
+        const t = v?.trim();
+        if (!t) continue;
+        const k = t.toLowerCase();
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push(t);
+    }
+    return out;
+};
+
+/** slug helper (local — avoids importing the image store into a pure module). */
+const slug = (name: string): string =>
+    name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+/** The variant-shaped inputs the contract hash keys off. */
+export interface VariantContractInput {
+    screen: ScreenItem;
+    viewport: MockupVariantTrustViewport;
+    stateName: string;
+    stateType?: string;
+    variantId: string;
+}
+
+/** Find the documented screen state a non-default variant renders (by slug). */
+function matchState(screen: ScreenItem, input: VariantContractInput): ScreenState | undefined {
+    if (!input.stateType || input.stateType === 'default') return undefined;
+    const target = slug(input.stateName);
+    return (screen.states ?? []).find(s => slug(s.name ?? '') === target);
+}
+
+/**
+ * Compute a deterministic hash of the screen-contract fields that materially
+ * affect THIS variant's rendered image. Mirrors the field selection in
+ * buildVariantGenerationRequest so the hash moves exactly when the generation
+ * inputs would. Excludes overlay-only UI metadata (notes / review status /
+ * variant marks) so cosmetic edits never trip a false stale warning.
+ */
+export function computeScreenContractHash(input: VariantContractInput): string {
+    const { screen } = input;
+    const state = matchState(screen, input);
+    const coreUIRegions = clean([
+        ...(screen.coreUIElements ?? []),
+        ...(screen.coreUIElements?.length ? [] : (screen.components ?? [])),
+    ]);
+    const userActions = clean([
+        ...((screen.handoff?.events ?? []).map(e => e.name)),
+        ...((screen.exitPaths ?? []).map(p => p.label)),
+    ]);
+    const acceptanceCriteria = clean([
+        ...(state?.acceptanceCriteria ?? []),
+        ...(state ? [] : (screen.acceptanceCriteria ?? [])),
+    ]);
+    const risks = clean([
+        ...((screen.riskDetails ?? []).map(r => r.description)),
+        ...(screen.riskDetails?.length ? [] : (screen.risks ?? [])),
+    ]);
+
+    const contract = {
+        name: screen.name ?? '',
+        purpose: screen.purpose ?? '',
+        userIntent: screen.userIntent ?? '',
+        priority: normalizePriority(screen.priority),
+        viewport: input.viewport,
+        stateName: input.stateName,
+        stateType: input.stateType ?? 'default',
+        state: state
+            ? {
+                type: state.type ?? null,
+                systemBehavior: state.systemBehavior ?? state.description ?? '',
+                trigger: state.trigger ?? '',
+                required: state.required ?? null,
+                needsMockup: state.needsMockup ?? null,
+                acceptanceCriteria: clean(state.acceptanceCriteria ?? []),
+            }
+            : null,
+        coreUIRegions,
+        userActions,
+        acceptanceCriteria,
+        risks,
+    };
+    return stableHash(contract);
+}
+
+// --- Source signature builder ------------------------------------------------
+
+/** Current PRD / design-system / screen version context for signature capture
+ * and comparison. All optional — sparse projects still get a valid signature. */
+export interface VariantTrustContext {
+    prdVersionId?: string;
+    screenVersionId?: string;
+    designSystemVersionId?: string;
+    designSystemHash?: string;
+    prdContextHash?: string;
+}
+
+/**
+ * Build the source signature to STORE with a freshly generated variant. Uses
+ * the same computeScreenContractHash as the comparison path, so storage and
+ * comparison can never drift apart.
+ */
+export function buildVariantSourceSignature(
+    input: VariantContractInput,
+    context: VariantTrustContext,
+    createdAt: string,
+): MockupVariantSourceSignature {
+    return {
+        prdVersionId: context.prdVersionId,
+        screenVersionId: context.screenVersionId,
+        designSystemVersionId: context.designSystemVersionId,
+        screenId: input.screen.id ?? slug(input.screen.name ?? ''),
+        screenTitle: input.screen.name,
+        viewport: input.viewport,
+        stateName: input.stateName,
+        variantId: input.variantId,
+        screenContractHash: computeScreenContractHash(input),
+        designSystemHash: context.designSystemHash,
+        prdContextHash: context.prdContextHash,
+        createdAt,
+    };
+}
+
+// --- Freshness comparison ----------------------------------------------------
+
+const REASON = {
+    screenSpec: 'Screen spec changed after this mockup was generated.',
+    designSystem: 'Design system version changed after this mockup was generated.',
+    designSystemMaybe: 'Design system may have changed — this mockup predates the current version.',
+    prd: 'PRD changed after this mockup was generated.',
+    prdMaybe: 'PRD context changed — this mockup predates the current PRD version.',
+    noMetadata: 'This older mockup does not include source metadata, so freshness cannot be confirmed.',
+    partial: 'Some source metadata is unavailable, so freshness cannot be fully confirmed.',
+    current: 'Matches the current screen spec, design system, and PRD context.',
+} as const;
+
+const unknownFreshness = (reason = REASON.noMetadata): MockupVariantFreshness => ({
+    status: 'unknown',
+    reasons: [reason],
+    severity: 'info',
+    estimated: true,
+});
+
+/**
+ * Compare a stored source signature against the current screen / design / PRD
+ * context. Returns a freshness verdict with calm, specific reasons.
+ *
+ * - `unknown`        — no stored signature (legacy / pre-Phase-3C record).
+ * - `stale`          — a hash we can compare moved (screen contract, design
+ *                      system, or PRD).
+ * - `possibly_stale` — version metadata changed but a hash to confirm with is
+ *                      missing (can't be sure it's material).
+ * - `current`        — everything we can compare matches.
+ */
+export function compareVariantFreshness(
+    stored: MockupVariantSourceSignature | undefined,
+    current: MockupVariantSourceSignature | undefined,
+): MockupVariantFreshness {
+    if (!stored) return unknownFreshness();
+    if (!current) return unknownFreshness(REASON.partial);
+
+    const reasons: string[] = [];
+    let stale = false;
+    let possibly = false;
+
+    // 1. Screen contract — the strongest signal.
+    if (stored.screenContractHash && current.screenContractHash) {
+        if (stored.screenContractHash !== current.screenContractHash) {
+            stale = true;
+            reasons.push(REASON.screenSpec);
+        }
+    } else {
+        // No contract hash to compare — fall through to version signals.
+        possibly = true;
+        reasons.push(REASON.partial);
+    }
+
+    // 2. Design system — hash first, else version id.
+    if (stored.designSystemHash && current.designSystemHash) {
+        if (stored.designSystemHash !== current.designSystemHash) {
+            stale = true;
+            reasons.push(REASON.designSystem);
+        }
+    } else if (
+        stored.designSystemVersionId && current.designSystemVersionId
+        && stored.designSystemVersionId !== current.designSystemVersionId
+    ) {
+        possibly = true;
+        reasons.push(REASON.designSystemMaybe);
+    }
+
+    // 3. PRD context — hash first, else version id.
+    if (stored.prdContextHash && current.prdContextHash) {
+        if (stored.prdContextHash !== current.prdContextHash) {
+            stale = true;
+            reasons.push(REASON.prd);
+        }
+    } else if (
+        stored.prdVersionId && current.prdVersionId
+        && stored.prdVersionId !== current.prdVersionId
+    ) {
+        possibly = true;
+        reasons.push(REASON.prdMaybe);
+    }
+
+    if (stale) {
+        // Keep only the concrete "changed" reasons (drop the soft "partial").
+        const concrete = reasons.filter(r => r !== REASON.partial);
+        return {
+            status: 'stale',
+            reasons: concrete.length ? concrete : [REASON.screenSpec],
+            severity: 'review',
+            estimated: true,
+        };
+    }
+    if (possibly) {
+        return {
+            status: 'possibly_stale',
+            reasons: reasons.length ? reasons : [REASON.partial],
+            severity: 'review',
+            estimated: true,
+        };
+    }
+    return {
+        status: 'current',
+        reasons: [REASON.current],
+        severity: 'info',
+        estimated: true,
+    };
+}
+
+// --- Rollup ------------------------------------------------------------------
+
+export interface VariantFreshnessRollup {
+    current: number;
+    /** possibly_stale + stale — variants worth a freshness review. */
+    review: number;
+    /** Generated variants with no comparable source metadata. */
+    unknown: number;
+    /** Total generated variants considered. */
+    total: number;
+}
+
+/** Roll up a set of freshness verdicts into current / review / unknown counts.
+ * Unknown is NEVER counted as review (stale) — it's just missing metadata. */
+export function summarizeVariantFreshness(
+    verdicts: readonly MockupVariantFreshness[],
+): VariantFreshnessRollup {
+    let current = 0;
+    let review = 0;
+    let unknown = 0;
+    for (const v of verdicts) {
+        if (v.status === 'current') current += 1;
+        else if (v.status === 'stale' || v.status === 'possibly_stale') review += 1;
+        else unknown += 1;
+    }
+    return { current, review, unknown, total: verdicts.length };
+}
+
+export const FRESHNESS_LABELS: Record<MockupVariantFreshnessStatus, string> = {
+    current: 'Current',
+    possibly_stale: 'Review freshness',
+    stale: 'Stale',
+    unknown: 'Freshness unknown',
+};

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -342,6 +342,11 @@ function buildVariant(
     const hasImage = legacyGenerated || Boolean(variantImage);
     if (hasImage && trustContext) {
         const storedSig = (variantImage ?? defaultSidecar)?.sourceSignature;
+        // The legacy default's image comes from buildScreenImagePrompt, which
+        // requests only the mockup screen's UI elements — so its contract hash
+        // must be built from those legacy inputs, not the full variant request
+        // (which would invent user-action / acceptance-criteria coverage).
+        const isLegacyDefault = seed.generatedSlot;
         const current = buildVariantSourceSignature(
             {
                 screen: item.screen,
@@ -349,6 +354,8 @@ function buildVariant(
                 stateName: seed.stateName,
                 stateType: seed.stateType,
                 variantId: seed.overlayKey,
+                legacyDefault: isLegacyDefault,
+                legacyUIRegions: isLegacyDefault ? item.mockupScreen?.coreUIElements : undefined,
             },
             trustContext,
             storedSig?.createdAt ?? '',

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -35,6 +35,11 @@ import type {
 import { slugifyScreenName } from './screenInventoryImageStore';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from './screenExperience';
 import { buildMockupSpecCoverage, type MockupVariantRowStatus } from './screenReadiness';
+import {
+    buildVariantSourceSignature, compareVariantFreshness, summarizeVariantFreshness,
+    type MockupVariantFreshness, type MockupVariantSourceSignature,
+    type VariantFreshnessRollup, type VariantTrustContext,
+} from './mockupVariantTrust';
 
 export type MockupViewport = 'desktop' | 'mobile' | 'tablet';
 
@@ -72,6 +77,10 @@ export interface DerivedMockupVariant {
     coverageEstimated: boolean;
     /** Short human notes explaining status / recommendation / coverage. */
     notes: string[];
+    /** Phase 3C: staleness of a generated variant vs. the current screen /
+     * design-system / PRD context. Absent for missing / not-generated variants.
+     * Legacy generated variants with no stored signature resolve to `unknown`. */
+    freshness?: MockupVariantFreshness;
 }
 
 export const VIEWPORT_LABELS: Record<MockupViewport, string> = {
@@ -140,6 +149,10 @@ function isImportantState(name: string, type?: ScreenStateType): boolean {
 export interface GeneratedVariantInfo {
     /** Coverage from the stored manifest's overallStatus. */
     coverage: MockupVariantCoverage;
+    /** Phase 3C: the source signature stored with this generated variant, used
+     * to derive freshness against the current context. Absent for pre-3C
+     * records → freshness resolves to `unknown`. */
+    sourceSignature?: MockupVariantSourceSignature;
 }
 
 /** Per-screen map of variantId -> generation info (from the variant image store). */
@@ -156,8 +169,14 @@ export interface BuildVariantOptions {
      * variant id. A non-default variant present here renders as 'generated'
      * with its manifest coverage. Absent → the Phase 3A derived-missing model.
      * The default variant's generation state still comes from the legacy
-     * mockup join (item.mockupScreen), never this map. */
+     * mockup join (item.mockupScreen), never this map. A `default` entry here
+     * is the Phase 3C coverage sidecar — it supplies the default variant's
+     * coverage + source signature WITHOUT changing its generation state. */
     generatedVariants?: GeneratedVariantMap;
+    /** Phase 3C: the CURRENT screen/design/PRD context, used to compute each
+     * generated variant's freshness. Absent → generated variants carry no
+     * freshness (the caller isn't wired for staleness yet). */
+    trustContext?: VariantTrustContext;
 }
 
 interface VariantSeed {
@@ -259,7 +278,7 @@ export function buildScreenMockupVariants(
     }
 
     const generatedVariants = options.generatedVariants ?? {};
-    return seeds.map(seed => buildVariant(item, seed, overlay, generatedVariants));
+    return seeds.map(seed => buildVariant(item, seed, overlay, generatedVariants, options.trustContext));
 }
 
 function buildVariant(
@@ -267,14 +286,19 @@ function buildVariant(
     seed: VariantSeed,
     overlay: Record<string, 'accepted' | 'not_needed'>,
     generatedVariants: GeneratedVariantMap,
+    trustContext?: VariantTrustContext,
 ): DerivedMockupVariant {
     const override: 'accepted' | 'not_needed' | undefined = overlay[seed.overlayKey];
     // The legacy default variant is generated iff the screen joins a mockup.
     const legacyGenerated = seed.generatedSlot && Boolean(item.mockupScreen);
     // A non-default variant is generated iff the per-variant image store has a
-    // record for it (Phase 3B). The default slot never reads this map — its
-    // image lives in the legacy store.
+    // record for it (Phase 3B). The default slot never reads this map for its
+    // generation state — its image lives in the legacy store.
     const variantImage = !seed.generatedSlot ? generatedVariants[seed.overlayKey] : undefined;
+    // Phase 3C: a coverage sidecar for the default variant (metadata only) —
+    // supplies the default's coverage + source signature without altering that
+    // it renders via the legacy path.
+    const defaultSidecar = seed.generatedSlot ? generatedVariants[seed.overlayKey] : undefined;
     const generated = legacyGenerated || Boolean(variantImage);
     const status: MockupVariantStatus = override ?? (generated ? 'generated' : 'missing');
     const source: MockupVariantSource = variantImage
@@ -286,6 +310,10 @@ function buildVariant(
     if (variantImage) {
         // Manifest-backed coverage captured during this variant's generation.
         coverageStatus = variantImage.coverage;
+        notes.push('Coverage manifest captured during generation — a self-report of the generation spec, not a visual inspection of the image.');
+    } else if (legacyGenerated && defaultSidecar) {
+        // The legacy default carries a Phase 3C sidecar manifest.
+        coverageStatus = defaultSidecar.coverage;
         notes.push('Coverage manifest captured during generation — a self-report of the generation spec, not a visual inspection of the image.');
     } else if (legacyGenerated) {
         const rows = buildMockupSpecCoverage(item.baseScreen, item.mockupScreen?.coreUIElements);
@@ -306,6 +334,28 @@ function buildVariant(
         notes.push(recommendationReason(item.screen, seed));
     }
 
+    // Phase 3C: freshness — only for variants that hold a real generated image
+    // (legacy default, sidecar default, or a per-variant image). A stored source
+    // signature (from the variant image / sidecar) is compared against a freshly
+    // computed one; no signature → `unknown` (never falsely stale).
+    let freshness: MockupVariantFreshness | undefined;
+    const hasImage = legacyGenerated || Boolean(variantImage);
+    if (hasImage && trustContext) {
+        const storedSig = (variantImage ?? defaultSidecar)?.sourceSignature;
+        const current = buildVariantSourceSignature(
+            {
+                screen: item.screen,
+                viewport: seed.viewport,
+                stateName: seed.stateName,
+                stateType: seed.stateType,
+                variantId: seed.overlayKey,
+            },
+            trustContext,
+            storedSig?.createdAt ?? '',
+        );
+        freshness = compareVariantFreshness(storedSig, current);
+    }
+
     return {
         id: seed.overlayKey,
         screenId: item.id,
@@ -319,6 +369,7 @@ function buildVariant(
         coverageStatus,
         coverageEstimated: true,
         notes,
+        freshness,
     };
 }
 
@@ -427,6 +478,9 @@ export interface MockupVariantCoverageSummary {
     /** Phase 3B: generated variants backed by a captured coverage manifest —
      * counted separately from legacy "unknown" coverage. */
     manifestBackedGenerated: number;
+    /** Phase 3C: freshness rollup across all generated variants (current /
+     * review / unknown). Only populated when trustContext is supplied. */
+    freshness: VariantFreshnessRollup;
 }
 
 /** Options for the artifact-level rollup. Extends BuildVariantOptions with a
@@ -450,6 +504,7 @@ export function buildMockupVariantCoverageSummary(
     let p0Total = 0;
     let legacyUnknownMockups = 0;
     let manifestBackedGenerated = 0;
+    const freshnessVerdicts: MockupVariantFreshness[] = [];
 
     const { generatedVariantsByScreen, ...variantOptions } = options;
 
@@ -477,6 +532,7 @@ export function buildMockupVariantCoverageSummary(
             if (v.source === 'variant' && isGeneratedOrAccepted(v.status)) {
                 manifestBackedGenerated += 1;
             }
+            if (v.freshness) freshnessVerdicts.push(v.freshness);
         }
     }
 
@@ -487,6 +543,7 @@ export function buildMockupVariantCoverageSummary(
         p0Total,
         legacyUnknownMockups,
         manifestBackedGenerated,
+        freshness: summarizeVariantFreshness(freshnessVerdicts),
     };
 }
 

--- a/src/store/__tests__/mockupVariantImageStore.test.ts
+++ b/src/store/__tests__/mockupVariantImageStore.test.ts
@@ -21,10 +21,11 @@ vi.mock('../../lib/mockupVariantImageStore', () => {
 });
 
 let shouldFail = false;
+let currentB64 = 'BASE64DATA';
 vi.mock('../../lib/openaiClient', () => ({
     callOpenAIImage: async () => {
         if (shouldFail) throw new Error('boom');
-        return 'BASE64DATA';
+        return currentB64;
     },
     hasOpenAIKey: () => true,
 }));
@@ -62,6 +63,7 @@ const genArgs = (request: MockupVariantGenerationRequest) => ({
 describe('mockupVariantImageStore.generate', () => {
     beforeEach(() => {
         shouldFail = false;
+        currentB64 = 'BASE64DATA';
         useMockupVariantImageStore.setState({ images: {}, inFlight: {}, errors: {} });
     });
 
@@ -106,5 +108,94 @@ describe('mockupVariantImageStore.generate', () => {
         // Mobile variant is absent and its scope carries an error.
         expect(state.getBestRecord('v1', 'scr-home', 'mobile:default')).toBeUndefined();
         expect(state.errors['v1:scr-home:mobile:default']).toBe('boom');
+    });
+
+    it('stores the source signature + provenance with a generated variant', async () => {
+        const req = makeRequest();
+        const sourceSignature = {
+            screenId: 'scr-home', viewport: 'mobile' as const, stateName: 'Default',
+            variantId: 'mobile:default', screenContractHash: 'abc', createdAt: '2026-01-01T00:00:00.000Z',
+        };
+        await useMockupVariantImageStore.getState().generate({
+            ...genArgs(req),
+            sourceSignature,
+            generatedFrom: { prdVersionId: 'prd-1', screenVersionId: 'inv-1', designSystemVersionId: 'ds-1' },
+        });
+        const rec = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        expect((rec?.sourceSignature as { screenContractHash?: string })?.screenContractHash).toBe('abc');
+        expect(rec?.generatedFrom?.prdVersionId).toBe('prd-1');
+    });
+
+    it('regenerating a variant preserves the previous successful record in history', async () => {
+        const store = useMockupVariantImageStore.getState();
+        const req = makeRequest();
+        // Distinguish the two renders by the returned base64.
+        currentB64 = 'FIRST';
+        await store.generate(genArgs(req));
+        currentB64 = 'SECOND';
+        await useMockupVariantImageStore.getState().generate(genArgs(req));
+
+        const rec = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        expect(rec?.dataUrl).toBe('data:image/png;base64,SECOND');
+        expect(rec?.history).toHaveLength(1);
+        expect(rec?.history?.[0].dataUrl).toBe('data:image/png;base64,FIRST');
+        expect(rec?.history?.[0].reason).toBe('regenerated');
+    });
+
+    it('failed regeneration preserves the current successful record and adds no history entry', async () => {
+        const store = useMockupVariantImageStore.getState();
+        const req = makeRequest();
+        currentB64 = 'GOOD';
+        await store.generate(genArgs(req));
+        // Now a regeneration that fails.
+        shouldFail = true;
+        await useMockupVariantImageStore.getState().generate(genArgs(req));
+
+        const rec = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        // The original good render survives untouched, with no bogus history.
+        expect(rec?.dataUrl).toBe('data:image/png;base64,GOOD');
+        expect(rec?.history ?? []).toHaveLength(0);
+        expect(useMockupVariantImageStore.getState().errors['v1:scr-home:mobile:default']).toBe('boom');
+    });
+
+    it('history is grouped by variant key (regen of one variant does not touch another)', async () => {
+        const store = useMockupVariantImageStore.getState();
+        currentB64 = 'A1';
+        await store.generate(genArgs(makeRequest({ variantId: 'desktop:default', viewport: 'desktop' })));
+        currentB64 = 'B1';
+        await useMockupVariantImageStore.getState()
+            .generate(genArgs(makeRequest({ variantId: 'mobile:default', viewport: 'mobile' })));
+        // Regenerate only the desktop variant.
+        currentB64 = 'A2';
+        await useMockupVariantImageStore.getState()
+            .generate(genArgs(makeRequest({ variantId: 'desktop:default', viewport: 'desktop' })));
+
+        const desktop = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'desktop:default');
+        const mobile = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        expect(desktop?.history).toHaveLength(1);
+        expect(desktop?.history?.[0].dataUrl).toBe('data:image/png;base64,A1');
+        // The mobile variant is untouched — no history.
+        expect(mobile?.history ?? []).toHaveLength(0);
+    });
+
+    it('putSidecar stores a metadata-only default record without generating', async () => {
+        const store = useMockupVariantImageStore.getState();
+        await store.putSidecar({
+            key: 'v1:scr-home:default:low',
+            projectId: 'p1', artifactId: 'a1', versionId: 'v1',
+            screenId: 'scr-home', variantId: 'default', viewport: 'desktop',
+            stateName: 'Default', dataUrl: '', quality: 'low', prompt: '',
+            coverageManifest: {
+                variant: { viewport: 'desktop', stateName: 'Default' },
+                overallStatus: 'aligned', estimated: true,
+                uiRegions: [], states: [], userActions: [], acceptanceCriteria: [], warnings: [],
+            },
+            sourceSignature: { screenId: 'scr-home', viewport: 'desktop', stateName: 'Default',
+                variantId: 'default', screenContractHash: 'zzz', createdAt: '2026-01-01T00:00:00.000Z' },
+            generatedAt: 1,
+        });
+        const rec = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'default');
+        expect(rec?.coverageManifest?.overallStatus).toBe('aligned');
+        expect((rec?.sourceSignature as { screenContractHash?: string })?.screenContractHash).toBe('zzz');
     });
 });

--- a/src/store/mockupImageStore.ts
+++ b/src/store/mockupImageStore.ts
@@ -95,6 +95,10 @@ interface ImageStoreState {
         payload: MockupPayload;
         settings: MockupSettings;
         quality: MockupImageQuality;
+        /** Phase 3C: fired after a successful render is stored, so a caller can
+         * capture a coverage sidecar for the default variant without changing
+         * this legacy image path. Best-effort — thrown callbacks are swallowed. */
+        onGenerated?: (record: MockupImageRecord) => void;
     }) => Promise<void>;
 
     /** Cancel an in-flight generation. */
@@ -157,7 +161,7 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
         return out;
     },
 
-    generate: async ({ projectId, artifactId, versionId, screen, payload, settings, quality }) => {
+    generate: async ({ projectId, artifactId, versionId, screen, payload, settings, quality, onGenerated }) => {
         const scope = screenScope(versionId, screen.id);
         if (get().inFlight[scope]) return; // already generating something for this screen
 
@@ -198,6 +202,9 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
             // signed out). Image generation writes IndexedDB directly and never
             // touches the project store, so the bundle-push path wouldn't see it.
             notifyMockupImageGenerated(projectId, versionId);
+            // Phase 3C: let a caller capture a default-variant coverage sidecar.
+            // Best-effort — a callback failure must never break generation.
+            try { onGenerated?.(record); } catch { /* ignore */ }
         } catch (err) {
             const aborted = (err as { name?: string })?.name === 'AbortError' || abort.signal.aborted;
             const message = aborted

--- a/src/store/mockupVariantImageStore.ts
+++ b/src/store/mockupVariantImageStore.ts
@@ -13,8 +13,9 @@
 
 import { create } from 'zustand';
 import type {
-    MockupImageQuality, MockupVariantImageRecord,
+    MockupImageQuality, MockupVariantImageRecord, MockupVariantImageHistoryEntry,
 } from '../types';
+import type { MockupVariantSourceSignature } from '../lib/mockupVariantTrust';
 import { callOpenAIImage } from '../lib/openaiClient';
 import { pickImageSize } from '../lib/services/mockupImageService';
 import {
@@ -65,13 +66,44 @@ interface VariantImageStoreState {
         platform: MockupPlatform;
         request: MockupVariantGenerationRequest;
         quality: MockupImageQuality;
+        /** Phase 3C: source signature to store with this render (freshness). */
+        sourceSignature?: MockupVariantSourceSignature;
+        /** Phase 3C: version provenance for this render. */
+        generatedFrom?: MockupVariantImageRecord['generatedFrom'];
     }) => Promise<void>;
+
+    /** Write a metadata-only sidecar record (no owned image) for a variant —
+     * used to attach a coverage manifest + source signature to the legacy
+     * default variant without moving its image into this store. */
+    putSidecar: (record: MockupVariantImageRecord) => Promise<void>;
 
     cancel: (versionId: string, screenId: string, variantId: string) => void;
     clearError: (versionId: string, screenId: string, variantId: string) => void;
 }
 
 const QUALITY_RANK: Record<MockupImageQuality, number> = { low: 0, medium: 1, high: 2 };
+
+/** Max preserved prior renders kept per variant (local-only). */
+const HISTORY_CAP = 6;
+
+/** Build the history list for a regenerated variant: the previous successful
+ * record becomes the newest history entry, ahead of its own prior history,
+ * capped. Returns undefined when there is no prior record (first generation). */
+const buildRegenHistory = (
+    previous: MockupVariantImageRecord | undefined,
+): MockupVariantImageHistoryEntry[] | undefined => {
+    if (!previous) return undefined;
+    const entry: MockupVariantImageHistoryEntry = {
+        dataUrl: previous.dataUrl,
+        quality: previous.quality,
+        prompt: previous.prompt,
+        coverageManifest: previous.coverageManifest,
+        sourceSignature: previous.sourceSignature,
+        generatedAt: previous.generatedAt,
+        reason: 'regenerated',
+    };
+    return [entry, ...(previous.history ?? [])].slice(0, HISTORY_CAP);
+};
 
 export const useMockupVariantImageStore = create<VariantImageStoreState>((set, get) => ({
     images: {},
@@ -99,7 +131,15 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
         return best;
     },
 
-    generate: async ({ projectId, artifactId, versionId, platform, request, quality }) => {
+    putSidecar: async (record) => {
+        await idbPutVariantImage(record);
+        set((state) => ({ images: { ...state.images, [record.key]: record } }));
+    },
+
+    generate: async ({
+        projectId, artifactId, versionId, platform, request, quality,
+        sourceSignature, generatedFrom,
+    }) => {
         const scope = variantScope(versionId, request.screenId, request.variantId);
         if (get().inFlight[scope]) return; // one generation per variant at a time
 
@@ -121,9 +161,17 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
             : platform;
         const size = pickImageSize(sizePlatform);
 
+        // Capture the prior successful render (same key first, else best quality
+        // for this variant) BEFORE the network call so a successful regeneration
+        // can preserve it in history. A failed regen never reaches the write path
+        // below, so the existing record is untouched.
+        const key = buildVariantImageKey(versionId, request.screenId, request.variantId, quality);
+        const previous = get().images[key]
+            ?? get().getBestRecord(versionId, request.screenId, request.variantId);
+
         try {
             const b64 = await callOpenAIImage(prompt, { quality, size, signal: abort.signal });
-            const key = buildVariantImageKey(versionId, request.screenId, request.variantId, quality);
+            const history = buildRegenHistory(previous);
             const record: MockupVariantImageRecord = {
                 key,
                 projectId,
@@ -137,6 +185,9 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
                 quality,
                 prompt,
                 coverageManifest: manifest,
+                sourceSignature,
+                generatedFrom,
+                ...(history ? { history } : {}),
                 generatedAt: Date.now(),
             };
             await idbPutVariantImage(record);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1380,6 +1380,23 @@ export interface MockupCoverageManifest {
 // never overwrites another (e.g. Mobile · Default vs Desktop · Default). This
 // is intentionally independent of the legacy single-image MockupImageRecord
 // path, which keeps rendering the "Desktop · Default" variant untouched.
+// Phase 3C: a preserved prior render of a variant, kept when the variant is
+// regenerated so the previous image + its coverage/source metadata stay
+// viewable. Local-only (lives in the same dedicated IndexedDB store); never
+// destroyed by a later regeneration (history is append-only, capped).
+export type MockupVariantImageHistoryEntry = {
+    dataUrl: string;
+    quality: MockupImageQuality;
+    prompt?: string;
+    coverageManifest?: MockupCoverageManifest;
+    /** Phase 3C source signature captured when this render was generated
+     * (absent for pre-3C records). Untyped here to avoid a lib→types import
+     * cycle; the shape is MockupVariantSourceSignature (mockupVariantTrust.ts). */
+    sourceSignature?: unknown;
+    generatedAt: number;
+    reason?: 'regenerated' | 'replaced';
+};
+
 export type MockupVariantImageRecord = {
     key: string;              // `${versionId}:${screenId}:${variantId}:${quality}`
     projectId: string;
@@ -1393,6 +1410,21 @@ export type MockupVariantImageRecord = {
     quality: MockupImageQuality;
     prompt: string;           // prompt sent to gpt-image-2 (for traceability)
     coverageManifest?: MockupCoverageManifest;
+    // --- Phase 3C trust metadata (all optional / back-compat) ---
+    /** Deterministic snapshot of the screen/design/PRD inputs at generation
+     * time; drives freshness comparison. Untyped here to avoid a lib→types
+     * import cycle — the shape is MockupVariantSourceSignature. */
+    sourceSignature?: unknown;
+    /** Version context this variant was generated from (provenance line). */
+    generatedFrom?: {
+        prdVersionId?: string;
+        screenVersionId?: string;
+        designSystemVersionId?: string;
+    };
+    /** Previous successful renders of this variant, newest-first. Preserved on
+     * regeneration so earlier images stay viewable. Failed regenerations never
+     * append here. */
+    history?: MockupVariantImageHistoryEntry[];
     generatedAt: number;
 };
 


### PR DESCRIPTION
## Summary

Phase 3C makes generated mockup **variants trustworthy over time**, building on Phase 3A (variant review surface) and Phase 3B (single-variant generation). It adds staleness detection, variant history, metadata comparison, a default-variant coverage sidecar, and clear local-only storage messaging — all as **trust metadata**, not a storage rewrite. No broad schema migration; legacy records keep working.

## What changed

**Source signatures & freshness** (`src/lib/mockupVariantTrust.ts`, pure)
- A `MockupVariantSourceSignature` deterministically snapshots the inputs that materially affect a variant's image: a **screen-contract hash** (keyed off the same screen-spec fields `buildVariantGenerationRequest` uses — viewport + state + core UI regions + actions + acceptance criteria + risks; **excludes** overlay-only UI metadata so cosmetic edits don't trip false warnings), plus the design-system tokens hash and PRD/screen/design-system version ids.
- `buildVariantSourceSignature` is used at **both** storage and comparison so they can't drift.
- `compareVariantFreshness(stored, current)` → `current` / `possibly_stale` / `stale` / `unknown`. Hash mismatch → stale; version-id changed with no hash to confirm → possibly_stale; **no stored signature → unknown (legacy records are never falsely stale).**

**Store metadata + history** (`MockupVariantImageRecord`, `mockupVariantImageStore`)
- Records now carry optional `sourceSignature`, `generatedFrom`, and `history`.
- Regeneration preserves the previous successful render as the newest history entry (capped, newest-first). **A failed regeneration never appends history and never erases the current record.**
- Added `putSidecar` for metadata-only default records.

**Freshness / history / comparison UI** (`MockupVariantsPanel`, `MockupVariantImage`, screen views)
- Per-variant freshness badges (Current / Review freshness / Stale / Freshness unknown), a calm explanation, a metadata-only **Source comparison** section (never a visual diff), and a collapsible **variant history** section.
- Freshness threaded through `ArtifactWorkspace` → Screen views via a `VariantTrustContext`; a rollup feeds the coverage panel ("Mockup freshness: N current · N review · N unknown") and screen cards show a compact "Freshness: N to review" chip.

**Default variant coverage sidecar**
- On a **new** default (re)generation the panel captures a coverage-manifest + source-signature sidecar keyed `versionId:screenId:default:quality` via an optional `onGenerated` callback on the legacy image store/component. The **legacy default image path is unchanged and never moved**; old defaults with no sidecar stay coverage-unknown (no fabricated coverage).

**Local-only clarity & docs**
- Calm note in the Mockups tab and per-variant detail that generated variant images are saved on this device until snapshot/sync support lands.
- `CLAUDE.md` documents Phase 3C and records the snapshot/sync gap as **Phase 3D: Portable variant image snapshots / cross-device sync**.

## Backward compatibility
- All new fields are optional. Legacy variant/mockup records with no signature read as `unknown`, never stale.
- The legacy default `MockupScreenImage` path, demo/keyless gating, and existing variant generation are unchanged. No migration required.

## Tests
- Pure: `mockupVariantTrust.test.ts` (signature determinism, contract-hash sensitivity, freshness verdicts, rollup).
- Store: history preserved on regen, failure safety, per-variant grouping, sidecar persistence, signature storage.
- Component: freshness badges (current/stale/unknown), history section, local-only note, legacy default stays coverage-unknown.
- Full suite (1248 tests), `npm run lint`, and `npm run build` all pass.

## Known limitations / follow-up
- Variant images (and now default sidecars) remain local IndexedDB only — **Phase 3D** will make them portable in snapshots / cross-device sync. Deliberately not entangled with `snapshotClient` / `imageRefsStore` this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CckB88z78oQXvFxW17fZtD)_