### PR TITLE
Phase 3D: Portable mockup variant image snapshots + cross-device restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,18 +154,27 @@ id**) **and its user-uploaded Screen Inventory images** (from
 behind a `SYNAPSE_OWNER_TOKEN` gate. The bundle also carries the project's
 **implementation tasks** (`tasks` slice) and **orchestration metrics**
 (`workflowRuns` slice) — every *persisted* store slice for the project, so a
-restored snapshot is a faithful copy. Both image kinds split out of the JSON
+restored snapshot is a faithful copy. It also carries the project's
+**per-variant mockup images** (Phase 3D — the Screens Mockups-tab variant
+gallery, from the dedicated `src/lib/mockupVariantImageStore.ts` IDB store, keyed
+`versionId:screenId:variantId:quality`) as `SnapshotProjectBundle.mockupVariantImages`
+(a `MockupVariantImageSnapshot` — see `src/lib/mockupVariantSnapshot.ts` and the
+Phase 3D bullet under Screens). All three image kinds split out of the JSON
 envelope and ship one request each (reusing the **same** per-image blob channel
-— each blob is keyed by a hash of the image key, and the two key shapes never
-collide) so neither upload nor download crosses Vercel's ~4.5 MB cap. The wire
-format carries mockup images in `payload.images` and screen-inventory images in
-`payload.screenImages`. One snapshot can be pinned as **the demo** (`_demo.json`
-pointer + public `?demo=1` read); `loadDemoProject` restores it under the stable
-`DEMO_PROJECT_ID`. Snapshot fields (`tasks`/`workflowRuns`/`screenImages`) are
+— each blob is keyed by a hash of the image key, and the key shapes never
+collide: mockup `versionId:screenId:quality`, screen `artifactVersionId:screenSlug:versionNumber`,
+variant bytes under `vimg:`-prefixed keys) so neither upload nor download crosses
+Vercel's ~4.5 MB cap. The wire format carries mockup images in `payload.images`,
+screen-inventory images in `payload.screenImages`, and variant image metadata
+inside `payload.project.mockupVariantImages` (bytes via the `vimg:` channel).
+One snapshot can be pinned as **the demo** (`_demo.json` pointer + public
+`?demo=1` read); `loadDemoProject` restores it under the stable `DEMO_PROJECT_ID`.
+Snapshot fields (`tasks`/`workflowRuns`/`screenImages`/`mockupVariantImages`) are
 all **optional on the wire** — pre-existing snapshots lack them and restore
-defaults each to `[]`. When adding a new persisted slice or IDB image store,
-add it to `collectProjectBundle`/`collectScreenImages`, the restore writers, and
-`namespaceSnapshotForRestore`, or it silently won't travel in snapshots.
+defaults each to empty. When adding a new persisted slice or IDB image store,
+add it to `collectProjectBundle`/`collectScreenImages`/`collectVariantImages`, the
+restore writers, and `namespaceSnapshotForRestore`, or it silently won't travel
+in snapshots.
 
 - **Demo cache freshness — never short-circuit on a `DEMO_PROJECT_ID` cache hit
   alone.** Each restored demo project stores its source snapshot id in the
@@ -1659,9 +1668,11 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     "covered" without structured metadata. Generation is gated on an OpenAI key
     (`hasOpenAIKey`) + `gpt_image` image mode — demo / keyless users see a
     disabled action with a clear explanation, never a silent failure. The
-    per-variant store is **independent of snapshots & cross-device sync** (a
-    documented Phase 3D gap, mirroring the screen-inventory-image sync gap) — do
-    not entangle it with `snapshotClient` / `imageRefsStore`.
+    per-variant store's image BYTES stay in its own dedicated IndexedDB store
+    (never in `imageRefsStore` or the legacy mockup store); Phase 3D made the
+    RECORDS portable through owner snapshots (see the Phase 3D bullet) but the
+    variant store is still **not on the per-user `/api/projects` cross-device
+    sync path** — do not entangle it with `imageRefsStore`.
   - **Phase 3C variant trust — freshness, history, default sidecar
     (`src/lib/mockupVariantTrust.ts`, pure).** A generated variant is captured
     with a **`MockupVariantSourceSignature`** — a deterministic snapshot of the
@@ -1701,11 +1712,47 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     callers unaffected). **Old defaults with no sidecar stay coverage-unknown; no
     fabricated coverage, and the legacy default image is never moved into the
     variant store.**
-    **Local-only clarity:** the Mockups tab and per-variant detail state that
-    generated variant images are saved on this device only until snapshot/sync
-    lands. **Snapshot/sync of variant images remains a documented gap →
-    Phase 3D: Portable variant image snapshots / cross-device sync.** Do not
-    entangle the variant store with `snapshotClient` / `imageRefsStore`.
+    **Storage clarity (updated by Phase 3D):** the Mockups tab and per-variant
+    detail now state that generated variant images are saved on this device AND
+    included in project snapshots (restorable on another device from a saved
+    snapshot); they do not yet auto-sync across devices.
+  - **Phase 3D — portable variant image snapshots
+    (`src/lib/mockupVariantSnapshot.ts`, pure except the injected-IDB restore).**
+    Generated variant images, coverage manifests, source signatures,
+    `generatedFrom` provenance, and variant history now travel in owner
+    **snapshots** (and therefore the demo) — closing the Phase 3C local-only
+    gap. `buildMockupVariantImageSnapshot(records)` serializes the dedicated
+    variant IDB store into a **schema-versioned** (`schemaVersion: 1`),
+    size-guarded transport (`MockupVariantImageSnapshot`);
+    `validateMockupVariantImageSnapshot` / `estimateMockupVariantSnapshotSize`
+    are the pure guards. **Wire path reuses the existing per-image blob
+    channel** (NO server change — `api/snapshots.js` hashes any key and persists
+    `project` verbatim): `splitVariantSnapshotImages` moves image bytes out of
+    the JSON envelope under `vimg:`-prefixed keys (never collide with
+    mockup/screen keys) so nothing crosses Vercel's ~4.5 MB cap; the stripped
+    metadata rides INSIDE `SnapshotProjectBundle.mockupVariantImages`;
+    `joinVariantSnapshotImages` re-attaches bytes on load (a failed per-image
+    fetch drops just that image, never the restore, and factors into the demo's
+    `imagesComplete`). **Safety:** only `image/png|jpeg|webp` (never SVG);
+    per-image cap 8 MB, total cap 50 MB, history cap 10 — oversized/unsafe
+    records are skipped with calm warnings (surfaced in `SnapshotsPanel` after
+    save). **Restore is CONSERVATIVE merge, not a clobber**
+    (`restoreMockupVariantImageSnapshot` + pure `mergeVariantRecords`): per key —
+    no local → restore; duplicate → keep one; snapshot newer → snapshot current,
+    local folds to history; local newer → keep local, snapshot folds to history;
+    inconclusive → keep local, snapshot to history + warning; an imageless
+    incoming never replaces a successful local image; history dedupes by
+    (image, generatedAt) and is capped. A malformed variant section is skipped
+    without ever breaking the surrounding project restore. Restore updates the
+    reactive cache via the new `useMockupVariantImageStore.mergeRecords`.
+    **Non-default variants require a real safe image to restore** (they render
+    an `<img>`); only the `variantId === 'default'` **sidecar** is metadata-only
+    (no image — the legacy default image path is untouched, old defaults without
+    a sidecar stay coverage-unknown). Demo restore under `DEMO_PROJECT_ID`
+    namespaces variant records via `namespaceVariantSnapshot` (remap versionId +
+    rebuild the composite key + `generatedFrom`, idempotent), invoked from
+    `namespaceSnapshotForRestore`. Still **not** on the `/api/projects`
+    cross-device sync path — that remains the documented next step.
   `parseDecisionBranches` (arrow-form +
   if/otherwise) powers both the branch-aware Flow-tab rendering
   (`DecisionBranches`) and the `decision_missing_branches` gap — an

--- a/src/components/SnapshotsPanel.tsx
+++ b/src/components/SnapshotsPanel.tsx
@@ -38,6 +38,7 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
     const [busy, setBusy] = useState<string | null>(null);
     const [saveProgress, setSaveProgress] = useState<SnapshotProgress | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [notices, setNotices] = useState<string[]>([]);
     const [title, setTitle] = useState<string>(project?.name ?? 'Untitled');
 
     const refresh = async () => {
@@ -76,8 +77,14 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
         setBusy('saving');
         setSaveProgress(null);
         setError(null);
+        setNotices([]);
         try {
-            await saveSnapshot(projectId, title.trim() || 'Untitled', (p) => setSaveProgress(p));
+            await saveSnapshot(
+                projectId,
+                title.trim() || 'Untitled',
+                (p) => setSaveProgress(p),
+                (warnings) => setNotices(warnings),
+            );
             await refresh();
         } catch (err) {
             setError(err instanceof Error ? err.message : String(err));
@@ -330,6 +337,18 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
                     {error && (
                         <div className="mt-4 px-3 py-2 text-xs text-red-300 bg-red-500/10 border border-red-500/30 rounded">
                             {error}
+                        </div>
+                    )}
+                    {notices.length > 0 && (
+                        <div className="mt-4 px-3 py-2 text-xs text-amber-200 bg-amber-500/10 border border-amber-500/30 rounded">
+                            <div className="font-medium mb-1">Saved with a note</div>
+                            <ul className="list-disc list-inside space-y-0.5 text-amber-200/90">
+                                {notices.map((n, i) => <li key={i}>{n}</li>)}
+                            </ul>
+                            <p className="mt-1.5 text-amber-200/70">
+                                The screen specs and mockup metadata are still saved — only some
+                                variant images were left out.
+                            </p>
                         </div>
                     )}
                 </div>

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -414,9 +414,11 @@ describe('Phase 3C variant freshness & history UI', () => {
         useMockupVariantImageStore.setState({ images: {}, inFlight: {}, errors: {} });
     });
 
-    it('shows the local-only storage note in the Mockups tab', () => {
+    it('shows the snapshot-inclusion storage note in the Mockups tab', () => {
         const { getByText } = renderContractDetail('mockups');
-        expect(getByText(/saved on this device for now/)).toBeTruthy();
+        // Phase 3D: variant images now travel in project snapshots, so the copy
+        // states they can be restored on another device (no longer "local-only").
+        expect(getByText(/included in project snapshots/)).toBeTruthy();
     });
 
     it('a legacy default with no source metadata reads Freshness unknown', () => {

--- a/src/components/experience/MockupVariantsPanel.tsx
+++ b/src/components/experience/MockupVariantsPanel.tsx
@@ -165,10 +165,11 @@ export function MockupVariantsPanel({
                     Generated product screen previews mapped to this screen&rsquo;s states and viewports.
                 </p>
                 <p className="mt-1.5 text-[11px] text-neutral-500">{summaryParts.join(' · ')}</p>
-                <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-neutral-400">
-                    <Info size={10} className="shrink-0" aria-hidden />
-                    Generated variant images are saved on this device for now — they may not appear on
-                    another browser until snapshot/sync support is added.
+                <p className="mt-1 inline-flex items-start gap-1 text-[11px] text-neutral-400">
+                    <Info size={10} className="shrink-0 mt-px" aria-hidden />
+                    Generated variant images are included in project snapshots, so they travel with a
+                    saved snapshot and can be restored on another device. They don&rsquo;t yet sync
+                    automatically across devices.
                 </p>
             </div>
 
@@ -467,13 +468,14 @@ function VariantDetail({
                 />
             )}
 
-            {/* Storage clarity — per-variant images are local to this device
-                (the legacy default image itself still syncs, so its note is
-                omitted; only the genuinely local-only variant images carry it). */}
+            {/* Storage clarity — per-variant images are saved on this device and
+                now travel in project snapshots (the legacy default image path is
+                unchanged, so only the generated variant images carry this note). */}
             {variant.source === 'variant' && (
-                <p className="text-[11px] text-neutral-400 flex items-center gap-1">
-                    <Info size={10} className="shrink-0" aria-hidden />
-                    Storage: Local browser cache — saved on this device until snapshot/sync support is added.
+                <p className="text-[11px] text-neutral-400 flex items-start gap-1">
+                    <Info size={10} className="shrink-0 mt-px" aria-hidden />
+                    Storage: Saved on this device and included in project snapshots — restorable on
+                    another device from a saved snapshot.
                 </p>
             )}
 
@@ -635,7 +637,7 @@ function VariantHistory({
                         </div>
                     ))}
                     <p className="text-[11px] text-neutral-400">
-                        Previous renders are kept on this device only.
+                        Previous renders are kept on this device and included in project snapshots.
                     </p>
                 </div>
             )}

--- a/src/lib/__tests__/mockupVariantSnapshot.test.ts
+++ b/src/lib/__tests__/mockupVariantSnapshot.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect } from 'vitest';
+import type { MockupCoverageManifest, MockupVariantImageRecord } from '../../types';
+import {
+    buildMockupVariantImageSnapshot,
+    validateMockupVariantImageSnapshot,
+    estimateMockupVariantSnapshotSize,
+    splitVariantSnapshotImages,
+    joinVariantSnapshotImages,
+    collectVariantSnapshotImageRefs,
+    restoreMockupVariantImageSnapshot,
+    mergeVariantRecords,
+    namespaceVariantSnapshot,
+    parseImageDataUrl,
+    MAX_VARIANT_IMAGE_BYTES,
+    type MockupVariantImageSnapshot,
+} from '../mockupVariantSnapshot';
+
+// A valid, small base64 PNG data URL (bytes are arbitrary — only the header +
+// base64 shape matter to the safety checks).
+const PNG = 'data:image/png;base64,aGVsbG8td29ybGQ=';
+const PNG2 = 'data:image/png;base64,c2Vjb25kLXJlbmRlcg==';
+
+const manifest = (): MockupCoverageManifest => ({
+    variant: { viewport: 'mobile', stateName: 'Default' },
+    overallStatus: 'aligned',
+    estimated: true,
+    uiRegions: [{ label: 'Feed', status: 'covered' }],
+    states: [], userActions: [], acceptanceCriteria: [], warnings: [],
+});
+
+const makeRecord = (
+    overrides: Partial<MockupVariantImageRecord> = {},
+): MockupVariantImageRecord => ({
+    key: 'v1:scr-home:mobile:default:low',
+    projectId: 'p1',
+    artifactId: 'a1',
+    versionId: 'v1',
+    screenId: 'scr-home',
+    variantId: 'mobile:default',
+    viewport: 'mobile',
+    stateName: 'Default',
+    dataUrl: PNG,
+    quality: 'low',
+    prompt: 'prompt',
+    coverageManifest: manifest(),
+    sourceSignature: {
+        screenId: 'scr-home', viewport: 'mobile', stateName: 'Default',
+        variantId: 'mobile:default', screenContractHash: 'hash-a',
+        createdAt: '2026-01-01T00:00:00.000Z',
+    },
+    generatedFrom: { prdVersionId: 'prd-1', screenVersionId: 'inv-1', designSystemVersionId: 'ds-1' },
+    generatedAt: 1000,
+    ...overrides,
+});
+
+describe('buildMockupVariantImageSnapshot', () => {
+    it('serializes a variant with image, manifest, source signature, generatedFrom, and history', () => {
+        const rec = makeRecord({
+            history: [{
+                dataUrl: PNG2, quality: 'low', coverageManifest: manifest(),
+                generatedAt: 500, reason: 'regenerated',
+            }],
+        });
+        const snap = buildMockupVariantImageSnapshot([rec], { exportedAt: 'now', projectId: 'p1' });
+        expect(snap.schemaVersion).toBe(1);
+        expect(snap.projectId).toBe('p1');
+        expect(snap.records).toHaveLength(1);
+        const out = snap.records[0];
+        expect(out.imageDataUrl).toBe(PNG);
+        expect(out.manifest?.overallStatus).toBe('aligned');
+        expect(out.sourceSignature?.screenContractHash).toBe('hash-a');
+        expect(out.generatedFrom?.prdVersionId).toBe('prd-1');
+        expect(out.source).toBe('generated_variant');
+        expect(out.history).toHaveLength(1);
+        expect(out.history?.[0].imageDataUrl).toBe(PNG2);
+        expect(snap.summary.recordCount).toBe(1);
+        expect(snap.summary.historyEntryCount).toBe(1);
+    });
+
+    it('serializes a default sidecar as metadata-only (no image)', () => {
+        const sidecar = makeRecord({
+            key: 'v1:scr-home:default:low', variantId: 'default', viewport: 'desktop',
+            dataUrl: '', prompt: '',
+        });
+        const snap = buildMockupVariantImageSnapshot([sidecar], { exportedAt: 'now' });
+        expect(snap.records).toHaveLength(1);
+        expect(snap.records[0].source).toBe('default_sidecar');
+        expect(snap.records[0].imageDataUrl).toBeUndefined();
+        expect(snap.records[0].manifest?.overallStatus).toBe('aligned');
+    });
+
+    it('skips a non-default record that has no restorable image', () => {
+        const rec = makeRecord({ dataUrl: '' });
+        const snap = buildMockupVariantImageSnapshot([rec], { exportedAt: 'now' });
+        expect(snap.records).toHaveLength(0);
+        expect(snap.summary.skippedCount).toBe(1);
+    });
+
+    it('skips (with a warning) an oversized image and keeps the rest', () => {
+        const big = 'data:image/png;base64,' + 'A'.repeat(Math.ceil((MAX_VARIANT_IMAGE_BYTES + 10) * 4 / 3));
+        const oversized = makeRecord({ key: 'v1:scr-a:mobile:default:low', screenId: 'scr-a', dataUrl: big });
+        const ok = makeRecord({ key: 'v1:scr-b:mobile:default:low', screenId: 'scr-b' });
+        const snap = buildMockupVariantImageSnapshot([oversized, ok], { exportedAt: 'now' });
+        expect(snap.records).toHaveLength(1);
+        expect(snap.records[0].screenId).toBe('scr-b');
+        expect(snap.summary.skippedCount).toBe(1);
+        expect(snap.summary.warnings?.some(w => /too large/i.test(w))).toBe(true);
+    });
+
+    it('does not serialize a default sidecar that carries no useful metadata', () => {
+        const bare = makeRecord({
+            key: 'v1:scr-home:default:low', variantId: 'default', dataUrl: '', prompt: '',
+            coverageManifest: undefined, sourceSignature: undefined, generatedFrom: undefined,
+        });
+        const snap = buildMockupVariantImageSnapshot([bare], { exportedAt: 'now' });
+        expect(snap.records).toHaveLength(0);
+    });
+});
+
+describe('validateMockupVariantImageSnapshot', () => {
+    const good = (): MockupVariantImageSnapshot =>
+        buildMockupVariantImageSnapshot([makeRecord()], { exportedAt: 'now' });
+
+    it('accepts a current-schema snapshot', () => {
+        const res = validateMockupVariantImageSnapshot(good());
+        expect(res.valid).toBe(true);
+        expect(res.errors).toHaveLength(0);
+        expect(res.safeImageCount).toBe(1);
+    });
+
+    it('rejects an unsupported schema version', () => {
+        const res = validateMockupVariantImageSnapshot({ ...good(), schemaVersion: 99 });
+        expect(res.valid).toBe(false);
+        expect(res.errors.join(' ')).toMatch(/schema/i);
+    });
+
+    it('rejects an unsafe (SVG) image mime', () => {
+        const snap = good();
+        snap.records[0].imageDataUrl = 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=';
+        const res = validateMockupVariantImageSnapshot(snap);
+        expect(res.errors.some(e => /unsafe|malformed/i.test(e))).toBe(true);
+        expect(res.safeImageCount).toBe(0);
+    });
+
+    it('rejects a malformed data url', () => {
+        const snap = good();
+        snap.records[0].imageDataUrl = 'not-a-data-url';
+        const res = validateMockupVariantImageSnapshot(snap);
+        expect(res.errors.some(e => /unsafe|malformed/i.test(e))).toBe(true);
+    });
+
+    it('rejects a non-object input', () => {
+        expect(validateMockupVariantImageSnapshot(null).valid).toBe(false);
+        expect(validateMockupVariantImageSnapshot('nope').valid).toBe(false);
+    });
+});
+
+describe('parseImageDataUrl + estimate', () => {
+    it('parses a safe png and estimates byte length', () => {
+        const parsed = parseImageDataUrl(PNG);
+        expect(parsed?.mime).toBe('image/png');
+        expect(parsed?.approxBytes).toBeGreaterThan(0);
+    });
+
+    it('rejects svg and non-data strings', () => {
+        expect(parseImageDataUrl('data:image/svg+xml;base64,PHN2Zz4=')).toBeNull();
+        expect(parseImageDataUrl('http://x/y.png')).toBeNull();
+    });
+
+    it('estimates snapshot size from image + history bytes', () => {
+        const snap = buildMockupVariantImageSnapshot([
+            makeRecord({ history: [{ dataUrl: PNG2, quality: 'low', generatedAt: 1 }] }),
+        ], { exportedAt: 'now' });
+        expect(estimateMockupVariantSnapshotSize(snap)).toBeGreaterThan(0);
+    });
+});
+
+describe('split / join wire transport', () => {
+    it('strips image bytes out and re-attaches them by ref key', () => {
+        const snap = buildMockupVariantImageSnapshot([
+            makeRecord({ history: [{ dataUrl: PNG2, quality: 'low', generatedAt: 1 }] }),
+        ], { exportedAt: 'now' });
+        const { snapshot: wire, images } = splitVariantSnapshotImages(snap);
+        expect(wire.records[0].imageDataUrl).toBeUndefined();
+        expect(wire.records[0].imageRef).toBe('vimg:v1:scr-home:mobile:default:low');
+        expect(wire.records[0].history?.[0].imageDataUrl).toBeUndefined();
+        expect(images).toHaveLength(2); // current + one history
+
+        const refs = collectVariantSnapshotImageRefs(wire);
+        expect(refs).toHaveLength(2);
+
+        const byKey = new Map(images.map(i => [i.key, i.dataUrl]));
+        const joined = joinVariantSnapshotImages(wire, byKey);
+        expect(joined.records[0].imageDataUrl).toBe(PNG);
+        expect(joined.records[0].imageRef).toBeUndefined();
+        expect(joined.records[0].history?.[0].imageDataUrl).toBe(PNG2);
+    });
+
+    it('drops an image whose ref is missing (failed fetch) without breaking the record', () => {
+        const snap = buildMockupVariantImageSnapshot([makeRecord()], { exportedAt: 'now' });
+        const { snapshot: wire } = splitVariantSnapshotImages(snap);
+        const joined = joinVariantSnapshotImages(wire, new Map()); // nothing fetched
+        expect(joined.records[0].imageDataUrl).toBeUndefined();
+        expect(joined.records[0].imageRef).toBeUndefined();
+    });
+});
+
+describe('mergeVariantRecords', () => {
+    it('restores when there is no local record', () => {
+        const out = mergeVariantRecords(undefined, makeRecord());
+        expect(out.action).toBe('restored');
+        expect(out.record?.key).toBe('v1:scr-home:mobile:default:low');
+    });
+
+    it('treats an identical record as a duplicate (no write)', () => {
+        const rec = makeRecord();
+        const out = mergeVariantRecords(rec, { ...rec });
+        expect(out.action).toBe('duplicate');
+        expect(out.record).toBeUndefined();
+    });
+
+    it('snapshot newer -> snapshot wins, local folds to history', () => {
+        const local = makeRecord({ dataUrl: PNG, generatedAt: 100 });
+        const incoming = makeRecord({ dataUrl: PNG2, generatedAt: 200 });
+        const out = mergeVariantRecords(local, incoming);
+        expect(out.action).toBe('updated');
+        expect(out.record?.dataUrl).toBe(PNG2);
+        expect(out.record?.history?.[0].dataUrl).toBe(PNG);
+    });
+
+    it('local newer -> local kept, snapshot folds to history', () => {
+        const local = makeRecord({ dataUrl: PNG2, generatedAt: 300 });
+        const incoming = makeRecord({ dataUrl: PNG, generatedAt: 100 });
+        const out = mergeVariantRecords(local, incoming);
+        expect(out.action).toBe('kept_local');
+        expect(out.record?.dataUrl).toBe(PNG2);
+        expect(out.record?.history?.some(h => h.dataUrl === PNG)).toBe(true);
+    });
+
+    it('inconclusive timestamps -> keep local, add snapshot to history + warn', () => {
+        const local = makeRecord({ dataUrl: PNG2, generatedAt: 100 });
+        const incoming = makeRecord({ dataUrl: PNG, generatedAt: 100 });
+        const out = mergeVariantRecords(local, incoming);
+        expect(out.action).toBe('kept_local');
+        expect(out.warning).toBeTruthy();
+        expect(out.record?.history?.some(h => h.dataUrl === PNG)).toBe(true);
+    });
+
+    it('an imageless incoming never replaces a successful local image', () => {
+        const local = makeRecord({ dataUrl: PNG, generatedAt: 100 });
+        const incoming = makeRecord({ dataUrl: '', generatedAt: 999 });
+        const out = mergeVariantRecords(local, incoming);
+        expect(out.action).toBe('skipped');
+    });
+
+    it('does not duplicate identical history entries when merging', () => {
+        const shared = { dataUrl: PNG2, quality: 'low' as const, generatedAt: 50 };
+        const local = makeRecord({ dataUrl: PNG, generatedAt: 300, history: [shared] });
+        const incoming = makeRecord({ dataUrl: PNG, generatedAt: 100, history: [shared] });
+        const out = mergeVariantRecords(local, incoming);
+        const count = (out.record?.history ?? []).filter(h => h.dataUrl === PNG2).length;
+        expect(count).toBe(1);
+    });
+});
+
+describe('restoreMockupVariantImageSnapshot', () => {
+    // A tiny in-memory IDB fake keyed by record.key.
+    const makeFakeIdb = (seed: MockupVariantImageRecord[] = []) => {
+        const db = new Map<string, MockupVariantImageRecord>();
+        for (const r of seed) db.set(r.key, r);
+        return {
+            db,
+            listExisting: async (versionId: string) =>
+                [...db.values()].filter(r => r.versionId === versionId),
+            put: async (r: MockupVariantImageRecord) => { db.set(r.key, r); },
+        };
+    };
+
+    it('restores into an empty store', async () => {
+        const snap = buildMockupVariantImageSnapshot([makeRecord()], { exportedAt: 'now' });
+        const idb = makeFakeIdb();
+        const notified: MockupVariantImageRecord[] = [];
+        const res = await restoreMockupVariantImageSnapshot(snap, {
+            listExisting: idb.listExisting, put: idb.put, notify: (r) => notified.push(...r),
+        });
+        expect(res.restored).toBe(1);
+        expect(idb.db.get('v1:scr-home:mobile:default:low')?.dataUrl).toBe(PNG);
+        expect(notified).toHaveLength(1);
+    });
+
+    it('same key + newer snapshot makes the snapshot current', async () => {
+        const local = makeRecord({ dataUrl: PNG, generatedAt: 100 });
+        const idb = makeFakeIdb([local]);
+        const snap = buildMockupVariantImageSnapshot(
+            [makeRecord({ dataUrl: PNG2, generatedAt: 200 })], { exportedAt: 'now' });
+        const res = await restoreMockupVariantImageSnapshot(snap, {
+            listExisting: idb.listExisting, put: idb.put,
+        });
+        expect(res.updated).toBe(1);
+        expect(idb.db.get(local.key)?.dataUrl).toBe(PNG2);
+    });
+
+    it('same key + newer local keeps the local record current', async () => {
+        const local = makeRecord({ dataUrl: PNG2, generatedAt: 300 });
+        const idb = makeFakeIdb([local]);
+        const snap = buildMockupVariantImageSnapshot(
+            [makeRecord({ dataUrl: PNG, generatedAt: 100 })], { exportedAt: 'now' });
+        const res = await restoreMockupVariantImageSnapshot(snap, {
+            listExisting: idb.listExisting, put: idb.put,
+        });
+        expect(res.keptLocal).toBe(1);
+        expect(idb.db.get(local.key)?.dataUrl).toBe(PNG2);
+        expect(idb.db.get(local.key)?.history?.some(h => h.dataUrl === PNG)).toBe(true);
+    });
+
+    it('skips a non-default record with no safe image without crashing', async () => {
+        const bad: MockupVariantImageSnapshot = {
+            schemaVersion: 1, exportedAt: 'now',
+            records: [{
+                key: 'v1:scr-x:mobile:default:low', versionId: 'v1', screenId: 'scr-x',
+                variantId: 'mobile:default', quality: 'low',
+                imageDataUrl: 'data:image/svg+xml;base64,PHN2Zz4=',
+            }],
+            summary: { recordCount: 1, historyEntryCount: 0, totalApproxBytes: 0 },
+        };
+        const idb = makeFakeIdb();
+        const res = await restoreMockupVariantImageSnapshot(bad, {
+            listExisting: idb.listExisting, put: idb.put,
+        });
+        expect(res.skipped).toBe(1);
+        expect(idb.db.size).toBe(0);
+    });
+
+    it('returns an empty result (no throw) for a malformed section', async () => {
+        const idb = makeFakeIdb();
+        const res = await restoreMockupVariantImageSnapshot(
+            { schemaVersion: 5 } as unknown as MockupVariantImageSnapshot,
+            { listExisting: idb.listExisting, put: idb.put },
+        );
+        expect(res.restored).toBe(0);
+        expect(res.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('restores a default sidecar without an image (metadata only)', async () => {
+        const sidecar = makeRecord({
+            key: 'v1:scr-home:default:low', variantId: 'default', dataUrl: '', prompt: '',
+        });
+        const snap = buildMockupVariantImageSnapshot([sidecar], { exportedAt: 'now' });
+        const idb = makeFakeIdb();
+        await restoreMockupVariantImageSnapshot(snap, {
+            listExisting: idb.listExisting, put: idb.put,
+        });
+        const restored = idb.db.get('v1:scr-home:default:low');
+        expect(restored?.dataUrl).toBe('');
+        expect(restored?.coverageManifest?.overallStatus).toBe('aligned');
+    });
+});
+
+describe('full wire round-trip (build -> split -> upload/fetch -> join -> restore)', () => {
+    it('reconstructs the current image, manifest, and history on a fresh device', async () => {
+        const rec = makeRecord({
+            history: [{ dataUrl: PNG2, quality: 'low', coverageManifest: manifest(), generatedAt: 500 }],
+        });
+        // 1. Build the portable snapshot and split image bytes out (what save does).
+        const snap = buildMockupVariantImageSnapshot([rec], { exportedAt: 'now' });
+        const { snapshot: wire, images } = splitVariantSnapshotImages(snap);
+
+        // 2. Simulate the server blob channel: bytes keyed by ref key.
+        const blobStore = new Map(images.map(i => [i.key, i.dataUrl]));
+
+        // 3. On load, fetch each ref and re-attach (what the loaders do).
+        const refs = collectVariantSnapshotImageRefs(wire);
+        const fetched = new Map(refs.map(k => [k, blobStore.get(k)!]));
+        const joined = joinVariantSnapshotImages(wire, fetched);
+
+        // 4. Restore into a fresh (empty) device store.
+        const db = new Map<string, MockupVariantImageRecord>();
+        const res = await restoreMockupVariantImageSnapshot(joined, {
+            listExisting: async (v) => [...db.values()].filter(r => r.versionId === v),
+            put: async (r) => { db.set(r.key, r); },
+        });
+
+        expect(res.restored).toBe(1);
+        const restored = db.get('v1:scr-home:mobile:default:low');
+        expect(restored?.dataUrl).toBe(PNG);
+        expect(restored?.coverageManifest?.overallStatus).toBe('aligned');
+        expect(restored?.sourceSignature).toBeTruthy();
+        expect(restored?.history?.[0].dataUrl).toBe(PNG2);
+    });
+});
+
+describe('namespaceVariantSnapshot', () => {
+    it('remaps versionId + rebuilds the composite key under the target project', () => {
+        const snap = buildMockupVariantImageSnapshot([makeRecord()], { exportedAt: 'now' });
+        const idMap = new Map([['v1', 'demo:v1']]);
+        const out = namespaceVariantSnapshot(snap, idMap, 'demo');
+        expect(out.records[0].versionId).toBe('demo:v1');
+        expect(out.records[0].key).toBe('demo:v1:scr-home:mobile:default:low');
+        expect(out.records[0].projectId).toBe('demo');
+    });
+
+    it('is idempotent when the id map is empty', () => {
+        const snap = buildMockupVariantImageSnapshot([makeRecord()], { exportedAt: 'now' });
+        const out = namespaceVariantSnapshot(snap, new Map(), 'demo');
+        expect(out.records[0].key).toBe(snap.records[0].key);
+    });
+});

--- a/src/lib/__tests__/snapshotClient.test.ts
+++ b/src/lib/__tests__/snapshotClient.test.ts
@@ -139,6 +139,39 @@ describe('namespaceSnapshotForRestore — screen images, tasks, metrics', () => 
         expect(bundle.tasks?.[0].projectId).toBe(DEMO_PROJECT_ID);
         expect(bundle.workflowRuns?.[0].projectId).toBe(DEMO_PROJECT_ID);
     });
+
+    it('namespaces bundled mockup variant images by versionId and rebuilds the key', () => {
+        const snap = makeSnapshot();
+        const withVariants: SnapshotPayload = {
+            ...snap,
+            project: {
+                ...snap.project,
+                mockupVariantImages: {
+                    schemaVersion: 1,
+                    projectId: SOURCE_PROJECT_ID,
+                    exportedAt: 'now',
+                    records: [{
+                        key: `${VERSION_ID}:scr-home:mobile:default:low`,
+                        versionId: VERSION_ID,
+                        screenId: 'scr-home',
+                        variantId: 'mobile:default',
+                        quality: 'low',
+                        projectId: SOURCE_PROJECT_ID,
+                        imageDataUrl: 'data:image/png;base64,aGk=',
+                        source: 'generated_variant',
+                        generatedAt: 1,
+                    }],
+                    summary: { recordCount: 1, historyEntryCount: 0, totalApproxBytes: 0 },
+                },
+            } as unknown as SnapshotPayload['project'],
+        };
+        const { bundle } = namespaceSnapshotForRestore(withVariants, DEMO_PROJECT_ID);
+        const namespacedVersionId = `${DEMO_PROJECT_ID}:${VERSION_ID}`;
+        const rec = bundle.mockupVariantImages?.records[0];
+        expect(rec?.versionId).toBe(namespacedVersionId);
+        expect(rec?.key).toBe(`${namespacedVersionId}:scr-home:mobile:default:low`);
+        expect(rec?.projectId).toBe(DEMO_PROJECT_ID);
+    });
 });
 
 // --- loadDemoSnapshotPublic image hydration -------------------------------

--- a/src/lib/mockupVariantSnapshot.ts
+++ b/src/lib/mockupVariantSnapshot.ts
@@ -1,0 +1,842 @@
+// Phase 3D: portable snapshot / restore layer for per-variant mockup images.
+//
+// Phase 3B/3C stored generated variant images, coverage manifests, source
+// signatures, and variant history ONLY in a device-local IndexedDB store
+// (src/lib/mockupVariantImageStore.ts). They did not travel in project
+// snapshots and could not be recovered on another device. This module makes
+// those records PORTABLE:
+//
+//   - `buildMockupVariantImageSnapshot` serializes the local store records into
+//     a schema-versioned, size-guarded transport format.
+//   - `validateMockupVariantImageSnapshot` / `estimateMockupVariantSnapshotSize`
+//     are pure guards used before writing or restoring.
+//   - `restoreMockupVariantImageSnapshot` hydrates a snapshot back into the
+//     variant store (IndexedDB + the reactive cache) with CONSERVATIVE merge
+//     semantics — it never blindly overwrites newer local work.
+//   - `splitVariantSnapshotImages` / `joinVariantSnapshotImages` move the image
+//     BYTES out of the JSON envelope so the wire path reuses the existing
+//     per-image blob channel in snapshotClient (dodging Vercel's ~4.5 MB cap),
+//     exactly like mockup + screen-inventory images already do.
+//
+// Everything here is PURE except `restoreMockupVariantImageSnapshot`, which
+// takes its IndexedDB accessors injected so it stays unit-testable without a
+// real IDB. Honesty rules from the rest of the Screens layer carry over: a
+// legacy record with no image/metadata is never fabricated, and only safe
+// raster image payloads (png/jpeg/webp — never SVG) travel.
+
+import type {
+    MockupCoverageManifest, MockupImageQuality, MockupVariantImageRecord,
+    MockupVariantImageHistoryEntry,
+} from '../types';
+import type { MockupVariantSourceSignature } from './mockupVariantTrust';
+import { buildVariantImageKey } from './mockupVariantImageStore';
+
+// --- Constants ---------------------------------------------------------------
+
+export const MOCKUP_VARIANT_SNAPSHOT_SCHEMA_VERSION = 1 as const;
+
+/** Per-image ceiling. A gpt-image-2 PNG is normally 0.2–2 MB; 8 MB is a
+ * generous cap that only skips pathological payloads. */
+export const MAX_VARIANT_IMAGE_BYTES = 8 * 1024 * 1024;
+/** Whole-section ceiling so one project can't produce a 500 MB snapshot. */
+export const MAX_VARIANT_SNAPSHOT_TOTAL_BYTES = 50 * 1024 * 1024;
+/** History entries preserved per variant in a snapshot (store cap is 6). */
+export const MAX_VARIANT_SNAPSHOT_HISTORY = 10;
+
+/** Only safe raster image types travel — never SVG (script-bearing) or other. */
+export const SAFE_VARIANT_IMAGE_MIME: readonly string[] = [
+    'image/png', 'image/jpeg', 'image/webp',
+];
+
+const VALID_QUALITIES: readonly MockupImageQuality[] = ['low', 'medium', 'high'];
+const VALID_VIEWPORTS: readonly string[] = ['desktop', 'mobile', 'tablet'];
+
+// --- Transport types ---------------------------------------------------------
+
+export type MockupVariantSnapshotSource =
+    | 'generated_variant'
+    | 'default_sidecar'
+    | 'legacy_sidecar';
+
+export interface MockupVariantImageSnapshotHistoryEntry {
+    imageDataUrl?: string;
+    imageMimeType?: string;
+    imageByteLength?: number;
+    quality?: MockupImageQuality;
+    prompt?: string;
+    manifest?: MockupCoverageManifest;
+    sourceSignature?: MockupVariantSourceSignature;
+    generatedAt?: number;
+    reason?: 'regenerated' | 'replaced';
+    /** Wire-only: key the image blob was shipped under (set by
+     * `splitVariantSnapshotImages`, cleared by `joinVariantSnapshotImages`). */
+    imageRef?: string;
+}
+
+export interface MockupVariantImageSnapshotRecord {
+    key: string;
+    versionId: string;
+    screenId: string;
+    variantId: string;
+    quality: MockupImageQuality;
+    projectId?: string;
+    artifactId?: string;
+    viewport?: 'desktop' | 'mobile' | 'tablet';
+    stateName?: string;
+    imageDataUrl?: string;
+    imageMimeType?: string;
+    imageByteLength?: number;
+    prompt?: string;
+    manifest?: MockupCoverageManifest;
+    sourceSignature?: MockupVariantSourceSignature;
+    generatedFrom?: {
+        prdVersionId?: string;
+        screenVersionId?: string;
+        designSystemVersionId?: string;
+    };
+    generatedAt?: number;
+    history?: MockupVariantImageSnapshotHistoryEntry[];
+    source?: MockupVariantSnapshotSource;
+    /** Wire-only: key the current image blob was shipped under. */
+    imageRef?: string;
+}
+
+export interface MockupVariantImageSnapshotSummary {
+    recordCount: number;
+    historyEntryCount: number;
+    totalApproxBytes: number;
+    skippedCount?: number;
+    warnings?: string[];
+}
+
+export interface MockupVariantImageSnapshot {
+    schemaVersion: 1;
+    projectId?: string;
+    exportedAt: string;
+    records: MockupVariantImageSnapshotRecord[];
+    summary: MockupVariantImageSnapshotSummary;
+}
+
+// --- Image data-url safety ---------------------------------------------------
+
+export interface ParsedImageDataUrl {
+    mime: string;
+    base64: string;
+    approxBytes: number;
+}
+
+/** Parse + validate a base64 image data URL. Returns null for anything that is
+ * not a well-formed `data:<safe-mime>;base64,<payload>` string. Rejects SVG and
+ * every non-raster / non-safe MIME. */
+export function parseImageDataUrl(dataUrl: unknown): ParsedImageDataUrl | null {
+    if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:')) return null;
+    const comma = dataUrl.indexOf(',');
+    if (comma < 0) return null;
+    const header = dataUrl.slice(5, comma); // between "data:" and ","
+    const base64 = dataUrl.slice(comma + 1);
+    if (!header.includes(';base64')) return null;
+    const mime = header.slice(0, header.indexOf(';')).trim().toLowerCase();
+    if (!SAFE_VARIANT_IMAGE_MIME.includes(mime)) return null;
+    if (base64.length === 0) return null;
+    // Decoded byte length ≈ 3/4 of the base64 length, minus padding.
+    const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+    const approxBytes = Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+    return { mime, base64, approxBytes };
+}
+
+export const isSafeVariantImageDataUrl = (dataUrl: unknown): boolean =>
+    parseImageDataUrl(dataUrl) !== null;
+
+// --- Build (store records -> portable snapshot) ------------------------------
+
+export interface BuildVariantSnapshotOptions {
+    projectId?: string;
+    /** ISO timestamp; defaults to now. Injectable for deterministic tests. */
+    exportedAt?: string;
+    maxImageBytes?: number;
+    maxTotalBytes?: number;
+    maxHistory?: number;
+}
+
+const classifySource = (record: MockupVariantImageRecord): MockupVariantSnapshotSource =>
+    record.variantId === 'default' ? 'default_sidecar' : 'generated_variant';
+
+const hasUsefulMetadata = (record: MockupVariantImageRecord): boolean =>
+    Boolean(record.coverageManifest || record.sourceSignature || record.generatedFrom);
+
+/**
+ * Serialize the local variant image records into a portable, size-guarded
+ * snapshot. Records are processed in the given order so the size caps are
+ * deterministic. Rules:
+ *   - `variantId === 'default'` → a metadata-only sidecar (no image bytes; the
+ *     legacy default image lives elsewhere and is never moved here).
+ *   - a non-default record with a SAFE, in-size image → a full generated variant
+ *     (with size-guarded history).
+ *   - a non-default record with no safe/in-size image → SKIPPED (a warning is
+ *     recorded) — never serialized as a fake image-bearing record, because on
+ *     restore a non-default variant record must carry a real image to render.
+ */
+export function buildMockupVariantImageSnapshot(
+    records: readonly MockupVariantImageRecord[],
+    options: BuildVariantSnapshotOptions = {},
+): MockupVariantImageSnapshot {
+    const maxImageBytes = options.maxImageBytes ?? MAX_VARIANT_IMAGE_BYTES;
+    const maxTotalBytes = options.maxTotalBytes ?? MAX_VARIANT_SNAPSHOT_TOTAL_BYTES;
+    const maxHistory = options.maxHistory ?? MAX_VARIANT_SNAPSHOT_HISTORY;
+
+    const out: MockupVariantImageSnapshotRecord[] = [];
+    const warnings: string[] = [];
+    let skippedCount = 0;
+    let historyEntryCount = 0;
+    let totalApproxBytes = 0;
+
+    const label = (r: MockupVariantImageRecord) =>
+        `${r.stateName || r.variantId} (${r.viewport}) on ${r.screenId}`;
+
+    for (const record of records) {
+        const source = classifySource(record);
+
+        // Base metadata carried by every serialized record.
+        const base: MockupVariantImageSnapshotRecord = {
+            key: record.key,
+            versionId: record.versionId,
+            screenId: record.screenId,
+            variantId: record.variantId,
+            quality: record.quality,
+            projectId: record.projectId,
+            artifactId: record.artifactId,
+            viewport: record.viewport,
+            stateName: record.stateName,
+            prompt: record.prompt || undefined,
+            manifest: record.coverageManifest,
+            sourceSignature: record.sourceSignature as MockupVariantSourceSignature | undefined,
+            generatedFrom: record.generatedFrom,
+            generatedAt: record.generatedAt,
+            source,
+        };
+
+        if (source === 'default_sidecar') {
+            // Metadata-only. Include only if it actually carries coverage /
+            // freshness metadata worth restoring.
+            if (!hasUsefulMetadata(record)) {
+                skippedCount += 1;
+                continue;
+            }
+            out.push(base);
+            continue;
+        }
+
+        // Non-default variant: needs a safe, in-size image to be portable.
+        const parsed = parseImageDataUrl(record.dataUrl);
+        if (!parsed) {
+            skippedCount += 1;
+            if (hasUsefulMetadata(record)) {
+                warnings.push(`Skipped a mockup variant with no restorable image: ${label(record)}.`);
+            }
+            continue;
+        }
+        if (parsed.approxBytes > maxImageBytes) {
+            skippedCount += 1;
+            warnings.push(`A mockup variant image was too large to include: ${label(record)}.`);
+            continue;
+        }
+        if (totalApproxBytes + parsed.approxBytes > maxTotalBytes) {
+            skippedCount += 1;
+            warnings.push(`Reached the snapshot size limit; some mockup variant images were left out (starting with ${label(record)}).`);
+            continue;
+        }
+
+        totalApproxBytes += parsed.approxBytes;
+
+        // History — size-guard each entry; drop (with a warning) any that are
+        // too large / unsafe. History is non-critical, so a dropped entry never
+        // skips the record itself.
+        const historyOut: MockupVariantImageSnapshotHistoryEntry[] = [];
+        for (const entry of (record.history ?? []).slice(0, maxHistory)) {
+            const hp = parseImageDataUrl(entry.dataUrl);
+            if (!hp) continue;
+            if (hp.approxBytes > maxImageBytes
+                || totalApproxBytes + hp.approxBytes > maxTotalBytes) {
+                warnings.push(`A previous render of ${label(record)} was too large to include in history.`);
+                continue;
+            }
+            totalApproxBytes += hp.approxBytes;
+            historyEntryCount += 1;
+            historyOut.push({
+                imageDataUrl: entry.dataUrl,
+                imageMimeType: hp.mime,
+                imageByteLength: hp.approxBytes,
+                quality: entry.quality,
+                prompt: entry.prompt,
+                manifest: entry.coverageManifest,
+                sourceSignature: entry.sourceSignature as MockupVariantSourceSignature | undefined,
+                generatedAt: entry.generatedAt,
+                reason: entry.reason,
+            });
+        }
+
+        out.push({
+            ...base,
+            imageDataUrl: record.dataUrl,
+            imageMimeType: parsed.mime,
+            imageByteLength: parsed.approxBytes,
+            ...(historyOut.length ? { history: historyOut } : {}),
+        });
+    }
+
+    return {
+        schemaVersion: MOCKUP_VARIANT_SNAPSHOT_SCHEMA_VERSION,
+        projectId: options.projectId,
+        exportedAt: options.exportedAt ?? new Date().toISOString(),
+        records: out,
+        summary: {
+            recordCount: out.length,
+            historyEntryCount,
+            totalApproxBytes,
+            ...(skippedCount ? { skippedCount } : {}),
+            ...(warnings.length ? { warnings } : {}),
+        },
+    };
+}
+
+// --- Validation --------------------------------------------------------------
+
+export interface VariantSnapshotValidationResult {
+    /** Envelope is a usable snapshot object (schema + records array). Per-record
+     * image-safety problems do NOT flip this — they are reported in `errors`
+     * and skipped at restore, so one bad image never blocks the whole section. */
+    valid: boolean;
+    errors: string[];
+    warnings: string[];
+    recordCount: number;
+    /** Records whose current image is a safe, in-size raster payload. */
+    safeImageCount: number;
+}
+
+/** Validate a value claiming to be a MockupVariantImageSnapshot. Envelope-level
+ * problems (not an object, unsupported schema, records not an array) make the
+ * result `invalid`. Individual records with unsafe/malformed images are flagged
+ * in `errors` for visibility but leave the envelope usable — restore skips them
+ * individually rather than failing wholesale. */
+export function validateMockupVariantImageSnapshot(
+    input: unknown,
+): VariantSnapshotValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    if (!input || typeof input !== 'object') {
+        return { valid: false, errors: ['Not a snapshot object.'], warnings, recordCount: 0, safeImageCount: 0 };
+    }
+    const snap = input as Partial<MockupVariantImageSnapshot>;
+    if (snap.schemaVersion !== MOCKUP_VARIANT_SNAPSHOT_SCHEMA_VERSION) {
+        return {
+            valid: false,
+            errors: [`Unsupported variant snapshot schema version: ${String(snap.schemaVersion)}.`],
+            warnings,
+            recordCount: 0,
+            safeImageCount: 0,
+        };
+    }
+    if (!Array.isArray(snap.records)) {
+        return { valid: false, errors: ['Snapshot has no records array.'], warnings, recordCount: 0, safeImageCount: 0 };
+    }
+
+    let safeImageCount = 0;
+    for (let i = 0; i < snap.records.length; i++) {
+        const r = snap.records[i] as Partial<MockupVariantImageSnapshotRecord> | null;
+        if (!r || typeof r !== 'object') {
+            errors.push(`Record ${i} is malformed.`);
+            continue;
+        }
+        if (typeof r.key !== 'string' || typeof r.versionId !== 'string'
+            || typeof r.screenId !== 'string' || typeof r.variantId !== 'string') {
+            errors.push(`Record ${i} is missing required identity fields.`);
+            continue;
+        }
+        if (r.quality !== undefined && !VALID_QUALITIES.includes(r.quality)) {
+            warnings.push(`Record ${r.key} has an unexpected quality; defaulting to "low".`);
+        }
+        if (r.viewport !== undefined && !VALID_VIEWPORTS.includes(r.viewport)) {
+            warnings.push(`Record ${r.key} has an unexpected viewport.`);
+        }
+        if (r.imageDataUrl !== undefined) {
+            if (isSafeVariantImageDataUrl(r.imageDataUrl)) {
+                safeImageCount += 1;
+            } else {
+                errors.push(`Record ${r.key} has an unsafe or malformed image payload; it will be skipped.`);
+            }
+        }
+    }
+
+    return { valid: true, errors, warnings, recordCount: snap.records.length, safeImageCount };
+}
+
+// --- Size estimation ---------------------------------------------------------
+
+/** Approximate the serialized byte cost of a snapshot: the decoded image bytes
+ * (the dominant term) plus a rough allowance for the JSON metadata. */
+export function estimateMockupVariantSnapshotSize(
+    snapshot: MockupVariantImageSnapshot,
+): number {
+    let bytes = 0;
+    for (const r of snapshot.records ?? []) {
+        bytes += r.imageByteLength ?? parseImageDataUrl(r.imageDataUrl)?.approxBytes ?? 0;
+        for (const h of r.history ?? []) {
+            bytes += h.imageByteLength ?? parseImageDataUrl(h.imageDataUrl)?.approxBytes ?? 0;
+        }
+    }
+    // Metadata overhead: manifests + signatures are small; a flat per-record
+    // allowance keeps the estimate an honest upper-ish bound without stringifying
+    // megabytes of base64.
+    const metadataOverhead = (snapshot.records?.length ?? 0) * 2048;
+    return bytes + metadataOverhead;
+}
+
+// --- Wire split / join (image bytes out of the JSON envelope) ----------------
+
+export interface SplitVariantSnapshot {
+    /** Snapshot with every `imageDataUrl` removed and replaced by an `imageRef`
+     * key; safe to embed in the (size-limited) bundle POST. */
+    snapshot: MockupVariantImageSnapshot;
+    /** The extracted image blobs, ready for the existing per-image upload
+     * channel. Keys are prefixed `vimg:` so they never collide with mockup or
+     * screen-inventory image keys (the server hashes the key anyway). */
+    images: Array<{ key: string; dataUrl: string }>;
+}
+
+const currentImageRefKey = (recordKey: string): string => `vimg:${recordKey}`;
+const historyImageRefKey = (recordKey: string, index: number): string =>
+    `vimg:${recordKey}#h${index}`;
+
+/** Move image bytes out of the snapshot into a flat `{key,dataUrl}` list. The
+ * returned snapshot carries `imageRef` keys instead of `imageDataUrl`, so it is
+ * small enough to ride inside the bundle POST while the bytes travel through the
+ * per-image blob channel. Metadata-only records (default sidecars) are left
+ * untouched. */
+export function splitVariantSnapshotImages(
+    snapshot: MockupVariantImageSnapshot,
+): SplitVariantSnapshot {
+    const images: Array<{ key: string; dataUrl: string }> = [];
+    const records = snapshot.records.map((record) => {
+        const next: MockupVariantImageSnapshotRecord = { ...record };
+        if (typeof next.imageDataUrl === 'string' && next.imageDataUrl.length > 0) {
+            const refKey = currentImageRefKey(record.key);
+            images.push({ key: refKey, dataUrl: next.imageDataUrl });
+            next.imageRef = refKey;
+            delete next.imageDataUrl;
+        }
+        if (next.history && next.history.length > 0) {
+            next.history = next.history.map((entry, i) => {
+                if (typeof entry.imageDataUrl !== 'string' || entry.imageDataUrl.length === 0) return entry;
+                const refKey = historyImageRefKey(record.key, i);
+                images.push({ key: refKey, dataUrl: entry.imageDataUrl });
+                const nextEntry = { ...entry, imageRef: refKey };
+                delete nextEntry.imageDataUrl;
+                return nextEntry;
+            });
+        }
+        return next;
+    });
+    return { snapshot: { ...snapshot, records }, images };
+}
+
+/** Collect the `imageRef` keys a split snapshot references, so the loader knows
+ * which per-image blobs to fetch. */
+export function collectVariantSnapshotImageRefs(
+    snapshot: MockupVariantImageSnapshot | undefined,
+): string[] {
+    if (!snapshot || !Array.isArray(snapshot.records)) return [];
+    const keys: string[] = [];
+    for (const r of snapshot.records) {
+        if (typeof r.imageRef === 'string') keys.push(r.imageRef);
+        for (const h of r.history ?? []) {
+            if (typeof h.imageRef === 'string') keys.push(h.imageRef);
+        }
+    }
+    return keys;
+}
+
+/** Re-attach image bytes fetched via the per-image channel. A ref missing from
+ * the map (a failed fetch) drops that image — the record/history entry is left
+ * without bytes and will be skipped on restore, never restored broken. */
+export function joinVariantSnapshotImages(
+    snapshot: MockupVariantImageSnapshot,
+    dataUrlByKey: Map<string, string>,
+): MockupVariantImageSnapshot {
+    const records = snapshot.records.map((record) => {
+        const next: MockupVariantImageSnapshotRecord = { ...record };
+        if (typeof next.imageRef === 'string') {
+            const dataUrl = dataUrlByKey.get(next.imageRef);
+            if (dataUrl) next.imageDataUrl = dataUrl;
+            delete next.imageRef;
+        }
+        if (next.history && next.history.length > 0) {
+            next.history = next.history.map((entry) => {
+                if (typeof entry.imageRef !== 'string') return entry;
+                const nextEntry = { ...entry };
+                const dataUrl = dataUrlByKey.get(entry.imageRef);
+                if (dataUrl) nextEntry.imageDataUrl = dataUrl;
+                delete nextEntry.imageRef;
+                return nextEntry;
+            });
+        }
+        return next;
+    });
+    return { ...snapshot, records };
+}
+
+// --- Restore (portable snapshot -> store records) ----------------------------
+
+const historyDedupeKey = (entry: { dataUrl?: string; imageDataUrl?: string; generatedAt?: number }): string =>
+    `${entry.dataUrl ?? entry.imageDataUrl ?? ''}|${entry.generatedAt ?? 0}`;
+
+/** Convert a portable history entry into a store history entry, inheriting the
+ * parent record's quality when the entry omits one. Returns null when the entry
+ * carries no safe image (a store history entry requires a real dataUrl). */
+function toStoreHistoryEntry(
+    entry: MockupVariantImageSnapshotHistoryEntry,
+    fallbackQuality: MockupImageQuality,
+): MockupVariantImageHistoryEntry | null {
+    if (!isSafeVariantImageDataUrl(entry.imageDataUrl)) return null;
+    return {
+        dataUrl: entry.imageDataUrl as string,
+        quality: entry.quality ?? fallbackQuality,
+        prompt: entry.prompt,
+        coverageManifest: entry.manifest,
+        sourceSignature: entry.sourceSignature,
+        generatedAt: entry.generatedAt ?? 0,
+        reason: entry.reason,
+    };
+}
+
+/** Convert a portable record into a store record. Returns null when the record
+ * cannot be safely restored (a non-default variant with no safe image). Default
+ * sidecars are metadata-only and always restorable when their identity is
+ * valid. */
+function toStoreRecord(
+    snap: MockupVariantImageSnapshotRecord,
+    maxHistory: number,
+): MockupVariantImageRecord | null {
+    if (typeof snap.key !== 'string' || typeof snap.versionId !== 'string'
+        || typeof snap.screenId !== 'string' || typeof snap.variantId !== 'string') {
+        return null;
+    }
+    const quality = VALID_QUALITIES.includes(snap.quality) ? snap.quality : 'low';
+    const isDefault = snap.variantId === 'default';
+    const parsed = parseImageDataUrl(snap.imageDataUrl);
+
+    if (!isDefault && !parsed) {
+        // A non-default variant with no safe image would render as a broken
+        // <img>. Its metadata has nowhere safe to live, so skip it.
+        return null;
+    }
+
+    const history = (snap.history ?? [])
+        .slice(0, maxHistory)
+        .map((e) => toStoreHistoryEntry(e, quality))
+        .filter((e): e is MockupVariantImageHistoryEntry => e !== null);
+
+    return {
+        key: snap.key,
+        projectId: snap.projectId ?? '',
+        artifactId: snap.artifactId ?? '',
+        versionId: snap.versionId,
+        screenId: snap.screenId,
+        variantId: snap.variantId,
+        viewport: snap.viewport ?? 'desktop',
+        stateName: snap.stateName ?? 'Default',
+        // Default sidecars carry no owned image (the legacy path renders it).
+        dataUrl: parsed ? (snap.imageDataUrl as string) : '',
+        quality,
+        prompt: snap.prompt ?? '',
+        coverageManifest: snap.manifest,
+        sourceSignature: snap.sourceSignature,
+        generatedFrom: snap.generatedFrom,
+        ...(history.length ? { history } : {}),
+        generatedAt: snap.generatedAt ?? 0,
+    };
+}
+
+const recordHasImage = (r: MockupVariantImageRecord): boolean =>
+    typeof r.dataUrl === 'string' && r.dataUrl.length > 0;
+
+const signatureHash = (sig: unknown): string => {
+    if (!sig || typeof sig !== 'object') return '';
+    const s = sig as MockupVariantSourceSignature;
+    return `${s.screenContractHash ?? ''}|${s.designSystemHash ?? ''}|${s.prdContextHash ?? ''}|${s.createdAt ?? ''}`;
+};
+
+/** True when two records represent the same render (no merge needed). */
+const isDuplicateRecord = (
+    a: MockupVariantImageRecord,
+    b: MockupVariantImageRecord,
+): boolean =>
+    a.generatedAt === b.generatedAt
+    && a.dataUrl === b.dataUrl
+    && signatureHash(a.sourceSignature) === signatureHash(b.sourceSignature);
+
+/** Merge two variant history lists: union, dedupe by (image, generatedAt),
+ * newest-first, capped. */
+const mergeHistories = (
+    ...lists: Array<MockupVariantImageHistoryEntry[] | undefined>
+): MockupVariantImageHistoryEntry[] => {
+    const seen = new Set<string>();
+    const merged: MockupVariantImageHistoryEntry[] = [];
+    for (const list of lists) {
+        for (const entry of list ?? []) {
+            const k = historyDedupeKey(entry);
+            if (seen.has(k)) continue;
+            seen.add(k);
+            merged.push(entry);
+        }
+    }
+    merged.sort((a, b) => (b.generatedAt ?? 0) - (a.generatedAt ?? 0));
+    return merged.slice(0, MAX_VARIANT_SNAPSHOT_HISTORY);
+};
+
+/** Fold a record's own current image into a history entry, so it survives when
+ * the OTHER record wins the "current" slot. */
+const asHistoryEntry = (
+    record: MockupVariantImageRecord,
+): MockupVariantImageHistoryEntry | null => {
+    if (!recordHasImage(record)) return null;
+    return {
+        dataUrl: record.dataUrl,
+        quality: record.quality,
+        prompt: record.prompt,
+        coverageManifest: record.coverageManifest,
+        sourceSignature: record.sourceSignature,
+        generatedAt: record.generatedAt,
+        reason: 'replaced',
+    };
+};
+
+export interface VariantMergeOutcome {
+    /** The record to persist (undefined = keep local unchanged, no write). */
+    record?: MockupVariantImageRecord;
+    /** 'restored' new, 'updated' snapshot won, 'kept_local' local won,
+     * 'duplicate' identical, 'skipped' incoming unusable. */
+    action: 'restored' | 'updated' | 'kept_local' | 'duplicate' | 'skipped';
+    warning?: string;
+}
+
+/**
+ * Conservative per-key merge. Pure so it can be unit-tested exhaustively.
+ *   - no local        → restore incoming.
+ *   - duplicate       → keep local, no write.
+ *   - incoming newer  → incoming becomes current; local's image folds to history.
+ *   - local newer     → keep local current; incoming's image folds to history.
+ *   - unclear         → keep local current; add incoming image to history; warn.
+ * A failed/imageless incoming never replaces a successful local image.
+ */
+export function mergeVariantRecords(
+    local: MockupVariantImageRecord | undefined,
+    incoming: MockupVariantImageRecord,
+): VariantMergeOutcome {
+    if (!local) return { record: incoming, action: 'restored' };
+
+    if (isDuplicateRecord(local, incoming)) {
+        return { action: 'duplicate' };
+    }
+
+    const localImg = recordHasImage(local);
+    const incomingImg = recordHasImage(incoming);
+    const isDefault = incoming.variantId === 'default';
+
+    // Never let an imageless incoming clobber a real local image (only relevant
+    // to non-default variants; default sidecars are metadata-only by design).
+    if (!isDefault && localImg && !incomingImg) {
+        return { action: 'skipped', warning: `Kept the local mockup variant for ${incoming.screenId} — the snapshot copy had no image.` };
+    }
+
+    const lt = local.generatedAt ?? 0;
+    const it = incoming.generatedAt ?? 0;
+
+    if (it > lt) {
+        // Snapshot is newer → it wins the current slot; local folds to history.
+        const localAsHist = asHistoryEntry(local);
+        const record: MockupVariantImageRecord = {
+            ...incoming,
+            history: mergeHistories(
+                incoming.history,
+                localAsHist ? [localAsHist] : undefined,
+                local.history,
+            ),
+        };
+        if (record.history && record.history.length === 0) delete record.history;
+        return { record, action: 'updated' };
+    }
+
+    if (lt > it) {
+        // Local is newer → keep it; snapshot's image joins history.
+        const incomingAsHist = asHistoryEntry(incoming);
+        const record: MockupVariantImageRecord = {
+            ...local,
+            history: mergeHistories(
+                local.history,
+                incomingAsHist ? [incomingAsHist] : undefined,
+                incoming.history,
+            ),
+        };
+        if (record.history && record.history.length === 0) delete record.history;
+        return { record, action: 'kept_local' };
+    }
+
+    // Equal (or missing) timestamps but different content → keep local, preserve
+    // the snapshot render in history, and flag the ambiguity.
+    const incomingAsHist = asHistoryEntry(incoming);
+    const record: MockupVariantImageRecord = {
+        ...local,
+        history: mergeHistories(
+            local.history,
+            incomingAsHist ? [incomingAsHist] : undefined,
+            incoming.history,
+        ),
+    };
+    if (record.history && record.history.length === 0) delete record.history;
+    return {
+        record,
+        action: 'kept_local',
+        warning: `Kept the local mockup variant for ${incoming.screenId}; the snapshot copy was saved as history (timestamps were inconclusive).`,
+    };
+}
+
+export interface RestoreVariantSnapshotOptions {
+    /** Read the existing local records for one artifact version. */
+    listExisting: (versionId: string) => Promise<MockupVariantImageRecord[]>;
+    /** Persist one record (IndexedDB put). */
+    put: (record: MockupVariantImageRecord) => Promise<void>;
+    /** Called once with every record written, so the reactive cache can update. */
+    notify?: (records: MockupVariantImageRecord[]) => void;
+    maxHistory?: number;
+}
+
+export interface RestoreVariantSnapshotResult {
+    restored: number;
+    updated: number;
+    keptLocal: number;
+    duplicates: number;
+    skipped: number;
+    warnings: string[];
+    writtenRecords: MockupVariantImageRecord[];
+}
+
+const emptyRestoreResult = (warnings: string[] = []): RestoreVariantSnapshotResult => ({
+    restored: 0, updated: 0, keptLocal: 0, duplicates: 0, skipped: 0, warnings, writtenRecords: [],
+});
+
+/**
+ * Hydrate a portable variant snapshot into the local store. Validates the
+ * envelope first and NEVER throws on a malformed section — a bad snapshot yields
+ * an empty result with a warning so the surrounding project restore is
+ * unaffected. Per-record merges are conservative (see `mergeVariantRecords`).
+ */
+export async function restoreMockupVariantImageSnapshot(
+    snapshot: MockupVariantImageSnapshot | undefined | null,
+    options: RestoreVariantSnapshotOptions,
+): Promise<RestoreVariantSnapshotResult> {
+    if (!snapshot) return emptyRestoreResult();
+
+    const validation = validateMockupVariantImageSnapshot(snapshot);
+    if (!validation.valid) {
+        return emptyRestoreResult(['Mockup variant images could not be restored (unrecognized format).']);
+    }
+
+    const maxHistory = options.maxHistory ?? MAX_VARIANT_SNAPSHOT_HISTORY;
+    const result = emptyRestoreResult();
+    result.warnings.push(...validation.warnings);
+
+    // Group incoming records by version and load the local set once per version.
+    const byVersion = new Map<string, MockupVariantImageSnapshotRecord[]>();
+    for (const r of snapshot.records) {
+        if (typeof r.versionId !== 'string') { result.skipped += 1; continue; }
+        const list = byVersion.get(r.versionId) ?? [];
+        list.push(r);
+        byVersion.set(r.versionId, list);
+    }
+
+    for (const [versionId, incomingRecords] of byVersion) {
+        let localList: MockupVariantImageRecord[] = [];
+        try {
+            localList = await options.listExisting(versionId);
+        } catch {
+            // Treat an unreadable local set as empty — we still restore, and a
+            // later merge can't lose data it couldn't read.
+            localList = [];
+        }
+        const localByKey = new Map(localList.map((r) => [r.key, r]));
+
+        for (const snapRecord of incomingRecords) {
+            const incoming = toStoreRecord(snapRecord, maxHistory);
+            if (!incoming) {
+                result.skipped += 1;
+                continue;
+            }
+            const outcome = mergeVariantRecords(localByKey.get(incoming.key), incoming);
+            if (outcome.warning) result.warnings.push(outcome.warning);
+            switch (outcome.action) {
+                case 'restored': result.restored += 1; break;
+                case 'updated': result.updated += 1; break;
+                case 'kept_local': result.keptLocal += 1; break;
+                case 'duplicate': result.duplicates += 1; break;
+                case 'skipped': result.skipped += 1; break;
+            }
+            if (outcome.record) {
+                try {
+                    await options.put(outcome.record);
+                    localByKey.set(outcome.record.key, outcome.record);
+                    result.writtenRecords.push(outcome.record);
+                } catch {
+                    result.warnings.push(`Failed to save a restored mockup variant for ${incoming.screenId}.`);
+                }
+            }
+        }
+    }
+
+    if (options.notify && result.writtenRecords.length > 0) {
+        options.notify(result.writtenRecords);
+    }
+    return result;
+}
+
+// --- Namespacing helper (for restore under a different project id) -----------
+
+/**
+ * Rewrite a variant snapshot's ids for restore under a DIFFERENT project id
+ * (the demo path). Mirrors `namespaceSnapshotForRestore` in snapshotClient:
+ * every artifact-version id in `idMap` is remapped and each record's composite
+ * `key` is rebuilt from the remapped fields (variant image keys embed the
+ * versionId). Pure. */
+export function namespaceVariantSnapshot(
+    snapshot: MockupVariantImageSnapshot,
+    idMap: Map<string, string>,
+    targetProjectId: string,
+): MockupVariantImageSnapshot {
+    if (idMap.size === 0) return snapshot;
+    const remap = (id: string | undefined): string | undefined =>
+        id && idMap.has(id) ? idMap.get(id) : id;
+
+    const records = snapshot.records.map((record) => {
+        const versionId = remap(record.versionId) ?? record.versionId;
+        const generatedFrom = record.generatedFrom
+            ? {
+                prdVersionId: remap(record.generatedFrom.prdVersionId),
+                screenVersionId: remap(record.generatedFrom.screenVersionId),
+                designSystemVersionId: remap(record.generatedFrom.designSystemVersionId),
+            }
+            : undefined;
+        return {
+            ...record,
+            projectId: targetProjectId,
+            versionId,
+            key: buildVariantImageKey(
+                versionId,
+                record.screenId,
+                record.variantId,
+                (VALID_QUALITIES.includes(record.quality) ? record.quality : 'low'),
+            ),
+            generatedFrom,
+        };
+    });
+    return { ...snapshot, projectId: targetProjectId, records };
+}

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -23,6 +23,7 @@ import type {
     Project, SpineVersion, HistoryEvent, Branch,
     Artifact, ArtifactVersion, FeedbackItem, MockupImageRecord,
     ScreenInventoryImageRecord, ProjectTask, WorkflowRun,
+    MockupVariantImageRecord,
 } from '../types';
 import { useProjectStore } from '../store/projectStore';
 import { buildImageKey, listImagesForVersion, putImage, deleteImagesForVersion } from './mockupImageStore';
@@ -32,6 +33,20 @@ import {
     putScreenImage,
     deleteScreenImagesForArtifactVersion,
 } from './screenInventoryImageStore';
+import {
+    listVariantImagesForVersion,
+    putVariantImage,
+} from './mockupVariantImageStore';
+import {
+    buildMockupVariantImageSnapshot,
+    splitVariantSnapshotImages,
+    collectVariantSnapshotImageRefs,
+    joinVariantSnapshotImages,
+    namespaceVariantSnapshot,
+    restoreMockupVariantImageSnapshot,
+    type MockupVariantImageSnapshot,
+} from './mockupVariantSnapshot';
+import { useMockupVariantImageStore } from '../store/mockupVariantImageStore';
 
 export const OWNER_TOKEN_KEY = 'synapse-owner-token';
 
@@ -49,6 +64,13 @@ export type SnapshotProjectBundle = {
     // existed won't have them, and restore defaults to [].
     tasks?: ProjectTask[];
     workflowRuns?: WorkflowRun[];
+    // Phase 3D: per-variant mockup images (the Screens Mockups-tab variant
+    // gallery) live in a dedicated IndexedDB store. They ride INSIDE the bundle
+    // (which the server persists verbatim) in their WIRE form — image bytes are
+    // stripped and shipped through the same per-image blob channel as the other
+    // two image kinds. Optional on the wire — older snapshots won't have it, and
+    // restore is a no-op when it's absent.
+    mockupVariantImages?: MockupVariantImageSnapshot;
 };
 
 export type SnapshotManifest = {
@@ -191,6 +213,21 @@ const collectScreenImages = async (
     return out;
 };
 
+// Gather every per-variant mockup image record (Phase 3B/3C) tied to one of
+// this project's artifact versions and serialize them into the portable,
+// size-guarded snapshot format. Same by-version walk as the other image
+// collectors — the variant IDB store is indexed by `versionId`.
+const collectVariantImages = async (
+    bundle: SnapshotProjectBundle,
+): Promise<MockupVariantImageSnapshot> => {
+    const records: MockupVariantImageRecord[] = [];
+    for (const v of bundle.artifactVersions) {
+        const forVersion = await listVariantImagesForVersion(v.id);
+        records.push(...forVersion);
+    }
+    return buildMockupVariantImageSnapshot(records, { projectId: bundle.project.id });
+};
+
 // Strip the (large) base64 payload off an image record so the bundle POST
 // only carries the routing metadata. The dataUrl is uploaded in its own
 // request immediately after.
@@ -208,10 +245,24 @@ export const saveSnapshot = async (
     projectId: string,
     title: string,
     onProgress?: SnapshotProgressCallback,
+    onWarnings?: (warnings: string[]) => void,
 ): Promise<SnapshotManifest> => {
     const bundle = collectProjectBundle(projectId);
     const images = await collectProjectImages(bundle);
     const screenImages = await collectScreenImages(bundle);
+
+    // Phase 3D: serialize the per-variant mockup images, then split their bytes
+    // out of the JSON envelope. The stripped (metadata-only) snapshot rides
+    // inside the bundle (the server persists `project` verbatim); the bytes join
+    // the per-image upload channel below. Any records the size guards dropped
+    // surface as non-fatal warnings.
+    const fullVariantSnapshot = await collectVariantImages(bundle);
+    const { snapshot: variantWire, images: variantImages } =
+        splitVariantSnapshotImages(fullVariantSnapshot);
+    bundle.mockupVariantImages = variantWire;
+    if (onWarnings && fullVariantSnapshot.summary.warnings?.length) {
+        onWarnings(fullVariantSnapshot.summary.warnings);
+    }
 
     onProgress?.({ phase: 'bundle', completed: 0, total: 0 });
 
@@ -233,11 +284,13 @@ export const saveSnapshot = async (
 
     // Step 2 — upload each image as a separate request. We go sequentially
     // so a slow/flaky uplink doesn't try to push all images at once and so
-    // browsers don't hold every base64 payload in flight concurrently. Mockup
-    // and screen-inventory images share the same per-image endpoint (the
-    // server keys each blob by a hash of the image key, and the two key shapes
-    // never collide), so we upload them in one combined pass.
-    const allImages: Array<{ key: string; dataUrl: string }> = [...images, ...screenImages];
+    // browsers don't hold every base64 payload in flight concurrently. Mockup,
+    // screen-inventory, and per-variant mockup images share the same per-image
+    // endpoint (the server keys each blob by a hash of the image key, and the
+    // key shapes never collide — variant keys are `vimg:`-prefixed), so we
+    // upload them in one combined pass.
+    const allImages: Array<{ key: string; dataUrl: string }> =
+        [...images, ...screenImages, ...variantImages];
     onProgress?.({ phase: 'images', completed: 0, total: allImages.length });
     for (let i = 0; i < allImages.length; i++) {
         const img = allImages[i];
@@ -381,6 +434,34 @@ const hydrateScreenImages = async (
     );
 };
 
+// Hydrate the per-variant mockup image bytes for a payload. The wire snapshot
+// (inside `payload.project.mockupVariantImages`) references its image bytes by
+// `vimg:`-prefixed keys; we fetch each through the same per-image channel the
+// mockup/screen images use, re-attach them, and write the joined snapshot back
+// onto the payload. A ref that keeps failing is dropped (reported in failedKeys)
+// so one bad image never poisons the whole restore. Returns the failed keys so
+// the caller can factor them into `imagesComplete`.
+const hydrateVariantImages = async (
+    payload: SnapshotPayload,
+    fetchOne: (key: string) => Promise<Response>,
+    options?: { tolerateFailures?: boolean },
+): Promise<string[]> => {
+    const wire = payload.project?.mockupVariantImages;
+    const refs = collectVariantSnapshotImageRefs(wire);
+    if (!wire || refs.length === 0) return [];
+
+    // Reuse the mockup image hydration machinery: it expects
+    // `{ key, dataUrl }`-shaped records keyed by the image key.
+    const { images, failedKeys } = await hydrateImages<{ key: string; dataUrl: string }>(
+        fetchOne,
+        refs.map((key) => ({ key })),
+        options,
+    );
+    const byKey = new Map(images.map((img) => [img.key, img.dataUrl]));
+    payload.project.mockupVariantImages = joinVariantSnapshotImages(wire, byKey);
+    return failedKeys;
+};
+
 // Public, lightweight: read just the demo pointer so callers can decide
 // whether their cached demo project is still current without paying the
 // full bundle+image download. Returns null when no demo has been pinned
@@ -424,11 +505,15 @@ export const loadDemoSnapshotPublic = async (): Promise<SnapshotPayload | null> 
             tolerate,
         );
     const screens = await hydrateScreenImages(payload, fetchOne, tolerate);
+    const variantFailed = await hydrateVariantImages(payload, fetchOne, tolerate);
     return {
         ...payload,
         images: mockups.images,
         screenImages: screens.images,
-        imagesComplete: mockups.failedKeys.length === 0 && screens.failedKeys.length === 0,
+        imagesComplete:
+            mockups.failedKeys.length === 0
+            && screens.failedKeys.length === 0
+            && variantFailed.length === 0,
     };
 };
 
@@ -450,6 +535,7 @@ export const loadSnapshot = async (id: string): Promise<SnapshotPayload> => {
             payload.images as unknown as Array<Omit<MockupImageRecord, 'dataUrl'>>,
         );
     const screens = await hydrateScreenImages(payload, fetchOne);
+    await hydrateVariantImages(payload, fetchOne);
     return { ...payload, images: mockups.images, screenImages: screens.images };
 };
 
@@ -488,6 +574,30 @@ const restoreScreenImagesToIdb = async (
     }
 };
 
+// Phase 3D: hydrate the per-variant mockup images into the dedicated variant
+// IndexedDB store + the reactive cache. Unlike the mockup/screen restores (a
+// clean delete-then-put replace), this uses CONSERVATIVE merge semantics
+// (`restoreMockupVariantImageSnapshot`) so a newer local variant is never
+// clobbered by an older snapshot copy — the snapshot copy is preserved in
+// history instead. A malformed variant section is skipped without throwing, so
+// it never breaks the surrounding project restore. Returns any restore warnings.
+const restoreVariantImagesToIdb = async (
+    snapshot: MockupVariantImageSnapshot | undefined,
+): Promise<string[]> => {
+    if (!snapshot) return [];
+    try {
+        const result = await restoreMockupVariantImageSnapshot(snapshot, {
+            listExisting: listVariantImagesForVersion,
+            put: putVariantImage,
+            notify: (records) => useMockupVariantImageStore.getState().mergeRecords(records),
+        });
+        return result.warnings;
+    } catch (err) {
+        console.warn('[snapshots] mockup variant images could not be restored', err);
+        return ['Mockup variant images could not be restored.'];
+    }
+};
+
 // Restore a snapshot into the live store. Replaces any existing project with
 // the same id (we use the snapshot's project id directly so external
 // references — e.g. screen URLs — keep working). Images are repopulated in
@@ -500,6 +610,7 @@ export const restoreSnapshot = async (snapshot: SnapshotPayload): Promise<string
     // so renderers don't briefly see "missing image" placeholders.
     await restoreMockupImagesToIdb(images);
     await restoreScreenImagesToIdb(snapshot.screenImages);
+    await restoreVariantImagesToIdb(bundle.mockupVariantImages);
 
     // Splice the bundle back into the Zustand store. We mutate the store
     // imperatively because there's no public action for "replace one project
@@ -580,6 +691,14 @@ export const namespaceSnapshotForRestore = (
     }
 
     const bundle = rewriteIds(snapshot.project, idMap);
+    // The variant snapshot's composite `key` embeds the versionId (with colons),
+    // so exact-string rewriteIds can't fix it — rebuild the keys (and projectId)
+    // deterministically from the source snapshot so re-restores stay idempotent.
+    if (snapshot.project.mockupVariantImages) {
+        bundle.mockupVariantImages = namespaceVariantSnapshot(
+            snapshot.project.mockupVariantImages, idMap, targetProjectId,
+        );
+    }
     const images = snapshot.images.map((record) => {
         const next = rewriteIds(record, idMap);
         // The composite `key` embeds the versionId, so rebuild it from the
@@ -613,6 +732,7 @@ export const restoreSnapshotAs = async (
 
     await restoreMockupImagesToIdb(images);
     await restoreScreenImagesToIdb(screenImages);
+    await restoreVariantImagesToIdb(remapped.mockupVariantImages);
 
     useProjectStore.setState((state) => ({
         projects: { ...state.projects, [targetProjectId]: remapped.project },

--- a/src/store/__tests__/mockupVariantImageStore.test.ts
+++ b/src/store/__tests__/mockupVariantImageStore.test.ts
@@ -178,6 +178,20 @@ describe('mockupVariantImageStore.generate', () => {
         expect(mobile?.history ?? []).toHaveLength(0);
     });
 
+    it('mergeRecords hydrates the reactive cache from restored records (snapshot restore)', () => {
+        const store = useMockupVariantImageStore.getState();
+        const record: MockupVariantImageRecord = {
+            key: 'v1:scr-home:mobile:default:low',
+            projectId: 'p1', artifactId: 'a1', versionId: 'v1',
+            screenId: 'scr-home', variantId: 'mobile:default', viewport: 'mobile',
+            stateName: 'Default', dataUrl: 'data:image/png;base64,RESTORED',
+            quality: 'low', prompt: '', generatedAt: 5,
+        };
+        store.mergeRecords([record]);
+        const rec = useMockupVariantImageStore.getState().getBestRecord('v1', 'scr-home', 'mobile:default');
+        expect(rec?.dataUrl).toBe('data:image/png;base64,RESTORED');
+    });
+
     it('putSidecar stores a metadata-only default record without generating', async () => {
         const store = useMockupVariantImageStore.getState();
         await store.putSidecar({

--- a/src/store/mockupVariantImageStore.ts
+++ b/src/store/mockupVariantImageStore.ts
@@ -77,6 +77,11 @@ interface VariantImageStoreState {
      * default variant without moving its image into this store. */
     putSidecar: (record: MockupVariantImageRecord) => Promise<void>;
 
+    /** Merge already-persisted records (e.g. from a snapshot restore that wrote
+     * them to IndexedDB) into the reactive cache so open views update without a
+     * reload. IndexedDB is the source of truth; this only refreshes the cache. */
+    mergeRecords: (records: MockupVariantImageRecord[]) => void;
+
     cancel: (versionId: string, screenId: string, variantId: string) => void;
     clearError: (versionId: string, screenId: string, variantId: string) => void;
 }
@@ -134,6 +139,15 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
     putSidecar: async (record) => {
         await idbPutVariantImage(record);
         set((state) => ({ images: { ...state.images, [record.key]: record } }));
+    },
+
+    mergeRecords: (records) => {
+        if (records.length === 0) return;
+        set((state) => {
+            const next = { ...state.images };
+            for (const r of records) next[r.key] = r;
+            return { images: next };
+        });
     },
 
     generate: async ({


### PR DESCRIPTION
## Summary

Phase 3D of the Screens artifact upgrade closes the Phase 3C limitation: generated mockup **variant images, coverage manifests, source signatures, `generatedFrom` provenance, and variant history** lived only in device-local IndexedDB and did not travel in snapshots or restore across devices. They now ride in owner **project snapshots** (and therefore the demo) and restore cleanly on another device.

Scope was kept narrow — no rewrite of the mockup, snapshot, image-ref, or artifact systems, and **no `api/snapshots.js` change** (the server already persists the `project` bundle verbatim and hashes any per-image key, so variant metadata rides inside the bundle and variant image bytes reuse the existing per-image blob channel).

## Portable snapshot format (`src/lib/mockupVariantSnapshot.ts`, new, pure)

- `MockupVariantImageSnapshot` — schema-versioned (`schemaVersion: 1`), size-guarded transport with per-record image + manifest + source signature + `generatedFrom` + history.
- `buildMockupVariantImageSnapshot` / `validateMockupVariantImageSnapshot` / `estimateMockupVariantSnapshotSize` — pure build + guards.
- Derived-missing placeholders are never serialized as images; default sidecars are serialized metadata-only.

## Export / import integration (`src/lib/snapshotClient.ts`)

- `collectVariantImages` walks the project's artifact versions and serializes the dedicated variant IDB store.
- `splitVariantSnapshotImages` moves image bytes out of the JSON envelope under `vimg:`-prefixed keys and ships them through the **same per-image channel** as mockup/screen images (dodges Vercel's ~4.5 MB body cap). Stripped metadata rides inside `SnapshotProjectBundle.mockupVariantImages`.
- `hydrateVariantImages` re-attaches bytes on load for both the owner load and the public demo path; a failed per-image fetch drops just that image and factors into the demo's `imagesComplete` flag.
- Demo restore under `DEMO_PROJECT_ID` namespaces variant records via `namespaceVariantSnapshot` (remap versionId + rebuild composite key + `generatedFrom`, idempotent).

## Restore / merge behavior

- `restoreMockupVariantImageSnapshot` (IDB accessors injected) validates the envelope, merges conservatively, and **never throws** — a malformed variant section is skipped without breaking the surrounding project restore.
- `mergeVariantRecords` (pure) per key: no local → restore; duplicate → keep one; snapshot newer → snapshot current + local folds to history; local newer → keep local + snapshot folds to history; inconclusive timestamps → keep local + snapshot to history + warning. An imageless incoming never replaces a successful local image; history dedupes by (image, generatedAt) and is capped (10).
- Restore refreshes the reactive cache via the new `useMockupVariantImageStore.mergeRecords`.

## Image safety & size limits

- Only `image/png` / `image/jpeg` / `image/webp` travel — **SVG and any non-raster payload are rejected**; malformed data URLs are rejected.
- Caps: 8 MB per image, 50 MB per snapshot section, 10 history entries per variant. Oversized/unsafe records are skipped with calm warnings, surfaced in `SnapshotsPanel` after save ("The screen specs and mockup metadata are still saved — only some variant images were left out").

## Default sidecar portability

- Default sidecar manifests/source signatures serialize and restore as **metadata-only** (no image). The legacy default image path is untouched; old defaults without a sidecar stay coverage-unknown.

## UI copy

- Mockups tab / per-variant detail / history footer: the "saved on this device only" notes are replaced with accurate "included in project snapshots — restorable on another device" copy. Does not overpromise — states variants don't yet auto-sync across devices.

## Backward compatibility

- Every new field is optional; `mockupVariantImages` is optional on the wire. Old snapshots without variant data restore exactly as before. Legacy variant records without source metadata are unaffected. No storage migration is required.

## Tests added

- `mockupVariantSnapshot.test.ts` — 31 pure tests: serialize (image/manifest/signature/history), skip derived-missing, default sidecar metadata, validation (accept current schema; reject unsafe MIME / malformed data URL / bad envelope), size estimation, oversized skip + warning, split/join wire round-trip, all merge branches, restore into empty / newer-snapshot / newer-local, malformed-section resilience, default-sidecar restore, namespacing, and a full build→split→fetch→join→restore round-trip.
- `mockupVariantImageStore.test.ts` — `mergeRecords` cache hydration.
- `snapshotClient.test.ts` — variant snapshot namespacing for the demo path.
- `ScreenExperienceViews.test.tsx` — updated for the new storage copy.
- Full suite: 1285 passed; `npm run build` and `npm run lint` clean.

## Known limitations / recommended next phase

- Variant images travel in **owner snapshots**, not yet on the per-user `/api/projects` automatic cross-device sync path (that path carries mockup images via `imageRefsStore`). Recommended next step: wire the generic `imageRefsStore` `kind` layer to carry variant images so they follow a signed-in user across devices without a manual snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyRQHzSXcLXv4uxDkBf5oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyRQHzSXcLXv4uxDkBf5oC)_