### PR TITLE
Gate mockup Mobile-variant recommendation on project mobile-relevance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1628,8 +1628,16 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     A legacy single-image mockup normalizes to **`Desktop · Default`**
     (`source: 'legacy'`, `coverageStatus: 'unknown'` — no per-variant coverage
     metadata was ever captured). Recommendations are DERIVED estimates:
-    `Desktop · Default` for every primary screen, `Mobile · Default` for P0
-    (and P1/supporting when `mobileRelevant`), and important documented states.
+    `Desktop · Default` for every primary screen, `Mobile · Default` **only
+    when the project is `mobileRelevant`** (mobile-first / responsive — then on
+    every screen, P0 included), and important documented states. **A web/desktop
+    project (`mobileRelevant` false) recommends NO Mobile variant — not even for
+    its P0 screens** — so it never surfaces "mobile coverage" gaps for a
+    platform that ships no mobile UI; `buildMockupVariantCoverageSummary` counts
+    a P0 screen toward `p0Total` only when a Mobile default is actually
+    recommended, so the "Mobile coverage (P0)" panel row stays hidden for
+    non-mobile projects. Do **not** re-gate the Mobile recommendation on
+    priority alone.
     **Overlay-key compatibility**: the primary-viewport Default reuses `default`
     and primary-viewport states reuse `state:<slug>` (shared with the readiness
     layer); only the secondary-viewport default introduces `${viewport}:default`.

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -263,6 +263,7 @@ function renderContractDetail(
             onNavigateToScreen={() => {}}
             availableScreenSlugs={index.availableSlugs}
             features={FEATURES}
+            mobileRelevant
             onSaveScreenEdit={opts.onSaveScreenEdit}
             mockupContext={opts.withMockupContext === false ? undefined : {
                 projectId: 'p1',

--- a/src/lib/__tests__/mockupVariantRequest.test.ts
+++ b/src/lib/__tests__/mockupVariantRequest.test.ts
@@ -40,7 +40,9 @@ function variantsFor(screen: ScreenItem) {
     const index = buildScreenIndex(
         { sections: [{ title: 'Main', screens: [screen] }] }, [], null,
     );
-    return { item: index.items[0], variants: buildScreenMockupVariants(index.items[0]) };
+    // mobileRelevant so the Mobile · Default variant is recommended (these
+    // tests exercise mobile-variant request/prompt/manifest building).
+    return { item: index.items[0], variants: buildScreenMockupVariants(index.items[0], { mobileRelevant: true }) };
 }
 
 describe('buildVariantGenerationRequest', () => {

--- a/src/lib/__tests__/mockupVariants.test.ts
+++ b/src/lib/__tests__/mockupVariants.test.ts
@@ -102,14 +102,23 @@ describe('buildScreenMockupVariants', () => {
         expect(dflt.source).toBe('derived_missing');
     });
 
-    it('recommends a Mobile · Default for P0 screens', () => {
+    it('recommends a Mobile · Default for P0 screens on a mobile-relevant project', () => {
         const index = buildScreenIndex(makeInventory([p0Screen]), [], null);
-        const variants = buildScreenMockupVariants(index.items[0]);
+        const variants = buildScreenMockupVariants(index.items[0], { mobileRelevant: true });
         const mobile = variants.find(v => v.id === 'mobile:default');
         expect(mobile).toBeDefined();
         expect(mobile!.viewport).toBe('mobile');
         expect(mobile!.required).toBe(true);
         expect(mobile!.status).toBe('missing');
+    });
+
+    it('does NOT recommend a Mobile default for a P0 screen on a web/desktop project', () => {
+        // Regression: a web/desktop project (mobileRelevant false) must never
+        // surface a Mobile variant — not even for its P0 screens — so it does
+        // not warn about mobile coverage it will never ship.
+        const index = buildScreenIndex(makeInventory([p0Screen]), [], null);
+        const variants = buildScreenMockupVariants(index.items[0]);
+        expect(variants.find(v => v.viewport === 'mobile')).toBeUndefined();
     });
 
     it('does NOT recommend Mobile default for a supporting screen unless mobile-relevant', () => {
@@ -148,7 +157,7 @@ describe('buildScreenMockupVariants', () => {
         const index = buildScreenIndex(makeInventory([p0Screen]), [], null, {
             'scr-home': { mockupVariantStatus: { 'mobile:default': 'accepted', 'state:loading': 'not_needed' } },
         });
-        const variants = buildScreenMockupVariants(index.items[0]);
+        const variants = buildScreenMockupVariants(index.items[0], { mobileRelevant: true });
         expect(variants.find(v => v.id === 'mobile:default')!.status).toBe('accepted');
         expect(variants.find(v => v.id === 'mobile:default')!.userSet).toBe(true);
         expect(variants.find(v => v.id === 'state:loading')!.status).toBe('not_needed');
@@ -188,7 +197,7 @@ describe('summarizeScreenVariants', () => {
             [],
             makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
         );
-        const summary = summarizeScreenVariants(buildScreenMockupVariants(index.items[0]));
+        const summary = summarizeScreenVariants(buildScreenMockupVariants(index.items[0], { mobileRelevant: true }));
         // recommended: desktop default (generated) + mobile default + Empty History + Loading = 4
         expect(summary.recommended).toBe(4);
         expect(summary.generated).toBe(1);
@@ -247,12 +256,25 @@ describe('buildMockupVariantCoverageSummary', () => {
             [],
             makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
         );
-        const rollup = buildMockupVariantCoverageSummary(index)!;
+        const rollup = buildMockupVariantCoverageSummary(index, { mobileRelevant: true })!;
         expect(rollup.p0Total).toBe(1);
         expect(rollup.p0WithMobile).toBe(0); // no mobile mockup for the P0 screen
         expect(rollup.legacyUnknownMockups).toBe(1);
         expect(rollup.recommendedGenerated).toBe(1);
         expect(rollup.recommendedTotal).toBeGreaterThan(1);
+    });
+
+    it('does not track P0 mobile coverage for a web/desktop project', () => {
+        // Regression: no Mobile variant is recommended for a non-mobile project,
+        // so p0Total is 0 and the "Mobile coverage (P0)" panel row stays hidden.
+        const index = buildScreenIndex(
+            makeInventory([p0Screen, supportingScreen]),
+            [],
+            makeMockupPayload([{ id: 'm1', name: 'Home Dashboard', sourceScreenId: 'scr-home' }]),
+        );
+        const rollup = buildMockupVariantCoverageSummary(index)!;
+        expect(rollup.p0Total).toBe(0);
+        expect(rollup.p0WithMobile).toBe(0);
     });
 
     it('returns null for an empty index', () => {
@@ -268,6 +290,7 @@ describe('buildMockupVariantCoverageSummary', () => {
         );
         // The Mobile · Default variant is generated with an "aligned" manifest.
         const rollup = buildMockupVariantCoverageSummary(index, {
+            mobileRelevant: true,
             generatedVariantsByScreen: (id) =>
                 id === 'scr-home' ? { 'mobile:default': { coverage: 'aligned' } } : undefined,
         })!;
@@ -286,6 +309,7 @@ describe('buildScreenMockupVariants with generatedVariants (Phase 3B)', () => {
     it('flips a missing non-default variant to generated with manifest coverage', () => {
         const index = buildScreenIndex(makeInventory([p0Screen]), [], null);
         const variants = buildScreenMockupVariants(index.items[0], {
+            mobileRelevant: true,
             generatedVariants: { 'mobile:default': { coverage: 'aligned' } },
         });
         const mobile = variants.find(v => v.id === 'mobile:default')!;
@@ -318,7 +342,7 @@ describe('buildScreenMockupVariants with generatedVariants (Phase 3B)', () => {
                 },
             },
         });
-        const rollup = buildMockupVariantCoverageSummary(index)!;
+        const rollup = buildMockupVariantCoverageSummary(index, { mobileRelevant: true })!;
         // Only desktop default counts toward the denominator now.
         expect(rollup.recommendedTotal).toBe(1);
         expect(rollup.recommendedGenerated).toBe(0);

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -162,8 +162,9 @@ export interface BuildVariantOptions {
     /** Generation platform of the current mockup set (mockup settings). */
     platform?: MockupPlatform;
     /** True when the project is mobile-relevant (mobile-first / responsive) —
-     * enables a recommended Mobile default on P1 / supporting screens. P0
-     * always recommends mobile regardless. */
+     * the sole gate for recommending a Mobile default variant (on every screen,
+     * P0 included). A web/desktop project (false) never recommends Mobile
+     * coverage, so mobile gaps don't surface for platforms with no mobile UI. */
     mobileRelevant?: boolean;
     /** Phase 3B: manifest-backed generated variants for THIS screen, keyed by
      * variant id. A non-default variant present here renders as 'generated'
@@ -222,10 +223,13 @@ export function buildScreenMockupVariants(
 
     // 2. Secondary-viewport Default recommendation.
     //    - Desktop is the baseline default for P0/P1 screens.
-    //    - Mobile default is recommended for P0 always, P1/supporting when the
-    //      project is mobile-relevant.
+    //    - Mobile default is recommended ONLY when the project is
+    //      mobile-relevant (mobile-first / responsive). A web/desktop project
+    //      never wants a Mobile variant — not even for its P0 screens — so it
+    //      must not surface "mobile coverage" gaps for platforms that ship no
+    //      mobile UI.
     const wantDesktopDefault = priority === 'P0' || priority === 'P1';
-    const wantMobileDefault = priority === 'P0' || mobileRelevant;
+    const wantMobileDefault = mobileRelevant;
     if (primary !== 'desktop' && wantDesktopDefault) {
         seeds.push({
             viewport: 'desktop',
@@ -384,8 +388,11 @@ function recommendationReason(screen: ScreenItem, seed: VariantSeed): string {
     const priority = normalizeScreenPriority(screen.priority);
     if (seed.stateType === 'default') {
         if (seed.viewport === 'mobile') {
+            // Mobile is only ever recommended for mobile-relevant projects, so
+            // the reason is the project's mobile relevance regardless of the
+            // screen's priority (a P0 screen just makes it more prominent).
             return priority === 'P0'
-                ? 'Recommended for P0 screen mobile coverage.'
+                ? 'Recommended because this P0 screen ships on a mobile-relevant project.'
                 : 'Recommended because the project appears mobile-relevant.';
         }
         return 'Recommended baseline coverage for a primary screen.';
@@ -519,7 +526,14 @@ export function buildMockupVariantCoverageSummary(
         const generatedVariants = generatedVariantsByScreen?.(item.id);
         const variants = buildScreenMockupVariants(item, { ...variantOptions, generatedVariants });
         const isP0 = normalizeScreenPriority(item.screen.priority) === 'P0';
-        if (isP0) p0Total += 1;
+        // Only P0 screens that actually recommend a Mobile default count toward
+        // the "Mobile coverage (P0)" rollup — a web/desktop project recommends
+        // no Mobile variant, so p0Total stays 0 and the panel hides that row
+        // instead of warning about mobile coverage the project will never ship.
+        const recommendsMobileDefault = variants.some(
+            v => v.viewport === 'mobile' && v.stateType === 'default',
+        );
+        if (isP0 && recommendsMobileDefault) p0Total += 1;
         for (const v of variants) {
             // A not_needed variant is deliberately skipped — drop it from the
             // denominator so a resolved gap never keeps the panel warning.


### PR DESCRIPTION
## Problem

The Screens artifact surfaced "mobile coverage" warnings for **web/desktop** projects — a "Mobile coverage (P0)" row in the Screen Coverage panel and a "Mobile: missing" chip on screen cards — even though those projects ship no mobile UI. This should only appear for mobile apps.

## Root cause

`buildScreenMockupVariants` (`src/lib/mockupVariants.ts`) computed:

```ts
const wantMobileDefault = priority === 'P0' || mobileRelevant;
```

So **every P0 screen got a recommended `Mobile · Default` variant regardless of platform**. For a web/desktop project (`mobileRelevant` is false), that produced a missing Mobile variant per P0 screen, which drove the coverage-panel warning and the card chip.

## Fix

- **Mobile default is now gated purely on `mobileRelevant`** (mobile-first / responsive projects) — recommended on every screen (P0 included) when relevant, and on **no** screen when the project is web/desktop.
- **`buildMockupVariantCoverageSummary` counts a P0 screen toward `p0Total` only when a Mobile default is actually recommended**, so the "Mobile coverage (P0)" panel row (gated on `p0Total > 0`) stays hidden entirely for non-mobile projects rather than showing "0 / N" in a warning tone.
- Updated the `recommendationReason` copy for the mobile variant so it reflects mobile-relevance rather than implying P0 always warrants mobile.

Because `mobileRelevant` in `ArtifactWorkspace` is already `projectPlatform === 'app' || mockupPlatform === 'mobile' || 'responsive'`, web/desktop projects correctly resolve to `false` and now show no mobile gaps.

## Tests

- Added regressions: a P0 screen on a web/desktop project recommends **no** Mobile variant, and `p0Total` is 0 for such a project.
- Updated existing tests that exercised the mobile gallery/rollup to pass `mobileRelevant: true` (they were implicitly relying on the old P0-always-mobile behavior).
- Full suite green: **1288 tests passing**; `npm run build` and `npm run lint` both clean.

## Docs

- Updated the Phase 3A discovery-layer section of `CLAUDE.md` to document the mobile-relevance gate and the `p0Total` counting rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2SMvPqi9XxFUWJshfPuPs)_