### PR TITLE
Group consecutive same-screen steps in the Flow Journey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1522,7 +1522,19 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   `FlowJourney`/`StepCard`/`FeatureDetailDrawer` with the current screen's
   steps highlighted (`highlightedStepIndices`) plus a per-flow "This screen
   appears in" context block (repeated appearances labeled "— Step N
-  (appearance i of k)"; decision steps flag unspecified branch outcomes);
+  (appearance i of k)"; decision steps flag unspecified branch outcomes).
+  The `FlowJourney` timeline **groups consecutive steps that share a screen**
+  (`buildJourneyGroups` in `journeyNode.ts`, grouped by `stepScreenSlug`) into
+  one card: the screen name shows once as the header (with a "Steps N–M"
+  range), and each step reads as a sub-row **labeled by its user action** (the
+  "— User action → System response" half the flat node list hid), so a screen
+  owning several sequential steps is no longer repeated node-after-node. It is
+  **pure presentation over the same parsed `user_flows` steps** — no schema,
+  prompt, or persistence change, so it fixes legacy/demo flows without
+  regeneration. The header navigates to the screen (slug-gated, unchanged),
+  sub-rows scroll to their step card, and single-step screens collapse to one
+  row (keep `buildJourneyGroups` keyed on the same slug navigation uses, or a
+  group header could point at the wrong screen);
   Mockups = the **Phase 3A `MockupVariantsPanel`**
   (`src/components/experience/MockupVariantsPanel.tsx`): a viewport × state
   **variant gallery** driven by `buildScreenMockupVariants`

--- a/src/components/renderers/userFlows/FlowJourney.tsx
+++ b/src/components/renderers/userFlows/FlowJourney.tsx
@@ -4,7 +4,10 @@ import {
     Sparkles, Workflow,
 } from 'lucide-react';
 import type { FlowJourneyNode, ParsedStep, FlowJourneyNodeKind } from './types';
-import { buildJourneyNodes, NODE_KIND_LABEL, nodeKindStyle } from './journeyNode';
+import {
+    buildJourneyGroups, NODE_KIND_LABEL, nodeKindStyle,
+    type FlowJourneyGroup,
+} from './journeyNode';
 import { stepScreenSlug } from '../../../lib/screenExperience';
 
 interface Props {
@@ -13,9 +16,9 @@ interface Props {
     issuesByStep: Map<number, number>;
     /**
      * Experience-workspace wiring (all optional — default behavior is
-     * unchanged). When a clicked node is a `screen` node whose slugified
-     * title exists in `availableScreenSlugs`, `onNavigateToScreen` fires
-     * instead of the scroll-to-step default. Other nodes keep scrolling.
+     * unchanged). When a group's screen slug exists in `availableScreenSlugs`,
+     * clicking its header fires `onNavigateToScreen` instead of scrolling to
+     * the step card.
      */
     onNavigateToScreen?: (screenSlug: string) => void;
     availableScreenSlugs?: ReadonlySet<string>;
@@ -44,6 +47,18 @@ function NodeBadge({ kind }: { kind: FlowJourneyNodeKind }) {
     );
 }
 
+function AltBadge({ count }: { count: number }) {
+    if (count <= 0) return null;
+    return (
+        <span
+            className="text-[9px] font-semibold px-1 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200"
+            title={`${count} alternate path${count === 1 ? '' : 's'} or edge case${count === 1 ? '' : 's'}`}
+        >
+            {count} alt
+        </span>
+    );
+}
+
 function Legend() {
     const kinds: FlowJourneyNodeKind[] = ['screen', 'state', 'action', 'decision', 'system'];
     return (
@@ -67,22 +82,32 @@ export function FlowJourney({
 }: Props) {
     const [legendOpen, setLegendOpen] = useState(false);
     if (steps.length === 0) return null;
-    const nodes = buildJourneyNodes(steps);
+    const groups = buildJourneyGroups(steps, stepScreenSlug);
+    const screenStyle = nodeKindStyle('screen');
 
-    const handleClick = (node: FlowJourneyNode) => {
-        // Screen nodes with a matching canonical screen navigate to that
-        // screen's detail view; everything else keeps the scroll behavior.
-        if (onNavigateToScreen && availableScreenSlugs && node.kind === 'screen') {
-            const step = steps.find(s => s.index === node.stepIndex);
-            const slug = step ? stepScreenSlug(step) : null;
-            if (slug && availableScreenSlugs.has(slug)) {
-                onNavigateToScreen(slug);
-                return;
-            }
-        }
-        const el = document.getElementById(`flow-${flowIndex}-step-${node.stepIndex}`);
+    const scrollToStep = (stepIndex: number) => {
+        const el = document.getElementById(`flow-${flowIndex}-step-${stepIndex}`);
         if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
+
+    // The screen header navigates to the screen's detail view when its slug is
+    // available; otherwise it scrolls to the group's first step card.
+    const openGroup = (group: FlowJourneyGroup) => {
+        if (onNavigateToScreen && availableScreenSlugs
+            && group.screenSlug && availableScreenSlugs.has(group.screenSlug)) {
+            onNavigateToScreen(group.screenSlug);
+            return;
+        }
+        scrollToStep(group.firstStepIndex);
+    };
+
+    const rangeLabel = (group: FlowJourneyGroup) =>
+        group.firstStepIndex === group.lastStepIndex
+            ? `Step ${group.firstStepIndex + 1}`
+            : `Steps ${group.firstStepIndex + 1}–${group.lastStepIndex + 1}`;
+
+    const isHighlighted = (node: FlowJourneyNode) =>
+        highlightedStepIndices?.has(node.stepIndex) ?? false;
 
     return (
         <section className="bg-white rounded-xl border border-neutral-200 p-4 mb-4">
@@ -91,76 +116,144 @@ export function FlowJourney({
                     <Workflow size={11} /> Flow journey
                 </p>
                 <span className="text-[10px] text-neutral-400">
-                    {steps.length} {steps.length === 1 ? 'step' : 'steps'}
+                    {groups.length} {groups.length === 1 ? 'screen' : 'screens'} · {steps.length} {steps.length === 1 ? 'step' : 'steps'}
                 </span>
             </div>
 
-            {/* Vertical timeline — readable at any width, no horizontal scroll,
-                and each row lines up 1:1 with the Step-by-Step cards below. */}
-            <ol className="relative">
-                {nodes.map((node, i) => {
-                    const Icon = KIND_ICON[node.kind];
-                    const style = nodeKindStyle(node.kind);
-                    const altCount = issuesByStep.get(node.stepIndex) ?? 0;
-                    const isLast = i === nodes.length - 1;
-                    const highlighted = highlightedStepIndices?.has(node.stepIndex) ?? false;
-                    return (
-                        <li key={node.stepIndex} className="relative flex gap-3">
-                            {/* Rail: number marker + connector line */}
-                            <div className="relative flex flex-col items-center">
-                                <span className="z-10 inline-flex items-center justify-center w-7 h-7 rounded-full bg-white border border-neutral-300 text-[11px] font-bold text-neutral-700">
-                                    {node.stepIndex + 1}
-                                </span>
-                                {!isLast && (
-                                    <span
-                                        aria-hidden="true"
-                                        className="w-px flex-1 bg-neutral-200 my-0.5"
-                                    />
-                                )}
-                            </div>
+            {/* Screens grouped into cards: the screen name shows once in the
+                header, its steps read as sub-rows labeled by user action — so a
+                screen that owns several sequential steps is no longer repeated
+                node-after-node. */}
+            <div className="space-y-3">
+                {groups.map(group => {
+                    const single = group.nodes.length === 1;
+                    const groupHighlighted = group.nodes.some(isHighlighted);
 
-                            {/* Node card */}
+                    if (single) {
+                        const node = group.nodes[0];
+                        const highlighted = isHighlighted(node);
+                        const alt = issuesByStep.get(node.stepIndex) ?? 0;
+                        return (
                             <button
+                                key={group.firstStepIndex}
                                 type="button"
-                                onClick={() => handleClick(node)}
+                                onClick={() => openGroup(group)}
                                 aria-current={highlighted ? 'true' : undefined}
-                                className={`group flex-1 min-w-0 text-left rounded-lg border ${style.border} ${style.bg} hover:ring-2 hover:ring-offset-1 hover:ring-indigo-300 transition px-3 py-2 mb-2 flex items-start gap-2.5 ${
+                                className={`group w-full text-left rounded-xl border ${screenStyle.border} ${screenStyle.bg} hover:ring-2 hover:ring-offset-1 hover:ring-indigo-300 transition ${
                                     highlighted ? 'ring-2 ring-offset-1 ring-indigo-500' : ''
                                 }`}
                             >
-                                <span className={`shrink-0 mt-0.5 inline-flex items-center justify-center w-5 h-5 rounded ${style.badgeBg} ${style.badgeText}`}>
-                                    <Icon size={12} />
-                                </span>
-                                <span className="min-w-0 flex-1">
-                                    <span className={`block text-[13px] font-medium leading-snug ${style.text}`} title={node.label}>
-                                        {node.label}
+                                <div className="flex items-center gap-2.5 px-3 py-2.5">
+                                    <span className={`shrink-0 inline-flex items-center justify-center w-6 h-6 rounded ${screenStyle.badgeBg} ${screenStyle.badgeText}`}>
+                                        <AppWindow size={13} />
                                     </span>
-                                    <span className="mt-1 flex items-center gap-1.5 flex-wrap">
-                                        <NodeBadge kind={node.kind} />
-                                        {altCount > 0 && (
-                                            <span
-                                                className="text-[9px] font-semibold px-1 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-200"
-                                                title={`${altCount} alternate path${altCount === 1 ? '' : 's'} or edge case${altCount === 1 ? '' : 's'}`}
-                                            >
-                                                {altCount} alt
+                                    <span className="min-w-0 flex-1">
+                                        <span className={`flex items-center gap-2`}>
+                                            <span className={`min-w-0 truncate text-[13px] font-semibold leading-snug ${screenStyle.text}`} title={group.screenLabel}>
+                                                {group.screenLabel}
                                             </span>
-                                        )}
+                                            <span className="shrink-0 text-[9px] font-semibold uppercase tracking-wider text-neutral-400 tabular-nums">
+                                                {rangeLabel(group)}
+                                            </span>
+                                        </span>
+                                        <span className="mt-1 flex items-center gap-2 flex-wrap">
+                                            {node.action && (
+                                                <span className="text-[12px] text-neutral-600 leading-snug">{node.action}</span>
+                                            )}
+                                            <NodeBadge kind={node.kind} />
+                                            <AltBadge count={alt} />
+                                        </span>
                                     </span>
+                                    <ChevronRight
+                                        size={14}
+                                        className="shrink-0 text-neutral-300 group-hover:text-indigo-400 transition-colors"
+                                        aria-hidden="true"
+                                    />
+                                </div>
+                            </button>
+                        );
+                    }
+
+                    return (
+                        <div
+                            key={group.firstStepIndex}
+                            className={`rounded-xl border overflow-hidden ${
+                                groupHighlighted ? 'border-indigo-300 ring-2 ring-offset-1 ring-indigo-200' : 'border-neutral-200'
+                            }`}
+                        >
+                            {/* Screen header — one label for the whole run. */}
+                            <button
+                                type="button"
+                                onClick={() => openGroup(group)}
+                                className={`group w-full text-left flex items-center gap-2.5 px-3 py-2.5 ${screenStyle.bg} border-b ${screenStyle.border} hover:brightness-[0.98] transition`}
+                            >
+                                <span className={`shrink-0 inline-flex items-center justify-center w-6 h-6 rounded ${screenStyle.badgeBg} ${screenStyle.badgeText}`}>
+                                    <AppWindow size={13} />
+                                </span>
+                                <span className={`min-w-0 flex-1 truncate text-[13px] font-semibold leading-snug ${screenStyle.text}`} title={group.screenLabel}>
+                                    {group.screenLabel}
+                                </span>
+                                <span className="shrink-0 text-[9px] font-semibold uppercase tracking-wider text-neutral-400 tabular-nums">
+                                    {rangeLabel(group)}
                                 </span>
                                 <ChevronRight
                                     size={14}
-                                    className="shrink-0 mt-1 text-neutral-300 group-hover:text-indigo-400 transition-colors"
+                                    className="shrink-0 text-neutral-300 group-hover:text-indigo-400 transition-colors"
                                     aria-hidden="true"
                                 />
                             </button>
-                        </li>
+
+                            {/* Sub-steps — labeled by user action, with the step
+                                number preserved and its kind badge. */}
+                            <ul className="divide-y divide-neutral-100 bg-white">
+                                {group.nodes.map(node => {
+                                    const highlighted = isHighlighted(node);
+                                    const alt = issuesByStep.get(node.stepIndex) ?? 0;
+                                    const Icon = KIND_ICON[node.kind];
+                                    const style = nodeKindStyle(node.kind);
+                                    return (
+                                        <li key={node.stepIndex}>
+                                            <button
+                                                type="button"
+                                                onClick={() => scrollToStep(node.stepIndex)}
+                                                aria-current={highlighted ? 'true' : undefined}
+                                                className={`group w-full text-left flex items-center gap-2.5 px-3 py-2 hover:bg-neutral-50 transition ${
+                                                    highlighted ? 'bg-indigo-50/60' : ''
+                                                }`}
+                                            >
+                                                <span className="shrink-0 inline-flex items-center justify-center w-[18px] h-[18px] rounded-full bg-neutral-50 border border-neutral-200 text-[10px] font-bold text-neutral-500 tabular-nums">
+                                                    {node.stepIndex + 1}
+                                                </span>
+                                                <span className={`shrink-0 inline-flex items-center justify-center w-5 h-5 rounded ${style.badgeBg} ${style.badgeText}`}>
+                                                    <Icon size={12} />
+                                                </span>
+                                                <span className="min-w-0 flex-1">
+                                                    <span className="block text-[12.5px] text-neutral-800 leading-snug truncate" title={node.action || node.label}>
+                                                        {node.action || node.label}
+                                                    </span>
+                                                    <span className="mt-1 flex items-center gap-1.5 flex-wrap">
+                                                        <NodeBadge kind={node.kind} />
+                                                        <AltBadge count={alt} />
+                                                    </span>
+                                                </span>
+                                                <ChevronRight
+                                                    size={13}
+                                                    className="shrink-0 text-neutral-300 group-hover:text-indigo-400 transition-colors"
+                                                    aria-hidden="true"
+                                                />
+                                            </button>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </div>
                     );
                 })}
-            </ol>
+            </div>
 
             {/* Compact, collapsible legend — the per-row kind badges already
                 label each node, so the color key is opt-in. */}
-            <div className="mt-1 pt-2 border-t border-neutral-100">
+            <div className="mt-3 pt-2 border-t border-neutral-100">
                 <button
                     type="button"
                     onClick={() => setLegendOpen(o => !o)}

--- a/src/components/renderers/userFlows/__tests__/FlowJourney.test.tsx
+++ b/src/components/renderers/userFlows/__tests__/FlowJourney.test.tsx
@@ -71,3 +71,48 @@ describe('FlowJourney screen-node navigation', () => {
         expect(screen.getByRole('button', { name: /Landing Page/ })).not.toHaveAttribute('aria-current');
     });
 });
+
+// A flow where several consecutive steps happen on the same screen — the exact
+// shape that used to render as repeated identical nodes (the demo quirk).
+const GROUPED_MARKDOWN = `### Flow: Submit
+**Goal:** Submit a project.
+**Steps:**
+1. [Landing Page] — User picks a role → System routes onward
+2. [Project Form] — User chooses submission type → System branches
+   - **Decision:** If guided, go to step 3; otherwise step 4
+3. [Project Form] — User fills in project details → System validates
+4. [Project Form] — User adds evaluation criteria → System saves draft
+5. [Progress Screen] — User watches analysis → System streams progress
+**Success Outcome:** Done.`;
+
+const groupedSteps = parseFlows(GROUPED_MARKDOWN)[0].steps;
+
+describe('FlowJourney screen grouping', () => {
+    it('renders one screen header per run of same-screen steps', () => {
+        render(<FlowJourney flowIndex={0} steps={groupedSteps} issuesByStep={new Map()} />);
+        // "Project Form" owns steps 2–4 but the name appears once as a header.
+        expect(screen.getAllByText('Project Form')).toHaveLength(1);
+        expect(screen.getByText('Steps 2–4')).toBeInTheDocument();
+    });
+
+    it('labels grouped sub-steps by their user action, not the screen name', () => {
+        render(<FlowJourney flowIndex={0} steps={groupedSteps} issuesByStep={new Map()} />);
+        expect(screen.getByText('User chooses submission type')).toBeInTheDocument();
+        expect(screen.getByText('User fills in project details')).toBeInTheDocument();
+        expect(screen.getByText('User adds evaluation criteria')).toBeInTheDocument();
+    });
+
+    it('highlights the sub-step for the current screen inside a group', () => {
+        render(
+            <FlowJourney
+                flowIndex={0}
+                steps={groupedSteps}
+                issuesByStep={new Map()}
+                highlightedStepIndices={new Set([2])}
+            />,
+        );
+        expect(
+            screen.getByRole('button', { name: /User fills in project details/ }),
+        ).toHaveAttribute('aria-current', 'true');
+    });
+});

--- a/src/components/renderers/userFlows/journeyNode.ts
+++ b/src/components/renderers/userFlows/journeyNode.ts
@@ -58,7 +58,66 @@ export function buildJourneyNodes(steps: ParsedStep[]): FlowJourneyNode[] {
         stepIndex: step.index,
         label: step.title?.trim() || step.userAction?.trim() || step.rawText.trim(),
         kind: inferNodeKind(step),
+        action: step.userAction?.trim() || undefined,
     }));
+}
+
+const BACKTICKS = /^`+|`+$/g;
+
+/** A run of consecutive journey steps that all happen on the same screen. */
+export interface FlowJourneyGroup {
+    /** Key shared by every step in the group (a screen slug), or null for a
+     * standalone step with no usable screen title. */
+    screenSlug: string | null;
+    /** The screen name, shown once as the group header. */
+    screenLabel: string;
+    /** The step nodes belonging to this screen, in flow order. */
+    nodes: FlowJourneyNode[];
+    /** 0-based indices of the first/last step — drives the "Steps N–M" range. */
+    firstStepIndex: number;
+    lastStepIndex: number;
+}
+
+/** Default screen key: the step's title, backtick-stripped and lowercased.
+ * Callers pass `stepScreenSlug` so grouping aligns with screen navigation. */
+function defaultScreenKey(step: ParsedStep): string | null {
+    const title = step.title ? step.title.replace(BACKTICKS, '').trim().toLowerCase() : '';
+    return title || null;
+}
+
+/**
+ * Collapse the flat step list into per-screen groups: consecutive steps that
+ * resolve to the same screen key become one group (rendered as a card with the
+ * screen name in the header and the steps as sub-rows), so a screen that owns
+ * several sequential steps is no longer repeated node-after-node. Steps with no
+ * screen key (null) never merge and stand alone. Order and step indices are
+ * preserved, so the grouping stays a pure presentation layer over the same
+ * parsed steps.
+ */
+export function buildJourneyGroups(
+    steps: ParsedStep[],
+    screenKeyFor: (step: ParsedStep) => string | null = defaultScreenKey,
+): FlowJourneyGroup[] {
+    const nodes = buildJourneyNodes(steps);
+    const groups: FlowJourneyGroup[] = [];
+    nodes.forEach((node, i) => {
+        const step = steps[i];
+        const key = screenKeyFor(step);
+        const prev = groups[groups.length - 1];
+        if (prev && key !== null && prev.screenSlug === key) {
+            prev.nodes.push(node);
+            prev.lastStepIndex = step.index;
+        } else {
+            groups.push({
+                screenSlug: key,
+                screenLabel: (step.title?.trim() || node.label).replace(BACKTICKS, '').trim(),
+                nodes: [node],
+                firstStepIndex: step.index,
+                lastStepIndex: step.index,
+            });
+        }
+    });
+    return groups;
 }
 
 export const NODE_KIND_LABEL: Record<FlowJourneyNodeKind, string> = {

--- a/src/components/renderers/userFlows/types.ts
+++ b/src/components/renderers/userFlows/types.ts
@@ -71,6 +71,9 @@ export type FlowJourneyNode = {
     stepIndex: number;
     label: string;
     kind: FlowJourneyNodeKind;
+    /** The step's user action ("Fill in project details"), shown as the
+     * sub-step label when steps are grouped under a shared screen header. */
+    action?: string;
 };
 
 export type ParsedFlow = {


### PR DESCRIPTION
## What & why

The Flow Journey timeline (Screens → a screen's **Flow** tab, and the standalone User Flows renderer) rendered **one node per parsed `user_flows` step**, and each node's label was only the screen name. A screen that owns several sequential steps — fill form → decide → validate → loading state — therefore showed up as a run of **identical nodes** (e.g. "Multi-Step Project Submission Form" four times in a row on the demo project).

Worth noting: this is **not** an old-project field gap. The `user_flows` generation format is unchanged by the recent Screens PRs, so a freshly generated project produces the same repetition. The fix is presentation, not regeneration.

## Change

Collapse consecutive steps that share a screen into **one card** (the "Option B — grouped cards" direction):

- The screen name shows **once** as the card header, with a `Steps N–M` range chip.
- Each step reads as a **sub-row labeled by its user action** — surfacing the "— User action → System response" detail the flat node list previously hid, which is what actually distinguishes steps on the same screen.
- Single-step screens collapse to one compact row.

## Implementation

- `buildJourneyGroups` (`journeyNode.ts`) — pure grouping of steps by `stepScreenSlug`, so grouping aligns with the slug the header navigation already uses. `FlowJourneyNode` gains an optional `action`.
- `FlowJourney.tsx` — renders grouped cards. Header navigates to the screen (slug-gated, unchanged); sub-rows scroll to their step card; `aria-current` highlight and the alt-count badge move onto the sub-rows.
- **Pure presentation over the same parsed steps** — no schema, prompt, sync, snapshot, or persistence change. Fixes legacy/demo flows without regeneration.

## Tests

- `FlowJourney.test.tsx`: existing 4 pass unchanged; added 3 covering grouped-header dedupe (screen name appears once + `Steps 2–4`), action-labeled sub-steps, and in-group `aria-current` highlight.
- `npm run build` and `npm run lint` pass; the wider userFlows + screen-experience suites (116 tests) pass.

## Docs

- `CLAUDE.md` Experience-workspace section updated to describe the grouped Flow Journey and the "keep grouping keyed on the navigation slug" invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013C7pKsBrb1ZNCATQNipsMY

---
_Generated by [Claude Code](https://claude.ai/code/session_013C7pKsBrb1ZNCATQNipsMY)_