### PR TITLE
Phase 4A: Screens review & approval workflow + implementation-readiness gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1572,8 +1572,11 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   only; route/accessibility have no data source and render "Not specified"),
   `buildMockupSpecCoverage` (token-overlap spec-to-spec comparison — present
   as "in the mockup spec", NEVER as visual detection of the image), and the
-  list filters (`SCREEN_LIST_FILTERS`/`screenMatchesFilter`: All / P0 /
-  Needs review / Missing mockups / Has risks / Ready). **Honesty rule:
+  list filters (`SCREEN_LIST_FILTERS`/`screenMatchesFilter`: All / P0 / Draft /
+  Needs review / Accepted / Ready / Has blockers / Review recommended /
+  Missing mockups / Has risks — `screenMatchesFilter` takes an optional
+  `ScreenFilterReview` so the review-status/blocker filters key off the Phase 4A
+  review model). **Honesty rule:
   everything derived is an estimate — keep the "estimated"/"derived" labels
   and "Not specified"/"Review recommended" fallbacks; never fabricate risk
   severity, mockup variants, routes, or per-state mockup coverage, and never
@@ -1584,6 +1587,58 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   rollup** (`buildMessage` uses `ready − readyWithWarnings`; `ScreenCoveragePanel`
   gates its green all-clear on `readyWithWarnings === 0`) so a human override
   can never make the artifact-level summary read clean while warnings remain.
+- **Phase 4A — screen review & approval workflow (`src/lib/screenReviewWorkflow.ts`,
+  pure, unit-tested).** Turns the Screens artifact from a reference surface into a
+  review workflow, layered ON TOP of the readiness/variant/trust layers (never
+  changing them). It deliberately keeps **two distinct concepts** — do not
+  collapse them: **(1) USER review status** — the human sign-off, persisted in the
+  existing `ScreenMetadataEdit.reviewStatus` overlay
+  (draft/needs_review/accepted/implementation_ready); and **(2) SYSTEM readiness**
+  (`SystemReadinessStatus`: ready / needs_review / blocked) — Synapse's derived
+  estimate from the issue set, never overridden by the buttons. A screen can be
+  user-Accepted while system readiness says "review recommended", or user-Draft
+  while the system says "ready to accept". `deriveScreenReviewIssues` reuses
+  `detectScreenGaps` + `resolveAcceptanceCriteria`/`resolveScreenHandoff` +
+  precomputed mockup/freshness signals to produce **`ScreenReviewIssue`s**
+  (severity `blocking` | `review` | `info`, categorized) with a `recommendedAction`.
+  Blocking = missing purpose, missing traceability/navigation on a **primary**
+  (P0/P1) screen, P0 without a default mockup, a required state with no behavior,
+  no derivable acceptance criteria, an unresolved high-severity risk on a P0
+  screen. Review = missing mobile mockup, stale mockups, unresolved risks,
+  decisions without branch outcomes, thin handoff, missing state variants, stale
+  PRD refs. Info = freshness/coverage unknown (legacy metadata — NEVER a
+  blocker), no flow refs. `buildScreenReviewModel`/`buildScreenReviewModelForItem`/
+  `buildScreenReviewIndex` assemble the per-screen `ScreenReviewModel` (status +
+  systemReadiness + issues + counts + `acceptedOverWarnings` + freshness +
+  checklist progress); the views use the `-ForItem`/`-Index` wrappers (which build
+  the variant grid), pure tests use the low-level fn with explicit signals.
+  **Supporting review record** rides a NEW additive overlay field
+  `ScreenMetadataEdit.review` (`ScreenReviewMeta` in `src/types`: checklist, note,
+  override reason, sign-off `signature`, transition timestamps) — status stays in
+  `reviewStatus`, so all existing wiring is untouched; `readScreenEdits` parses it
+  defensively and preserves unknown keys. **Review freshness (re-review after
+  acceptance):** `buildScreenReviewSignature` captures `computeScreenReviewHash`
+  (a self-contained FNV-1a hash of the substantive spec — purpose/intent/priority/
+  states/nav/UI/risks/criteria/traceability/handoff, **excluding the display-only
+  `name` rename and overlay-only fields** so a pure rename never trips it) at
+  accept/implementation-ready; `compareReviewFreshness` → `current` | `outdated` |
+  `unknown` (**no stored signature = `unknown`, legacy records NEVER falsely
+  outdated**, mirroring mockup freshness). **Artifact-level readiness gate:**
+  `buildScreenArtifactReviewReadiness`/`summarizeArtifactReviewReadiness` roll the
+  models up — **P0 screens are the gate**: ready iff every P0 screen is
+  user-signed-off (accepted/implementation_ready) AND no P0 screen carries
+  blocking issues. It is a **readiness signal, NOT a hard lock** — nothing gates
+  rendering or generation. UI: `ScreenReviewPanel` (Screen Detail header — status
+  line, Accept / Request changes / Mark ready-to-build actions with an inline
+  override-reason capture when blockers exist, readiness-issue list, review
+  checklist, a calm "review may be outdated" banner + Re-review), review status +
+  issue counts on `ScreenListView` cards, and a "Review readiness" rollup + gate
+  callout in `ScreenCoveragePanel`. Persistence flows through the existing
+  `handleSaveScreenEdit` → `updateArtifactVersionMetadata` overlay path
+  (timestamps/signatures stamped in `ScreenDetailView`, not the pure module).
+  Language stays calm ("Review recommended", never "Invalid"). **Not yet done
+  (Phase 4B):** cross-artifact downstream invalidation when an accepted screen
+  changes (today only a note), and a dedicated export/finalization preflight.
 - **Phase 2 — source-grounded screen contracts.** New screen_inventory
   generations emit an explicit contract per screen (all fields optional &
   back-compat on `ScreenItem`/`ScreenState` in `src/types`): structured

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -37,6 +37,7 @@ import {
     type ScreenMetadataEdit,
 } from '../lib/screenExperience';
 import { buildReadinessIndex, buildScreenCoverageSummary } from '../lib/screenReadiness';
+import { buildScreenReviewIndex, summarizeArtifactReviewReadiness } from '../lib/screenReviewWorkflow';
 import { buildMockupVariantCoverageSummary, type GeneratedVariantMap } from '../lib/mockupVariants';
 import type { MockupVariantSourceSignature, VariantTrustContext } from '../lib/mockupVariantTrust';
 import { useMockupVariantImageStore } from '../store/mockupVariantImageStore';
@@ -449,6 +450,24 @@ export function ArtifactWorkspace({
             generatedVariantsByScreen: (id) => generatedVariantsByScreen.get(id),
         }),
         [screenIndex, mockupPlatform, mobileRelevant, trustContext, generatedVariantsByScreen],
+    );
+
+    // Phase 4A: per-screen review models (user status vs. system readiness,
+    // issues, checklist, freshness) + the artifact-level readiness gate for the
+    // coverage panel. Pure & read-time — see src/lib/screenReviewWorkflow.ts.
+    const screenReviewModels = useMemo(
+        () => buildScreenReviewIndex(screenIndex, {
+            features: structuredPRD.features,
+            platform: mockupPlatform,
+            mobileRelevant,
+            trustContext,
+            generatedVariantsByScreen: (id) => generatedVariantsByScreen.get(id),
+        }),
+        [screenIndex, structuredPRD.features, mockupPlatform, mobileRelevant, trustContext, generatedVariantsByScreen],
+    );
+    const artifactReview = useMemo(
+        () => summarizeArtifactReviewReadiness(screenIndex, screenReviewModels),
+        [screenIndex, screenReviewModels],
     );
 
     // Validation issues minus the user's persisted dismissals.
@@ -998,6 +1017,8 @@ export function ArtifactWorkspace({
                     <ScreenListView
                         index={screenIndex}
                         readiness={screenReadiness}
+                        reviewModels={screenReviewModels}
+                        artifactReview={artifactReview}
                         coverage={screenCoverage}
                         variantCoverage={variantCoverage}
                         mockupPlatform={mockupPlatform}

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import type { Feature, MockupPayload, ScreenInventoryContent, ScreenItem } from '../../types';
 import { buildScreenIndex, type ScreenMetadataEdit } from '../../lib/screenExperience';
 import { buildReadinessIndex, buildScreenCoverageSummary } from '../../lib/screenReadiness';
+import { buildScreenReviewIndex, summarizeArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
 import { parseFlows } from '../renderers/userFlows/parseFlow';
 import { ScreenListView } from '../experience/ScreenListView';
 import { ScreenDetailView } from '../experience/ScreenDetailView';
@@ -173,9 +174,11 @@ describe('ScreenDetailView tabs', () => {
     });
 
     it('Overview survives a legacy screen with no optional fields', () => {
-        const { getByText } = renderDetail('bare-legacy-screen', 'overview');
+        const { getByText, getAllByText } = renderDetail('bare-legacy-screen', 'overview');
         expect(getByText(/No linked PRD features found/)).toBeTruthy();
-        expect(getByText(/No UI states documented/)).toBeTruthy();
+        // "No UI states documented" now appears in both the Overview section and
+        // the Phase 4A review-issue list — assert it's present rather than unique.
+        expect(getAllByText(/No UI states documented/).length).toBeGreaterThan(0);
         expect(getByText(/Not enough detail/)).toBeTruthy();
     });
 
@@ -369,6 +372,106 @@ describe('Phase 2 contract rendering', () => {
         expect(getAllByText('Ready to build').length).toBeGreaterThan(0);
         // The derived warnings are still surfaced in the handoff footer.
         expect(getByText(/Before building:/)).toBeTruthy();
+    });
+});
+
+// --- Phase 4A: review & approval workflow ------------------------------------
+
+describe('Phase 4A review workflow UI', () => {
+    it('Screen Detail renders the review header, status, and actions', () => {
+        const { getByText } = renderContractDetail('overview', { onSaveScreenEdit: vi.fn() });
+        expect(getByText('User review')).toBeTruthy();
+        expect(getByText('System readiness')).toBeTruthy();
+        expect(getByText('Accept screen')).toBeTruthy();
+        expect(getByText('Mark ready to build')).toBeTruthy();
+    });
+
+    it('accepting a clean screen persists the accepted status + a sign-off signature', () => {
+        const onSave = vi.fn();
+        const { getByText } = renderContractDetail('overview', { onSaveScreenEdit: onSave });
+        fireEvent.click(getByText('Accept screen'));
+        expect(onSave).toHaveBeenCalledTimes(1);
+        const [id, edit] = onSave.mock.calls[0] as [string, Record<string, unknown>];
+        expect(id).toBe('scr-submission');
+        expect(edit.reviewStatus).toBe('accepted');
+        const review = edit.review as Record<string, unknown>;
+        expect(review.acceptedAt).toBeTruthy();
+        expect((review.signature as Record<string, unknown>).screenContractHash).toBeTruthy();
+    });
+
+    it('the review checklist persists a ticked item into the overlay', () => {
+        const onSave = vi.fn();
+        const { getByText, getByLabelText } = renderContractDetail('overview', { onSaveScreenEdit: onSave });
+        fireEvent.click(getByText('Review checklist'));
+        fireEvent.click(getByLabelText('Purpose matches the PRD'));
+        expect(onSave).toHaveBeenCalledTimes(1);
+        const [, edit] = onSave.mock.calls[0] as [string, Record<string, unknown>];
+        const review = edit.review as Record<string, unknown>;
+        expect((review.checklist as Record<string, unknown>).purposeMatchesPrd).toBe(true);
+    });
+});
+
+function buildReviewFixtures() {
+    const flows = parseFlows(FLOWS_MD);
+    const index = buildScreenIndex(inventory, flows, payload);
+    const readiness = buildReadinessIndex(index, FEATURES);
+    const coverage = buildScreenCoverageSummary(index, readiness, flows, FEATURES);
+    const reviewModels = buildScreenReviewIndex(index, { features: FEATURES });
+    const artifactReview = summarizeArtifactReviewReadiness(index, reviewModels);
+    return { index, readiness, coverage, reviewModels, artifactReview };
+}
+
+describe('Phase 4A Screens list + coverage panel', () => {
+    it('cards show the review status and issue counts', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildReviewFixtures();
+        const { getAllByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                onSelectScreen={() => {}}
+            />,
+        );
+        // Both screens are unreviewed → each card shows the review status line.
+        expect(getAllByText('Not reviewed').length).toBeGreaterThan(0);
+    });
+
+    it('the Has blockers filter shows only screens with blocking issues', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildReviewFixtures();
+        const { getByText, queryByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                onSelectScreen={() => {}}
+            />,
+        );
+        fireEvent.click(getByText('Has blockers'));
+        // The bare legacy screen (no purpose / acceptance) has blockers; the
+        // full P0 dashboard does not.
+        expect(getByText('Bare Legacy Screen')).toBeTruthy();
+        expect(queryByText('Home Dashboard')).toBeNull();
+    });
+
+    it('the coverage panel shows the review-readiness rollup + gate', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildReviewFixtures();
+        const { getByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                onSelectScreen={() => {}}
+            />,
+        );
+        expect(getByText('Review readiness')).toBeTruthy();
+        // No P0 screen is accepted yet → not ready for implementation planning.
+        expect(getByText('Not ready for implementation planning yet')).toBeTruthy();
     });
 });
 

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -8,9 +8,10 @@
 
 import { useState } from 'react';
 import {
-    AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, Gauge, Image as ImageIcon,
+    AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, ClipboardCheck, Gauge, Image as ImageIcon,
 } from 'lucide-react';
 import type { ScreenCoverageSummary } from '../../lib/screenReadiness';
+import type { ScreenArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
 import type { MockupVariantCoverageSummary } from '../../lib/mockupVariants';
 import type { VariantFreshnessRollup } from '../../lib/mockupVariantTrust';
 
@@ -28,6 +29,9 @@ interface Props {
     /** Artifact-level mockup-variant rollup (Phase 3A). Absent/null → the
      * variant rows are hidden (e.g. no screens). */
     variantCoverage?: MockupVariantCoverageSummary | null;
+    /** Artifact-level review readiness gate (Phase 4A). Absent → the review
+     * readiness section is hidden (legacy callers). */
+    artifactReview?: ScreenArtifactReviewReadiness;
     /** Opens the confirmed "Generate remaining mockups" flow (absent → no
      * mockup artifact yet; the action row is hidden). */
     onGenerateMissingMockups?: () => void;
@@ -54,7 +58,7 @@ function MetricRow({
     );
 }
 
-export function ScreenCoveragePanel({ summary, variantCoverage, onGenerateMissingMockups }: Props) {
+export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, onGenerateMissingMockups }: Props) {
     const [showUncovered, setShowUncovered] = useState(false);
     const {
         totalScreens, prdFeatures, stateVariants, flows, p0, states, mockups, openRisks,
@@ -234,6 +238,59 @@ export function ScreenCoveragePanel({ summary, variantCoverage, onGenerateMissin
                         <p className="mt-3 inline-flex items-center gap-1.5 text-[11px] text-emerald-700">
                             <CheckCircle2 size={12} /> Derived checks pass — statuses are estimates, so give screens a final review.
                         </p>
+                    )}
+
+                    {artifactReview && artifactReview.totalScreens > 0 && (
+                        <ReviewReadinessSection review={artifactReview} />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** Phase 4A: the review & approval rollup + implementation-readiness gate. A
+ * readiness signal, never a hard lock — the UI stays fully usable either way. */
+function ReviewReadinessSection({ review }: { review: ScreenArtifactReviewReadiness }) {
+    return (
+        <div className="mt-4 pt-4 border-t border-neutral-100">
+            <div className="flex items-center gap-1.5 mb-2">
+                <ClipboardCheck size={13} className="text-neutral-400" aria-hidden />
+                <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">Review readiness</h4>
+            </div>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-neutral-600">
+                <span>{review.totalScreens} {review.totalScreens === 1 ? 'screen' : 'screens'} total</span>
+                <span className="text-sky-700">{review.accepted} accepted</span>
+                <span className="text-emerald-700">{review.implementationReady} ready to build</span>
+                <span className="text-amber-700">{review.needsReview + review.draft} need review</span>
+                {review.blockers > 0 && (
+                    <span className="text-red-700">{review.blockers} {review.blockers === 1 ? 'blocker' : 'blockers'}</span>
+                )}
+                {review.reviewItems > 0 && (
+                    <span className="text-amber-700">{review.reviewItems} review {review.reviewItems === 1 ? 'item' : 'items'}</span>
+                )}
+            </div>
+
+            <div className={`mt-3 rounded-lg border p-3 flex items-start gap-2 ${
+                review.ready ? 'border-emerald-200 bg-emerald-50/60' : 'border-amber-200 bg-amber-50/60'
+            }`}>
+                {review.ready
+                    ? <CheckCircle2 size={15} className="text-emerald-600 mt-0.5 shrink-0" aria-hidden />
+                    : <AlertTriangle size={15} className="text-amber-600 mt-0.5 shrink-0" aria-hidden />}
+                <div className="min-w-0">
+                    <p className={`text-xs font-medium ${review.ready ? 'text-emerald-800' : 'text-amber-800'}`}>
+                        {review.ready ? 'Ready for implementation planning' : 'Not ready for implementation planning yet'}
+                    </p>
+                    <p className="text-[11px] text-neutral-600 mt-0.5">{review.message}</p>
+                    {!review.ready && review.reasons.length > 0 && (
+                        <ul className="mt-1.5 space-y-0.5 text-[11px] text-amber-700">
+                            {review.reasons.map((r, i) => (
+                                <li key={i} className="flex gap-1.5">
+                                    <span className="text-amber-400 select-none">·</span>
+                                    <span>{r}</span>
+                                </li>
+                            ))}
+                        </ul>
                     )}
                 </div>
             </div>

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react';
 import type {
     Feature, GenerationStatus, MockupPayload,
-    MockupSettings, ScreenPriority,
+    MockupSettings, ScreenPriority, ScreenReviewChecklist, ScreenReviewMeta,
 } from '../../types';
 import {
     groupFlowRefsByFlow,
@@ -33,12 +33,17 @@ import {
     type ScreenReadiness, type ScreenReviewStatus,
 } from '../../lib/screenReadiness';
 import {
+    buildScreenReviewModelForItem, buildScreenReviewSignature,
+    type ScreenReviewModel,
+} from '../../lib/screenReviewWorkflow';
+import {
     buildScreenMockupVariants, formatVariantLabel, summarizeScreenVariants,
     VARIANT_STATUS_LABELS, type GeneratedVariantMap,
 } from '../../lib/mockupVariants';
 import type { MockupVariantSourceSignature, VariantTrustContext } from '../../lib/mockupVariantTrust';
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import { MockupVariantsPanel } from './MockupVariantsPanel';
+import { ScreenReviewPanel } from './ScreenReviewPanel';
 import { ScreenOverviewPanel } from './ScreenOverviewPanel';
 import { ReadinessBadge } from './ReadinessBadge';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
@@ -125,6 +130,93 @@ export function ScreenDetailView({
         if (artifactVersionId) void loadForArtifactVersion(artifactVersionId);
     }, [artifactVersionId, loadForArtifactVersion]);
 
+    // Phase 3B/4A: manifest-backed generated variants for this screen (viewport ×
+    // state), loaded lazily so the review model + Mockups tab both reflect real
+    // generation state. Lifted from MockupsTab so the review header can factor in
+    // per-variant coverage/freshness.
+    const versionId = mockupContext?.versionId;
+    const loadVariantImages = useMockupVariantImageStore(s => s.loadForVersion);
+    const variantImages = useMockupVariantImageStore(s => s.images);
+    useEffect(() => {
+        if (versionId) void loadVariantImages(versionId);
+    }, [versionId, loadVariantImages]);
+    const generatedVariants = useMemo<GeneratedVariantMap>(() => {
+        if (!versionId) return {};
+        const out: GeneratedVariantMap = {};
+        for (const key of Object.keys(variantImages)) {
+            const r = variantImages[key];
+            if (r.versionId !== versionId || r.screenId !== item.id) continue;
+            out[r.variantId] = {
+                coverage: r.coverageManifest?.overallStatus ?? 'unknown',
+                sourceSignature: r.sourceSignature as MockupVariantSourceSignature | undefined,
+            };
+        }
+        return out;
+    }, [variantImages, versionId, item.id]);
+
+    // Phase 4A: derived review model (user status vs. system readiness, issues,
+    // checklist, freshness). Uses the same variant inputs as the Mockups tab.
+    const reviewModel = useMemo<ScreenReviewModel>(() => buildScreenReviewModelForItem(item, {
+        platform: mockupContext?.settings.platform,
+        mobileRelevant,
+        features,
+        trustContext: mockupContext?.trustContext,
+        generatedVariants,
+    }), [item, mockupContext?.settings.platform, mockupContext?.trustContext, mobileRelevant, features, generatedVariants]);
+
+    // Persist a review change into the screenEdits overlay. Status rides
+    // `reviewStatus`; the supporting record (checklist / note / override reason /
+    // sign-off signature / timestamps) rides `review`. Merges from the existing
+    // edit so name/notes/variant marks and any unknown fields survive.
+    const persistReview = useCallback((change: {
+        status?: ScreenReviewStatus;
+        reviewPatch?: Partial<ScreenReviewMeta>;
+        captureSignature?: boolean;
+    }) => {
+        if (!onSaveScreenEdit) return;
+        const now = new Date().toISOString();
+        const edit: ScreenMetadataEdit = { ...(item.edit ?? {}) };
+        if (change.status) edit.reviewStatus = change.status;
+        const review: ScreenReviewMeta = { ...(edit.review ?? {}), ...change.reviewPatch, updatedAt: now };
+        if (change.captureSignature) {
+            review.signature = buildScreenReviewSignature(item.screen, {
+                prdVersionId: mockupContext?.trustContext?.prdVersionId,
+                screenVersionId: mockupContext?.trustContext?.screenVersionId,
+                designSystemVersionId: mockupContext?.trustContext?.designSystemVersionId,
+            });
+        }
+        edit.review = review;
+        onSaveScreenEdit(item.id, edit);
+    }, [onSaveScreenEdit, item.edit, item.id, item.screen, mockupContext?.trustContext]);
+
+    const handleAccept = useCallback((overrideReason?: string) => {
+        const now = new Date().toISOString();
+        persistReview({
+            status: 'accepted',
+            reviewPatch: { acceptedAt: now, overrideReason: overrideReason || undefined },
+            captureSignature: true,
+        });
+    }, [persistReview]);
+    const handleRequestChanges = useCallback((note?: string) => {
+        const now = new Date().toISOString();
+        persistReview({ status: 'needs_review', reviewPatch: { requestedChangesAt: now, notes: note || undefined } });
+    }, [persistReview]);
+    const handleMarkImplReady = useCallback((overrideReason?: string) => {
+        const now = new Date().toISOString();
+        persistReview({
+            status: 'implementation_ready',
+            reviewPatch: { implementationReadyAt: now, overrideReason: overrideReason || undefined },
+            captureSignature: true,
+        });
+    }, [persistReview]);
+    const handleReReview = useCallback(() => persistReview({ captureSignature: true }), [persistReview]);
+    const handleToggleChecklist = useCallback((key: keyof ScreenReviewChecklist, checked: boolean) => {
+        const checklist: ScreenReviewChecklist = { ...(item.edit?.review?.checklist ?? {}) };
+        if (checked) checklist[key] = true;
+        else delete checklist[key];
+        persistReview({ reviewPatch: { checklist: Object.keys(checklist).length > 0 ? checklist : undefined } });
+    }, [persistReview, item.edit?.review?.checklist]);
+
     const flowGroups = useMemo(
         () => groupFlowRefsByFlow(item.relatedFlows),
         [item.relatedFlows],
@@ -180,6 +272,16 @@ export function ScreenDetailView({
                     </p>
                 )}
             </div>
+
+            <ScreenReviewPanel
+                model={reviewModel}
+                onAccept={handleAccept}
+                onRequestChanges={handleRequestChanges}
+                onMarkImplementationReady={handleMarkImplReady}
+                onToggleChecklist={handleToggleChecklist}
+                onReReview={handleReReview}
+                readOnly={!onSaveScreenEdit}
+            />
 
             <ScreenDetailTabs
                 active={activeTab}
@@ -265,6 +367,7 @@ export function ScreenDetailView({
                     unmatchedMockups={unmatchedMockups}
                     onLinkMockup={onLinkMockup}
                     onSaveScreenEdit={onSaveScreenEdit}
+                    generatedVariants={generatedVariants}
                 />
             )}
         </div>
@@ -601,7 +704,7 @@ function DecisionBranches({ decision }: { decision: string }) {
 
 function MockupsTab({
     item, mockupContext, mobileRelevant, mockupStatus, onRetryMockup, onAddToMockups,
-    unmatchedMockups, onLinkMockup, onSaveScreenEdit,
+    unmatchedMockups, onLinkMockup, onSaveScreenEdit, generatedVariants,
 }: {
     item: ScreenExperienceItem;
     mockupContext?: ScreenDetailMockupContext;
@@ -612,31 +715,10 @@ function MockupsTab({
     unmatchedMockups?: Array<{ id: string; name: string }>;
     onLinkMockup?: (mockupScreenId: string) => void;
     onSaveScreenEdit?: (screenId: string, edit: ScreenMetadataEdit | null) => void;
+    /** Manifest-backed generated variants for this screen (loaded by the parent). */
+    generatedVariants: GeneratedVariantMap;
 }) {
     const [linkTarget, setLinkTarget] = useState('');
-
-    // Phase 3B: manifest-backed generated variants for this screen (viewport ×
-    // state), from the per-variant image store. Loaded lazily on view; a
-    // generated variant flips the derived model from missing → generated.
-    const versionId = mockupContext?.versionId;
-    const loadVariantImages = useMockupVariantImageStore(s => s.loadForVersion);
-    const variantImages = useMockupVariantImageStore(s => s.images);
-    useEffect(() => {
-        if (versionId) void loadVariantImages(versionId);
-    }, [versionId, loadVariantImages]);
-    const generatedVariants = useMemo<GeneratedVariantMap>(() => {
-        if (!versionId) return {};
-        const out: GeneratedVariantMap = {};
-        for (const key of Object.keys(variantImages)) {
-            const r = variantImages[key];
-            if (r.versionId !== versionId || r.screenId !== item.id) continue;
-            out[r.variantId] = {
-                coverage: r.coverageManifest?.overallStatus ?? 'unknown',
-                sourceSignature: r.sourceSignature as MockupVariantSourceSignature | undefined,
-            };
-        }
-        return out;
-    }, [variantImages, versionId, item.id]);
 
     // Derived viewport × state variant grid (see src/lib/mockupVariants.ts).
     const variants = buildScreenMockupVariants(item, {

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -13,8 +13,12 @@ import type { MockupPlatform } from '../../types';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
 import {
     SCREEN_LIST_FILTERS, screenMatchesFilter,
-    type ScreenCoverageSummary, type ScreenListFilter, type ScreenReadiness,
+    type ScreenCoverageSummary, type ScreenFilterReview, type ScreenListFilter, type ScreenReadiness,
 } from '../../lib/screenReadiness';
+import {
+    REVIEW_STATUS_LABELS, SYSTEM_READINESS_LABELS,
+    type ScreenArtifactReviewReadiness, type ScreenReviewModel,
+} from '../../lib/screenReviewWorkflow';
 import {
     buildScreenMockupVariants, summarizeScreenVariants,
     type GeneratedVariantMap, type MockupVariantCoverageSummary,
@@ -24,10 +28,17 @@ import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 import { ScreenCoveragePanel } from './ScreenCoveragePanel';
 import { ReadinessBadge } from './ReadinessBadge';
 
+const EMPTY_REVIEW_MODELS: ReadonlyMap<string, ScreenReviewModel> = new Map();
+
 interface Props {
     index: ScreenExperienceIndex;
     /** Per-screen readiness keyed by canonical id (src/lib/screenReadiness). */
     readiness: ReadonlyMap<string, ScreenReadiness>;
+    /** Per-screen review model keyed by canonical id (Phase 4A). Absent → cards
+     * fall back to readiness-only, filters treat everything as unreviewed. */
+    reviewModels?: ReadonlyMap<string, ScreenReviewModel>;
+    /** Artifact-level review readiness gate for the coverage panel (Phase 4A). */
+    artifactReview?: ScreenArtifactReviewReadiness;
     /** Artifact-level coverage rollup for the top panel. */
     coverage: ScreenCoverageSummary;
     /** Artifact-level mockup-variant rollup for the coverage panel (Phase 3A). */
@@ -53,20 +64,32 @@ interface Props {
 }
 
 export function ScreenListView({
-    index, readiness, coverage, variantCoverage, mockupPlatform, mobileRelevant,
+    index, readiness, reviewModels = EMPTY_REVIEW_MODELS, artifactReview, coverage,
+    variantCoverage, mockupPlatform, mobileRelevant,
     generatedVariantsByScreen, trustContext, onSelectScreen, onGenerateMissingMockups,
 }: Props) {
     const [filter, setFilter] = useState<ScreenListFilter>('all');
+
+    const filterReviewFor = (item: ScreenExperienceItem): ScreenFilterReview | undefined => {
+        const model = reviewModels.get(item.id);
+        if (!model) return undefined;
+        return {
+            userStatus: model.userStatus,
+            blockingCount: model.blockingCount,
+            reviewCount: model.reviewCount,
+        };
+    };
 
     // Per-filter match counts so empty filters are obvious before clicking.
     const filterCounts = useMemo(() => {
         const counts = new Map<ScreenListFilter, number>();
         for (const { id } of SCREEN_LIST_FILTERS) {
             counts.set(id, index.items.filter(item =>
-                screenMatchesFilter(item, readiness.get(item.id), id)).length);
+                screenMatchesFilter(item, readiness.get(item.id), id, filterReviewFor(item))).length);
         }
         return counts;
-    }, [index, readiness]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [index, readiness, reviewModels]);
 
     if (index.items.length === 0) {
         return (
@@ -86,7 +109,7 @@ export function ScreenListView({
         .map(section => ({
             ...section,
             items: section.items.filter(item =>
-                screenMatchesFilter(item, readiness.get(item.id), filter)),
+                screenMatchesFilter(item, readiness.get(item.id), filter, filterReviewFor(item))),
         }))
         .filter(section => section.items.length > 0);
 
@@ -95,6 +118,7 @@ export function ScreenListView({
             <ScreenCoveragePanel
                 summary={coverage}
                 variantCoverage={variantCoverage}
+                artifactReview={artifactReview}
                 onGenerateMissingMockups={onGenerateMissingMockups}
             />
 
@@ -154,6 +178,7 @@ export function ScreenListView({
                                 <ScreenRow
                                     item={item}
                                     readiness={readiness.get(item.id)}
+                                    reviewModel={reviewModels.get(item.id)}
                                     mockupPlatform={mockupPlatform}
                                     mobileRelevant={mobileRelevant}
                                     generatedVariants={generatedVariantsByScreen?.(item.id)}
@@ -169,11 +194,18 @@ export function ScreenListView({
     );
 }
 
+const SYSTEM_READINESS_TONE: Record<ScreenReviewModel['systemReadiness'], string> = {
+    ready: 'text-emerald-600',
+    needs_review: 'text-amber-600',
+    blocked: 'text-red-600',
+};
+
 function ScreenRow({
-    item, readiness, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
+    item, readiness, reviewModel, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
 }: {
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
+    reviewModel?: ScreenReviewModel;
     mockupPlatform?: MockupPlatform;
     mobileRelevant?: boolean;
     generatedVariants?: GeneratedVariantMap;
@@ -277,7 +309,37 @@ function ScreenRow({
                         Coverage: unknown
                     </span>
                 )}
+                {reviewModel?.freshness === 'outdated' && (
+                    <span
+                        className="text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full"
+                        title="This screen changed after it was reviewed — re-review recommended"
+                    >
+                        Review may be outdated
+                    </span>
+                )}
             </div>
+
+            {reviewModel && (
+                <div className="mt-2 flex items-center gap-2 flex-wrap text-[11px]">
+                    <span className="text-neutral-400 uppercase tracking-wide text-[10px]">Review</span>
+                    <span className="font-medium text-neutral-700">
+                        {reviewModel.userStatus ? REVIEW_STATUS_LABELS[reviewModel.userStatus] : 'Not reviewed'}
+                    </span>
+                    <span className="text-neutral-300" aria-hidden>·</span>
+                    <span className={SYSTEM_READINESS_TONE[reviewModel.systemReadiness]}>
+                        {reviewModel.blockingCount > 0
+                            ? `${reviewModel.blockingCount} ${reviewModel.blockingCount === 1 ? 'blocker' : 'blockers'}`
+                            : reviewModel.reviewCount > 0
+                                ? `${reviewModel.reviewCount} review ${reviewModel.reviewCount === 1 ? 'item' : 'items'}`
+                                : SYSTEM_READINESS_LABELS[reviewModel.systemReadiness]}
+                    </span>
+                    {reviewModel.blockingCount > 0 && reviewModel.reviewCount > 0 && (
+                        <span className="text-amber-600">
+                            + {reviewModel.reviewCount} review {reviewModel.reviewCount === 1 ? 'item' : 'items'}
+                        </span>
+                    )}
+                </div>
+            )}
 
             <div className="mt-auto pt-3 flex items-center gap-3 flex-wrap text-[11px] text-neutral-500">
                 <span

--- a/src/components/experience/ScreenReviewPanel.tsx
+++ b/src/components/experience/ScreenReviewPanel.tsx
@@ -1,0 +1,330 @@
+// Phase 4A: the per-screen review & approval control, shown near the top of the
+// Screen Detail view. Presents (and lets the user drive) two DISTINCT signals:
+//
+//   - User review status  — the human sign-off (Draft / Needs review / Accepted
+//     / Ready to build), set via the action buttons here.
+//   - System readiness     — Synapse's derived estimate (Ready to accept /
+//     Review recommended / Blocking issues), never overridden by the buttons.
+//
+// It also renders the readiness issue list (blockers / review items / info), a
+// lightweight review checklist, and a calm "review may be outdated" banner when
+// the screen spec changed after sign-off. Presentational only — every mutation
+// goes back through the callbacks (persisted by ScreenDetailView via the
+// screenEdits overlay). Copy stays calm and helpful, never alarming.
+
+import { useState } from 'react';
+import {
+    AlertOctagon, CheckCircle2, ChevronDown, ChevronUp, ClipboardCheck, Info,
+    RefreshCw, ShieldQuestion, X,
+} from 'lucide-react';
+import type { ScreenReviewChecklist } from '../../types';
+import {
+    CHECKLIST_LABELS, REVIEW_STATUS_LABELS, SYSTEM_READINESS_LABELS,
+    reviewTransitionsFor,
+    type ScreenReviewIssue, type ScreenReviewIssueSeverity, type ScreenReviewModel,
+} from '../../lib/screenReviewWorkflow';
+
+interface Props {
+    model: ScreenReviewModel;
+    /** Accept the screen. A reason is supplied only when overriding open issues. */
+    onAccept: (overrideReason?: string) => void;
+    /** Request changes, with an optional "what needs to change?" note. */
+    onRequestChanges: (note?: string) => void;
+    /** Promote to Ready to build. A reason is supplied only when overriding. */
+    onMarkImplementationReady: (overrideReason?: string) => void;
+    /** Toggle one review-checklist item. */
+    onToggleChecklist: (key: keyof ScreenReviewChecklist, checked: boolean) => void;
+    /** Re-affirm the review against the current spec (clears "outdated"). */
+    onReReview: () => void;
+    /** Absent onSave → the panel is read-only (demo / legacy inventory). */
+    readOnly?: boolean;
+}
+
+const SYSTEM_READINESS_STYLES: Record<ScreenReviewModel['systemReadiness'], string> = {
+    ready: 'text-emerald-700',
+    needs_review: 'text-amber-700',
+    blocked: 'text-red-700',
+};
+
+const USER_STATUS_STYLES: Record<NonNullable<ScreenReviewModel['userStatus']>, string> = {
+    draft: 'bg-neutral-100 text-neutral-600 ring-neutral-200',
+    needs_review: 'bg-amber-50 text-amber-700 ring-amber-200',
+    accepted: 'bg-sky-50 text-sky-700 ring-sky-200',
+    implementation_ready: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+};
+
+const SEVERITY_META: Record<ScreenReviewIssueSeverity, { label: string; dot: string; text: string }> = {
+    blocking: { label: 'Blocking', dot: 'bg-red-500', text: 'text-red-700' },
+    review: { label: 'Review recommended', dot: 'bg-amber-500', text: 'text-amber-700' },
+    info: { label: 'For your information', dot: 'bg-neutral-400', text: 'text-neutral-600' },
+};
+
+type PendingAction = 'accept' | 'implementation_ready' | 'request_changes' | null;
+
+export function ScreenReviewPanel({
+    model, onAccept, onRequestChanges, onMarkImplementationReady,
+    onToggleChecklist, onReReview, readOnly,
+}: Props) {
+    const [pending, setPending] = useState<PendingAction>(null);
+    const [reason, setReason] = useState('');
+    const [showChecklist, setShowChecklist] = useState(false);
+    const [showIssues, setShowIssues] = useState(true);
+
+    const transitions = reviewTransitionsFor(model.userStatus);
+    const hasBlockers = model.blockingCount > 0;
+
+    const closePending = () => { setPending(null); setReason(''); };
+
+    const confirmPending = () => {
+        const trimmed = reason.trim() || undefined;
+        if (pending === 'accept') onAccept(trimmed);
+        else if (pending === 'implementation_ready') onMarkImplementationReady(trimmed);
+        else if (pending === 'request_changes') onRequestChanges(trimmed);
+        closePending();
+    };
+
+    const startAccept = () => {
+        if (hasBlockers) { setPending('accept'); setReason(''); }
+        else onAccept();
+    };
+    const startImplReady = () => {
+        // Promoting to Ready to build over blockers needs an explicit reason.
+        if (hasBlockers) { setPending('implementation_ready'); setReason(''); }
+        else onMarkImplementationReady();
+    };
+
+    const btn = 'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition disabled:opacity-50 disabled:cursor-not-allowed';
+
+    return (
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm space-y-3">
+            {/* Status line */}
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div className="min-w-0 space-y-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-[11px] uppercase tracking-wide text-neutral-400">User review</span>
+                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ring-1 ${
+                            model.userStatus
+                                ? USER_STATUS_STYLES[model.userStatus]
+                                : 'bg-neutral-50 text-neutral-500 ring-neutral-200'
+                        }`}>
+                            {model.userStatus ? REVIEW_STATUS_LABELS[model.userStatus] : 'Not reviewed'}
+                        </span>
+                    </div>
+                    <div className="flex items-center gap-2 flex-wrap text-xs">
+                        <span className="text-[11px] uppercase tracking-wide text-neutral-400">System readiness</span>
+                        <span className={`font-medium ${SYSTEM_READINESS_STYLES[model.systemReadiness]}`}>
+                            {SYSTEM_READINESS_LABELS[model.systemReadiness]}
+                        </span>
+                        <span className="text-neutral-400">·</span>
+                        <span className="text-neutral-500">
+                            {model.blockingCount > 0 && `${model.blockingCount} ${model.blockingCount === 1 ? 'blocker' : 'blockers'}`}
+                            {model.blockingCount > 0 && model.reviewCount > 0 && ' · '}
+                            {model.reviewCount > 0 && `${model.reviewCount} review ${model.reviewCount === 1 ? 'item' : 'items'}`}
+                            {model.blockingCount === 0 && model.reviewCount === 0 && 'No blocking issues'}
+                        </span>
+                    </div>
+                    {model.acceptedOverWarnings && (
+                        <p className="text-[11px] text-amber-700">
+                            Accepted with open review items — see the issues below.
+                        </p>
+                    )}
+                </div>
+                {!readOnly && (
+                    <div className="flex items-center gap-2 flex-wrap shrink-0">
+                        {transitions.canRequestChanges && model.userStatus !== 'needs_review' && (
+                            <button
+                                type="button"
+                                onClick={() => { setPending('request_changes'); setReason(''); }}
+                                className={`${btn} bg-neutral-100 hover:bg-neutral-200 text-neutral-700`}
+                            >
+                                Request changes
+                            </button>
+                        )}
+                        {transitions.canAccept && (
+                            <button
+                                type="button"
+                                onClick={startAccept}
+                                className={`${btn} bg-sky-600 hover:bg-sky-700 text-white`}
+                            >
+                                <CheckCircle2 size={13} /> Accept screen
+                            </button>
+                        )}
+                        {transitions.canMarkImplementationReady && (
+                            <button
+                                type="button"
+                                onClick={startImplReady}
+                                className={`${btn} ${
+                                    model.userStatus === 'accepted'
+                                        ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+                                        : 'bg-white ring-1 ring-neutral-200 hover:ring-emerald-300 text-neutral-700 hover:text-emerald-700'
+                                }`}
+                            >
+                                Mark ready to build
+                            </button>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* Inline reason / note capture */}
+            {pending && (
+                <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 space-y-2">
+                    <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-neutral-700">
+                            {pending === 'request_changes'
+                                ? 'What needs to change? (optional)'
+                                : hasBlockers
+                                    ? `${pending === 'accept' ? 'Accept' : 'Mark ready'} with a review note`
+                                    : 'Add a note (optional)'}
+                        </span>
+                        <button type="button" onClick={closePending} className="text-neutral-400 hover:text-neutral-600">
+                            <X size={14} />
+                        </button>
+                    </div>
+                    {pending !== 'request_changes' && hasBlockers && (
+                        <p className="text-[11px] text-amber-700">
+                            This screen still has {model.blockingCount} blocking {model.blockingCount === 1 ? 'issue' : 'issues'}.
+                            You can proceed with a note explaining why.
+                        </p>
+                    )}
+                    <textarea
+                        value={reason}
+                        onChange={e => setReason(e.target.value)}
+                        rows={2}
+                        placeholder={pending === 'request_changes' ? 'e.g. the empty state is missing' : 'e.g. mockup will follow in a later pass'}
+                        className="w-full text-sm border border-neutral-300 rounded-md px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                    />
+                    <div className="flex items-center justify-end gap-2">
+                        <button type="button" onClick={closePending} className="px-3 py-1.5 text-xs text-neutral-600 hover:bg-neutral-100 rounded-md">
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={confirmPending}
+                            className={`${btn} bg-indigo-600 hover:bg-indigo-700 text-white`}
+                        >
+                            {pending === 'request_changes'
+                                ? 'Request changes'
+                                : hasBlockers ? 'Proceed with note' : 'Confirm'}
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {/* Review outdated banner */}
+            {model.freshness === 'outdated' && (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 flex items-start gap-2">
+                    <RefreshCw size={14} className="text-amber-600 mt-0.5 shrink-0" aria-hidden />
+                    <div className="min-w-0 flex-1">
+                        <p className="text-xs font-medium text-amber-800">This screen changed after it was reviewed.</p>
+                        <p className="text-[11px] text-amber-700 mt-0.5">
+                            The spec was edited or regenerated since sign-off. Re-review recommended.
+                            Changing an accepted screen may also make downstream artifacts (mockups, data
+                            model, implementation plan) worth re-checking.
+                        </p>
+                    </div>
+                    {!readOnly && (
+                        <button
+                            type="button"
+                            onClick={onReReview}
+                            className={`${btn} bg-amber-600 hover:bg-amber-700 text-white shrink-0`}
+                        >
+                            Re-review
+                        </button>
+                    )}
+                </div>
+            )}
+
+            {/* Readiness issues */}
+            {model.issues.length > 0 && (
+                <div className="rounded-lg border border-neutral-200 overflow-hidden">
+                    <button
+                        type="button"
+                        onClick={() => setShowIssues(v => !v)}
+                        className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-neutral-50 hover:bg-neutral-100 transition"
+                    >
+                        <span className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                            Readiness issues
+                        </span>
+                        {showIssues ? <ChevronUp size={14} className="text-neutral-400" /> : <ChevronDown size={14} className="text-neutral-400" />}
+                    </button>
+                    {showIssues && (
+                        <ul className="divide-y divide-neutral-100">
+                            {model.issues.map(issue => <IssueRow key={issue.id} issue={issue} />)}
+                        </ul>
+                    )}
+                </div>
+            )}
+
+            {/* Review checklist */}
+            <div className="rounded-lg border border-neutral-200 overflow-hidden">
+                <button
+                    type="button"
+                    onClick={() => setShowChecklist(v => !v)}
+                    className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-neutral-50 hover:bg-neutral-100 transition"
+                >
+                    <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                        <ClipboardCheck size={13} className="text-neutral-400" />
+                        Review checklist
+                        <span className="font-normal normal-case tracking-normal text-neutral-400">
+                            {model.checklistProgress.checked} / {model.checklistProgress.total}
+                        </span>
+                    </span>
+                    {showChecklist ? <ChevronUp size={14} className="text-neutral-400" /> : <ChevronDown size={14} className="text-neutral-400" />}
+                </button>
+                {showChecklist && (
+                    <div className="p-3">
+                        <p className="text-[11px] text-neutral-400 mb-2">
+                            Optional — checking items tracks your progress but never blocks a status change.
+                        </p>
+                        <ul className="space-y-1.5">
+                            {(Object.keys(CHECKLIST_LABELS) as Array<keyof ScreenReviewChecklist>).map(key => (
+                                <li key={key}>
+                                    <label className="flex items-center gap-2 text-xs text-neutral-700 cursor-pointer">
+                                        <input
+                                            type="checkbox"
+                                            checked={model.checklist[key] === true}
+                                            disabled={readOnly}
+                                            onChange={e => onToggleChecklist(key, e.target.checked)}
+                                            className="rounded border-neutral-300 text-indigo-600 focus:ring-indigo-300 disabled:opacity-50"
+                                        />
+                                        {CHECKLIST_LABELS[key]}
+                                    </label>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function IssueRow({ issue }: { issue: ScreenReviewIssue }) {
+    const meta = SEVERITY_META[issue.severity];
+    const Icon = issue.severity === 'blocking'
+        ? AlertOctagon
+        : issue.severity === 'review'
+            ? ShieldQuestion
+            : Info;
+    return (
+        <li className="px-3 py-2.5 flex items-start gap-2.5">
+            <Icon size={14} className={`${meta.text} mt-0.5 shrink-0`} aria-hidden />
+            <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-xs font-medium text-neutral-800">{issue.title}</span>
+                    <span className={`inline-flex items-center gap-1 text-[9px] uppercase tracking-wide ${meta.text}`}>
+                        <span className={`h-1.5 w-1.5 rounded-full ${meta.dot}`} aria-hidden />
+                        {meta.label}
+                    </span>
+                </div>
+                <p className="text-[11px] text-neutral-600 mt-0.5">{issue.description}</p>
+                {issue.recommendedAction && (
+                    <p className="text-[11px] text-neutral-500 mt-0.5">
+                        <span className="text-neutral-400">Suggested: </span>{issue.recommendedAction}
+                    </p>
+                )}
+            </div>
+        </li>
+    );
+}

--- a/src/lib/__tests__/screenReviewWorkflow.test.ts
+++ b/src/lib/__tests__/screenReviewWorkflow.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import type { Feature, ScreenItem } from '../../types';
+import {
+    deriveScreenReviewIssues,
+    buildScreenReviewModel,
+    buildScreenArtifactReviewReadiness,
+    compareReviewFreshness,
+    buildScreenReviewSignature,
+    computeScreenReviewHash,
+    reviewTransitionsFor,
+    canMarkImplementationReadyCleanly,
+    type ScreenReviewSignals,
+    type ScreenReviewModel,
+} from '../screenReviewWorkflow';
+
+const FEATURES: Feature[] = [
+    { id: 'F1', name: 'Activity feed', description: '', userValue: '', complexity: 'low' },
+];
+
+/** A screen with no review issues at all. */
+const cleanScreen: ScreenItem = {
+    id: 'scr-clean',
+    name: 'Home Dashboard',
+    priority: 'P0',
+    purpose: 'Landing surface summarizing recent activity.',
+    userIntent: 'See what changed',
+    featureRefs: ['F1: Activity feed'],
+    states: [{ name: 'Default', description: 'Shows the feed', trigger: 'data loads', type: 'default' }],
+    entryPoints: ['App launch'],
+    exitPaths: [{ label: 'Open item', target: 'Item Detail' }],
+    coreUIElements: ['Activity feed', 'Header'],
+    acceptanceCriteria: ['Feed renders latest activity'],
+};
+
+function cleanSignals(overrides: Partial<ScreenReviewSignals> = {}): ScreenReviewSignals {
+    return {
+        screen: cleanScreen,
+        hasMockup: true,
+        flowRefCount: 1,
+        features: FEATURES,
+        ...overrides,
+    };
+}
+
+describe('deriveScreenReviewIssues', () => {
+    it('a clean screen has no issues and can be accepted', () => {
+        const model = buildScreenReviewModel(cleanSignals());
+        expect(model.issues).toHaveLength(0);
+        expect(model.systemReadiness).toBe('ready');
+        expect(model.blockingCount).toBe(0);
+        expect(reviewTransitionsFor(model.userStatus).canAccept).toBe(true);
+        expect(canMarkImplementationReadyCleanly(model)).toBe(true);
+    });
+
+    it('a P0 screen with no derivable acceptance criteria has a blocking issue', () => {
+        const bare: ScreenItem = { id: 's', name: 'Bare', priority: 'P0', purpose: '' };
+        const issues = deriveScreenReviewIssues({ screen: bare, hasMockup: true, flowRefCount: 1 });
+        const acceptance = issues.find(i => i.id === 'acceptance_missing');
+        expect(acceptance?.severity).toBe('blocking');
+    });
+
+    it('a P0 screen missing its default mockup has a blocking issue', () => {
+        const issues = deriveScreenReviewIssues(cleanSignals({ hasMockup: false }));
+        expect(issues.find(i => i.id === 'mockup_missing_p0')?.severity).toBe('blocking');
+    });
+
+    it('a missing mobile mockup is a review warning, not a blocker', () => {
+        const issues = deriveScreenReviewIssues(cleanSignals({ mobileMockupMissing: true }));
+        const mobile = issues.find(i => i.id === 'mockup_mobile_missing');
+        expect(mobile?.severity).toBe('review');
+        expect(issues.some(i => i.severity === 'blocking')).toBe(false);
+    });
+
+    it('a stale mockup creates a review issue', () => {
+        const issues = deriveScreenReviewIssues(cleanSignals({ freshnessStale: 1 }));
+        expect(issues.find(i => i.id === 'mockup_freshness_stale')?.severity).toBe('review');
+    });
+
+    it('a high-severity unresolved risk on a P0 screen is blocking', () => {
+        const screen: ScreenItem = {
+            ...cleanScreen,
+            riskDetails: [{ description: 'Data loss on refresh', severity: 'high' }],
+        };
+        const issues = deriveScreenReviewIssues(cleanSignals({ screen }));
+        expect(issues.find(i => i.id === 'risk_high_unresolved')?.severity).toBe('blocking');
+    });
+
+    it('a high-severity risk with proposed handling is not a blocker', () => {
+        const screen: ScreenItem = {
+            ...cleanScreen,
+            riskDetails: [{ description: 'Data loss', severity: 'high', proposedHandling: 'Autosave every 5s' }],
+        };
+        const issues = deriveScreenReviewIssues(cleanSignals({ screen }));
+        expect(issues.some(i => i.severity === 'blocking')).toBe(false);
+    });
+
+    it('missing PRD traceability blocks a primary screen but only warns a supporting one', () => {
+        const primary: ScreenItem = { ...cleanScreen, featureRefs: [] };
+        const supporting: ScreenItem = { ...cleanScreen, priority: 'P3', featureRefs: [] };
+        const pIssue = deriveScreenReviewIssues(cleanSignals({ screen: primary }))
+            .find(i => i.id === 'traceability_missing');
+        const sIssue = deriveScreenReviewIssues({ screen: supporting, hasMockup: true, flowRefCount: 1 })
+            .find(i => i.id === 'traceability_missing');
+        expect(pIssue?.severity).toBe('blocking');
+        expect(sIssue?.severity).toBe('review');
+    });
+
+    it('freshness unknown is info, never a blocker', () => {
+        const issues = deriveScreenReviewIssues(cleanSignals({ freshnessUnknown: 1 }));
+        const unknown = issues.find(i => i.id === 'mockup_freshness_unknown');
+        expect(unknown?.severity).toBe('info');
+        expect(issues.some(i => i.severity === 'blocking' || i.severity === 'review')).toBe(false);
+    });
+});
+
+describe('buildScreenReviewModel', () => {
+    it('records acceptedOverWarnings when a user accepts a screen with open issues', () => {
+        const model = buildScreenReviewModel(cleanSignals({
+            hasMockup: false, // introduces a blocking issue
+            userStatus: 'accepted',
+        }));
+        expect(model.userStatus).toBe('accepted');
+        expect(model.systemReadiness).toBe('blocked');
+        expect(model.acceptedOverWarnings).toBe(true);
+    });
+
+    it('keeps user status distinct from system readiness', () => {
+        // Draft user status, but the system says it's ready to accept.
+        const model = buildScreenReviewModel(cleanSignals({ userStatus: 'draft' }));
+        expect(model.userStatus).toBe('draft');
+        expect(model.systemReadiness).toBe('ready');
+    });
+});
+
+describe('review freshness', () => {
+    it('is unknown when the review has no stored signature (legacy record)', () => {
+        expect(compareReviewFreshness(undefined, cleanScreen)).toBe('unknown');
+    });
+
+    it('is current when the stored signature matches the screen', () => {
+        const sig = buildScreenReviewSignature(cleanScreen, { prdVersionId: 'prd-1' });
+        expect(compareReviewFreshness(sig, cleanScreen)).toBe('current');
+    });
+
+    it('is outdated when the screen contract changes after sign-off', () => {
+        const sig = buildScreenReviewSignature(cleanScreen);
+        const changed: ScreenItem = { ...cleanScreen, purpose: 'A completely different purpose now.' };
+        expect(compareReviewFreshness(sig, changed)).toBe('outdated');
+    });
+
+    it('a display rename alone does NOT make the review outdated', () => {
+        const sig = buildScreenReviewSignature(cleanScreen);
+        const renamed: ScreenItem = { ...cleanScreen, name: 'Renamed Dashboard' };
+        expect(compareReviewFreshness(sig, renamed)).toBe('current');
+        // Sanity: the hash is stable across the rename.
+        expect(computeScreenReviewHash(renamed)).toBe(computeScreenReviewHash(cleanScreen));
+    });
+});
+
+describe('buildScreenArtifactReviewReadiness', () => {
+    function modelWith(overrides: Partial<ScreenReviewSignals>): ScreenReviewModel {
+        return buildScreenReviewModel(cleanSignals(overrides));
+    }
+
+    it('is ready when every P0 screen is accepted and no blockers remain', () => {
+        const readiness = buildScreenArtifactReviewReadiness([
+            { id: 'a', name: 'A', isP0: true, model: modelWith({ userStatus: 'accepted' }) },
+            { id: 'b', name: 'B', isP0: true, model: modelWith({ userStatus: 'implementation_ready' }) },
+            { id: 'c', name: 'C', isP0: false, model: modelWith({ userStatus: 'draft' }) },
+        ]);
+        expect(readiness.ready).toBe(true);
+        expect(readiness.reasons).toHaveLength(0);
+        expect(readiness.message).toMatch(/Ready for implementation planning/);
+    });
+
+    it('is not ready when a P0 screen still needs changes', () => {
+        const readiness = buildScreenArtifactReviewReadiness([
+            { id: 'a', name: 'A', isP0: true, model: modelWith({ userStatus: 'accepted' }) },
+            { id: 'b', name: 'Checkout', isP0: true, model: modelWith({ userStatus: 'needs_review' }) },
+        ]);
+        expect(readiness.ready).toBe(false);
+        expect(readiness.p0.notSignedOff.map(s => s.name)).toContain('Checkout');
+        expect(readiness.reasons.join(' ')).toMatch(/not been accepted/);
+    });
+
+    it('is not ready when a P0 screen has blocking issues even if accepted', () => {
+        const readiness = buildScreenArtifactReviewReadiness([
+            { id: 'a', name: 'A', isP0: true, model: modelWith({ userStatus: 'accepted', hasMockup: false }) },
+        ]);
+        expect(readiness.ready).toBe(false);
+        expect(readiness.p0.withBlockers).toBe(1);
+        expect(readiness.reasons.join(' ')).toMatch(/blocking issues/);
+    });
+});

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -21,6 +21,9 @@ import type {
     ScreenInventoryContent,
     ScreenItem,
     ScreenPriority,
+    ScreenReviewChecklist,
+    ScreenReviewMeta,
+    ScreenReviewSignature,
 } from '../types';
 import { slugifyScreenName } from './screenInventoryImageStore';
 import type {
@@ -58,6 +61,13 @@ export interface ScreenMetadataEdit {
      * a readiness gap). Absent entries stay derived.
      */
     mockupVariantStatus?: Record<string, 'accepted' | 'not_needed'>;
+    /**
+     * Phase 4A: supporting review record (checklist, note, override reason,
+     * sign-off signature, transition timestamps). The review *status* stays in
+     * `reviewStatus` above — this is the metadata around it. Optional &
+     * back-compat; see ScreenReviewMeta in src/types.
+     */
+    review?: ScreenReviewMeta;
 }
 
 export type ScreenEditsMap = Record<string, ScreenMetadataEdit>;
@@ -71,9 +81,46 @@ const VALID_REVIEW_STATUSES: ReadonlySet<string> = new Set([
  * (forward compatibility — an older build must never drop a newer build's
  * overlay fields on a read-modify-write). */
 const KNOWN_EDIT_KEYS: ReadonlySet<string> = new Set([
-    'name', 'purpose', 'userIntent', 'priority', 'notes', 'reviewStatus', 'mockupVariantStatus',
+    'name', 'purpose', 'userIntent', 'priority', 'notes', 'reviewStatus', 'mockupVariantStatus', 'review',
 ]);
 const VALID_VARIANT_STATUSES: ReadonlySet<string> = new Set(['accepted', 'not_needed']);
+const CHECKLIST_KEYS: ReadonlySet<string> = new Set([
+    'purposeMatchesPrd', 'entryExitPathsReviewed', 'statesReviewed', 'risksReviewed',
+    'mockupsReviewed', 'mobileReviewed', 'acceptanceCriteriaReviewed', 'developerHandoffReviewed',
+]);
+
+/** Parse the Phase 4A review metadata overlay defensively. Returns undefined
+ * when nothing usable is present so an empty object never lands on the edit. */
+function parseReviewMeta(raw: unknown): ScreenReviewMeta | undefined {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+    const r = raw as Record<string, unknown>;
+    const meta: ScreenReviewMeta = {};
+    if (r.checklist && typeof r.checklist === 'object' && !Array.isArray(r.checklist)) {
+        const checklist: ScreenReviewChecklist = {};
+        for (const [k, v] of Object.entries(r.checklist as Record<string, unknown>)) {
+            if (CHECKLIST_KEYS.has(k) && typeof v === 'boolean') {
+                (checklist as Record<string, boolean>)[k] = v;
+            }
+        }
+        if (Object.keys(checklist).length > 0) meta.checklist = checklist;
+    }
+    if (typeof r.notes === 'string' && r.notes.trim()) meta.notes = r.notes;
+    if (typeof r.overrideReason === 'string' && r.overrideReason.trim()) meta.overrideReason = r.overrideReason;
+    if (r.signature && typeof r.signature === 'object' && !Array.isArray(r.signature)) {
+        const s = r.signature as Record<string, unknown>;
+        if (typeof s.screenContractHash === 'string' && s.screenContractHash) {
+            const sig: ScreenReviewSignature = { screenContractHash: s.screenContractHash };
+            if (typeof s.prdVersionId === 'string') sig.prdVersionId = s.prdVersionId;
+            if (typeof s.screenVersionId === 'string') sig.screenVersionId = s.screenVersionId;
+            if (typeof s.designSystemVersionId === 'string') sig.designSystemVersionId = s.designSystemVersionId;
+            meta.signature = sig;
+        }
+    }
+    for (const key of ['updatedAt', 'acceptedAt', 'requestedChangesAt', 'implementationReadyAt'] as const) {
+        if (typeof r[key] === 'string' && r[key]) meta[key] = r[key] as string;
+    }
+    return Object.keys(meta).length > 0 ? meta : undefined;
+}
 
 /** Safely extract the screenEdits overlay from ArtifactVersion metadata. */
 export function readScreenEdits(metadata: Record<string, unknown> | undefined): ScreenEditsMap {
@@ -103,6 +150,8 @@ export function readScreenEdits(metadata: Record<string, unknown> | undefined): 
             }
             if (Object.keys(statuses).length > 0) edit.mockupVariantStatus = statuses;
         }
+        const review = parseReviewMeta(v.review);
+        if (review) edit.review = review;
         // Preserve unknown fields verbatim so a save round-trip never drops
         // overlay data written by newer code.
         for (const [key, unknownValue] of Object.entries(v)) {

--- a/src/lib/screenReadiness.ts
+++ b/src/lib/screenReadiness.ts
@@ -917,38 +917,69 @@ export function buildScreenCoverageSummary(
 export type ScreenListFilter =
     | 'all'
     | 'p0'
+    | 'draft'
     | 'needs_review'
+    | 'accepted'
+    | 'ready'
+    | 'has_blockers'
+    | 'review_recommended'
     | 'missing_mockups'
-    | 'has_risks'
-    | 'ready';
+    | 'has_risks';
 
 export const SCREEN_LIST_FILTERS: Array<{ id: ScreenListFilter; label: string }> = [
     { id: 'all', label: 'All' },
     { id: 'p0', label: 'P0' },
+    { id: 'draft', label: 'Draft' },
     { id: 'needs_review', label: 'Needs review' },
+    { id: 'accepted', label: 'Accepted' },
+    { id: 'ready', label: 'Ready' },
+    { id: 'has_blockers', label: 'Has blockers' },
+    { id: 'review_recommended', label: 'Review recommended' },
     { id: 'missing_mockups', label: 'Missing mockups' },
     { id: 'has_risks', label: 'Has risks' },
-    { id: 'ready', label: 'Ready' },
 ];
+
+/** Optional review signals (Phase 4A) so filters can key off the user review
+ * status and derived blockers/review items, not just the combined readiness. */
+export interface ScreenFilterReview {
+    /** Explicit user-set status, or undefined when unreviewed (treated as draft). */
+    userStatus?: ScreenReviewStatus;
+    blockingCount: number;
+    reviewCount: number;
+}
 
 export function screenMatchesFilter(
     item: ScreenExperienceItem,
     readiness: ScreenReadiness | undefined,
     filter: ScreenListFilter,
+    review?: ScreenFilterReview,
 ): boolean {
+    const userStatus = review?.userStatus;
     switch (filter) {
         case 'all':
             return true;
         case 'p0':
             return isP0(item.screen);
+        case 'draft':
+            // Unreviewed screens read as draft (the derived default), so match
+            // either an explicit draft status or no user status at all.
+            return userStatus === 'draft' || (!userStatus && readiness?.source === 'derived');
         case 'needs_review':
-            return readiness?.status === 'needs_review';
+            return userStatus === 'needs_review'
+                || (!userStatus && readiness?.status === 'needs_review');
+        case 'accepted':
+            return userStatus === 'accepted' || userStatus === 'implementation_ready';
+        case 'ready':
+            return userStatus === 'implementation_ready'
+                || (!userStatus && readiness?.status === 'implementation_ready');
+        case 'has_blockers':
+            return (review?.blockingCount ?? 0) > 0;
+        case 'review_recommended':
+            return (review?.blockingCount ?? 0) > 0 || (review?.reviewCount ?? 0) > 0;
         case 'missing_mockups':
             return !item.mockupScreen;
         case 'has_risks':
             return (item.screen.risks?.length ?? 0) > 0;
-        case 'ready':
-            return readiness?.status === 'implementation_ready';
     }
 }
 

--- a/src/lib/screenReviewWorkflow.ts
+++ b/src/lib/screenReviewWorkflow.ts
@@ -1,0 +1,844 @@
+// Phase 4A: the screen review & approval workflow layer.
+//
+// This module turns the Screens artifact from a reference surface into a
+// review workflow. It answers, per screen and per artifact:
+//   - which screens are reviewed / accepted / implementation-ready?
+//   - what issues block confidence (blockers vs. review items vs. info)?
+//   - can this artifact safely inform implementation planning?
+//   - has an accepted screen changed since it was signed off (re-review)?
+//
+// It is layered ON TOP of the existing readiness/coverage layers
+// (src/lib/screenReadiness.ts, src/lib/mockupVariants.ts,
+// src/lib/mockupVariantTrust.ts) and NEVER changes their logic. It is PURE and
+// read-time only (no store, no IDB, no React, no LLM). Two distinct concepts,
+// deliberately not collapsed:
+//
+//   1. USER review status  — set by the user (draft / needs_review / accepted /
+//      implementation_ready), persisted in the screenEdits `reviewStatus`
+//      overlay. This is a human sign-off.
+//   2. SYSTEM readiness    — derived from quality signals (blockers / review
+//      items). This is Synapse's estimate, never a human decision.
+//
+// A screen can be user-Accepted while system readiness says "review
+// recommended" (e.g. a stale mobile mockup), or user-Draft while the system
+// says "ready to accept". The UI must show both.
+//
+// Honesty rules (mirroring the rest of the Screens layer): every derived
+// signal is an estimate; freshness/coverage come from stored metadata, never
+// from inspecting rendered pixels; language is calm and helpful, never
+// alarming ("Review recommended", not "Invalid").
+
+import type {
+    Feature, ScreenItem, ScreenState, ScreenReviewChecklist, ScreenReviewMeta, ScreenReviewSignature,
+    LegacyScreenPriority, ScreenPriority,
+} from '../types';
+import type { ScreenExperienceIndex, ScreenExperienceItem } from './screenExperience';
+import {
+    detectScreenGaps, resolveAcceptanceCriteria, resolveScreenHandoff, countDecisionsWithoutBranches,
+    DEFAULT_VARIANT_ID,
+    type ScreenReviewStatus,
+} from './screenReadiness';
+import {
+    buildScreenMockupVariants, summarizeScreenVariants,
+    type BuildVariantOptions, type DerivedMockupVariant,
+} from './mockupVariants';
+
+export type { ScreenReviewStatus } from './screenReadiness';
+export { REVIEW_STATUS_LABELS } from './screenReadiness';
+
+// --- Review issues -----------------------------------------------------------
+
+export type ScreenReviewIssueSeverity = 'blocking' | 'review' | 'info';
+
+export type ScreenReviewIssueCategory =
+    | 'purpose'
+    | 'prd_traceability'
+    | 'navigation'
+    | 'states'
+    | 'risks'
+    | 'mockups'
+    | 'mockup_freshness'
+    | 'acceptance_criteria'
+    | 'handoff'
+    | 'flow'
+    | 'mobile'
+    | 'data_model';
+
+export interface ScreenReviewIssue {
+    /** Stable id for keys/dedupe. */
+    id: string;
+    severity: ScreenReviewIssueSeverity;
+    category: ScreenReviewIssueCategory;
+    /** Short headline (calm language). */
+    title: string;
+    /** One-sentence explanation. */
+    description: string;
+    /** What the user could do about it, when there's a clear next step. */
+    recommendedAction?: string;
+}
+
+export const SEVERITY_LABELS: Record<ScreenReviewIssueSeverity, string> = {
+    blocking: 'Blocking',
+    review: 'Review recommended',
+    info: 'For your information',
+};
+
+// --- System readiness --------------------------------------------------------
+
+/** Synapse's derived estimate of a screen's build-readiness — distinct from
+ * the user's review status. */
+export type SystemReadinessStatus = 'ready' | 'needs_review' | 'blocked';
+
+export const SYSTEM_READINESS_LABELS: Record<SystemReadinessStatus, string> = {
+    ready: 'Ready to accept',
+    needs_review: 'Review recommended',
+    blocked: 'Blocking issues',
+};
+
+// --- Signals the derivation consumes -----------------------------------------
+
+/** Everything `deriveScreenReviewIssues` / `buildScreenReviewModel` need. The
+ * mockup/freshness fields are precomputed by the caller (the views already
+ * build the variant grid); pure tests can pass them directly. */
+export interface ScreenReviewSignals {
+    screen: ScreenItem;
+    hasMockup: boolean;
+    flowRefCount: number;
+    features?: readonly Feature[];
+    /** Explicit user-set status (screenEdits.reviewStatus). */
+    userStatus?: ScreenReviewStatus;
+    /** Supporting review record (screenEdits.review). */
+    reviewMeta?: ScreenReviewMeta;
+    /** A recommended Mobile default variant is missing (from the variant grid). */
+    mobileMockupMissing?: boolean;
+    /** A generated mockup carries no captured coverage metadata (legacy). */
+    coverageUnknown?: boolean;
+    /** Generated variants that read stale / possibly-stale (freshness review). */
+    freshnessStale?: number;
+    /** Generated variants whose freshness can't be confirmed (legacy metadata). */
+    freshnessUnknown?: number;
+    /** Flow decision steps on this screen with no parseable branch outcomes. */
+    decisionsWithoutBranches?: number;
+    /** Recommended state mockup variants still missing. */
+    missingRequiredVariants?: number;
+}
+
+const isP0 = (screen: ScreenItem): boolean =>
+    screen.priority === 'P0' || screen.priority === 'core';
+
+/** Primary = a screen users routinely land on (P0/P1). Navigation/traceability
+ * blockers only apply to primary screens; supporting UI can legitimately lack
+ * flow refs or its own PRD feature. */
+const isPrimary = (screen: ScreenItem): boolean =>
+    isP0(screen) || screen.priority === 'P1' || screen.priority === 'secondary';
+
+function stateHasBehavior(state: ScreenState): boolean {
+    return Boolean(
+        (state.description && state.description.trim())
+        || (state.trigger && state.trigger.trim())
+        || (state.systemBehavior && state.systemBehavior.trim()),
+    );
+}
+
+/**
+ * Derive the review issues (blockers / review items / info) for one screen.
+ * Reuses the existing gap detection and resolvers so it never drifts from the
+ * readiness layer, then classifies by severity with priority-awareness.
+ */
+export function deriveScreenReviewIssues(signals: ScreenReviewSignals): ScreenReviewIssue[] {
+    const { screen } = signals;
+    const primary = isPrimary(screen);
+    const p0 = isP0(screen);
+    const issues: ScreenReviewIssue[] = [];
+
+    const gaps = detectScreenGaps({
+        screen,
+        hasMockup: signals.hasMockup,
+        flowRefCount: signals.flowRefCount,
+        features: signals.features,
+        missingRequiredVariants: signals.missingRequiredVariants,
+        decisionsWithoutBranches: signals.decisionsWithoutBranches,
+    });
+    const gapKinds = new Set(gaps.map(g => g.kind));
+    const gapMessage = (kind: string): string | undefined =>
+        gaps.find(g => g.kind === kind)?.message;
+
+    // --- Purpose (blocking) ---------------------------------------------------
+    if (gapKinds.has('missing_purpose')) {
+        issues.push({
+            id: 'purpose_missing',
+            severity: 'blocking',
+            category: 'purpose',
+            title: 'No purpose recorded',
+            description: 'This screen has no description of what it is for.',
+            recommendedAction: 'Add a short purpose so the intent is clear before building.',
+        });
+    }
+
+    // --- PRD traceability -----------------------------------------------------
+    if (gapKinds.has('missing_traceability')) {
+        issues.push({
+            id: 'traceability_missing',
+            severity: primary ? 'blocking' : 'review',
+            category: 'prd_traceability',
+            title: 'No linked PRD features',
+            description: primary
+                ? 'This primary screen is not linked to any PRD feature, so its coverage is unclear.'
+                : 'This screen is not linked to any PRD feature — confirm it is intentional supporting UI.',
+            recommendedAction: 'Link the PRD features this screen serves, or confirm it is supporting UI.',
+        });
+    }
+    if (gapKinds.has('invalid_traceability')) {
+        issues.push({
+            id: 'traceability_invalid',
+            severity: 'review',
+            category: 'prd_traceability',
+            title: 'Some linked features may be stale',
+            description: gapMessage('invalid_traceability')
+                ?? 'One or more linked feature ids no longer match the PRD.',
+            recommendedAction: 'Re-link the screen to current PRD features.',
+        });
+    }
+
+    // --- Navigation (blocking for primary) ------------------------------------
+    if (gapKinds.has('missing_navigation')) {
+        issues.push({
+            id: 'navigation_missing',
+            severity: primary ? 'blocking' : 'review',
+            category: 'navigation',
+            title: 'Entry or exit path not specified',
+            description: gapMessage('missing_navigation')
+                ?? 'How users arrive at or leave this screen is not specified.',
+            recommendedAction: 'Document how users reach this screen and where they go next.',
+        });
+    }
+
+    // --- States ---------------------------------------------------------------
+    const states = screen.states ?? [];
+    const requiredNoBehavior = states.filter(s => s.required === true && !stateHasBehavior(s));
+    if (requiredNoBehavior.length > 0) {
+        issues.push({
+            id: 'required_state_no_behavior',
+            severity: 'blocking',
+            category: 'states',
+            title: 'Required state has no behavior',
+            description: requiredNoBehavior.length === 1
+                ? `The required "${requiredNoBehavior[0].name}" state has no trigger or behavior described.`
+                : `${requiredNoBehavior.length} required states have no trigger or behavior described.`,
+            recommendedAction: 'Describe what triggers each required state and what the user sees.',
+        });
+    } else if (gapKinds.has('states_without_behavior')) {
+        issues.push({
+            id: 'state_no_behavior',
+            severity: 'review',
+            category: 'states',
+            title: 'Some states lack behavior',
+            description: gapMessage('states_without_behavior')
+                ?? 'A documented state has no trigger or behavior described.',
+        });
+    }
+    if (gapKinds.has('missing_states')) {
+        issues.push({
+            id: 'states_missing',
+            severity: 'review',
+            category: 'states',
+            title: 'No UI states documented',
+            description: 'Empty, loading, and error states may still be needed.',
+            recommendedAction: 'Add the empty / loading / error states this screen needs.',
+        });
+    }
+
+    // --- Mockups --------------------------------------------------------------
+    if (gapKinds.has('missing_mockup_p0')) {
+        issues.push({
+            id: 'mockup_missing_p0',
+            severity: 'blocking',
+            category: 'mockups',
+            title: 'P0 screen without a mockup',
+            description: 'This is a P0 screen with no default mockup generated yet.',
+            recommendedAction: 'Generate or upload a mockup for this screen.',
+        });
+    }
+    if (signals.mobileMockupMissing) {
+        issues.push({
+            id: 'mockup_mobile_missing',
+            severity: 'review',
+            category: 'mobile',
+            title: 'Mobile mockup recommended',
+            description: 'A mobile variant is recommended for this screen but has not been generated.',
+            recommendedAction: 'Generate a mobile variant, or mark it not needed if the screen is desktop-only.',
+        });
+    }
+    if (gapKinds.has('missing_state_variants')) {
+        issues.push({
+            id: 'mockup_state_variants_missing',
+            severity: 'review',
+            category: 'mockups',
+            title: 'Recommended state mockups missing',
+            description: gapMessage('missing_state_variants')
+                ?? 'Some recommended state mockup variants have not been generated.',
+        });
+    }
+    if ((signals.freshnessStale ?? 0) > 0) {
+        const n = signals.freshnessStale ?? 0;
+        issues.push({
+            id: 'mockup_freshness_stale',
+            severity: 'review',
+            category: 'mockup_freshness',
+            title: n === 1 ? 'A mockup may be out of date' : 'Some mockups may be out of date',
+            description: n === 1
+                ? 'A generated mockup predates a change to the screen spec, design system, or PRD.'
+                : `${n} generated mockups predate a change to the screen spec, design system, or PRD.`,
+            recommendedAction: 'Regenerate the affected mockups to match the current spec.',
+        });
+    }
+
+    // --- Risks ----------------------------------------------------------------
+    const risks = screen.riskDetails ?? [];
+    const highUnresolved = risks.filter(r => r.severity === 'high' && !r.proposedHandling?.trim());
+    if (highUnresolved.length > 0) {
+        issues.push({
+            id: 'risk_high_unresolved',
+            // A high-severity unresolved risk blocks build-readiness on a P0
+            // screen; elsewhere it is a strong review item.
+            severity: p0 ? 'blocking' : 'review',
+            category: 'risks',
+            title: 'Unresolved high-severity risk',
+            description: highUnresolved.length === 1
+                ? `A high-severity risk has no proposed handling: ${highUnresolved[0].description}`
+                : `${highUnresolved.length} high-severity risks have no proposed handling recorded.`,
+            recommendedAction: 'Record how each high-severity risk will be handled.',
+        });
+    } else if (gapKinds.has('unresolved_risks')) {
+        issues.push({
+            id: 'risk_unresolved',
+            severity: 'review',
+            category: 'risks',
+            title: 'Risks noted without handling',
+            description: gapMessage('unresolved_risks')
+                ?? 'Risk notes in the spec have no recorded handling yet.',
+            recommendedAction: 'Note how each risk will be handled, or mark it acceptable.',
+        });
+    }
+
+    // --- Acceptance criteria (blocking when none can even be derived) ---------
+    if (resolveAcceptanceCriteria(screen).criteria.length === 0) {
+        issues.push({
+            id: 'acceptance_missing',
+            severity: 'blocking',
+            category: 'acceptance_criteria',
+            title: 'No acceptance criteria',
+            description: 'There is not enough detail (intent, navigation, states) to state acceptance criteria.',
+            recommendedAction: 'Add the intent, navigation, and states so acceptance criteria can be written.',
+        });
+    }
+
+    // --- Developer handoff (review only when genuinely empty) -----------------
+    const handoff = resolveScreenHandoff(screen);
+    const handoffEmpty = !handoff.route && handoff.components.length === 0
+        && handoff.events.length === 0 && handoff.exitEvents.length === 0;
+    if (handoffEmpty) {
+        issues.push({
+            id: 'handoff_incomplete',
+            severity: 'review',
+            category: 'handoff',
+            title: 'Developer handoff is thin',
+            description: 'Route, primary components, and interactions are all unspecified for this screen.',
+            recommendedAction: 'Fill in a route, key components, and interactions before implementation.',
+        });
+    }
+
+    // --- Flow decisions -------------------------------------------------------
+    if (gapKinds.has('decision_missing_branches')) {
+        issues.push({
+            id: 'decision_unspecified',
+            severity: 'review',
+            category: 'flow',
+            title: 'Flow decision without outcomes',
+            description: gapMessage('decision_missing_branches')
+                ?? 'A flow decision on this screen has no branch outcomes specified.',
+            recommendedAction: 'Specify what each decision branch leads to in the user flow.',
+        });
+    }
+
+    // --- Info: freshness/coverage unknown, no flow refs -----------------------
+    if ((signals.freshnessUnknown ?? 0) > 0) {
+        issues.push({
+            id: 'mockup_freshness_unknown',
+            severity: 'info',
+            category: 'mockup_freshness',
+            title: 'Mockup freshness unknown',
+            description: 'An older mockup has no source metadata, so Synapse cannot confirm it is up to date.',
+        });
+    } else if (signals.coverageUnknown) {
+        issues.push({
+            id: 'coverage_unknown',
+            severity: 'info',
+            category: 'mockups',
+            title: 'Mockup coverage unknown',
+            description: 'This mockup predates coverage metadata, so which spec items it represents is unconfirmed.',
+        });
+    }
+    if (gapKinds.has('no_flow_refs')) {
+        issues.push({
+            id: 'flow_missing',
+            severity: 'info',
+            category: 'flow',
+            title: 'Not referenced by a user flow',
+            description: 'No user flow currently references this screen — that may be fine for supporting UI.',
+        });
+    }
+
+    return issues;
+}
+
+// --- Review model (per screen) -----------------------------------------------
+
+export interface ScreenReviewModel {
+    /** User-set status, or undefined when the user hasn't reviewed it. */
+    userStatus?: ScreenReviewStatus;
+    /** Synapse's derived readiness (independent of userStatus). */
+    systemReadiness: SystemReadinessStatus;
+    issues: ScreenReviewIssue[];
+    blockingCount: number;
+    reviewCount: number;
+    infoCount: number;
+    /** True when a user-set status carries open blocking/review issues — the
+     * screen was accepted/promoted over warnings. */
+    acceptedOverWarnings: boolean;
+    /** Re-review status vs. the sign-off signature (see compareReviewFreshness). */
+    freshness: ScreenReviewFreshnessStatus;
+    checklist: ScreenReviewChecklist;
+    /** Ticked / total checklist items. */
+    checklistProgress: { checked: number; total: number };
+    reviewMeta?: ScreenReviewMeta;
+}
+
+const CHECKLIST_ITEM_KEYS: Array<keyof ScreenReviewChecklist> = [
+    'purposeMatchesPrd', 'entryExitPathsReviewed', 'statesReviewed', 'risksReviewed',
+    'mockupsReviewed', 'mobileReviewed', 'acceptanceCriteriaReviewed', 'developerHandoffReviewed',
+];
+
+export const CHECKLIST_LABELS: Record<keyof ScreenReviewChecklist, string> = {
+    purposeMatchesPrd: 'Purpose matches the PRD',
+    entryExitPathsReviewed: 'Entry and exit paths are correct',
+    statesReviewed: 'Required states are complete',
+    risksReviewed: 'Risks and edge cases are handled',
+    mockupsReviewed: 'Mockups match the intended layout',
+    mobileReviewed: 'Mobile / responsive behavior reviewed',
+    acceptanceCriteriaReviewed: 'Acceptance criteria are sufficient',
+    developerHandoffReviewed: 'Developer handoff details are sufficient',
+};
+
+function systemReadinessFrom(issues: readonly ScreenReviewIssue[]): SystemReadinessStatus {
+    if (issues.some(i => i.severity === 'blocking')) return 'blocked';
+    if (issues.some(i => i.severity === 'review')) return 'needs_review';
+    return 'ready';
+}
+
+/** Build the full review model for one screen from precomputed signals. */
+export function buildScreenReviewModel(signals: ScreenReviewSignals): ScreenReviewModel {
+    const issues = deriveScreenReviewIssues(signals);
+    const systemReadiness = systemReadinessFrom(issues);
+    const blockingCount = issues.filter(i => i.severity === 'blocking').length;
+    const reviewCount = issues.filter(i => i.severity === 'review').length;
+    const infoCount = issues.filter(i => i.severity === 'info').length;
+    const userStatus = signals.userStatus;
+    const signedOff = userStatus === 'accepted' || userStatus === 'implementation_ready';
+    const acceptedOverWarnings = signedOff && (blockingCount > 0 || reviewCount > 0);
+    const checklist = signals.reviewMeta?.checklist ?? {};
+    const checked = CHECKLIST_ITEM_KEYS.filter(k => checklist[k] === true).length;
+    return {
+        userStatus,
+        systemReadiness,
+        issues,
+        blockingCount,
+        reviewCount,
+        infoCount,
+        acceptedOverWarnings,
+        freshness: compareReviewFreshness(signals.reviewMeta?.signature, signals.screen),
+        checklist,
+        checklistProgress: { checked, total: CHECKLIST_ITEM_KEYS.length },
+        reviewMeta: signals.reviewMeta,
+    };
+}
+
+// --- Item-level convenience (view helper) ------------------------------------
+
+export interface BuildReviewModelOptions extends BuildVariantOptions {
+    features?: readonly Feature[];
+}
+
+/** Compute the review model for a joined ScreenExperienceItem, deriving the
+ * mockup/freshness signals from the variant grid so callers don't repeat it.
+ * The views (list + detail) use this; pure tests can use buildScreenReviewModel
+ * directly with explicit signals. */
+export function buildScreenReviewModelForItem(
+    item: ScreenExperienceItem,
+    options: BuildReviewModelOptions = {},
+): ScreenReviewModel {
+    const { features, ...variantOptions } = options;
+    const variants = buildScreenMockupVariants(item, variantOptions);
+    const summary = summarizeScreenVariants(variants);
+    const missingRequiredVariants = variants.filter(
+        v => v.id !== DEFAULT_VARIANT_ID && v.required && v.status === 'missing',
+    ).length;
+    const freshness = countVariantFreshness(variants);
+    return buildScreenReviewModel({
+        screen: item.screen,
+        hasMockup: Boolean(item.mockupScreen),
+        flowRefCount: item.relatedFlows.length,
+        features,
+        userStatus: item.edit?.reviewStatus,
+        reviewMeta: item.edit?.review,
+        mobileMockupMissing: summary.mobileMissing,
+        coverageUnknown: summary.coverageUnknown,
+        freshnessStale: freshness.stale,
+        freshnessUnknown: freshness.unknown,
+        decisionsWithoutBranches: countDecisionsWithoutBranches(item),
+        missingRequiredVariants,
+    });
+}
+
+function countVariantFreshness(variants: readonly DerivedMockupVariant[]): { stale: number; unknown: number } {
+    let stale = 0;
+    let unknown = 0;
+    for (const v of variants) {
+        if (!v.freshness) continue;
+        if (v.freshness.status === 'stale' || v.freshness.status === 'possibly_stale') stale += 1;
+        else if (v.freshness.status === 'unknown') unknown += 1;
+    }
+    return { stale, unknown };
+}
+
+/** Options for the whole-index builder: the per-item options plus an optional
+ * per-screen generated-variant lookup (mirrors the coverage summary). */
+export interface BuildReviewIndexOptions extends Omit<BuildReviewModelOptions, 'generatedVariants'> {
+    generatedVariantsByScreen?: (screenId: string) => BuildVariantOptions['generatedVariants'];
+}
+
+/** Review model for every screen in the index, keyed by canonical id. */
+export function buildScreenReviewIndex(
+    index: ScreenExperienceIndex,
+    options: BuildReviewIndexOptions = {},
+): Map<string, ScreenReviewModel> {
+    const { generatedVariantsByScreen, ...itemOptions } = options;
+    const out = new Map<string, ScreenReviewModel>();
+    for (const item of index.items) {
+        out.set(item.id, buildScreenReviewModelForItem(item, {
+            ...itemOptions,
+            generatedVariants: generatedVariantsByScreen?.(item.id),
+        }));
+    }
+    return out;
+}
+
+// --- Status transitions ------------------------------------------------------
+
+/** The transitions the UI offers, given the current user status. A screen with
+ * no user status yet behaves like 'draft'. */
+export interface ReviewTransitions {
+    canAccept: boolean;
+    canRequestChanges: boolean;
+    canMarkImplementationReady: boolean;
+}
+
+export function reviewTransitionsFor(status: ScreenReviewStatus | undefined): ReviewTransitions {
+    const s = status ?? 'draft';
+    return {
+        // Accept is offered from any state except already-accepted.
+        canAccept: s !== 'accepted',
+        // Request changes is always available (an escape hatch).
+        canRequestChanges: true,
+        // Implementation-ready is a promotion from accepted (or a direct
+        // promotion the UI confirms) — never offered when already there.
+        canMarkImplementationReady: s !== 'implementation_ready',
+    };
+}
+
+/** Whether marking implementation-ready is clean (no blocking issues) — the UI
+ * still allows an override with a reason when blockers exist. */
+export function canMarkImplementationReadyCleanly(model: ScreenReviewModel): boolean {
+    return model.blockingCount === 0;
+}
+
+// --- Review freshness (re-review after acceptance) ---------------------------
+
+export type ScreenReviewFreshnessStatus = 'current' | 'outdated' | 'unknown';
+
+export const REVIEW_FRESHNESS_LABELS: Record<ScreenReviewFreshnessStatus, string> = {
+    current: 'Review current',
+    outdated: 'Review may be outdated',
+    unknown: 'Review freshness unknown',
+};
+
+/**
+ * Compare the signature captured at sign-off against the current screen spec.
+ *   - 'unknown'  — no stored signature (never reviewed, or a legacy record).
+ *   - 'outdated' — the screen-contract hash moved since sign-off.
+ *   - 'current'  — the hash matches; the review still reflects the spec.
+ * Mirrors the mockup-freshness ethos: legacy records are NEVER falsely
+ * "outdated", and this is a metadata comparison, never a visual check.
+ */
+export function compareReviewFreshness(
+    signature: ScreenReviewSignature | undefined,
+    screen: ScreenItem,
+): ScreenReviewFreshnessStatus {
+    if (!signature?.screenContractHash) return 'unknown';
+    return signature.screenContractHash === computeScreenReviewHash(screen) ? 'current' : 'outdated';
+}
+
+/** Build the signature to STORE when a screen is accepted / implementation-
+ * ready. Uses the same hash as the comparison so storage and comparison can't
+ * drift. */
+export function buildScreenReviewSignature(
+    screen: ScreenItem,
+    context: { prdVersionId?: string; screenVersionId?: string; designSystemVersionId?: string } = {},
+): ScreenReviewSignature {
+    return {
+        screenContractHash: computeScreenReviewHash(screen),
+        prdVersionId: context.prdVersionId,
+        screenVersionId: context.screenVersionId,
+        designSystemVersionId: context.designSystemVersionId,
+    };
+}
+
+// --- Screen-contract hashing (self-contained; mirrors mockupVariantTrust) -----
+
+function canonicalStringify(value: unknown): string {
+    if (value === null || value === undefined || typeof value !== 'object') {
+        return JSON.stringify(value ?? null);
+    }
+    if (Array.isArray(value)) return `[${value.map(canonicalStringify).join(',')}]`;
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return `{${keys.map(k => `${JSON.stringify(k)}:${canonicalStringify(obj[k])}`).join(',')}}`;
+}
+
+function fnv1a(input: string): string {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+        h ^= input.charCodeAt(i);
+        h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+    }
+    return h.toString(16).padStart(8, '0');
+}
+
+function stableHash(value: unknown): string {
+    const canonical = canonicalStringify(value);
+    return `${fnv1a(canonical)}${fnv1a(canonical + ':v1')}`;
+}
+
+function normalizePriority(priority: ScreenPriority | LegacyScreenPriority): ScreenPriority {
+    switch (priority) {
+        case 'P0': case 'core': return 'P0';
+        case 'P1': case 'secondary': return 'P1';
+        case 'P2': case 'supporting': return 'P2';
+        case 'P3': return 'P3';
+        default: return 'P1';
+    }
+}
+
+const cleanList = (values: Array<string | undefined | null>): string[] => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const v of values) {
+        const t = v?.trim();
+        if (!t) continue;
+        const key = t.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(t);
+    }
+    return out;
+};
+
+/**
+ * Hash the screen-spec content a reviewer signs off on. Covers the substantive
+ * spec fields (purpose, intent, priority, states, navigation, UI regions,
+ * risks, acceptance criteria, traceability, handoff) and DELIBERATELY excludes
+ * the display-only rename (`name`) and overlay-only fields (notes, review
+ * status, variant marks) — so a pure display rename never trips "review
+ * outdated", while a spec regeneration or a substantive edit does.
+ */
+export function computeScreenReviewHash(screen: ScreenItem): string {
+    const states = (screen.states ?? []).map(s => ({
+        name: s.name ?? '',
+        type: s.type ?? null,
+        trigger: s.trigger ?? '',
+        description: s.description ?? '',
+        systemBehavior: s.systemBehavior ?? '',
+        required: s.required ?? null,
+        needsMockup: s.needsMockup ?? null,
+        acceptanceCriteria: cleanList(s.acceptanceCriteria ?? []),
+    }));
+    const risks = (screen.riskDetails && screen.riskDetails.length > 0)
+        ? screen.riskDetails.map(r => ({
+            description: r.description ?? '',
+            severity: r.severity ?? null,
+            proposedHandling: r.proposedHandling ?? '',
+        }))
+        : cleanList(screen.risks ?? []).map(description => ({ description, severity: null, proposedHandling: '' }));
+    const contract = {
+        purpose: screen.purpose ?? '',
+        userIntent: screen.userIntent ?? '',
+        priority: normalizePriority(screen.priority),
+        entryPoints: cleanList(screen.entryPoints ?? []),
+        exitPaths: (screen.exitPaths ?? []).map(e => ({
+            label: e.label ?? '', target: e.target ?? '', condition: e.condition ?? '',
+        })),
+        coreUIRegions: cleanList([
+            ...(screen.coreUIElements ?? []),
+            ...(screen.coreUIElements?.length ? [] : (screen.components ?? [])),
+        ]),
+        outputData: cleanList(screen.outputData ?? []),
+        featureRefs: cleanList(screen.featureRefs ?? []),
+        acceptanceCriteria: cleanList(screen.acceptanceCriteria ?? []),
+        handoff: screen.handoff ? canonicalStringify(screen.handoff) : '',
+        states,
+        risks,
+    };
+    return stableHash(contract);
+}
+
+// --- Artifact-level readiness gate -------------------------------------------
+
+export interface ScreenArtifactReviewReadiness {
+    /** Whether the Screens artifact is ready to inform implementation planning.
+     * A readiness gate, NOT a hard lock — the UI stays fully usable either way. */
+    ready: boolean;
+    totalScreens: number;
+    accepted: number;
+    implementationReady: number;
+    needsReview: number;
+    draft: number;
+    /** Total blocking issues across all screens. */
+    blockers: number;
+    /** Total review items across all screens. */
+    reviewItems: number;
+    p0: {
+        total: number;
+        /** P0 screens the user has Accepted or marked Implementation ready. */
+        signedOff: number;
+        /** P0 screens with ≥1 blocking issue. */
+        withBlockers: number;
+        /** P0 screens the user has not yet Accepted/promoted (draft/needs_review/unset). */
+        notSignedOff: Array<{ id: string; name: string }>;
+    };
+    /** Human-readable "why not ready" reasons (empty when ready). */
+    reasons: string[];
+    /** One deterministic headline for the panel. */
+    message: string;
+}
+
+interface ArtifactReadinessScreen {
+    id: string;
+    name: string;
+    isP0: boolean;
+    model: ScreenReviewModel;
+}
+
+/**
+ * Roll the per-screen review models up into the artifact-level gate. P0 screens
+ * are the gate: the artifact is ready when every P0 screen is user-signed-off
+ * (Accepted or Implementation ready) and no P0 screen carries blocking issues.
+ * Everything is advisory — nothing here blocks rendering or generation.
+ */
+export function buildScreenArtifactReviewReadiness(
+    screens: readonly ArtifactReadinessScreen[],
+): ScreenArtifactReviewReadiness {
+    let accepted = 0;
+    let implementationReady = 0;
+    let needsReview = 0;
+    let draft = 0;
+    let blockers = 0;
+    let reviewItems = 0;
+    let p0Total = 0;
+    let p0SignedOff = 0;
+    let p0WithBlockers = 0;
+    const notSignedOff: Array<{ id: string; name: string }> = [];
+
+    for (const { id, name, isP0: p0, model } of screens) {
+        const status = model.userStatus;
+        if (status === 'accepted') accepted += 1;
+        else if (status === 'implementation_ready') implementationReady += 1;
+        else if (status === 'needs_review') needsReview += 1;
+        else draft += 1; // unset behaves as draft
+        blockers += model.blockingCount;
+        reviewItems += model.reviewCount;
+        if (p0) {
+            p0Total += 1;
+            const signedOff = status === 'accepted' || status === 'implementation_ready';
+            if (signedOff) p0SignedOff += 1;
+            else notSignedOff.push({ id, name });
+            if (model.blockingCount > 0) p0WithBlockers += 1;
+        }
+    }
+
+    const reasons: string[] = [];
+    if (notSignedOff.length > 0) {
+        reasons.push(notSignedOff.length === 1
+            ? '1 P0 screen has not been accepted yet.'
+            : `${notSignedOff.length} P0 screens have not been accepted yet.`);
+    }
+    if (p0WithBlockers > 0) {
+        reasons.push(p0WithBlockers === 1
+            ? '1 P0 screen has blocking issues.'
+            : `${p0WithBlockers} P0 screens have blocking issues.`);
+    }
+    // No P0 screens at all → nothing to gate on, but we still note it so the
+    // panel isn't misleadingly green for an empty/atypical set.
+    const ready = p0Total > 0 && notSignedOff.length === 0 && p0WithBlockers === 0;
+
+    let message: string;
+    if (screens.length === 0) {
+        message = 'No screens to review yet.';
+    } else if (ready) {
+        message = 'Ready for implementation planning — all P0 screens are accepted and no blocking issues remain.';
+    } else if (p0Total === 0) {
+        message = 'No P0 screens are marked yet. Set priorities and review the key screens before building.';
+    } else {
+        message = 'Not ready for implementation planning yet. Review the P0 screens flagged below before using this artifact as the build source.';
+    }
+
+    return {
+        ready,
+        totalScreens: screens.length,
+        accepted,
+        implementationReady,
+        needsReview,
+        draft,
+        blockers,
+        reviewItems,
+        p0: { total: p0Total, signedOff: p0SignedOff, withBlockers: p0WithBlockers, notSignedOff },
+        reasons,
+        message,
+    };
+}
+
+/** Convenience: build the artifact readiness gate straight from an index +
+ * a review-model map. */
+export function summarizeArtifactReviewReadiness(
+    index: ScreenExperienceIndex,
+    models: ReadonlyMap<string, ScreenReviewModel>,
+): ScreenArtifactReviewReadiness {
+    const screens: ArtifactReadinessScreen[] = index.items.map(item => ({
+        id: item.id,
+        name: item.screen.name || item.id,
+        isP0: isP0(item.screen),
+        model: models.get(item.id) ?? EMPTY_REVIEW_MODEL,
+    }));
+    return buildScreenArtifactReviewReadiness(screens);
+}
+
+const EMPTY_REVIEW_MODEL: ScreenReviewModel = {
+    systemReadiness: 'ready',
+    issues: [],
+    blockingCount: 0,
+    reviewCount: 0,
+    infoCount: 0,
+    acceptedOverWarnings: false,
+    freshness: 'unknown',
+    checklist: {},
+    checklistProgress: { checked: 0, total: CHECKLIST_ITEM_KEYS.length },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -800,6 +800,61 @@ export interface ScreenItem {
     navigationTo?: string[];
 }
 
+// --- Screen review workflow (Phase 4A) ---------------------------------------
+// Lightweight, per-screen review metadata persisted on the screen_inventory
+// ArtifactVersion's `metadata.screenEdits[id].review` overlay (see
+// ScreenMetadataEdit). The user's review STATUS stays in the existing
+// `reviewStatus` overlay field (draft/needs_review/accepted/implementation_ready);
+// this object carries the supporting record: the review checklist, a note, an
+// override reason (when a screen is accepted/promoted over open warnings), the
+// source signature captured at sign-off (for re-review detection), and
+// transition timestamps. Every field is optional & back-compat — legacy
+// overlays have none of it and default cleanly.
+
+/** Review checklist the user ticks off in the Screen Detail view. Optional
+ * support — checking items never gates a status change. */
+export interface ScreenReviewChecklist {
+    purposeMatchesPrd?: boolean;
+    entryExitPathsReviewed?: boolean;
+    statesReviewed?: boolean;
+    risksReviewed?: boolean;
+    mockupsReviewed?: boolean;
+    mobileReviewed?: boolean;
+    acceptanceCriteriaReviewed?: boolean;
+    developerHandoffReviewed?: boolean;
+}
+
+/** A deterministic snapshot of the screen-spec inputs at review sign-off,
+ * captured when a screen is accepted / marked implementation-ready. Compared
+ * against the current spec later to surface "this screen changed after it was
+ * accepted — re-review recommended" (see src/lib/screenReviewWorkflow.ts). */
+export interface ScreenReviewSignature {
+    /** Hash of the screen-contract fields the reviewer signed off on. */
+    screenContractHash: string;
+    /** PRD/spine version id at sign-off (provenance). */
+    prdVersionId?: string;
+    /** screen_inventory artifact version id at sign-off. */
+    screenVersionId?: string;
+    /** design_system artifact version id at sign-off. */
+    designSystemVersionId?: string;
+}
+
+/** Supporting record for a screen's review, riding the screenEdits overlay
+ * alongside the status in `reviewStatus`. */
+export interface ScreenReviewMeta {
+    checklist?: ScreenReviewChecklist;
+    /** Optional "what needs to change?" note (Request changes) or sign-off note. */
+    notes?: string;
+    /** Reason recorded when a screen is accepted / promoted over open warnings. */
+    overrideReason?: string;
+    /** Signature captured at accept / implementation-ready (re-review baseline). */
+    signature?: ScreenReviewSignature;
+    updatedAt?: string;
+    acceptedAt?: string;
+    requestedChangesAt?: string;
+    implementationReadyAt?: string;
+}
+
 export interface ScreenInventorySection {
     title: string;
     description?: string;


### PR DESCRIPTION
## Summary

Turns the **Screens** artifact from a reference surface into a real **review & approval workflow**. Users can review screens one at a time, see what's blocking confidence, accept / request changes / mark ready-to-build, tick a review checklist, and see whether the artifact is ready to inform implementation planning. Everything is layered on top of the existing readiness/variant/trust layers and **never changes them**; the readiness gate is advisory — nothing blocks rendering or generation.

## User review status vs. system readiness (kept distinct)

- **User review status** — the human sign-off, persisted in the existing `ScreenMetadataEdit.reviewStatus` overlay (draft / needs_review / accepted / implementation_ready).
- **System readiness** (`ready` / `needs_review` / `blocked`) — Synapse's derived estimate from the issue set, never overridden by the buttons.

A screen can be user-Accepted while the system says "review recommended" (e.g. a stale mobile mockup), or user-Draft while the system says "ready to accept". The UI shows both.

## What's included

- **New pure module `src/lib/screenReviewWorkflow.ts`** (unit-tested): categorized `ScreenReviewIssue`s (blocking / review / info, each with a recommended action) reusing the existing gap detection + resolvers; the per-screen `ScreenReviewModel`; status transitions; review-signature **freshness** (re-review after a screen changes); and the **artifact-level readiness gate** (P0 screens are the gate — ready iff every P0 screen is signed off and no P0 screen has blockers).
- **Additive persistence**: `ScreenReviewMeta` (`src/types`) rides a new optional `ScreenMetadataEdit.review` overlay (checklist, note, override reason, sign-off signature, timestamps), parsed defensively in `readScreenEdits`. Status stays in `reviewStatus`, so all prior wiring is untouched and legacy overlays default cleanly.
- **UI**: `ScreenReviewPanel` in the Screen Detail header (status line, Accept / Request changes / Mark ready-to-build with inline override-reason capture when blockers exist, readiness-issue list, review checklist, calm "review may be outdated" banner + Re-review); review status + issue counts on `ScreenListView` cards; new review-status and Has-blockers filters; a "Review readiness" rollup + gate callout in `ScreenCoveragePanel`. Wired through `ArtifactWorkspace`.

## Backward compatibility & honesty

- Existing artifacts with no review data render unchanged; review state persists across reloads keyed by stable screen id.
- Legacy records are **never falsely stale/outdated**; freshness/coverage come from stored metadata, never pixel inspection; language stays calm ("Review recommended", never "Invalid").
- A display rename alone does not trip "review outdated" (the review hash excludes the display-only name).

## Tests

- 18 pure workflow tests (`screenReviewWorkflow.test.ts`): clean-screen acceptance, blocking vs. review classification (acceptance criteria, P0 mockup, mobile, stale mockup, high-severity risk, primary-vs-supporting traceability), user-status-vs-system-readiness independence, review freshness (current/outdated/unknown + rename safety), and the artifact gate.
- 6 review-UI component tests (`ScreenExperienceViews.test.tsx`): detail header + actions, accept persists status + signature, checklist persistence, card review status, Has-blockers filter, coverage-panel readiness gate.
- Full suite green (1306+ tests), `npm run build` and `npm run lint` pass.

## Deferred to Phase 4B

- Cross-artifact **downstream invalidation** when an accepted screen changes (today only a note).
- A dedicated **export/finalization preflight** warning (the coverage-panel gate covers the readiness signal for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1YZQHpEQjWh7HqReXhgWe

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1YZQHpEQjWh7HqReXhgWe)_