### PR TITLE
Phase 4B: Screens downstream impact tracking + implementation preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1648,9 +1648,56 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   callout in `ScreenCoveragePanel`. Persistence flows through the existing
   `handleSaveScreenEdit` → `updateArtifactVersionMetadata` overlay path
   (timestamps/signatures stamped in `ScreenDetailView`, not the pure module).
-  Language stays calm ("Review recommended", never "Invalid"). **Not yet done
-  (Phase 4B):** cross-artifact downstream invalidation when an accepted screen
-  changes (today only a note), and a dedicated export/finalization preflight.
+  Language stays calm ("Review recommended", never "Invalid").
+- **Phase 4B — downstream impact tracking + Screens preflight
+  (`src/lib/screenDownstreamImpact.ts`, pure, unit-tested).** Layers ON TOP of
+  the Phase 4A review layer (never changing it) to answer "an accepted screen
+  changed — now what?". All **derived, never persisted** (a stale persisted
+  verdict is worse than none). `buildScreenDownstreamImpact(input)` maps a
+  screen's review signals to the downstream artifacts a change/blocker may have
+  invalidated, one entry per **`DownstreamArtifactKind`** (mockups / data_model /
+  implementation_plan / prompt_pack / user_flows / design_system / export),
+  highest severity per kind (`blocking` | `review` | `info`). Conservative,
+  explainable rules: (1) an **accepted/implementation-ready screen that changed
+  after sign-off** (`reviewFreshness === 'outdated'` — from Phase 4A's
+  `compareReviewFreshness`) → Mockups (review), Implementation Plan (review, or
+  **blocking** when a P0 was already `implementation_ready`), Data Model (review,
+  only when the screen carries data requirements — `outputData` / handoff
+  data-deps), Prompt Pack (info); (2) a **P0 screen with blockers** → Implementation
+  Plan **blocking**; (3) **stale mockup variants** (Phase 3C freshness, surfaced as
+  the `mockup_freshness_stale` review issue) → Mockups review; (4) **unknown
+  mockup freshness** (legacy metadata) → **info, never a blocker**. A draft/
+  unsigned screen never produces the change-driven impacts.
+  `screenDownstreamInputFromModel(item, model)` derives the input from the Phase 4A
+  `ScreenReviewModel` (so the two layers can't drift). `buildScreensDownstreamImpactRollup`
+  rolls per-screen impacts up to `overallStatus` **ready / review_recommended /
+  not_ready** — **not_ready** iff the Phase 4A gate isn't ready OR any P0
+  accepted/impl-ready screen is outdated OR any P0 has a blocking downstream
+  impact; **review_recommended** for review-level impacts with a clean P0 gate;
+  **ready** otherwise. `buildRecommendedNextActions` produces a prioritized list
+  (P0 blockers → re-review outdated accepted P0 → accept remaining P0 → stale P0
+  mockups → implementation plan → supporting screens → unknown legacy mockups),
+  **capped to 5**. `buildScreensPreflight` assembles the implementation/export
+  preflight (blocking / review / info / recommended next steps / export-snapshot
+  caveats — e.g. the Phase 3D variant-image cross-device-sync gap).
+  `analyzeScreensDownstream(index, reviewModels, artifactReview)` is the single
+  entry point the workspace calls. **UI:** `ScreenDownstreamImpactSection`
+  (Screen Detail, below the review panel — impacted-artifact list, or a calm
+  "No downstream impact detected" / "cannot be fully confirmed for this older
+  review" empty state), a compact `DownstreamChip` on `ScreenListView` cards
+  (only when a blocking/review impact exists — info-only shows nothing), a
+  **Downstream readiness** section in `ScreenCoveragePanel`, and a collapsible
+  **`ScreenPreflightPanel`** ("Implementation preflight") above the screen list.
+  Two new list filters — **Outdated review** (`reviewFreshness === 'outdated'`)
+  and **Downstream review** (`downstreamReviewNeeded`) — extend
+  `SCREEN_LIST_FILTERS` / `ScreenFilterReview` (the caller supplies the new
+  signals; `screenReadiness.ts` must NOT import `screenDownstreamImpact` — that
+  would cycle). **No export/finalization hook was added**: there is no
+  Screens-specific export/share/finalize action today (the PRD Mark-as-Final /
+  UpdateAssetsPlan flow is PRD-level, not per-artifact), so the local preflight
+  panel is the Phase 4B decision surface — a safer choice than hooking into an
+  unrelated flow. Everything stays **advisory** — nothing gates rendering or
+  generation, and legacy artifacts (no review data) show no impact/blocker.
 - **Phase 2 — source-grounded screen contracts.** New screen_inventory
   generations emit an explicit contract per screen (all fields optional &
   back-compat on `ScreenItem`/`ScreenState` in `src/types`): structured

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -590,3 +590,130 @@ describe('Phase 3C variant freshness & history UI', () => {
         expect(getByText('Previous render 1')).toBeTruthy();
     });
 });
+
+// --- Phase 4B: downstream impact + Screens preflight -------------------------
+
+import { ScreenDownstreamImpactSection } from '../experience/ScreenDownstreamImpactSection';
+import { ScreenPreflightPanel } from '../experience/ScreenPreflightPanel';
+import { buildScreenDownstreamImpact, buildScreensPreflight } from '../../lib/screenDownstreamImpact';
+import type { ScreenArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
+
+/** Fixtures where the P0 dashboard is Accepted but its stored review signature
+ * no longer matches — i.e. it changed after sign-off (freshness 'outdated'). */
+function buildDownstreamFixtures() {
+    const flows = parseFlows(FLOWS_MD);
+    const edits: Record<string, ScreenMetadataEdit> = {
+        'scr-home': {
+            reviewStatus: 'accepted',
+            review: { signature: { screenContractHash: 'stale-hash-that-will-not-match' } },
+        },
+    };
+    const index = buildScreenIndex(inventory, flows, payload, edits);
+    const readiness = buildReadinessIndex(index, FEATURES);
+    const coverage = buildScreenCoverageSummary(index, readiness, flows, FEATURES);
+    const reviewModels = buildScreenReviewIndex(index, { features: FEATURES });
+    const artifactReview = summarizeArtifactReviewReadiness(index, reviewModels);
+    return { index, readiness, coverage, reviewModels, artifactReview };
+}
+
+describe('Phase 4B downstream impact section', () => {
+    it('11. shows the impacted artifacts when an accepted screen is outdated', () => {
+        const impact = buildScreenDownstreamImpact({
+            screenId: 's', title: 'Dashboard', isP0: true,
+            userStatus: 'accepted', reviewFreshness: 'outdated',
+            blockingCount: 0, blockingTitles: [],
+            mockupFreshnessStale: false, mockupFreshnessUnknown: false, hasDataRequirements: true,
+        });
+        const { getByText, getAllByText } = render(<ScreenDownstreamImpactSection impact={impact} />);
+        expect(getAllByText('Downstream impact').length).toBeGreaterThan(0);
+        expect(getByText('Mockups')).toBeTruthy();
+        expect(getByText('Implementation Plan')).toBeTruthy();
+    });
+
+    it('12. shows a calm no-impact empty state', () => {
+        const impact = buildScreenDownstreamImpact({
+            screenId: 's', title: 'Settings', isP0: false,
+            userStatus: 'draft', reviewFreshness: 'current',
+            blockingCount: 0, blockingTitles: [],
+            mockupFreshnessStale: false, mockupFreshnessUnknown: false, hasDataRequirements: false,
+        });
+        const { getByText } = render(<ScreenDownstreamImpactSection impact={impact} />);
+        expect(getByText('No downstream impact detected for this screen.')).toBeTruthy();
+    });
+});
+
+describe('Phase 4B list card + coverage panel', () => {
+    it('13. a card shows a downstream review chip only when relevant', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildDownstreamFixtures();
+        const { getByText, queryAllByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                onSelectScreen={() => {}}
+            />,
+        );
+        // The accepted-but-outdated P0 dashboard surfaces a downstream chip…
+        expect(queryAllByText(/Downstream review/).length).toBeGreaterThan(0);
+        // …but the header still renders normally.
+        expect(getByText('Screen Coverage & Readiness')).toBeTruthy();
+    });
+
+    it('14. the coverage panel shows the downstream readiness section', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildDownstreamFixtures();
+        const { getByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                onSelectScreen={() => {}}
+            />,
+        );
+        expect(getByText('Downstream readiness')).toBeTruthy();
+    });
+});
+
+describe('Phase 4B preflight panel', () => {
+    function readyGate(overrides: Partial<ScreenArtifactReviewReadiness> = {}): ScreenArtifactReviewReadiness {
+        return {
+            ready: true, totalScreens: 1, accepted: 1, implementationReady: 0, needsReview: 0, draft: 0,
+            blockers: 0, reviewItems: 0,
+            p0: { total: 1, signedOff: 1, withBlockers: 0, notSignedOff: [] },
+            reasons: [], message: 'Ready', ...overrides,
+        };
+    }
+
+    it('15. shows blockers, review items, and recommended next steps', () => {
+        const preflight = buildScreensPreflight(
+            [{
+                screenId: 'p0', title: 'Dashboard', isP0: true,
+                userStatus: undefined, reviewFreshness: 'current',
+                blockingCount: 1, blockingTitles: ['No acceptance criteria'],
+                mockupFreshnessStale: true, mockupFreshnessUnknown: false, hasDataRequirements: false,
+            }],
+            readyGate({ ready: false, p0: { total: 1, signedOff: 0, withBlockers: 1, notSignedOff: [{ id: 'p0', name: 'Dashboard' }] } }),
+        );
+        const { getByText } = render(<ScreenPreflightPanel preflight={preflight} />);
+        expect(getByText('Implementation preflight')).toBeTruthy();
+        expect(getByText('Blocking')).toBeTruthy();
+        expect(getByText('Recommended next steps')).toBeTruthy();
+    });
+
+    it('16. renders a ready state when no blockers remain', () => {
+        const preflight = buildScreensPreflight(
+            [{
+                screenId: 'p0', title: 'Dashboard', isP0: true,
+                userStatus: 'accepted', reviewFreshness: 'current',
+                blockingCount: 0, blockingTitles: [],
+                mockupFreshnessStale: false, mockupFreshnessUnknown: false, hasDataRequirements: false,
+            }],
+            readyGate(),
+        );
+        const { getByText } = render(<ScreenPreflightPanel preflight={preflight} />);
+        expect(getByText('Ready for implementation planning')).toBeTruthy();
+    });
+});

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import type { ScreenCoverageSummary } from '../../lib/screenReadiness';
 import type { ScreenArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
+import type { ScreensDownstreamImpactRollup } from '../../lib/screenDownstreamImpact';
 import type { MockupVariantCoverageSummary } from '../../lib/mockupVariants';
 import type { VariantFreshnessRollup } from '../../lib/mockupVariantTrust';
 
@@ -32,6 +33,9 @@ interface Props {
     /** Artifact-level review readiness gate (Phase 4A). Absent → the review
      * readiness section is hidden (legacy callers). */
     artifactReview?: ScreenArtifactReviewReadiness;
+    /** Artifact-level downstream-impact rollup (Phase 4B). Absent → the
+     * downstream readiness section is hidden (legacy callers). */
+    downstreamRollup?: ScreensDownstreamImpactRollup;
     /** Opens the confirmed "Generate remaining mockups" flow (absent → no
      * mockup artifact yet; the action row is hidden). */
     onGenerateMissingMockups?: () => void;
@@ -58,7 +62,7 @@ function MetricRow({
     );
 }
 
-export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, onGenerateMissingMockups }: Props) {
+export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, downstreamRollup, onGenerateMissingMockups }: Props) {
     const [showUncovered, setShowUncovered] = useState(false);
     const {
         totalScreens, prdFeatures, stateVariants, flows, p0, states, mockups, openRisks,
@@ -242,6 +246,67 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
 
                     {artifactReview && artifactReview.totalScreens > 0 && (
                         <ReviewReadinessSection review={artifactReview} />
+                    )}
+
+                    {downstreamRollup && (
+                        <DownstreamReadinessSection rollup={downstreamRollup} />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** Phase 4B: the artifact-level downstream-readiness verdict (how changes to
+ * accepted screens ripple into mockups / data model / implementation plan).
+ * Advisory only — never a hard lock. */
+const DOWNSTREAM_STATUS_META: Record<ScreensDownstreamImpactRollup['overallStatus'], {
+    label: string; tone: 'good' | 'warn';
+}> = {
+    ready: { label: 'Ready for implementation planning', tone: 'good' },
+    review_recommended: { label: 'Review recommended', tone: 'warn' },
+    not_ready: { label: 'Not ready for implementation planning', tone: 'warn' },
+};
+
+function DownstreamReadinessSection({ rollup }: { rollup: ScreensDownstreamImpactRollup }) {
+    const meta = DOWNSTREAM_STATUS_META[rollup.overallStatus];
+    const good = meta.tone === 'good';
+    return (
+        <div className="mt-4 pt-4 border-t border-neutral-100">
+            <div className="flex items-center gap-1.5 mb-2">
+                <Gauge size={13} className="text-neutral-400" aria-hidden />
+                <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">Downstream readiness</h4>
+            </div>
+            <div className={`rounded-lg border p-3 flex items-start gap-2 ${
+                good ? 'border-emerald-200 bg-emerald-50/60' : 'border-amber-200 bg-amber-50/60'
+            }`}>
+                {good
+                    ? <CheckCircle2 size={15} className="text-emerald-600 mt-0.5 shrink-0" aria-hidden />
+                    : <AlertTriangle size={15} className="text-amber-600 mt-0.5 shrink-0" aria-hidden />}
+                <div className="min-w-0">
+                    <p className={`text-xs font-medium ${good ? 'text-emerald-800' : 'text-amber-800'}`}>
+                        {meta.label}
+                    </p>
+                    {rollup.overallStatus === 'ready' ? (
+                        <p className="text-[11px] text-neutral-600 mt-0.5">
+                            All P0 screens are signed off, current, and free of blocking downstream impacts.
+                        </p>
+                    ) : (
+                        <p className="text-[11px] text-neutral-600 mt-0.5">
+                            {rollup.totalImpactedScreens === 1
+                                ? '1 screen may affect downstream artifacts (mockups, data model, implementation plan).'
+                                : `${rollup.totalImpactedScreens} screens may affect downstream artifacts (mockups, data model, implementation plan).`}
+                        </p>
+                    )}
+                    {rollup.recommendedNextActions.length > 0 && (
+                        <ul className="mt-1.5 space-y-0.5 text-[11px] text-neutral-600">
+                            {rollup.recommendedNextActions.slice(0, 3).map((a, i) => (
+                                <li key={i} className="flex gap-1.5">
+                                    <span className="text-neutral-400 select-none">·</span>
+                                    <span>{a}</span>
+                                </li>
+                            ))}
+                        </ul>
                     )}
                 </div>
             </div>

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -37,6 +37,9 @@ import {
     type ScreenReviewModel,
 } from '../../lib/screenReviewWorkflow';
 import {
+    buildScreenDownstreamImpact, screenDownstreamInputFromModel,
+} from '../../lib/screenDownstreamImpact';
+import {
     buildScreenMockupVariants, formatVariantLabel, summarizeScreenVariants,
     VARIANT_STATUS_LABELS, type GeneratedVariantMap,
 } from '../../lib/mockupVariants';
@@ -44,6 +47,7 @@ import type { MockupVariantSourceSignature, VariantTrustContext } from '../../li
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import { MockupVariantsPanel } from './MockupVariantsPanel';
 import { ScreenReviewPanel } from './ScreenReviewPanel';
+import { ScreenDownstreamImpactSection } from './ScreenDownstreamImpactSection';
 import { ScreenOverviewPanel } from './ScreenOverviewPanel';
 import { ReadinessBadge } from './ReadinessBadge';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
@@ -164,6 +168,14 @@ export function ScreenDetailView({
         generatedVariants,
     }), [item, mockupContext?.settings.platform, mockupContext?.trustContext, mobileRelevant, features, generatedVariants]);
 
+    // Phase 4B: derived downstream impact for this screen (which artifacts a
+    // change / blocker on this screen may have invalidated). Purely derived
+    // from the same review model — never persisted.
+    const downstreamImpact = useMemo(
+        () => buildScreenDownstreamImpact(screenDownstreamInputFromModel(item, reviewModel)),
+        [item, reviewModel],
+    );
+
     // Persist a review change into the screenEdits overlay. Status rides
     // `reviewStatus`; the supporting record (checklist / note / override reason /
     // sign-off signature / timestamps) rides `review`. Merges from the existing
@@ -282,6 +294,8 @@ export function ScreenDetailView({
                 onReReview={handleReReview}
                 readOnly={!onSaveScreenEdit}
             />
+
+            <ScreenDownstreamImpactSection impact={downstreamImpact} />
 
             <ScreenDetailTabs
                 active={activeTab}

--- a/src/components/experience/ScreenDownstreamImpactSection.tsx
+++ b/src/components/experience/ScreenDownstreamImpactSection.tsx
@@ -1,0 +1,118 @@
+// Phase 4B: the per-screen "Downstream impact" section, shown in the Screen
+// Detail view below the review panel. When an accepted screen changed after
+// sign-off (or a P0 screen carries blockers, or its mockups read stale), it
+// names the downstream artifacts worth re-checking — grouped by artifact, with
+// calm severity language. Purely presentational over the derived
+// ScreenDownstreamImpact (src/lib/screenDownstreamImpact.ts). Never blocks use.
+
+import { AlertOctagon, CheckCircle2, HelpCircle, Info, ShieldQuestion } from 'lucide-react';
+import type {
+    DownstreamArtifactKind, DownstreamImpactSeverity, ScreenDownstreamImpact,
+} from '../../lib/screenDownstreamImpact';
+
+const ARTIFACT_LABELS: Record<DownstreamArtifactKind, string> = {
+    mockups: 'Mockups',
+    data_model: 'Data Model',
+    implementation_plan: 'Implementation Plan',
+    prompt_pack: 'Developer Prompts',
+    user_flows: 'User Flows',
+    design_system: 'Design System',
+    export: 'Export',
+};
+
+const SEVERITY_META: Record<DownstreamImpactSeverity, { label: string; dot: string; text: string }> = {
+    blocking: { label: 'Blocking', dot: 'bg-red-500', text: 'text-red-700' },
+    review: { label: 'Review recommended', dot: 'bg-amber-500', text: 'text-amber-700' },
+    info: { label: 'For your information', dot: 'bg-neutral-400', text: 'text-neutral-600' },
+};
+
+interface Props {
+    impact: ScreenDownstreamImpact;
+}
+
+export function ScreenDownstreamImpactSection({ impact }: Props) {
+    const { impactedArtifacts, summary } = impact;
+    const signedOff = impact.userStatus === 'accepted' || impact.userStatus === 'implementation_ready';
+
+    // No impacts: distinguish "cannot confirm for a legacy review" from a clean
+    // "no impact detected".
+    if (impactedArtifacts.length === 0) {
+        if (signedOff && impact.reviewFreshness === 'unknown') {
+            return (
+                <Shell tone="neutral">
+                    <div className="flex items-start gap-2">
+                        <HelpCircle size={14} className="text-neutral-400 mt-0.5 shrink-0" aria-hidden />
+                        <p className="text-xs text-neutral-600">
+                            Downstream impact cannot be fully confirmed for this older review.
+                            Review before implementation if this screen is critical.
+                        </p>
+                    </div>
+                </Shell>
+            );
+        }
+        return (
+            <Shell tone="good">
+                <div className="flex items-start gap-2">
+                    <CheckCircle2 size={14} className="text-emerald-600 mt-0.5 shrink-0" aria-hidden />
+                    <p className="text-xs text-neutral-600">No downstream impact detected for this screen.</p>
+                </div>
+            </Shell>
+        );
+    }
+
+    const lead = summary.hasBlockingImpact
+        ? 'This screen affects downstream artifacts. Resolve the blockers before building.'
+        : 'This screen changed or needs review. The artifacts below may be worth re-checking before implementation.';
+
+    return (
+        <Shell tone={summary.hasBlockingImpact ? 'warn' : 'review'}>
+            <p className="text-xs text-neutral-600 mb-2">{lead}</p>
+            <ul className="space-y-2">
+                {impactedArtifacts.map(a => {
+                    const meta = SEVERITY_META[a.severity];
+                    const Icon = a.severity === 'blocking'
+                        ? AlertOctagon
+                        : a.severity === 'review' ? ShieldQuestion : Info;
+                    return (
+                        <li key={a.kind} className="flex items-start gap-2.5">
+                            <Icon size={14} className={`${meta.text} mt-0.5 shrink-0`} aria-hidden />
+                            <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <span className="text-xs font-medium text-neutral-800">{ARTIFACT_LABELS[a.kind]}</span>
+                                    <span className={`inline-flex items-center gap-1 text-[9px] uppercase tracking-wide ${meta.text}`}>
+                                        <span className={`h-1.5 w-1.5 rounded-full ${meta.dot}`} aria-hidden />
+                                        {meta.label}
+                                    </span>
+                                </div>
+                                <p className="text-[11px] text-neutral-600 mt-0.5">{a.description}</p>
+                                {a.recommendedAction && (
+                                    <p className="text-[11px] text-neutral-500 mt-0.5">
+                                        <span className="text-neutral-400">Suggested: </span>{a.recommendedAction}
+                                    </p>
+                                )}
+                            </div>
+                        </li>
+                    );
+                })}
+            </ul>
+        </Shell>
+    );
+}
+
+function Shell({ children, tone }: { children: React.ReactNode; tone: 'good' | 'neutral' | 'review' | 'warn' }) {
+    const border = tone === 'warn'
+        ? 'border-amber-200 bg-amber-50/50'
+        : tone === 'review'
+            ? 'border-amber-200 bg-white'
+            : 'border-neutral-200 bg-white';
+    return (
+        <div className={`rounded-xl border p-4 shadow-sm ${border}`}>
+            <div className="flex items-center gap-1.5 mb-2">
+                <span className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                    Downstream impact
+                </span>
+            </div>
+            {children}
+        </div>
+    );
+}

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -20,12 +20,17 @@ import {
     type ScreenArtifactReviewReadiness, type ScreenReviewModel,
 } from '../../lib/screenReviewWorkflow';
 import {
+    analyzeScreensDownstream,
+    type ScreenDownstreamImpact,
+} from '../../lib/screenDownstreamImpact';
+import {
     buildScreenMockupVariants, summarizeScreenVariants,
     type GeneratedVariantMap, type MockupVariantCoverageSummary,
 } from '../../lib/mockupVariants';
 import type { VariantTrustContext } from '../../lib/mockupVariantTrust';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 import { ScreenCoveragePanel } from './ScreenCoveragePanel';
+import { ScreenPreflightPanel } from './ScreenPreflightPanel';
 import { ReadinessBadge } from './ReadinessBadge';
 
 const EMPTY_REVIEW_MODELS: ReadonlyMap<string, ScreenReviewModel> = new Map();
@@ -70,13 +75,27 @@ export function ScreenListView({
 }: Props) {
     const [filter, setFilter] = useState<ScreenListFilter>('all');
 
+    // Phase 4B: downstream impact analysis — per-screen impacts (row chips +
+    // filters), the artifact-level rollup, and the implementation preflight.
+    // Derived once from the review models; pure & memoized, never persisted.
+    const downstream = useMemo(
+        () => analyzeScreensDownstream(index, reviewModels, artifactReview),
+        [index, reviewModels, artifactReview],
+    );
+    const downstreamByScreen = downstream.impactsByScreen;
+
     const filterReviewFor = (item: ScreenExperienceItem): ScreenFilterReview | undefined => {
         const model = reviewModels.get(item.id);
         if (!model) return undefined;
+        const impact = downstreamByScreen.get(item.id);
         return {
             userStatus: model.userStatus,
             blockingCount: model.blockingCount,
             reviewCount: model.reviewCount,
+            reviewFreshness: model.freshness,
+            downstreamReviewNeeded: impact
+                ? impact.summary.hasBlockingImpact || impact.summary.reviewCount > 0
+                : false,
         };
     };
 
@@ -89,7 +108,7 @@ export function ScreenListView({
         }
         return counts;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [index, readiness, reviewModels]);
+    }, [index, readiness, reviewModels, downstreamByScreen]);
 
     if (index.items.length === 0) {
         return (
@@ -119,8 +138,12 @@ export function ScreenListView({
                 summary={coverage}
                 variantCoverage={variantCoverage}
                 artifactReview={artifactReview}
+                downstreamRollup={downstream.rollup}
                 onGenerateMissingMockups={onGenerateMissingMockups}
             />
+
+            <ScreenPreflightPanel preflight={downstream.preflight} />
+
 
             <div className="flex items-center gap-1.5 flex-wrap" role="group" aria-label="Filter screens">
                 {SCREEN_LIST_FILTERS.map(f => {
@@ -179,6 +202,7 @@ export function ScreenListView({
                                     item={item}
                                     readiness={readiness.get(item.id)}
                                     reviewModel={reviewModels.get(item.id)}
+                                    downstreamImpact={downstreamByScreen.get(item.id)}
                                     mockupPlatform={mockupPlatform}
                                     mobileRelevant={mobileRelevant}
                                     generatedVariants={generatedVariantsByScreen?.(item.id)}
@@ -201,11 +225,12 @@ const SYSTEM_READINESS_TONE: Record<ScreenReviewModel['systemReadiness'], string
 };
 
 function ScreenRow({
-    item, readiness, reviewModel, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
+    item, readiness, reviewModel, downstreamImpact, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
 }: {
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
     reviewModel?: ScreenReviewModel;
+    downstreamImpact?: ScreenDownstreamImpact;
     mockupPlatform?: MockupPlatform;
     mobileRelevant?: boolean;
     generatedVariants?: GeneratedVariantMap;
@@ -317,6 +342,7 @@ function ScreenRow({
                         Review may be outdated
                     </span>
                 )}
+                {downstreamImpact && <DownstreamChip impact={downstreamImpact} />}
             </div>
 
             {reviewModel && (
@@ -375,5 +401,41 @@ function ScreenRow({
                 <ChevronRight size={13} className="ml-auto text-neutral-300 group-hover:text-indigo-400 transition-colors" aria-hidden />
             </div>
         </button>
+    );
+}
+
+const DOWNSTREAM_LABELS: Record<string, string> = {
+    mockups: 'Mockups',
+    data_model: 'Data Model',
+    implementation_plan: 'Implementation Plan',
+    prompt_pack: 'Developer Prompts',
+    user_flows: 'User Flows',
+    design_system: 'Design System',
+    export: 'Export',
+};
+
+/** Compact downstream-impact chip — shown only when a change/blocker actually
+ * impacts a downstream artifact (info-only impacts show no chip, to avoid
+ * cluttering every legacy card). */
+function DownstreamChip({ impact }: { impact: ScreenDownstreamImpact }) {
+    const actionable = impact.impactedArtifacts.filter(a => a.severity !== 'info');
+    if (actionable.length === 0) return null;
+    const blocking = impact.summary.hasBlockingImpact;
+    const names = actionable.slice(0, 2).map(a => DOWNSTREAM_LABELS[a.kind] ?? a.kind);
+    const label = blocking
+        ? 'Implementation not ready'
+        : `Downstream review: ${names.join(', ')}${actionable.length > names.length ? '…' : ''}`;
+    const tone = blocking
+        ? 'text-red-700 bg-red-50 ring-red-200'
+        : 'text-amber-700 bg-amber-50 ring-amber-200';
+    return (
+        <span
+            className={`text-[10px] px-1.5 py-0.5 rounded-full ring-1 ${tone}`}
+            title={blocking
+                ? 'This screen has blocking readiness issues — downstream implementation is affected'
+                : 'This screen changed or needs review — the named downstream artifacts may be worth re-checking'}
+        >
+            {label}
+        </span>
     );
 }

--- a/src/components/experience/ScreenPreflightPanel.tsx
+++ b/src/components/experience/ScreenPreflightPanel.tsx
@@ -1,0 +1,156 @@
+// Phase 4B: the Screens implementation preflight — a local, collapsible
+// decision surface shown above the screen list. It summarizes whether the
+// Screens artifact is ready to inform implementation planning / export:
+// blocking items, review-recommended items, informational notes, prioritized
+// next steps, and export/snapshot caveats. Purely presentational over the
+// derived ScreensPreflightModel (src/lib/screenDownstreamImpact.ts) — it is a
+// decision surface, NEVER a hard gate (nothing here blocks normal use). We
+// deliberately avoid hooking into export/finalization flows: there is no
+// Screens-specific export action today, so this local panel is the Phase 4B
+// preflight surface (see the export-hook note in CLAUDE.md).
+
+import { useState } from 'react';
+import {
+    AlertOctagon, CheckCircle2, ChevronDown, ChevronUp, ClipboardList, Info, ListChecks, ShieldQuestion,
+} from 'lucide-react';
+import type { ScreensPreflightModel } from '../../lib/screenDownstreamImpact';
+
+interface Props {
+    preflight: ScreensPreflightModel;
+}
+
+const STATUS_META: Record<ScreensPreflightModel['status'], { tone: 'good' | 'warn'; }> = {
+    ready: { tone: 'good' },
+    review_recommended: { tone: 'warn' },
+    not_ready: { tone: 'warn' },
+};
+
+export function ScreenPreflightPanel({ preflight }: Props) {
+    // Default open only when there's something to act on — a ready artifact
+    // stays collapsed so it doesn't nag.
+    const hasContent = preflight.blocking.length > 0 || preflight.review.length > 0
+        || preflight.recommendedNextActions.length > 0;
+    const [open, setOpen] = useState(preflight.status !== 'ready' && hasContent);
+
+    const good = STATUS_META[preflight.status].tone === 'good';
+
+    return (
+        <div className="rounded-xl border border-neutral-200 bg-white shadow-sm overflow-hidden">
+            <button
+                type="button"
+                onClick={() => setOpen(v => !v)}
+                className="w-full flex items-center justify-between gap-3 px-4 py-3 hover:bg-neutral-50 transition"
+            >
+                <div className="flex items-center gap-2 min-w-0">
+                    <div className={`h-7 w-7 shrink-0 rounded-lg flex items-center justify-center ${good ? 'bg-emerald-50' : 'bg-amber-50'}`}>
+                        <ClipboardList size={15} className={good ? 'text-emerald-600' : 'text-amber-600'} />
+                    </div>
+                    <div className="min-w-0 text-left">
+                        <h3 className="text-sm font-semibold text-neutral-900">Implementation preflight</h3>
+                        <p className={`text-[11px] ${good ? 'text-emerald-700' : 'text-amber-700'}`}>{preflight.headline}</p>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                    {preflight.blocking.length > 0 && (
+                        <span className="text-[10px] font-medium text-red-700 bg-red-50 ring-1 ring-red-200 px-1.5 py-0.5 rounded-full">
+                            {preflight.blocking.length} blocking
+                        </span>
+                    )}
+                    {preflight.review.length > 0 && (
+                        <span className="text-[10px] font-medium text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full">
+                            {preflight.review.length} review
+                        </span>
+                    )}
+                    {open ? <ChevronUp size={16} className="text-neutral-400" /> : <ChevronDown size={16} className="text-neutral-400" />}
+                </div>
+            </button>
+
+            {open && (
+                <div className="px-4 pb-4 space-y-3 border-t border-neutral-100 pt-3">
+                    {preflight.status === 'ready' && preflight.blocking.length === 0 && preflight.review.length === 0 && (
+                        <p className="inline-flex items-center gap-1.5 text-xs text-emerald-700">
+                            <CheckCircle2 size={13} />
+                            All P0 screens are signed off and current. No blocking downstream impacts detected.
+                        </p>
+                    )}
+
+                    {preflight.blocking.length > 0 && (
+                        <Group
+                            icon={<AlertOctagon size={13} className="text-red-600" />}
+                            title="Blocking"
+                            items={preflight.blocking}
+                            tone="text-red-700"
+                        />
+                    )}
+                    {preflight.review.length > 0 && (
+                        <Group
+                            icon={<ShieldQuestion size={13} className="text-amber-600" />}
+                            title="Review recommended"
+                            items={preflight.review}
+                            tone="text-amber-700"
+                        />
+                    )}
+                    {preflight.info.length > 0 && (
+                        <Group
+                            icon={<Info size={13} className="text-neutral-400" />}
+                            title="For your information"
+                            items={preflight.info}
+                            tone="text-neutral-600"
+                        />
+                    )}
+
+                    {preflight.recommendedNextActions.length > 0 && (
+                        <div className="rounded-lg border border-indigo-100 bg-indigo-50/50 p-3">
+                            <div className="flex items-center gap-1.5 mb-1.5">
+                                <ListChecks size={13} className="text-indigo-500" aria-hidden />
+                                <h4 className="text-[11px] font-semibold uppercase tracking-wide text-indigo-600">
+                                    Recommended next steps
+                                </h4>
+                            </div>
+                            <ol className="space-y-1 text-xs text-neutral-700 list-decimal list-inside">
+                                {preflight.recommendedNextActions.map((a, i) => <li key={i}>{a}</li>)}
+                            </ol>
+                        </div>
+                    )}
+
+                    {preflight.caveats.length > 0 && (
+                        <ul className="space-y-1 text-[11px] text-neutral-400">
+                            {preflight.caveats.map((c, i) => (
+                                <li key={i} className="flex gap-1.5">
+                                    <span className="select-none">·</span>
+                                    <span>{c}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+
+                    <p className="text-[11px] text-neutral-400">
+                        Preflight is advisory and derived from the current screen state — it never blocks using
+                        the Screens artifact.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function Group({ icon, title, items, tone }: {
+    icon: React.ReactNode; title: string; items: string[]; tone: string;
+}) {
+    return (
+        <div>
+            <div className="flex items-center gap-1.5 mb-1">
+                {icon}
+                <h4 className={`text-[11px] font-semibold uppercase tracking-wide ${tone}`}>{title}</h4>
+            </div>
+            <ul className="space-y-0.5 text-xs text-neutral-700">
+                {items.map((item, i) => (
+                    <li key={i} className="flex gap-1.5">
+                        <span className="text-neutral-300 select-none">·</span>
+                        <span>{item}</span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/lib/__tests__/screenDownstreamImpact.test.ts
+++ b/src/lib/__tests__/screenDownstreamImpact.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildScreenDownstreamImpact,
+    buildScreensDownstreamImpactRollup,
+    buildRecommendedNextActions,
+    buildScreensPreflight,
+    type DownstreamScreenInput,
+} from '../screenDownstreamImpact';
+import type { ScreenArtifactReviewReadiness } from '../screenReviewWorkflow';
+
+function input(overrides: Partial<DownstreamScreenInput> = {}): DownstreamScreenInput {
+    return {
+        screenId: 's',
+        title: 'Screen',
+        isP0: false,
+        userStatus: undefined,
+        reviewFreshness: 'current',
+        blockingCount: 0,
+        blockingTitles: [],
+        mockupFreshnessStale: false,
+        mockupFreshnessUnknown: false,
+        hasDataRequirements: false,
+        ...overrides,
+    };
+}
+
+/** A minimal "ready" artifact-review gate for rollup/preflight tests. */
+function gate(overrides: Partial<ScreenArtifactReviewReadiness> = {}): ScreenArtifactReviewReadiness {
+    return {
+        ready: true,
+        totalScreens: 1,
+        accepted: 1,
+        implementationReady: 0,
+        needsReview: 0,
+        draft: 0,
+        blockers: 0,
+        reviewItems: 0,
+        p0: { total: 1, signedOff: 1, withBlockers: 0, notSignedOff: [] },
+        reasons: [],
+        message: 'Ready',
+        ...overrides,
+    };
+}
+
+describe('buildScreenDownstreamImpact', () => {
+    it('1. an accepted screen changed after sign-off creates downstream impacts', () => {
+        const impact = buildScreenDownstreamImpact(input({
+            userStatus: 'accepted',
+            reviewFreshness: 'outdated',
+            hasDataRequirements: true,
+        }));
+        const kinds = impact.impactedArtifacts.map(a => a.kind);
+        expect(kinds).toContain('mockups');
+        expect(kinds).toContain('implementation_plan');
+        expect(kinds).toContain('data_model');
+        expect(kinds).toContain('prompt_pack');
+        expect(impact.summary.reviewCount).toBeGreaterThan(0);
+    });
+
+    it('2. a draft screen with outdated/unknown review does NOT create the sign-off impacts', () => {
+        const impact = buildScreenDownstreamImpact(input({
+            userStatus: 'draft',
+            reviewFreshness: 'outdated',
+            hasDataRequirements: true,
+        }));
+        // No sign-off → no change-driven impacts at all.
+        expect(impact.impactedArtifacts).toHaveLength(0);
+    });
+
+    it('3. a P0 screen with a blocker creates a blocking implementation impact', () => {
+        const impact = buildScreenDownstreamImpact(input({
+            isP0: true,
+            blockingCount: 1,
+            blockingTitles: ['No acceptance criteria'],
+        }));
+        const impl = impact.impactedArtifacts.find(a => a.kind === 'implementation_plan');
+        expect(impl?.severity).toBe('blocking');
+        expect(impl?.evidence).toContain('No acceptance criteria');
+        expect(impact.summary.hasBlockingImpact).toBe(true);
+    });
+
+    it('4. stale mockup variants create a mockup review impact', () => {
+        const impact = buildScreenDownstreamImpact(input({ mockupFreshnessStale: true }));
+        const m = impact.impactedArtifacts.find(a => a.kind === 'mockups');
+        expect(m?.severity).toBe('review');
+    });
+
+    it('5. unknown mockup freshness creates an info impact, not a blocker', () => {
+        const impact = buildScreenDownstreamImpact(input({ mockupFreshnessUnknown: true }));
+        const m = impact.impactedArtifacts.find(a => a.kind === 'mockups');
+        expect(m?.severity).toBe('info');
+        expect(impact.summary.hasBlockingImpact).toBe(false);
+    });
+
+    it('a non-data screen changed after sign-off does not impact the data model', () => {
+        const impact = buildScreenDownstreamImpact(input({
+            userStatus: 'accepted',
+            reviewFreshness: 'outdated',
+            hasDataRequirements: false,
+        }));
+        expect(impact.impactedArtifacts.some(a => a.kind === 'data_model')).toBe(false);
+    });
+});
+
+describe('buildScreensDownstreamImpactRollup', () => {
+    it('6. is ready when the gate is ready and there are no P0 downstream blockers', () => {
+        const rollup = buildScreensDownstreamImpactRollup(
+            [input({ isP0: true, userStatus: 'accepted' })],
+            gate(),
+        );
+        expect(rollup.overallStatus).toBe('ready');
+        expect(rollup.totalImpactedScreens).toBe(0);
+    });
+
+    it('7. is not ready when a P0 accepted screen is outdated', () => {
+        const rollup = buildScreensDownstreamImpactRollup(
+            [input({ isP0: true, userStatus: 'accepted', reviewFreshness: 'outdated' })],
+            gate(),
+        );
+        expect(rollup.overallStatus).toBe('not_ready');
+        expect(rollup.impactedP0Screens).toBe(1);
+    });
+
+    it('8. is review recommended for a non-P0 outdated accepted screen (P0 gate clean)', () => {
+        const rollup = buildScreensDownstreamImpactRollup(
+            [
+                input({ screenId: 'p0', isP0: true, userStatus: 'accepted' }),
+                input({ screenId: 'sup', isP0: false, userStatus: 'accepted', reviewFreshness: 'outdated' }),
+            ],
+            gate(),
+        );
+        expect(rollup.overallStatus).toBe('review_recommended');
+        expect(rollup.byArtifact.mockups.review).toBeGreaterThan(0);
+    });
+
+    it('is not ready when the Phase 4A gate itself is not ready', () => {
+        const rollup = buildScreensDownstreamImpactRollup(
+            [input({ isP0: true, userStatus: 'draft' })],
+            gate({ ready: false, p0: { total: 1, signedOff: 0, withBlockers: 0, notSignedOff: [{ id: 'p0', name: 'P0' }] } }),
+        );
+        expect(rollup.overallStatus).toBe('not_ready');
+    });
+});
+
+describe('buildRecommendedNextActions', () => {
+    it('9. prioritizes P0 blockers first', () => {
+        const actions = buildRecommendedNextActions([
+            input({ screenId: 'sup', title: 'Settings', isP0: false, userStatus: 'accepted', reviewFreshness: 'outdated' }),
+            input({ screenId: 'p0', title: 'Checkout', isP0: true, blockingCount: 1, blockingTitles: ['No purpose'] }),
+        ]);
+        expect(actions[0]).toMatch(/Resolve blockers on Checkout/);
+    });
+
+    it('10. caps the action list to a small useful size (<= 5)', () => {
+        const inputs = Array.from({ length: 12 }, (_, i) => input({
+            screenId: `p${i}`, title: `P0 ${i}`, isP0: true, blockingCount: 1, blockingTitles: ['x'],
+        }));
+        const actions = buildRecommendedNextActions(inputs);
+        expect(actions.length).toBeLessThanOrEqual(5);
+        expect(actions.length).toBeGreaterThan(0);
+    });
+});
+
+describe('buildScreensPreflight', () => {
+    it('reports ready with no blockers when the gate is clean', () => {
+        const pre = buildScreensPreflight([input({ isP0: true, userStatus: 'accepted' })], gate());
+        expect(pre.status).toBe('ready');
+        expect(pre.blocking).toHaveLength(0);
+        expect(pre.headline).toMatch(/Ready for implementation planning/);
+    });
+
+    it('surfaces blockers, review items, and recommended next steps', () => {
+        const pre = buildScreensPreflight(
+            [
+                input({ screenId: 'p0', title: 'Dashboard', isP0: true, blockingCount: 1, blockingTitles: ['No acceptance criteria'] }),
+                input({ screenId: 'sup', title: 'Settings', isP0: false, userStatus: 'accepted', reviewFreshness: 'outdated' }),
+            ],
+            gate({ ready: false, p0: { total: 1, signedOff: 0, withBlockers: 1, notSignedOff: [{ id: 'p0', name: 'Dashboard' }] } }),
+        );
+        expect(pre.status).toBe('not_ready');
+        expect(pre.blocking.length).toBeGreaterThan(0);
+        expect(pre.review.length).toBeGreaterThan(0);
+        expect(pre.recommendedNextActions.length).toBeGreaterThan(0);
+    });
+});

--- a/src/lib/screenDownstreamImpact.ts
+++ b/src/lib/screenDownstreamImpact.ts
@@ -1,0 +1,486 @@
+// Phase 4B: downstream impact tracking + Screens implementation preflight.
+//
+// Phase 4A gave each screen a review workflow (user sign-off vs. system
+// readiness) and an artifact-level readiness gate. Phase 4B layers ON TOP of
+// that (and NEVER changes it): when an accepted screen changes after sign-off,
+// or a P0 screen carries blockers, or its mockups read stale, downstream
+// artifacts (mockups, data model, implementation plan, …) may now be worth
+// re-checking. This module derives — purely, at read time, from already-computed
+// review models — *which* downstream artifacts are impacted and *how urgently*,
+// rolls that up to an artifact-level "downstream readiness" verdict, and
+// assembles a lightweight implementation/export preflight.
+//
+// It is PURE (no store, no IDB, no React, no LLM) and DERIVED (nothing here is
+// persisted — a stale persisted verdict would be worse than none). Honesty
+// rules mirror the rest of the Screens layer: everything is an estimate; legacy
+// metadata is INFO, never a blocker; language stays calm and actionable
+// ("Review recommended", "Changed after sign-off"), never punitive.
+
+import type { ScreenItem } from '../types';
+import type { ScreenExperienceIndex, ScreenExperienceItem } from './screenExperience';
+import type { ScreenReviewStatus } from './screenReadiness';
+import type {
+    ScreenArtifactReviewReadiness, ScreenReviewFreshnessStatus, ScreenReviewModel,
+} from './screenReviewWorkflow';
+
+// --- Types -------------------------------------------------------------------
+
+export type DownstreamArtifactKind =
+    | 'mockups'
+    | 'data_model'
+    | 'implementation_plan'
+    | 'prompt_pack'
+    | 'user_flows'
+    | 'design_system'
+    | 'export';
+
+export type DownstreamImpactSeverity = 'blocking' | 'review' | 'info';
+
+export interface DownstreamArtifactImpact {
+    kind: DownstreamArtifactKind;
+    severity: DownstreamImpactSeverity;
+    /** Short calm headline. */
+    title: string;
+    /** One-sentence explanation. */
+    description: string;
+    /** What the user could do about it, when there's a clear next step. */
+    recommendedAction?: string;
+    /** Supporting detail (e.g. the blocking issue titles). */
+    evidence?: string[];
+}
+
+export interface ScreenDownstreamImpact {
+    screenId: string;
+    screenTitle?: string;
+    isP0: boolean;
+    userStatus?: ScreenReviewStatus;
+    reviewFreshness: ScreenReviewFreshnessStatus;
+    impactedArtifacts: DownstreamArtifactImpact[];
+    summary: {
+        hasBlockingImpact: boolean;
+        reviewCount: number;
+        infoCount: number;
+    };
+}
+
+/** Everything `buildScreenDownstreamImpact` needs, decoupled from the review
+ * model so pure tests can pass explicit signals. */
+export interface DownstreamScreenInput {
+    screenId: string;
+    title: string;
+    isP0: boolean;
+    /** User review status (accepted / implementation_ready = signed off). */
+    userStatus?: ScreenReviewStatus;
+    /** Re-review freshness vs. the sign-off signature (Phase 4A). */
+    reviewFreshness: ScreenReviewFreshnessStatus;
+    /** Blocking readiness issues on this screen. */
+    blockingCount: number;
+    /** Titles of the blocking readiness issues (for evidence / preflight). */
+    blockingTitles: string[];
+    /** A generated mockup variant reads stale / possibly-stale (Phase 3C). */
+    mockupFreshnessStale: boolean;
+    /** A generated mockup variant has no freshness metadata (legacy). */
+    mockupFreshnessUnknown: boolean;
+    /** The screen carries data requirements (outputData / handoff data deps),
+     * so a change to it may ripple into the data model. */
+    hasDataRequirements: boolean;
+}
+
+export interface ScreensDownstreamImpactRollup {
+    totalImpactedScreens: number;
+    impactedP0Screens: number;
+    byArtifact: Record<DownstreamArtifactKind, { blocking: number; review: number; info: number }>;
+    recommendedNextActions: string[];
+    overallStatus: 'ready' | 'review_recommended' | 'not_ready';
+}
+
+export interface ScreensPreflightModel {
+    status: 'ready' | 'review_recommended' | 'not_ready';
+    headline: string;
+    /** Must-fix items before this artifact is a safe build source. */
+    blocking: string[];
+    /** Review-recommended items — safe to proceed, worth a look. */
+    review: string[];
+    /** Informational notes (legacy metadata, unknown freshness). */
+    info: string[];
+    /** Short prioritized next steps (top 3–5). */
+    recommendedNextActions: string[];
+    /** Export / snapshot caveats (e.g. Phase 3D sync gap). */
+    caveats: string[];
+}
+
+export interface ScreensDownstreamAnalysis {
+    inputs: DownstreamScreenInput[];
+    impactsByScreen: Map<string, ScreenDownstreamImpact>;
+    rollup: ScreensDownstreamImpactRollup;
+    preflight: ScreensPreflightModel;
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+const isSignedOff = (status: ScreenReviewStatus | undefined): boolean =>
+    status === 'accepted' || status === 'implementation_ready';
+
+const SEVERITY_RANK: Record<DownstreamImpactSeverity, number> = { info: 0, review: 1, blocking: 2 };
+
+const ALL_ARTIFACT_KINDS: DownstreamArtifactKind[] = [
+    'mockups', 'data_model', 'implementation_plan', 'prompt_pack', 'user_flows', 'design_system', 'export',
+];
+
+function screenHasDataRequirements(screen: ScreenItem): boolean {
+    if ((screen.outputData?.length ?? 0) > 0) return true;
+    const h = screen.handoff;
+    return Boolean(
+        (h?.dataDependencies?.length ?? 0) > 0
+        || (h?.apiDependencies?.length ?? 0) > 0
+        || (h?.stateVariables?.length ?? 0) > 0,
+    );
+}
+
+const isP0Screen = (screen: ScreenItem): boolean =>
+    screen.priority === 'P0' || screen.priority === 'core';
+
+/** Derive the downstream-impact signals for one screen from its review model. */
+export function screenDownstreamInputFromModel(
+    item: ScreenExperienceItem,
+    model: ScreenReviewModel,
+): DownstreamScreenInput {
+    const blockingTitles = model.issues.filter(i => i.severity === 'blocking').map(i => i.title);
+    return {
+        screenId: item.id,
+        title: item.screen.name || item.id,
+        isP0: isP0Screen(item.screen),
+        userStatus: model.userStatus,
+        reviewFreshness: model.freshness,
+        blockingCount: model.blockingCount,
+        blockingTitles,
+        mockupFreshnessStale: model.issues.some(i => i.id === 'mockup_freshness_stale'),
+        mockupFreshnessUnknown: model.issues.some(i => i.id === 'mockup_freshness_unknown'),
+        hasDataRequirements: screenHasDataRequirements(item.screen),
+    };
+}
+
+// --- Per-screen impact -------------------------------------------------------
+
+/**
+ * Derive the downstream artifacts a screen change (or its blockers) may have
+ * invalidated. Conservative and explainable — only the accepted/implementation-
+ * ready + changed, P0-blocker, and mockup-freshness rules fire. Unknown/legacy
+ * metadata is always INFO. One entry per artifact kind (highest severity wins).
+ */
+export function buildScreenDownstreamImpact(input: DownstreamScreenInput): ScreenDownstreamImpact {
+    const signedOff = isSignedOff(input.userStatus);
+    const changedAfterSignOff = signedOff && input.reviewFreshness === 'outdated';
+
+    const candidates: DownstreamArtifactImpact[] = [];
+
+    // Rule 2 first so it wins the implementation_plan tie when P0 blockers exist
+    // (a more accurate message than the generic "may be out of date").
+    if (input.isP0 && input.blockingCount > 0) {
+        candidates.push({
+            kind: 'implementation_plan',
+            severity: 'blocking',
+            title: 'P0 screen has unresolved blockers',
+            description: 'This P0 screen has unresolved readiness blockers, so it is not a safe build source yet.',
+            recommendedAction: 'Resolve the blockers before using this screen as a build source.',
+            evidence: input.blockingTitles.length > 0 ? input.blockingTitles : undefined,
+        });
+    }
+
+    if (changedAfterSignOff) {
+        // Implementation Plan — blocking when a P0 screen was already marked
+        // implementation-ready (build tasks likely exist against the old spec).
+        const implBlocking = input.isP0 && input.userStatus === 'implementation_ready';
+        candidates.push({
+            kind: 'implementation_plan',
+            severity: implBlocking ? 'blocking' : 'review',
+            title: 'Implementation tasks may be out of date',
+            description: 'This screen changed after approval, so implementation tasks may reference the older accepted screen.',
+            recommendedAction: 'Review implementation tasks for this screen before building.',
+        });
+        // Mockups.
+        candidates.push({
+            kind: 'mockups',
+            severity: 'review',
+            title: 'Mockups may not match this screen',
+            description: 'This screen changed after approval. Existing mockups may no longer match the accepted screen spec.',
+            recommendedAction: 'Review mockup variants and regenerate stale or mismatched variants.',
+        });
+        // Data Model — only when the screen actually carries data requirements.
+        if (input.hasDataRequirements) {
+            candidates.push({
+                kind: 'data_model',
+                severity: 'review',
+                title: 'Screen data requirements may have changed',
+                description: 'Inputs, outputs, or data assumptions for this screen may have changed since it was approved.',
+                recommendedAction: 'Review related entities, fields, and API assumptions.',
+            });
+        }
+        // Prompt Pack (legacy artifact) — informational.
+        candidates.push({
+            kind: 'prompt_pack',
+            severity: 'info',
+            title: 'Prompts may reference the old behavior',
+            description: 'Prompts may still reference the previous screen behavior.',
+            recommendedAction: 'Review the prompt pack if this screen affects generation or user-facing AI behavior.',
+        });
+    }
+
+    // Rule 3 — stale mockup variants (independent of a review change).
+    if (input.mockupFreshnessStale) {
+        candidates.push({
+            kind: 'mockups',
+            severity: 'review',
+            title: 'Mockup variants may be stale',
+            description: 'One or more generated mockup variants predate a change to the screen spec, design system, or PRD.',
+            recommendedAction: 'Review stale variants or regenerate the affected mockups.',
+        });
+    }
+
+    // Rule 4 — unknown mockup freshness (legacy metadata) → INFO, never a blocker.
+    if (input.mockupFreshnessUnknown) {
+        candidates.push({
+            kind: 'mockups',
+            severity: 'info',
+            title: 'Mockup freshness unknown',
+            description: 'Some older mockups do not include freshness metadata. Review visually if this screen is implementation-critical.',
+        });
+    }
+
+    // Reduce to one entry per artifact kind, keeping the highest severity (ties
+    // keep the first pushed — hence the ordering above).
+    const byKind = new Map<DownstreamArtifactKind, DownstreamArtifactImpact>();
+    for (const c of candidates) {
+        const existing = byKind.get(c.kind);
+        if (!existing || SEVERITY_RANK[c.severity] > SEVERITY_RANK[existing.severity]) {
+            byKind.set(c.kind, c);
+        }
+    }
+    const impactedArtifacts = [...byKind.values()];
+
+    return {
+        screenId: input.screenId,
+        screenTitle: input.title,
+        isP0: input.isP0,
+        userStatus: input.userStatus,
+        reviewFreshness: input.reviewFreshness,
+        impactedArtifacts,
+        summary: {
+            hasBlockingImpact: impactedArtifacts.some(a => a.severity === 'blocking'),
+            reviewCount: impactedArtifacts.filter(a => a.severity === 'review').length,
+            infoCount: impactedArtifacts.filter(a => a.severity === 'info').length,
+        },
+    };
+}
+
+// --- Artifact-level rollup ---------------------------------------------------
+
+function emptyByArtifact(): Record<DownstreamArtifactKind, { blocking: number; review: number; info: number }> {
+    const out = {} as Record<DownstreamArtifactKind, { blocking: number; review: number; info: number }>;
+    for (const k of ALL_ARTIFACT_KINDS) out[k] = { blocking: 0, review: 0, info: 0 };
+    return out;
+}
+
+/**
+ * Roll per-screen impacts up to an artifact-level downstream-readiness verdict.
+ *   - not_ready: the Phase 4A gate is not ready, OR any P0 accepted/impl-ready
+ *     screen is outdated, OR any P0 screen has a blocking downstream impact.
+ *   - review_recommended: no P0 blocker, but there are review-level impacts
+ *     (supporting screens outdated, stale/unknown mockups, impl-plan review).
+ *   - ready: gate ready, no P0 outdated, no P0 blocking impact, no review impacts.
+ * Advisory only — nothing here blocks rendering or generation.
+ */
+export function buildScreensDownstreamImpactRollup(
+    inputs: readonly DownstreamScreenInput[],
+    artifactReview?: ScreenArtifactReviewReadiness,
+): ScreensDownstreamImpactRollup {
+    const byArtifact = emptyByArtifact();
+    let totalImpactedScreens = 0;
+    let impactedP0Screens = 0;
+    let p0Outdated = false;
+    let p0BlockingImpact = false;
+    let anyReviewImpact = false;
+
+    for (const input of inputs) {
+        const impact = buildScreenDownstreamImpact(input);
+        if (impact.impactedArtifacts.length === 0) continue;
+        totalImpactedScreens += 1;
+        if (input.isP0) impactedP0Screens += 1;
+        for (const a of impact.impactedArtifacts) byArtifact[a.kind][a.severity] += 1;
+        if (impact.summary.reviewCount > 0) anyReviewImpact = true;
+        if (input.isP0 && impact.summary.hasBlockingImpact) p0BlockingImpact = true;
+        if (input.isP0 && isSignedOff(input.userStatus) && input.reviewFreshness === 'outdated') {
+            p0Outdated = true;
+        }
+    }
+
+    const gateReady = artifactReview?.ready ?? false;
+    let overallStatus: ScreensDownstreamImpactRollup['overallStatus'];
+    if (!gateReady || p0Outdated || p0BlockingImpact) overallStatus = 'not_ready';
+    else if (anyReviewImpact) overallStatus = 'review_recommended';
+    else overallStatus = 'ready';
+
+    return {
+        totalImpactedScreens,
+        impactedP0Screens,
+        byArtifact,
+        recommendedNextActions: buildRecommendedNextActions(inputs),
+        overallStatus,
+    };
+}
+
+// --- Recommended next actions ------------------------------------------------
+
+/**
+ * Turn the review/impact findings into a short prioritized action list.
+ * Priority order: P0 blockers → re-review outdated accepted P0 → accept
+ * remaining P0 → stale P0 mockups → implementation plan → supporting screens →
+ * unknown legacy mockups. Capped to the top 5.
+ */
+export function buildRecommendedNextActions(inputs: readonly DownstreamScreenInput[]): string[] {
+    const actions: string[] = [];
+    const push = (a: string) => { if (!actions.includes(a)) actions.push(a); };
+
+    // 1. Fix P0 blockers.
+    for (const i of inputs) {
+        if (i.isP0 && i.blockingCount > 0) push(`Resolve blockers on ${i.title} before using it as a build source.`);
+    }
+    // 2. Re-review outdated accepted P0 screens.
+    for (const i of inputs) {
+        if (i.isP0 && isSignedOff(i.userStatus) && i.reviewFreshness === 'outdated') {
+            push(`Review and re-accept ${i.title} because its spec changed after sign-off.`);
+        }
+    }
+    // 3. Accept remaining P0 screens.
+    for (const i of inputs) {
+        if (i.isP0 && !isSignedOff(i.userStatus)) push(`Accept ${i.title} to sign off this P0 screen.`);
+    }
+    // 4. Regenerate / review stale P0 mockups.
+    for (const i of inputs) {
+        if (i.isP0 && i.mockupFreshnessStale) push(`Regenerate stale mockups for ${i.title}.`);
+    }
+    // 5. Review implementation plan assumptions (once) when any P0 screen changed
+    //    after sign-off or carries blockers.
+    if (inputs.some(i => i.isP0 && (i.blockingCount > 0
+        || (isSignedOff(i.userStatus) && i.reviewFreshness === 'outdated')))) {
+        push('Re-run or review the implementation plan after the P0 screens are current.');
+    }
+    // 6. Review supporting screens changed after sign-off.
+    for (const i of inputs) {
+        if (!i.isP0 && isSignedOff(i.userStatus) && i.reviewFreshness === 'outdated') {
+            push(`Review ${i.title} because it changed after sign-off.`);
+        }
+    }
+    // 7. Review unknown legacy mockups if implementation-critical (P0).
+    for (const i of inputs) {
+        if (i.isP0 && i.mockupFreshnessUnknown) {
+            push(`Review legacy mockups for ${i.title} if it is implementation-critical.`);
+        }
+    }
+
+    return actions.slice(0, 5);
+}
+
+// --- Preflight ---------------------------------------------------------------
+
+const PREFLIGHT_HEADLINES: Record<ScreensPreflightModel['status'], string> = {
+    ready: 'Ready for implementation planning',
+    review_recommended: 'Review recommended before implementation',
+    not_ready: 'Not ready for implementation planning',
+};
+
+const plural = (n: number, one: string, many = `${one}s`): string => (n === 1 ? one : many);
+
+/**
+ * Assemble the Screens implementation/export preflight: blockers, review items,
+ * info notes, prioritized next steps, and export/snapshot caveats. Derived live
+ * — never persisted. A decision surface, never a hard gate.
+ */
+export function buildScreensPreflight(
+    inputs: readonly DownstreamScreenInput[],
+    artifactReview?: ScreenArtifactReviewReadiness,
+): ScreensPreflightModel {
+    const rollup = buildScreensDownstreamImpactRollup(inputs, artifactReview);
+    const blocking: string[] = [];
+    const review: string[] = [];
+    const info: string[] = [];
+
+    // Blocking — the Phase 4A P0 sign-off gate + P0 readiness blockers.
+    if (artifactReview) {
+        for (const s of artifactReview.p0.notSignedOff) {
+            blocking.push(`${s.name} (P0) is not accepted yet.`);
+        }
+    }
+    for (const i of inputs) {
+        if (!i.isP0) continue;
+        for (const title of i.blockingTitles) {
+            blocking.push(`${i.title}: ${title.toLowerCase()}.`);
+        }
+        if (isSignedOff(i.userStatus) && i.userStatus === 'implementation_ready' && i.reviewFreshness === 'outdated') {
+            blocking.push(`${i.title} was marked ready to build but changed afterwards.`);
+        }
+    }
+
+    // Review — outdated accepted screens + stale mockups + impl-plan review.
+    const outdatedSignedOff = inputs.filter(i => isSignedOff(i.userStatus) && i.reviewFreshness === 'outdated'
+        && !(i.isP0 && i.userStatus === 'implementation_ready'));
+    if (outdatedSignedOff.length > 0) {
+        review.push(`${outdatedSignedOff.length} accepted ${plural(outdatedSignedOff.length, 'screen')} changed after sign-off.`);
+    }
+    const staleMockups = inputs.filter(i => i.mockupFreshnessStale).length;
+    if (staleMockups > 0) {
+        review.push(`${staleMockups} ${plural(staleMockups, 'screen')} may have stale mockup variants.`);
+    }
+    if (rollup.byArtifact.implementation_plan.review > 0 || rollup.byArtifact.implementation_plan.blocking > 0) {
+        review.push('Implementation Plan review recommended once the P0 screens are current.');
+    }
+
+    // Info — unknown legacy mockup freshness.
+    const unknownMockups = inputs.filter(i => i.mockupFreshnessUnknown).length;
+    if (unknownMockups > 0) {
+        info.push(`${unknownMockups} ${plural(unknownMockups, 'screen')} have legacy mockups with no freshness metadata.`);
+    }
+
+    // Export / snapshot caveats — Phase 3D: variant images travel in snapshots
+    // but do not yet sync across devices.
+    const caveats: string[] = [];
+    if (staleMockups > 0 || unknownMockups > 0) {
+        caveats.push('Generated mockup variant images are saved on this device and in project snapshots, but do not yet sync across devices.');
+    }
+
+    return {
+        status: rollup.overallStatus,
+        headline: PREFLIGHT_HEADLINES[rollup.overallStatus],
+        blocking,
+        review,
+        info,
+        recommendedNextActions: rollup.recommendedNextActions,
+        caveats,
+    };
+}
+
+// --- Convenience: whole-index analysis ---------------------------------------
+
+/** Build the full downstream analysis for a Screens index + its review models.
+ * The single entry point the workspace calls. */
+export function analyzeScreensDownstream(
+    index: ScreenExperienceIndex,
+    reviewModels: ReadonlyMap<string, ScreenReviewModel>,
+    artifactReview?: ScreenArtifactReviewReadiness,
+): ScreensDownstreamAnalysis {
+    const inputs: DownstreamScreenInput[] = [];
+    const impactsByScreen = new Map<string, ScreenDownstreamImpact>();
+    for (const item of index.items) {
+        const model = reviewModels.get(item.id);
+        if (!model) continue;
+        const input = screenDownstreamInputFromModel(item, model);
+        inputs.push(input);
+        impactsByScreen.set(item.id, buildScreenDownstreamImpact(input));
+    }
+    return {
+        inputs,
+        impactsByScreen,
+        rollup: buildScreensDownstreamImpactRollup(inputs, artifactReview),
+        preflight: buildScreensPreflight(inputs, artifactReview),
+    };
+}

--- a/src/lib/screenReadiness.ts
+++ b/src/lib/screenReadiness.ts
@@ -923,6 +923,8 @@ export type ScreenListFilter =
     | 'ready'
     | 'has_blockers'
     | 'review_recommended'
+    | 'outdated_review'
+    | 'downstream_review'
     | 'missing_mockups'
     | 'has_risks';
 
@@ -935,17 +937,26 @@ export const SCREEN_LIST_FILTERS: Array<{ id: ScreenListFilter; label: string }>
     { id: 'ready', label: 'Ready' },
     { id: 'has_blockers', label: 'Has blockers' },
     { id: 'review_recommended', label: 'Review recommended' },
+    // Phase 4B: re-review + downstream-impact filters. Grouped after the
+    // existing review filters so the review-focused controls stay together.
+    { id: 'outdated_review', label: 'Outdated review' },
+    { id: 'downstream_review', label: 'Downstream review' },
     { id: 'missing_mockups', label: 'Missing mockups' },
     { id: 'has_risks', label: 'Has risks' },
 ];
 
-/** Optional review signals (Phase 4A) so filters can key off the user review
- * status and derived blockers/review items, not just the combined readiness. */
+/** Optional review signals (Phase 4A/4B) so filters can key off the user review
+ * status, derived blockers/review items, re-review freshness, and downstream
+ * impact — not just the combined readiness. */
 export interface ScreenFilterReview {
     /** Explicit user-set status, or undefined when unreviewed (treated as draft). */
     userStatus?: ScreenReviewStatus;
     blockingCount: number;
     reviewCount: number;
+    /** Phase 4B: 'outdated' when an accepted screen changed after sign-off. */
+    reviewFreshness?: 'current' | 'outdated' | 'unknown';
+    /** Phase 4B: true when this screen has a blocking/review downstream impact. */
+    downstreamReviewNeeded?: boolean;
 }
 
 export function screenMatchesFilter(
@@ -976,6 +987,10 @@ export function screenMatchesFilter(
             return (review?.blockingCount ?? 0) > 0;
         case 'review_recommended':
             return (review?.blockingCount ?? 0) > 0 || (review?.reviewCount ?? 0) > 0;
+        case 'outdated_review':
+            return review?.reviewFreshness === 'outdated';
+        case 'downstream_review':
+            return review?.downstreamReviewNeeded === true;
         case 'missing_mockups':
             return !item.mockupScreen;
         case 'has_risks':


### PR DESCRIPTION
## Summary

Phase 4B builds directly on the Phase 4A screen review workflow. It makes that workflow more trustworthy by showing **what happens after accepted screens change** and by adding a lightweight **Screens implementation/export preflight** — without overhauling the artifact system, adding a dependency engine, or blocking normal use.

Everything is **derived at read time and never persisted** (a stale persisted verdict is worse than none) and stays **advisory** — nothing gates rendering or generation, and legacy artifacts with no review data show no impact/blocker.

## Downstream impact logic (`src/lib/screenDownstreamImpact.ts`, pure)

`buildScreenDownstreamImpact(input)` maps a screen's Phase 4A review signals to the downstream artifacts a change/blocker may have invalidated — one entry per `DownstreamArtifactKind` (mockups / data_model / implementation_plan / prompt_pack / user_flows / design_system / export), highest severity per kind (`blocking` | `review` | `info`). Conservative, explainable rules:

1. **Accepted / implementation-ready screen changed after sign-off** (`reviewFreshness === 'outdated'`) → Mockups (review), Implementation Plan (review, or **blocking** when a P0 was already `implementation_ready`), Data Model (review, only when the screen carries data requirements), Prompt Pack (info).
2. **P0 screen with blockers** → Implementation Plan **blocking**.
3. **Stale mockup variants** (Phase 3C freshness) → Mockups review.
4. **Unknown mockup freshness** (legacy metadata) → **info, never a blocker**.

A draft / unsigned screen never produces the change-driven impacts. `screenDownstreamInputFromModel(item, model)` derives the input from the Phase 4A `ScreenReviewModel` so the layers can't drift.

## Artifact-level downstream readiness

`buildScreensDownstreamImpactRollup` rolls per-screen impacts up to `overallStatus`:
- **not_ready** — the Phase 4A gate isn't ready, OR any P0 accepted/impl-ready screen is outdated, OR any P0 has a blocking downstream impact.
- **review_recommended** — review-level impacts with a clean P0 gate.
- **ready** — otherwise.

`buildRecommendedNextActions` produces a prioritized list (P0 blockers → re-review outdated accepted P0 → accept remaining P0 → stale P0 mockups → implementation plan → supporting screens → unknown legacy mockups), **capped to 5**.

## Screens preflight

`buildScreensPreflight` assembles the implementation/export preflight — blocking / review / info items, recommended next steps, and export-snapshot caveats (e.g. the Phase 3D variant-image cross-device-sync gap). Surfaced as a collapsible **Implementation preflight** panel above the screen list. Shows ready / review recommended / not ready; advisory, never a hard gate.

## UI integration

- **Screen Detail** — `ScreenDownstreamImpactSection` below the review panel (impacted-artifact list, or a calm "No downstream impact detected" / "cannot be fully confirmed for this older review" empty state).
- **Screen List cards** — compact downstream chip, shown only when a blocking/review impact exists.
- **Coverage panel** — a Downstream readiness section.
- **Filters** — two new list filters (**Outdated review**, **Downstream review**) extending `SCREEN_LIST_FILTERS` / `ScreenFilterReview`.

## Export/finalization hook — intentionally skipped

There is no Screens-specific export/share/finalize action today (the PRD Mark-as-Final / UpdateAssetsPlan flow is PRD-level, not per-artifact), so the local preflight panel is the Phase 4B decision surface rather than hooking into an unrelated flow. Documented in CLAUDE.md.

## Persistence & backward compatibility

No new persisted state, no schema migration. All Phase 4B state is derived live from the existing review models. Phase 4A review model and mockup-variant behavior are unchanged; legacy artifacts without review data render normally.

## Tests

- 14 pure unit tests (`src/lib/__tests__/screenDownstreamImpact.test.ts`): per-screen impact rules, rollup statuses, prioritized/capped actions, preflight.
- 6 component tests (`ScreenExperienceViews.test.tsx`): detail impact section (impact + empty state), list card chip, coverage downstream section, preflight blockers/review/actions, ready state.

Full suite: **1335 tests pass**; `npm run build` and `npm run lint` clean.

## Known limitations / Phase 5 follow-up

- Downstream impact is estimated from screen metadata, never a real cross-artifact dependency trace or visual diff.
- No cross-device sync for generated variant images (Phase 3D snapshot-only gap remains).
- A future export/finalization preflight hook if a Screens-specific finalize flow is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfGincF9ciemUef5sKLJ9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfGincF9ciemUef5sKLJ9f)_