### PR TITLE
Phase 5A: Screens implementation handoff packages + build-task bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1698,6 +1698,54 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   panel is the Phase 4B decision surface — a safer choice than hooking into an
   unrelated flow. Everything stays **advisory** — nothing gates rendering or
   generation, and legacy artifacts (no review data) show no impact/blocker.
+- **Phase 5A — implementation handoff packages + build-task bridge
+  (`src/lib/screenImplementationHandoff.ts`, pure, unit-tested).** Layers ON TOP
+  of the Phase 4A review + Phase 4B downstream layers (never changing them) to
+  turn an accepted screen into a **developer-ready build contract**. All
+  **derived, never persisted**. `buildScreenImplementationHandoff({item,
+  reviewModel, variants, downstream?, features?})` produces a
+  `ScreenImplementationHandoff`: **route** (explicit generated `handoff.route` →
+  small keyword map → slugified title, tagged `explicit`/`derived`/`missing`),
+  **components** (handoff `primaryComponents` → core UI regions → mockup UI
+  elements → title, PascalCased), **state** (handoff `stateVariables` +
+  per-non-default-state status vars), **events** (handoff `events` + exit-path +
+  flow user-action handlers, `on…`-named), **data dependencies** (handoff
+  data/api deps + `outputData`, keyword-classified entity/api/storage/…, with a
+  "No linked data model entities found" review warning when empty — **there is no
+  real Data Model trace; everything is estimated, never claimed as verified**),
+  **mockup references** (variants holding a real image / accepted, with Phase 3C
+  freshness + coverage), **acceptance criteria** (`resolveAcceptanceCriteria`),
+  a **QA checklist** (rendering/interaction/state/data/accessibility/responsive/
+  error_handling/acceptance, restated from the spec), and a small **build-task
+  list** (route/component/state/data/mockup/qa/accessibility, each with a
+  `priority` and a `source`). Individual derivers (`deriveHandoffRoute`/
+  `…Components`/`…State`/`…Events`/`…DataDependencies`/`…QaChecklist`/
+  `…BuildTasks`/`…Readiness`) are exported for pure testing. **Readiness**
+  (`deriveHandoffReadiness` → `ready` | `review_recommended` | `blocked`):
+  blocked on the clear cases (system-readiness blockers, unsigned/outdated/
+  downstream-blocking P0, no acceptance criteria, no route/component guidance on
+  a primary screen); review-recommended is the honest common state (accepted
+  with review items, stale/unknown mockups, missing mobile, missing data trace,
+  thin handoff); ready requires sign-off + no blockers + minimal guidance.
+  `buildScreensHandoffRollup(handoffs, p0Ids)` rolls up ready/review/blocked
+  **gated on P0**; `renderHandoffMarkdown` is the copy-to-clipboard export;
+  `buildHandoffPreflightContribution` feeds the Phase 4B preflight via the
+  structural `PreflightContribution` param on `buildScreensPreflight` /
+  `analyzeScreensDownstream` (screenDownstreamImpact **never imports** the handoff
+  module — that would cycle; the caller passes the contribution in). **UI:** a
+  Screen Detail **Handoff tab** (`ScreenHandoffView` + a `handoff` value on
+  `ScreenDetailTab`, URL-addressable via `?screenTab=handoff`) with a
+  readiness-colored tab dot, compact sections, and a Copy-handoff action
+  (clipboard → textarea fallback); a compact **handoff readiness chip** on
+  `ScreenListView` cards; **Handoff ready / Handoff blocked** list filters
+  (`SCREEN_LIST_FILTERS` + `ScreenFilterReview.handoffReadiness`); and an
+  **Implementation handoff** rollup section in `ScreenCoveragePanel`. Everything
+  stays **advisory** — nothing gates rendering or generation, and legacy/sparse
+  screens degrade to "Not specified" / review warnings, never crash. **No
+  Implementation Plan bridge was added in Phase 5A** (deliberately — the plan
+  artifact is not mutated or coupled; a trace-backed plan bridge is deferred to
+  Phase 5B) and no Screens-specific export/finalization hook was added (the local
+  Handoff tab + copy action is the decision surface, mirroring Phase 4B).
 - **Phase 2 — source-grounded screen contracts.** New screen_inventory
   generations emit an explicit contract per screen (all fields optional &
   back-compat on `ScreenItem`/`ScreenState` in `src/types`): structured

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -304,7 +304,8 @@ export function ArtifactWorkspace({
     const selectedScreenId = searchParams.get('screen');
     const rawScreenTab = searchParams.get('screenTab');
     const screenTab: ScreenDetailTab =
-        rawScreenTab === 'flow' || rawScreenTab === 'mockups' ? rawScreenTab : 'overview';
+        rawScreenTab === 'flow' || rawScreenTab === 'mockups' || rawScreenTab === 'handoff'
+            ? rawScreenTab : 'overview';
 
     // Update the screen params, preserving unrelated query params (debug
     // flags etc). `replace` is used for tab switches so history stays one

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -1025,6 +1025,7 @@ export function ArtifactWorkspace({
                         mockupPlatform={mockupPlatform}
                         mobileRelevant={mobileRelevant}
                         trustContext={trustContext}
+                        features={structuredPRD.features}
                         generatedVariantsByScreen={(id) => generatedVariantsByScreen.get(id)}
                         onSelectScreen={handleOpenScreen}
                         onGenerateMissingMockups={

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -717,3 +717,43 @@ describe('Phase 4B preflight panel', () => {
         expect(getByText('Ready for implementation planning')).toBeTruthy();
     });
 });
+
+// --- Phase 5A: implementation handoff tab ------------------------------------
+
+describe('Phase 5A handoff tab', () => {
+    it('19. the Handoff tab renders the developer sections', () => {
+        const { getByText, getAllByText } = renderContractDetail('handoff', { onSaveScreenEdit: vi.fn() });
+        expect(getAllByText('Implementation handoff').length).toBeGreaterThan(0);
+        expect(getByText('Route')).toBeTruthy();
+        expect(getByText('Components')).toBeTruthy();
+        expect(getByText('QA checklist')).toBeTruthy();
+        expect(getByText('Build task checklist')).toBeTruthy();
+        // The generated handoff route renders.
+        expect(getAllByText('/submission').length).toBeGreaterThan(0);
+    });
+
+    it('20. an unsigned P0 screen shows Handoff blocked; accepting clears it', () => {
+        const blocked = renderContractDetail('handoff', { onSaveScreenEdit: vi.fn() });
+        expect(blocked.getByText('Handoff blocked')).toBeTruthy();
+        blocked.unmount();
+
+        const accepted = renderContractDetail('handoff', {
+            edits: { 'scr-submission': { reviewStatus: 'accepted' } } as never,
+            onSaveScreenEdit: vi.fn(),
+        });
+        expect(accepted.queryByText('Handoff blocked')).toBeNull();
+    });
+
+    it('21. Copy handoff produces markdown with the main sections', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+        const { getByText } = renderContractDetail('handoff', { onSaveScreenEdit: vi.fn() });
+        fireEvent.click(getByText('Copy handoff'));
+        await Promise.resolve();
+        expect(writeText).toHaveBeenCalledTimes(1);
+        const md = writeText.mock.calls[0][0] as string;
+        expect(md).toMatch(/# Submission Wizard .*Implementation Handoff/);
+        expect(md).toContain('## Route');
+        expect(md).toContain('## Build Tasks');
+    });
+});

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -245,7 +245,7 @@ const contractPayload: MockupPayload = {
 };
 
 function renderContractDetail(
-    tab: 'overview' | 'flow' | 'mockups',
+    tab: 'overview' | 'flow' | 'mockups' | 'handoff',
     opts: {
         edits?: Parameters<typeof buildScreenIndex>[3];
         onSaveScreenEdit?: (id: string, edit: ScreenMetadataEdit | null) => void;
@@ -755,5 +755,56 @@ describe('Phase 5A handoff tab', () => {
         expect(md).toMatch(/# Submission Wizard .*Implementation Handoff/);
         expect(md).toContain('## Route');
         expect(md).toContain('## Build Tasks');
+    });
+
+    it('22. a screen card shows a handoff readiness chip', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildReviewFixtures();
+        const { getAllByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                features={FEATURES}
+                onSelectScreen={() => {}}
+            />,
+        );
+        // The unsigned P0 Home Dashboard has a blocked handoff.
+        expect(getAllByText('Handoff blocked').length).toBeGreaterThan(0);
+    });
+
+    it('23. the coverage panel shows the handoff rollup', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildReviewFixtures();
+        const { getByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                features={FEATURES}
+                onSelectScreen={() => {}}
+            />,
+        );
+        expect(getByText('Implementation handoff')).toBeTruthy();
+        expect(getByText('Implementation handoff not ready')).toBeTruthy();
+    });
+
+    it('24. the preflight includes handoff blocking items', () => {
+        const { index, readiness, coverage, reviewModels, artifactReview } = buildReviewFixtures();
+        const { getByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                reviewModels={reviewModels}
+                artifactReview={artifactReview}
+                coverage={coverage}
+                features={FEATURES}
+                onSelectScreen={() => {}}
+            />,
+        );
+        // The blocked P0 handoff surfaces in the implementation preflight.
+        expect(getByText(/Home Dashboard handoff is blocked/)).toBeTruthy();
     });
 });

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { ScreenCoverageSummary } from '../../lib/screenReadiness';
 import type { ScreenArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
 import type { ScreensDownstreamImpactRollup } from '../../lib/screenDownstreamImpact';
+import type { ScreensHandoffRollup } from '../../lib/screenImplementationHandoff';
 import type { MockupVariantCoverageSummary } from '../../lib/mockupVariants';
 import type { VariantFreshnessRollup } from '../../lib/mockupVariantTrust';
 
@@ -36,6 +37,9 @@ interface Props {
     /** Artifact-level downstream-impact rollup (Phase 4B). Absent → the
      * downstream readiness section is hidden (legacy callers). */
     downstreamRollup?: ScreensDownstreamImpactRollup;
+    /** Artifact-level implementation-handoff rollup (Phase 5A). Absent → the
+     * handoff readiness section is hidden (legacy callers). */
+    handoffRollup?: ScreensHandoffRollup;
     /** Opens the confirmed "Generate remaining mockups" flow (absent → no
      * mockup artifact yet; the action row is hidden). */
     onGenerateMissingMockups?: () => void;
@@ -62,7 +66,7 @@ function MetricRow({
     );
 }
 
-export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, downstreamRollup, onGenerateMissingMockups }: Props) {
+export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, downstreamRollup, handoffRollup, onGenerateMissingMockups }: Props) {
     const [showUncovered, setShowUncovered] = useState(false);
     const {
         totalScreens, prdFeatures, stateVariants, flows, p0, states, mockups, openRisks,
@@ -251,6 +255,49 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
                     {downstreamRollup && (
                         <DownstreamReadinessSection rollup={downstreamRollup} />
                     )}
+
+                    {handoffRollup && handoffRollup.total > 0 && (
+                        <HandoffReadinessSection rollup={handoffRollup} />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** Phase 5A: the artifact-level implementation-handoff readiness rollup — how
+ * many screens have build-ready handoff packages, gated on P0. Advisory only. */
+const HANDOFF_STATUS_META: Record<ScreensHandoffRollup['status'], { label: string; tone: 'good' | 'warn' }> = {
+    ready: { label: 'Implementation handoff ready', tone: 'good' },
+    review_recommended: { label: 'Implementation handoff needs review', tone: 'warn' },
+    blocked: { label: 'Implementation handoff not ready', tone: 'warn' },
+};
+
+function HandoffReadinessSection({ rollup }: { rollup: ScreensHandoffRollup }) {
+    const meta = HANDOFF_STATUS_META[rollup.status];
+    const good = meta.tone === 'good';
+    return (
+        <div className="mt-4 pt-4 border-t border-neutral-100">
+            <div className="flex items-center gap-1.5 mb-2">
+                <ClipboardCheck size={13} className="text-neutral-400" aria-hidden />
+                <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">Implementation handoff</h4>
+            </div>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-neutral-600 mb-2">
+                <span className="text-emerald-700">{rollup.ready} ready</span>
+                <span className="text-amber-700">{rollup.reviewRecommended} review recommended</span>
+                {rollup.blocked > 0 && (
+                    <span className="text-red-700">{rollup.blocked} blocked</span>
+                )}
+            </div>
+            <div className={`rounded-lg border p-3 flex items-start gap-2 ${
+                good ? 'border-emerald-200 bg-emerald-50/60' : 'border-amber-200 bg-amber-50/60'
+            }`}>
+                {good
+                    ? <CheckCircle2 size={15} className="text-emerald-600 mt-0.5 shrink-0" aria-hidden />
+                    : <AlertTriangle size={15} className="text-amber-600 mt-0.5 shrink-0" aria-hidden />}
+                <div className="min-w-0">
+                    <p className={`text-xs font-medium ${good ? 'text-emerald-800' : 'text-amber-800'}`}>{meta.label}</p>
+                    <p className="text-[11px] text-neutral-600 mt-0.5">{rollup.message}</p>
                 </div>
             </div>
         </div>

--- a/src/components/experience/ScreenDetailTabs.tsx
+++ b/src/components/experience/ScreenDetailTabs.tsx
@@ -3,7 +3,7 @@
 // navigation from a flow node can land on a specific tab. Mirrors the
 // underline-tab idiom already used by ProjectWorkspace's right-rail tabs.
 
-export type ScreenDetailTab = 'overview' | 'flow' | 'mockups';
+export type ScreenDetailTab = 'overview' | 'flow' | 'mockups' | 'handoff';
 
 interface Props {
     active: ScreenDetailTab;
@@ -12,15 +12,24 @@ interface Props {
     flowRefCount: number;
     /** Whether a matching mockup screen exists — shown as a subtle dot. */
     hasMockup: boolean;
+    /** Phase 5A: implementation-handoff readiness — colors the Handoff tab dot. */
+    handoffTone?: 'good' | 'warn' | 'block';
 }
 
 const TABS: Array<{ id: ScreenDetailTab; label: string }> = [
     { id: 'overview', label: 'Overview' },
     { id: 'flow', label: 'Flow' },
     { id: 'mockups', label: 'Mockups' },
+    { id: 'handoff', label: 'Handoff' },
 ];
 
-export function ScreenDetailTabs({ active, onChange, flowRefCount, hasMockup }: Props) {
+const HANDOFF_DOT: Record<'good' | 'warn' | 'block', string> = {
+    good: 'bg-emerald-500',
+    warn: 'bg-amber-500',
+    block: 'bg-red-500',
+};
+
+export function ScreenDetailTabs({ active, onChange, flowRefCount, hasMockup, handoffTone }: Props) {
     return (
         <div
             role="tablist"
@@ -54,6 +63,13 @@ export function ScreenDetailTabs({ active, onChange, flowRefCount, hasMockup }: 
                             <span
                                 className="w-1.5 h-1.5 rounded-full bg-emerald-500"
                                 title="A mockup exists for this screen"
+                                aria-hidden="true"
+                            />
+                        )}
+                        {tab.id === 'handoff' && handoffTone && (
+                            <span
+                                className={`w-1.5 h-1.5 rounded-full ${HANDOFF_DOT[handoffTone]}`}
+                                title="Implementation handoff readiness"
                                 aria-hidden="true"
                             />
                         )}

--- a/src/components/experience/ScreenDetailView.tsx
+++ b/src/components/experience/ScreenDetailView.tsx
@@ -39,6 +39,7 @@ import {
 import {
     buildScreenDownstreamImpact, screenDownstreamInputFromModel,
 } from '../../lib/screenDownstreamImpact';
+import { buildScreenImplementationHandoff } from '../../lib/screenImplementationHandoff';
 import {
     buildScreenMockupVariants, formatVariantLabel, summarizeScreenVariants,
     VARIANT_STATUS_LABELS, type GeneratedVariantMap,
@@ -47,6 +48,7 @@ import type { MockupVariantSourceSignature, VariantTrustContext } from '../../li
 import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore';
 import { MockupVariantsPanel } from './MockupVariantsPanel';
 import { ScreenReviewPanel } from './ScreenReviewPanel';
+import { ScreenHandoffView } from './ScreenHandoffView';
 import { ScreenDownstreamImpactSection } from './ScreenDownstreamImpactSection';
 import { ScreenOverviewPanel } from './ScreenOverviewPanel';
 import { ReadinessBadge } from './ReadinessBadge';
@@ -176,6 +178,25 @@ export function ScreenDetailView({
         [item, reviewModel],
     );
 
+    // Phase 5A: derived implementation handoff package (route, components,
+    // state, events, data deps, mockups, acceptance, QA, build tasks, trace) +
+    // its readiness verdict. Uses the same variant inputs as the review model /
+    // Mockups tab. Purely derived — never persisted.
+    const handoff = useMemo(() => {
+        const variants = buildScreenMockupVariants(item, {
+            platform: mockupContext?.settings.platform,
+            mobileRelevant,
+            trustContext: mockupContext?.trustContext,
+            generatedVariants,
+        });
+        return buildScreenImplementationHandoff({
+            item, reviewModel, variants, downstream: downstreamImpact, features,
+        });
+    }, [item, reviewModel, downstreamImpact, features, mockupContext?.settings.platform, mockupContext?.trustContext, mobileRelevant, generatedVariants]);
+    const handoffTone = handoff.readiness.status === 'ready'
+        ? 'good' as const
+        : handoff.readiness.status === 'blocked' ? 'block' as const : 'warn' as const;
+
     // Persist a review change into the screenEdits overlay. Status rides
     // `reviewStatus`; the supporting record (checklist / note / override reason /
     // sign-off signature / timestamps) rides `review`. Merges from the existing
@@ -302,6 +323,7 @@ export function ScreenDetailView({
                 onChange={onTabChange}
                 flowRefCount={item.relatedFlows.length}
                 hasMockup={Boolean(item.mockupScreen)}
+                handoffTone={handoffTone}
             />
 
             {activeTab === 'overview' && (
@@ -384,6 +406,8 @@ export function ScreenDetailView({
                     generatedVariants={generatedVariants}
                 />
             )}
+
+            {activeTab === 'handoff' && <ScreenHandoffView handoff={handoff} />}
         </div>
     );
 }

--- a/src/components/experience/ScreenHandoffView.tsx
+++ b/src/components/experience/ScreenHandoffView.tsx
@@ -1,0 +1,354 @@
+// Phase 5A: the Screen Detail "Handoff" tab. Turns an accepted screen into a
+// developer-ready build contract — route, components, state, events, data
+// dependencies, mockups to reference, acceptance criteria, a QA checklist, a
+// build-task checklist, and trace/confidence notes — plus a copy-to-markdown
+// action. Purely presentational over the derived ScreenImplementationHandoff
+// (src/lib/screenImplementationHandoff.ts). Everything is an estimate; missing
+// data reads "Not specified", never fabricated. Never blocks use.
+
+import { useCallback, useState } from 'react';
+import {
+    AlertOctagon, CheckCircle2, ClipboardCopy, ClipboardList, Copy, Route as RouteIcon,
+    ShieldQuestion,
+} from 'lucide-react';
+import type {
+    HandoffConfidence, HandoffQaCategory, HandoffTaskPriority,
+    ScreenImplementationHandoff, ScreenImplementationReadiness,
+} from '../../lib/screenImplementationHandoff';
+import { IMPLEMENTATION_READINESS_LABELS, renderHandoffMarkdown } from '../../lib/screenImplementationHandoff';
+import { copyToClipboard } from '../../lib/utils/copyToClipboard';
+
+interface Props {
+    handoff: ScreenImplementationHandoff;
+}
+
+const STATUS_META: Record<ScreenImplementationReadiness, {
+    tone: 'good' | 'warn' | 'block'; ring: string; text: string; Icon: typeof CheckCircle2;
+}> = {
+    ready: { tone: 'good', ring: 'border-emerald-200 bg-emerald-50/60', text: 'text-emerald-800', Icon: CheckCircle2 },
+    review_recommended: { tone: 'warn', ring: 'border-amber-200 bg-amber-50/60', text: 'text-amber-800', Icon: ShieldQuestion },
+    blocked: { tone: 'block', ring: 'border-red-200 bg-red-50/60', text: 'text-red-800', Icon: AlertOctagon },
+};
+
+const CONFIDENCE_LABELS: Record<HandoffConfidence, string> = {
+    explicit: 'From generated spec',
+    derived: 'Derived — confirm before building',
+    missing: 'Not specified',
+};
+
+const QA_CATEGORY_LABELS: Record<HandoffQaCategory, string> = {
+    rendering: 'Rendering',
+    interaction: 'Interaction',
+    state: 'State',
+    data: 'Data',
+    accessibility: 'Accessibility',
+    responsive: 'Responsive',
+    error_handling: 'Error handling',
+    acceptance: 'Acceptance',
+};
+
+const PRIORITY_STYLES: Record<HandoffTaskPriority, string> = {
+    must: 'text-red-700 bg-red-50 ring-red-200',
+    should: 'text-amber-700 bg-amber-50 ring-amber-200',
+    could: 'text-neutral-600 bg-neutral-50 ring-neutral-200',
+};
+
+export function ScreenHandoffView({ handoff }: Props) {
+    const meta = STATUS_META[handoff.readiness.status];
+    const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+    const [showMarkdown, setShowMarkdown] = useState(false);
+
+    const handleCopy = useCallback(async () => {
+        const md = renderHandoffMarkdown(handoff);
+        const ok = await copyToClipboard(md);
+        if (ok) {
+            setCopyState('copied');
+            setTimeout(() => setCopyState('idle'), 2000);
+        } else {
+            // Clipboard unavailable → reveal the markdown for manual copy.
+            setCopyState('failed');
+            setShowMarkdown(true);
+        }
+    }, [handoff]);
+
+    const markdown = renderHandoffMarkdown(handoff);
+
+    return (
+        <div className="space-y-4">
+            {/* Header + status + copy */}
+            <div className={`rounded-xl border p-4 ${meta.ring}`}>
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <div className="flex items-start gap-2 min-w-0">
+                        <meta.Icon size={18} className={`${meta.text} mt-0.5 shrink-0`} aria-hidden />
+                        <div className="min-w-0">
+                            <h3 className="text-sm font-semibold text-neutral-900">Implementation handoff</h3>
+                            <p className={`text-xs font-medium ${meta.text}`}>
+                                {IMPLEMENTATION_READINESS_LABELS[handoff.readiness.status]}
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-white ring-1 ring-neutral-200 hover:ring-indigo-300 hover:text-indigo-700 text-neutral-700 rounded-md transition shrink-0"
+                    >
+                        {copyState === 'copied' ? <ClipboardCopy size={13} /> : <Copy size={13} />}
+                        {copyState === 'copied' ? 'Copied' : 'Copy handoff'}
+                    </button>
+                </div>
+                {handoff.readiness.reasons.length > 0 && (
+                    <ul className="mt-2 space-y-0.5 text-[11px] text-neutral-600">
+                        {handoff.readiness.reasons.map((r, i) => (
+                            <li key={i} className="flex gap-1.5">
+                                <span className="text-neutral-300 select-none">·</span>
+                                <span>{r}</span>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+                {copyState === 'failed' && (
+                    <p className="mt-2 text-[11px] text-amber-700">
+                        Clipboard unavailable — copy the markdown below manually.
+                    </p>
+                )}
+            </div>
+
+            {showMarkdown && (
+                <div className="rounded-xl border border-neutral-200 bg-white p-3">
+                    <label className="text-[10px] uppercase tracking-wide text-neutral-400">Handoff markdown</label>
+                    <textarea
+                        readOnly
+                        value={markdown}
+                        onFocus={e => e.currentTarget.select()}
+                        rows={12}
+                        className="mt-1 w-full text-[11px] font-mono border border-neutral-200 rounded-md p-2 bg-neutral-50"
+                    />
+                </div>
+            )}
+
+            {/* Route */}
+            <Section title="Route" icon={<RouteIcon size={13} className="text-neutral-400" />}>
+                {handoff.route.path ? (
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <code className="text-xs bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded">{handoff.route.path}</code>
+                        <ConfidenceTag confidence={handoff.route.confidence} />
+                    </div>
+                ) : (
+                    <p className="text-xs text-neutral-400">Not specified</p>
+                )}
+                {handoff.route.notes.map((n, i) => (
+                    <p key={i} className="text-[11px] text-neutral-400 mt-1">{n}</p>
+                ))}
+            </Section>
+
+            {/* Components */}
+            <Section title="Components">
+                {handoff.components.length > 0 ? (
+                    <ul className="flex flex-wrap gap-1.5">
+                        {handoff.components.map(c => (
+                            <li
+                                key={c.name}
+                                className="text-[11px] text-neutral-700 bg-neutral-100 px-2 py-0.5 rounded-full"
+                                title={c.purpose}
+                            >
+                                {c.name}
+                                {!c.required && <span className="text-neutral-400"> · optional</span>}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-xs text-neutral-400">Not specified</p>
+                )}
+            </Section>
+
+            {/* State + events */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Section title="State">
+                    {handoff.state.length > 0 ? (
+                        <ul className="space-y-1 text-xs text-neutral-700">
+                            {handoff.state.map(s => (
+                                <li key={s.name}>
+                                    <span className="font-mono text-[11px] text-neutral-800">{s.name}</span>
+                                    {s.purpose && <span className="text-neutral-500"> — {s.purpose}</span>}
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-xs text-neutral-400">Not specified</p>
+                    )}
+                </Section>
+                <Section title="Events">
+                    {handoff.events.length > 0 ? (
+                        <ul className="space-y-1 text-xs text-neutral-700">
+                            {handoff.events.map(e => (
+                                <li key={e.name}>
+                                    <span className="font-mono text-[11px] text-neutral-800">{e.name}</span>
+                                    {e.expectedOutcome && <span className="text-neutral-500"> → {e.expectedOutcome}</span>}
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-xs text-neutral-400">Not specified</p>
+                    )}
+                </Section>
+            </div>
+
+            {/* Data dependencies */}
+            <Section title="Data dependencies">
+                {handoff.dataDependencies.length > 0 ? (
+                    <ul className="space-y-1 text-xs text-neutral-700">
+                        {handoff.dataDependencies.map((d, i) => (
+                            <li key={`${d.label}-${i}`} className="flex items-center gap-2 flex-wrap">
+                                <span className="text-neutral-800">{d.label}</span>
+                                {d.direction && (
+                                    <span className="text-[10px] text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded-full">
+                                        {d.direction.replace('_', '/')}
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-xs text-amber-700">
+                        No linked data model entities found. Review recommended before implementation.
+                    </p>
+                )}
+            </Section>
+
+            {/* Mockups */}
+            <Section title="Mockups to reference">
+                {handoff.mockupReferences.length > 0 ? (
+                    <ul className="space-y-1 text-xs text-neutral-700">
+                        {handoff.mockupReferences.map(m => (
+                            <li key={m.variantId} className="flex items-center gap-2 flex-wrap">
+                                <span className="text-neutral-800">{m.label}</span>
+                                {m.freshness && (
+                                    <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${
+                                        m.freshness === 'current'
+                                            ? 'text-emerald-700 bg-emerald-50'
+                                            : m.freshness === 'unknown'
+                                                ? 'text-neutral-500 bg-neutral-100'
+                                                : 'text-amber-700 bg-amber-50'
+                                    }`}>
+                                        {m.freshness === 'possibly_stale' ? 'possibly stale' : m.freshness}
+                                    </span>
+                                )}
+                                {m.coverage && m.coverage !== 'unknown' && (
+                                    <span className="text-[10px] text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded-full">
+                                        coverage: {m.coverage.replace('_', ' ')}
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-xs text-neutral-400">No generated mockups to reference yet.</p>
+                )}
+            </Section>
+
+            {/* Acceptance criteria */}
+            <Section title="Acceptance criteria">
+                {handoff.acceptanceCriteria.length > 0 ? (
+                    <ul className="space-y-1 text-xs text-neutral-700 list-disc list-inside">
+                        {handoff.acceptanceCriteria.map((c, i) => <li key={i}>{c}</li>)}
+                    </ul>
+                ) : (
+                    <p className="text-xs text-neutral-400">Not specified</p>
+                )}
+            </Section>
+
+            {/* QA checklist */}
+            <Section title="QA checklist" icon={<ClipboardList size={13} className="text-neutral-400" />}>
+                {handoff.qaChecklist.length > 0 ? (
+                    <ul className="space-y-1.5">
+                        {handoff.qaChecklist.map(q => (
+                            <li key={q.id} className="flex items-start gap-2 text-xs text-neutral-700">
+                                <span className="mt-0.5 h-3.5 w-3.5 rounded border border-neutral-300 shrink-0" aria-hidden />
+                                <span className="min-w-0">
+                                    <span className="text-[9px] uppercase tracking-wide text-neutral-400 mr-1.5">
+                                        {QA_CATEGORY_LABELS[q.category]}
+                                    </span>
+                                    {q.label}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-xs text-neutral-400">Not specified</p>
+                )}
+            </Section>
+
+            {/* Build tasks */}
+            <Section title="Build task checklist">
+                {handoff.buildTasks.length > 0 ? (
+                    <ol className="space-y-2">
+                        {handoff.buildTasks.map((t, i) => (
+                            <li key={t.id} className="flex items-start gap-2 text-xs text-neutral-700">
+                                <span className="text-neutral-400 tabular-nums shrink-0">{i + 1}.</span>
+                                <div className="min-w-0">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <span className="font-medium text-neutral-800">{t.title}</span>
+                                        <span className={`text-[9px] uppercase tracking-wide px-1.5 py-0.5 rounded-full ring-1 ${PRIORITY_STYLES[t.priority]}`}>
+                                            {t.priority}
+                                        </span>
+                                    </div>
+                                    <p className="text-[11px] text-neutral-500 mt-0.5">{t.description}</p>
+                                    <p className="text-[10px] text-neutral-400 mt-0.5">Why: {t.source}</p>
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                ) : (
+                    <p className="text-xs text-neutral-400">Not specified</p>
+                )}
+            </Section>
+
+            {/* Trace / confidence */}
+            <Section title="Trace & confidence">
+                <div className="space-y-1 text-xs text-neutral-600">
+                    <p>
+                        <span className="text-neutral-400">PRD features: </span>
+                        {handoff.trace.prdFeatures.length > 0 ? handoff.trace.prdFeatures.join(', ') : 'None linked'}
+                    </p>
+                    <p>
+                        <span className="text-neutral-400">User flows: </span>
+                        {handoff.trace.userFlows.length > 0 ? handoff.trace.userFlows.join(', ') : 'None'}
+                    </p>
+                    {handoff.trace.warnings.map((w, i) => (
+                        <p key={i} className="text-amber-700">{w}</p>
+                    ))}
+                    <p className="text-[11px] text-neutral-400">
+                        Every field here is estimated from the generated spec — confirm before building.
+                    </p>
+                </div>
+            </Section>
+        </div>
+    );
+}
+
+function ConfidenceTag({ confidence }: { confidence: HandoffConfidence }) {
+    const tone = confidence === 'explicit'
+        ? 'text-emerald-700 bg-emerald-50'
+        : confidence === 'derived'
+            ? 'text-amber-700 bg-amber-50'
+            : 'text-neutral-500 bg-neutral-100';
+    return (
+        <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${tone}`}>
+            {CONFIDENCE_LABELS[confidence]}
+        </span>
+    );
+}
+
+function Section({ title, icon, children }: {
+    title: string; icon?: React.ReactNode; children: React.ReactNode;
+}) {
+    return (
+        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+            <div className="flex items-center gap-1.5 mb-2">
+                {icon}
+                <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">{title}</h4>
+            </div>
+            {children}
+        </div>
+    );
+}

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -9,7 +9,7 @@
 
 import { AlertTriangle, AppWindow, ChevronRight, Image as ImageIcon, Layers, Workflow } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import type { MockupPlatform } from '../../types';
+import type { Feature, MockupPlatform } from '../../types';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
 import {
     SCREEN_LIST_FILTERS, screenMatchesFilter,
@@ -20,9 +20,13 @@ import {
     type ScreenArtifactReviewReadiness, type ScreenReviewModel,
 } from '../../lib/screenReviewWorkflow';
 import {
-    analyzeScreensDownstream,
+    analyzeScreensDownstream, buildScreensPreflight,
     type ScreenDownstreamImpact,
 } from '../../lib/screenDownstreamImpact';
+import {
+    buildScreenImplementationHandoff, buildScreensHandoffRollup, buildHandoffPreflightContribution,
+    type ScreenImplementationHandoff,
+} from '../../lib/screenImplementationHandoff';
 import {
     buildScreenMockupVariants, summarizeScreenVariants,
     type GeneratedVariantMap, type MockupVariantCoverageSummary,
@@ -58,6 +62,8 @@ interface Props {
     generatedVariantsByScreen?: (screenId: string) => GeneratedVariantMap | undefined;
     /** Phase 3C: current trust context for per-screen variant freshness. */
     trustContext?: VariantTrustContext;
+    /** Canonical PRD features — enables handoff/traceability derivation (Phase 5A). */
+    features?: readonly Feature[];
     /** Opens the Screen Detail view — keyed by the stable canonical id. */
     onSelectScreen: (screenId: string) => void;
     /**
@@ -71,7 +77,7 @@ interface Props {
 export function ScreenListView({
     index, readiness, reviewModels = EMPTY_REVIEW_MODELS, artifactReview, coverage,
     variantCoverage, mockupPlatform, mobileRelevant,
-    generatedVariantsByScreen, trustContext, onSelectScreen, onGenerateMissingMockups,
+    generatedVariantsByScreen, trustContext, features, onSelectScreen, onGenerateMissingMockups,
 }: Props) {
     const [filter, setFilter] = useState<ScreenListFilter>('all');
 
@@ -83,6 +89,41 @@ export function ScreenListView({
         [index, reviewModels, artifactReview],
     );
     const downstreamByScreen = downstream.impactsByScreen;
+
+    // Phase 5A: per-screen implementation handoff packages (route/components/
+    // state/events/data/mockups/QA/build tasks + readiness). Derived from the
+    // review model + variant grid + downstream impact — pure & memoized.
+    const handoffByScreen = useMemo(() => {
+        const map = new Map<string, ScreenImplementationHandoff>();
+        for (const item of index.items) {
+            const model = reviewModels.get(item.id);
+            if (!model) continue;
+            const variants = buildScreenMockupVariants(item, {
+                platform: mockupPlatform, mobileRelevant,
+                generatedVariants: generatedVariantsByScreen?.(item.id), trustContext,
+            });
+            map.set(item.id, buildScreenImplementationHandoff({
+                item, reviewModel: model, variants,
+                downstream: downstreamByScreen.get(item.id), features,
+            }));
+        }
+        return map;
+    }, [index, reviewModels, downstreamByScreen, mockupPlatform, mobileRelevant, generatedVariantsByScreen, trustContext, features]);
+
+    const p0Ids = useMemo(
+        () => new Set(index.items.filter(i => i.screen.priority === 'P0' || i.screen.priority === 'core').map(i => i.id)),
+        [index],
+    );
+    const handoffRollup = useMemo(
+        () => buildScreensHandoffRollup([...handoffByScreen.values()], p0Ids),
+        [handoffByScreen, p0Ids],
+    );
+    // Fold handoff issues into the Phase 4B preflight (handoff contributions are
+    // structural — screenDownstreamImpact never imports the handoff module).
+    const preflight = useMemo(() => {
+        const contribution = buildHandoffPreflightContribution([...handoffByScreen.values()], p0Ids);
+        return buildScreensPreflight(downstream.inputs, artifactReview, contribution);
+    }, [handoffByScreen, p0Ids, downstream.inputs, artifactReview]);
 
     const filterReviewFor = (item: ScreenExperienceItem): ScreenFilterReview | undefined => {
         const model = reviewModels.get(item.id);
@@ -96,6 +137,7 @@ export function ScreenListView({
             downstreamReviewNeeded: impact
                 ? impact.summary.hasBlockingImpact || impact.summary.reviewCount > 0
                 : false,
+            handoffReadiness: handoffByScreen.get(item.id)?.readiness.status,
         };
     };
 
@@ -108,7 +150,7 @@ export function ScreenListView({
         }
         return counts;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [index, readiness, reviewModels, downstreamByScreen]);
+    }, [index, readiness, reviewModels, downstreamByScreen, handoffByScreen]);
 
     if (index.items.length === 0) {
         return (
@@ -139,10 +181,11 @@ export function ScreenListView({
                 variantCoverage={variantCoverage}
                 artifactReview={artifactReview}
                 downstreamRollup={downstream.rollup}
+                handoffRollup={handoffRollup}
                 onGenerateMissingMockups={onGenerateMissingMockups}
             />
 
-            <ScreenPreflightPanel preflight={downstream.preflight} />
+            <ScreenPreflightPanel preflight={preflight} />
 
 
             <div className="flex items-center gap-1.5 flex-wrap" role="group" aria-label="Filter screens">
@@ -203,6 +246,7 @@ export function ScreenListView({
                                     readiness={readiness.get(item.id)}
                                     reviewModel={reviewModels.get(item.id)}
                                     downstreamImpact={downstreamByScreen.get(item.id)}
+                                    handoff={handoffByScreen.get(item.id)}
                                     mockupPlatform={mockupPlatform}
                                     mobileRelevant={mobileRelevant}
                                     generatedVariants={generatedVariantsByScreen?.(item.id)}
@@ -225,12 +269,13 @@ const SYSTEM_READINESS_TONE: Record<ScreenReviewModel['systemReadiness'], string
 };
 
 function ScreenRow({
-    item, readiness, reviewModel, downstreamImpact, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
+    item, readiness, reviewModel, downstreamImpact, handoff, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
 }: {
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
     reviewModel?: ScreenReviewModel;
     downstreamImpact?: ScreenDownstreamImpact;
+    handoff?: ScreenImplementationHandoff;
     mockupPlatform?: MockupPlatform;
     mobileRelevant?: boolean;
     generatedVariants?: GeneratedVariantMap;
@@ -343,6 +388,7 @@ function ScreenRow({
                     </span>
                 )}
                 {downstreamImpact && <DownstreamChip impact={downstreamImpact} />}
+                {handoff && <HandoffChip status={handoff.readiness.status} />}
             </div>
 
             {reviewModel && (
@@ -436,6 +482,36 @@ function DownstreamChip({ impact }: { impact: ScreenDownstreamImpact }) {
                 : 'This screen changed or needs review — the named downstream artifacts may be worth re-checking'}
         >
             {label}
+        </span>
+    );
+}
+
+const HANDOFF_CHIP_META: Record<ScreenImplementationHandoff['readiness']['status'], {
+    label: string; tone: string; title: string;
+}> = {
+    ready: {
+        label: 'Handoff ready',
+        tone: 'text-emerald-700 bg-emerald-50 ring-emerald-200',
+        title: 'This screen has an accepted spec and a build-ready handoff package',
+    },
+    review_recommended: {
+        label: 'Handoff needs review',
+        tone: 'text-amber-700 bg-amber-50 ring-amber-200',
+        title: 'The handoff package is usable but has review items — confirm before building',
+    },
+    blocked: {
+        label: 'Handoff blocked',
+        tone: 'text-red-700 bg-red-50 ring-red-200',
+        title: 'Resolve the blockers before using this screen as a build source',
+    },
+};
+
+/** Compact implementation-handoff readiness chip (Phase 5A). */
+function HandoffChip({ status }: { status: ScreenImplementationHandoff['readiness']['status'] }) {
+    const meta = HANDOFF_CHIP_META[status];
+    return (
+        <span className={`text-[10px] px-1.5 py-0.5 rounded-full ring-1 ${meta.tone}`} title={meta.title}>
+            {meta.label}
         </span>
     );
 }

--- a/src/lib/__tests__/screenImplementationHandoff.test.ts
+++ b/src/lib/__tests__/screenImplementationHandoff.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect } from 'vitest';
+import type { Feature, ScreenItem } from '../../types';
+import type { ScreenExperienceItem } from '../screenExperience';
+import type { ScreenReviewModel, SystemReadinessStatus, ScreenReviewFreshnessStatus } from '../screenReviewWorkflow';
+import type { DerivedMockupVariant } from '../mockupVariants';
+import type { ScreenReviewStatus } from '../screenReadiness';
+import {
+    buildScreenImplementationHandoff,
+    buildScreensHandoffRollup,
+    buildHandoffPreflightContribution,
+    deriveHandoffRoute,
+    deriveHandoffComponents,
+    deriveHandoffState,
+    deriveHandoffEvents,
+    deriveHandoffDataDependencies,
+    deriveHandoffQaChecklist,
+    deriveHandoffReadiness,
+    renderHandoffMarkdown,
+    type ScreenHandoffInput,
+    type HandoffReadinessSignals,
+} from '../screenImplementationHandoff';
+
+// --- Fixtures ----------------------------------------------------------------
+
+function screen(overrides: Partial<ScreenItem> = {}): ScreenItem {
+    return {
+        name: 'Landing & Role Selection',
+        priority: 'P0',
+        purpose: 'Entry point where the user picks a target role.',
+        userIntent: 'Select a target role and start an evaluation',
+        featureRefs: ['F1: Role selection'],
+        states: [
+            { name: 'Default', description: 'Roles shown', trigger: 'load', type: 'default', required: true },
+            { name: 'Empty history', description: 'No prior evaluations', trigger: 'none', type: 'empty', required: true, needsMockup: true },
+        ],
+        entryPoints: ['App launch'],
+        exitPaths: [{ label: 'Start evaluation', target: 'Dashboard' }],
+        coreUIElements: ['Hero banner', 'Role selection grid'],
+        outputData: ['selected role id'],
+        acceptanceCriteria: ['User can select exactly one target role.'],
+        ...overrides,
+    };
+}
+
+function reviewModel(overrides: Partial<ScreenReviewModel> = {}): ScreenReviewModel {
+    return {
+        userStatus: undefined,
+        systemReadiness: 'ready' as SystemReadinessStatus,
+        issues: [],
+        blockingCount: 0,
+        reviewCount: 0,
+        infoCount: 0,
+        acceptedOverWarnings: false,
+        freshness: 'unknown' as ScreenReviewFreshnessStatus,
+        checklist: {},
+        checklistProgress: { checked: 0, total: 8 },
+        ...overrides,
+    };
+}
+
+function variant(overrides: Partial<DerivedMockupVariant> = {}): DerivedMockupVariant {
+    return {
+        id: 'default',
+        screenId: 's',
+        viewport: 'desktop',
+        stateName: 'Default',
+        stateType: 'default',
+        status: 'generated',
+        required: true,
+        userSet: false,
+        source: 'legacy',
+        coverageStatus: 'unknown',
+        coverageEstimated: true,
+        notes: [],
+        ...overrides,
+    };
+}
+
+function item(scr: ScreenItem, overrides: Partial<ScreenExperienceItem> = {}): ScreenExperienceItem {
+    return {
+        id: 'scr-landing',
+        slug: 'landing-role-selection',
+        screen: scr,
+        baseScreen: scr,
+        isEdited: false,
+        sectionTitle: 'Main',
+        relatedFlows: [],
+        ...overrides,
+    };
+}
+
+const FEATURES: Feature[] = [
+    { id: 'F1', name: 'Role selection', description: '', userValue: '', complexity: 'low' },
+];
+
+function handoffInput(overrides: Partial<ScreenHandoffInput> = {}): ScreenHandoffInput {
+    const scr = overrides.item?.screen ?? screen();
+    return {
+        item: item(scr),
+        reviewModel: reviewModel(),
+        variants: [variant()],
+        features: FEATURES,
+        ...overrides,
+    };
+}
+
+// --- 1-3. Route --------------------------------------------------------------
+
+describe('deriveHandoffRoute', () => {
+    it('1. uses the explicit handoff route when available', () => {
+        const r = deriveHandoffRoute(screen({ handoff: { route: '/evaluate' } }));
+        expect(r.path).toBe('/evaluate');
+        expect(r.confidence).toBe('explicit');
+    });
+
+    it('2. derives a fallback route from the screen title when explicit is missing', () => {
+        const r = deriveHandoffRoute(screen({ name: 'Landing & Role Selection', handoff: undefined }));
+        // Landing maps to '/'.
+        expect(r.path).toBe('/');
+        expect(r.confidence).toBe('derived');
+    });
+
+    it('3. marks confidence derived and slugifies an unknown title', () => {
+        const r = deriveHandoffRoute(screen({ name: 'Widget Config Panel', handoff: undefined }));
+        expect(r.path).toBe('/widget-config-panel');
+        expect(r.confidence).toBe('derived');
+    });
+});
+
+// --- 4-7. Components / State / Events / Data ---------------------------------
+
+describe('deriveHandoffComponents', () => {
+    it('4. derives components from core UI regions', () => {
+        const comps = deriveHandoffComponents(screen());
+        const names = comps.map(c => c.name);
+        expect(names).toContain('HeroBanner');
+        expect(names).toContain('RoleSelectionGrid');
+        expect(comps.every(c => c.source === 'core_ui')).toBe(true);
+    });
+
+    it('prefers generated handoff primaryComponents over core UI', () => {
+        const comps = deriveHandoffComponents(screen({
+            handoff: { primaryComponents: ['SubmissionWizard'] },
+        }));
+        expect(comps[0].name).toBe('SubmissionWizard');
+        expect(comps[0].source).toBe('handoff');
+    });
+});
+
+describe('deriveHandoffState', () => {
+    it('5. derives state entries from required states and handoff fields', () => {
+        const state = deriveHandoffState(screen({
+            handoff: { stateVariables: ['selectedRoleId'] },
+        }));
+        const names = state.map(s => s.name);
+        expect(names).toContain('selectedRoleId');
+        // The non-default "Empty history" state contributes a status entry.
+        expect(names.some(n => n.includes('empty_history'))).toBe(true);
+    });
+});
+
+describe('deriveHandoffEvents', () => {
+    it('6. derives events from user actions and exit paths', () => {
+        const events = deriveHandoffEvents(screen(), ['User selects a role']);
+        const names = events.map(e => e.name);
+        // From exit path "Start evaluation".
+        expect(names).toContain('onStartEvaluation');
+        // From the flow user action.
+        expect(names.some(n => n.startsWith('on'))).toBe(true);
+        expect(events.some(e => e.source === 'flow')).toBe(true);
+    });
+});
+
+describe('deriveHandoffDataDependencies', () => {
+    it('7. derives data dependencies from outputs, handoff data, and api deps', () => {
+        const deps = deriveHandoffDataDependencies(screen({
+            outputData: ['selected role id'],
+            handoff: { dataDependencies: ['Evaluation', 'localStorage.recentEvaluations'], apiDependencies: ['POST /submissions'] },
+        }));
+        const labels = deps.map(d => d.label);
+        expect(labels).toContain('Evaluation');
+        expect(labels).toContain('selected role id');
+        expect(deps.find(d => d.label === 'localStorage.recentEvaluations')?.type).toBe('storage');
+        expect(deps.find(d => d.label === 'POST /submissions')?.type).toBe('api');
+        expect(deps.find(d => d.label === 'selected role id')?.direction).toBe('write');
+    });
+});
+
+// --- 8-10. QA checklist ------------------------------------------------------
+
+describe('deriveHandoffQaChecklist', () => {
+    const base = { mobileMissing: false, hasMockup: true, mockupFreshnessConcern: false };
+
+    it('8. includes acceptance criteria', () => {
+        const qa = deriveHandoffQaChecklist(screen(), {
+            ...base, acceptanceCriteria: ['User can select exactly one target role.'],
+        });
+        expect(qa.some(q => q.category === 'acceptance')).toBe(true);
+    });
+
+    it('9. includes required states', () => {
+        const qa = deriveHandoffQaChecklist(screen(), { ...base, acceptanceCriteria: [] });
+        expect(qa.some(q => q.category === 'state' && /Empty history/.test(q.label))).toBe(true);
+    });
+
+    it('10. includes risk / error-handling items', () => {
+        const qa = deriveHandoffQaChecklist(
+            screen({ riskDetails: [{ description: 'Stored data is corrupt', severity: 'medium' }] }),
+            { ...base, acceptanceCriteria: [] },
+        );
+        expect(qa.some(q => q.category === 'error_handling' && q.source === 'risks')).toBe(true);
+    });
+});
+
+// --- 11. Build tasks ---------------------------------------------------------
+
+describe('buildScreenImplementationHandoff build tasks', () => {
+    it('11. includes route / component / state / QA tasks', () => {
+        const h = buildScreenImplementationHandoff(handoffInput());
+        const cats = new Set(h.buildTasks.map(t => t.category));
+        expect(cats.has('route')).toBe(true);
+        expect(cats.has('component')).toBe(true);
+        expect(cats.has('state')).toBe(true);
+        expect(cats.has('qa')).toBe(true);
+    });
+});
+
+// --- 12-15. Readiness --------------------------------------------------------
+
+function readinessSignals(overrides: Partial<HandoffReadinessSignals> = {}): HandoffReadinessSignals {
+    return {
+        isP0: true,
+        isPrimary: true,
+        userStatus: 'accepted' as ScreenReviewStatus,
+        systemReadiness: 'ready',
+        blockingCount: 0,
+        reviewCount: 0,
+        reviewFreshness: 'current',
+        hasAcceptanceCriteria: true,
+        hasRouteOrComponentGuidance: true,
+        mockupFreshnessConcern: false,
+        mobileMissing: false,
+        dataDependenciesMissing: false,
+        handoffThin: false,
+        downstreamBlocking: false,
+        ...overrides,
+    };
+}
+
+describe('deriveHandoffReadiness', () => {
+    it('12. a P0 unsigned screen is blocked', () => {
+        const r = deriveHandoffReadiness(readinessSignals({ userStatus: undefined }));
+        expect(r.status).toBe('blocked');
+    });
+
+    it('13. an accepted current P0 screen with no blockers is ready', () => {
+        const r = deriveHandoffReadiness(readinessSignals());
+        expect(r.status).toBe('ready');
+    });
+
+    it('14. a stale mockup creates review recommended, not blocked', () => {
+        const r = deriveHandoffReadiness(readinessSignals({ mockupFreshnessConcern: true }));
+        expect(r.status).toBe('review_recommended');
+    });
+
+    it('15. missing data trace creates a review warning', () => {
+        const r = deriveHandoffReadiness(readinessSignals({ dataDependenciesMissing: true }));
+        expect(r.status).toBe('review_recommended');
+        expect(r.reasons.some(x => /No linked data model entities/.test(x))).toBe(true);
+    });
+
+    it('no acceptance criteria blocks', () => {
+        const r = deriveHandoffReadiness(readinessSignals({ hasAcceptanceCriteria: false }));
+        expect(r.status).toBe('blocked');
+    });
+});
+
+// --- 16. Rollup --------------------------------------------------------------
+
+describe('buildScreensHandoffRollup', () => {
+    it('16. counts ready / review / blocked and gates on P0', () => {
+        const ready = buildScreenImplementationHandoff(handoffInput({
+            reviewModel: reviewModel({ userStatus: 'accepted', freshness: 'current' }),
+            variants: [variant({ freshness: { status: 'current', reasons: [] } })],
+        }));
+        const blocked = buildScreenImplementationHandoff(handoffInput({
+            item: item(screen({ purpose: '', acceptanceCriteria: [], userIntent: '', states: [], exitPaths: [], name: 'Broken', handoff: undefined, coreUIElements: [], components: [] }), { id: 'scr-broken' }),
+            reviewModel: reviewModel(),
+        }));
+        const rollup = buildScreensHandoffRollup([ready, blocked], new Set(['scr-broken']));
+        expect(rollup.total).toBe(2);
+        expect(rollup.blocked).toBeGreaterThanOrEqual(1);
+        expect(rollup.status).toBe('blocked');
+    });
+
+    it('is ready when every P0 handoff is ready', () => {
+        const ready = buildScreenImplementationHandoff(handoffInput({
+            reviewModel: reviewModel({ userStatus: 'accepted', freshness: 'current' }),
+            variants: [variant({ freshness: { status: 'current', reasons: [] } })],
+        }));
+        const rollup = buildScreensHandoffRollup([ready], new Set(['scr-landing']));
+        expect(rollup.status).toBe('ready');
+        expect(rollup.message).toMatch(/build-ready handoff/);
+    });
+});
+
+// --- 17. Markdown ------------------------------------------------------------
+
+describe('renderHandoffMarkdown', () => {
+    it('17. includes the key sections', () => {
+        const h = buildScreenImplementationHandoff(handoffInput());
+        const md = renderHandoffMarkdown(h);
+        expect(md).toMatch(/# Landing & Role Selection .*Implementation Handoff/);
+        expect(md).toContain('## Route');
+        expect(md).toContain('## Components');
+        expect(md).toContain('## State');
+        expect(md).toContain('## Events');
+        expect(md).toContain('## Data Dependencies');
+        expect(md).toContain('## Acceptance Criteria');
+        expect(md).toContain('## QA Checklist');
+        expect(md).toContain('## Build Tasks');
+    });
+
+    it('renders a "no data model entities" line when there are no data deps', () => {
+        const h = buildScreenImplementationHandoff(handoffInput({
+            item: item(screen({ outputData: [], handoff: undefined })),
+        }));
+        const md = renderHandoffMarkdown(h);
+        expect(md).toMatch(/No linked data model entities found/);
+    });
+});
+
+// --- 18. Legacy safety -------------------------------------------------------
+
+describe('legacy / incomplete screens', () => {
+    it('18. an incomplete/legacy screen does not throw', () => {
+        const legacy: ScreenItem = { name: 'Bare', priority: 'P2', purpose: '' };
+        expect(() => {
+            const h = buildScreenImplementationHandoff({
+                item: item(legacy, { id: 'scr-bare' }),
+                reviewModel: reviewModel(),
+                variants: [],
+            });
+            renderHandoffMarkdown(h);
+        }).not.toThrow();
+    });
+});
+
+// --- Preflight contribution --------------------------------------------------
+
+describe('buildHandoffPreflightContribution', () => {
+    it('surfaces blocked P0 handoffs as blocking preflight items', () => {
+        const blocked = buildScreenImplementationHandoff(handoffInput({
+            item: item(screen({ acceptanceCriteria: [], userIntent: '', name: 'Dashboard' }), { id: 'scr-dash' }),
+            reviewModel: reviewModel(),
+        }));
+        const contrib = buildHandoffPreflightContribution([blocked], new Set(['scr-dash']));
+        expect(contrib.blocking.length).toBeGreaterThan(0);
+        expect(contrib.recommendedNextActions.some(a => /Dashboard/.test(a))).toBe(true);
+    });
+});

--- a/src/lib/__tests__/screenImplementationHandoff.test.ts
+++ b/src/lib/__tests__/screenImplementationHandoff.test.ts
@@ -281,7 +281,7 @@ describe('buildScreensHandoffRollup', () => {
     it('16. counts ready / review / blocked and gates on P0', () => {
         const ready = buildScreenImplementationHandoff(handoffInput({
             reviewModel: reviewModel({ userStatus: 'accepted', freshness: 'current' }),
-            variants: [variant({ freshness: { status: 'current', reasons: [] } })],
+            variants: [variant({ freshness: { status: 'current', reasons: [], severity: 'info', estimated: true } })],
         }));
         const blocked = buildScreenImplementationHandoff(handoffInput({
             item: item(screen({ purpose: '', acceptanceCriteria: [], userIntent: '', states: [], exitPaths: [], name: 'Broken', handoff: undefined, coreUIElements: [], components: [] }), { id: 'scr-broken' }),
@@ -296,7 +296,7 @@ describe('buildScreensHandoffRollup', () => {
     it('is ready when every P0 handoff is ready', () => {
         const ready = buildScreenImplementationHandoff(handoffInput({
             reviewModel: reviewModel({ userStatus: 'accepted', freshness: 'current' }),
-            variants: [variant({ freshness: { status: 'current', reasons: [] } })],
+            variants: [variant({ freshness: { status: 'current', reasons: [], severity: 'info', estimated: true } })],
         }));
         const rollup = buildScreensHandoffRollup([ready], new Set(['scr-landing']));
         expect(rollup.status).toBe('ready');

--- a/src/lib/screenDownstreamImpact.ts
+++ b/src/lib/screenDownstreamImpact.ts
@@ -116,6 +116,18 @@ export interface ScreensDownstreamAnalysis {
     preflight: ScreensPreflightModel;
 }
 
+/**
+ * Extra preflight items contributed by a higher layer (Phase 5A implementation
+ * handoff). Kept structural — screenDownstreamImpact never imports the handoff
+ * module (that would cycle), so the caller passes this in. All fields optional.
+ */
+export interface PreflightContribution {
+    blocking?: readonly string[];
+    review?: readonly string[];
+    info?: readonly string[];
+    recommendedNextActions?: readonly string[];
+}
+
 // --- Helpers -----------------------------------------------------------------
 
 const isSignedOff = (status: ScreenReviewStatus | undefined): boolean =>
@@ -399,6 +411,7 @@ const plural = (n: number, one: string, many = `${one}s`): string => (n === 1 ? 
 export function buildScreensPreflight(
     inputs: readonly DownstreamScreenInput[],
     artifactReview?: ScreenArtifactReviewReadiness,
+    handoff?: PreflightContribution,
 ): ScreensPreflightModel {
     const rollup = buildScreensDownstreamImpactRollup(inputs, artifactReview);
     const blocking: string[] = [];
@@ -448,13 +461,29 @@ export function buildScreensPreflight(
         caveats.push('Generated mockup variant images are saved on this device and in project snapshots, but do not yet sync across devices.');
     }
 
+    // Phase 5A: fold in implementation-handoff contributions (deduped). A
+    // handoff blocker pushes the status to not_ready; a handoff review item
+    // downgrades a ready status to review_recommended.
+    const dedupePush = (target: string[], items?: readonly string[]) => {
+        for (const it of items ?? []) if (it && !target.includes(it)) target.push(it);
+    };
+    dedupePush(blocking, handoff?.blocking);
+    dedupePush(review, handoff?.review);
+    dedupePush(info, handoff?.info);
+    const recommendedNextActions = [...rollup.recommendedNextActions];
+    dedupePush(recommendedNextActions, handoff?.recommendedNextActions);
+
+    let status = rollup.overallStatus;
+    if ((handoff?.blocking?.length ?? 0) > 0) status = 'not_ready';
+    else if (status === 'ready' && (handoff?.review?.length ?? 0) > 0) status = 'review_recommended';
+
     return {
-        status: rollup.overallStatus,
-        headline: PREFLIGHT_HEADLINES[rollup.overallStatus],
+        status,
+        headline: PREFLIGHT_HEADLINES[status],
         blocking,
         review,
         info,
-        recommendedNextActions: rollup.recommendedNextActions,
+        recommendedNextActions: recommendedNextActions.slice(0, 6),
         caveats,
     };
 }
@@ -467,6 +496,7 @@ export function analyzeScreensDownstream(
     index: ScreenExperienceIndex,
     reviewModels: ReadonlyMap<string, ScreenReviewModel>,
     artifactReview?: ScreenArtifactReviewReadiness,
+    handoffPreflight?: PreflightContribution,
 ): ScreensDownstreamAnalysis {
     const inputs: DownstreamScreenInput[] = [];
     const impactsByScreen = new Map<string, ScreenDownstreamImpact>();
@@ -481,6 +511,6 @@ export function analyzeScreensDownstream(
         inputs,
         impactsByScreen,
         rollup: buildScreensDownstreamImpactRollup(inputs, artifactReview),
-        preflight: buildScreensPreflight(inputs, artifactReview),
+        preflight: buildScreensPreflight(inputs, artifactReview, handoffPreflight),
     };
 }

--- a/src/lib/screenImplementationHandoff.ts
+++ b/src/lib/screenImplementationHandoff.ts
@@ -26,7 +26,7 @@ import type { Feature, ScreenItem } from '../types';
 import type { ScreenExperienceItem } from './screenExperience';
 import { slugifyScreenName } from './screenInventoryImageStore';
 import {
-    buildScreenTraceability, resolveAcceptanceCriteria, resolveScreenHandoff,
+    buildScreenTraceability, resolveAcceptanceCriteria,
     type ScreenReviewStatus,
 } from './screenReadiness';
 import {
@@ -185,7 +185,7 @@ const displayPriority = (screen: ScreenItem): string | undefined => {
     }
 };
 
-const clean = (values: Array<string | undefined | null>): string[] => {
+const clean = (values: readonly (string | undefined | null)[]): string[] => {
     const out: string[] = [];
     const seen = new Set<string>();
     for (const v of values) {

--- a/src/lib/screenImplementationHandoff.ts
+++ b/src/lib/screenImplementationHandoff.ts
@@ -1,0 +1,1115 @@
+// Phase 5A: the screen → implementation handoff layer.
+//
+// Phases 4A/4B turned the Screens artifact into a review workflow (user
+// sign-off vs. system readiness) and a downstream-impact + preflight surface.
+// Phase 5A layers ON TOP of those (and NEVER changes them) to make an accepted
+// screen directly useful for development: it derives a lightweight, per-screen
+// *implementation handoff package* — route, components, state, events, data
+// dependencies, mockup references, acceptance criteria, a QA checklist, and a
+// small build-task list — plus a per-screen implementation-readiness verdict.
+//
+// It is PURE and read-time only (no store, no IDB, no React, no LLM). It is
+// DERIVED (nothing here is persisted — a stale persisted handoff would be worse
+// than none). It reuses the existing resolvers (resolveScreenHandoff,
+// resolveAcceptanceCriteria, buildScreenTraceability) so it never drifts from
+// the readiness layer, and it consumes the already-computed Phase 4A review
+// model and Phase 4B downstream impact rather than recomputing them.
+//
+// Honesty rules (mirroring the rest of the Screens layer): every derived value
+// is an estimate from the generated spec; a route/component/state inferred from
+// the title is labeled `derived`, never presented as final; missing data is
+// shown as "Not specified" / a review warning, never fabricated as certain;
+// language stays calm and practical ("Review recommended", "Derived route —
+// confirm before building"), never punitive ("Invalid", "Broken").
+
+import type { Feature, ScreenItem } from '../types';
+import type { ScreenExperienceItem } from './screenExperience';
+import { slugifyScreenName } from './screenInventoryImageStore';
+import {
+    buildScreenTraceability, resolveAcceptanceCriteria, resolveScreenHandoff,
+    type ScreenReviewStatus,
+} from './screenReadiness';
+import {
+    formatVariantLabel, type DerivedMockupVariant, type MockupVariantCoverage,
+} from './mockupVariants';
+import type {
+    ScreenReviewFreshnessStatus, ScreenReviewModel, SystemReadinessStatus,
+} from './screenReviewWorkflow';
+import type { MockupVariantFreshness } from './mockupVariantTrust';
+import type { ScreenDownstreamImpact } from './screenDownstreamImpact';
+
+// --- Types -------------------------------------------------------------------
+
+export type ScreenImplementationReadiness = 'ready' | 'review_recommended' | 'blocked';
+
+export const IMPLEMENTATION_READINESS_LABELS: Record<ScreenImplementationReadiness, string> = {
+    ready: 'Ready for implementation',
+    review_recommended: 'Handoff needs review',
+    blocked: 'Handoff blocked',
+};
+
+export type HandoffConfidence = 'explicit' | 'derived' | 'missing';
+
+export interface HandoffRoute {
+    path?: string;
+    routeName?: string;
+    confidence: HandoffConfidence;
+    notes: string[];
+}
+
+export type HandoffComponentSource = 'core_ui' | 'handoff' | 'derived' | 'mockup' | 'unknown';
+
+export interface HandoffComponent {
+    name: string;
+    purpose?: string;
+    source: HandoffComponentSource;
+    required: boolean;
+}
+
+export type HandoffStateSource = 'screen_state' | 'handoff' | 'derived';
+
+export interface HandoffStateEntry {
+    name: string;
+    purpose?: string;
+    source: HandoffStateSource;
+}
+
+export type HandoffEventSource = 'user_action' | 'flow' | 'handoff' | 'derived';
+
+export interface HandoffEvent {
+    name: string;
+    trigger?: string;
+    expectedOutcome?: string;
+    source: HandoffEventSource;
+}
+
+export type HandoffDataType =
+    | 'entity' | 'field' | 'api' | 'storage' | 'input' | 'output' | 'unknown';
+export type HandoffDataDirection = 'read' | 'write' | 'read_write';
+export type HandoffDataSource =
+    | 'screen_outputs' | 'screen_inputs' | 'handoff' | 'data_model_trace' | 'derived';
+
+export interface HandoffDataDependency {
+    label: string;
+    type: HandoffDataType;
+    direction?: HandoffDataDirection;
+    source: HandoffDataSource;
+}
+
+export interface HandoffMockupReference {
+    variantId: string;
+    label: string;
+    viewport?: string;
+    stateName?: string;
+    freshness?: MockupVariantFreshness['status'];
+    coverage?: MockupVariantCoverage;
+    recommendedForBuild: boolean;
+}
+
+export type HandoffQaCategory =
+    | 'rendering' | 'interaction' | 'state' | 'data'
+    | 'accessibility' | 'responsive' | 'error_handling' | 'acceptance';
+export type HandoffQaSource =
+    | 'acceptance_criteria' | 'states' | 'risks' | 'mockups' | 'derived';
+
+export interface HandoffQaItem {
+    id: string;
+    label: string;
+    category: HandoffQaCategory;
+    source: HandoffQaSource;
+    required: boolean;
+}
+
+export type HandoffTaskCategory =
+    | 'route' | 'component' | 'state' | 'data' | 'mockup' | 'qa' | 'accessibility';
+export type HandoffTaskPriority = 'must' | 'should' | 'could';
+
+export interface HandoffBuildTask {
+    id: string;
+    title: string;
+    description: string;
+    category: HandoffTaskCategory;
+    priority: HandoffTaskPriority;
+    source: string;
+}
+
+export interface HandoffTrace {
+    prdFeatures: string[];
+    userFlows: string[];
+    relatedArtifacts: string[];
+    estimated: boolean;
+    warnings: string[];
+}
+
+export interface ScreenImplementationReadinessDetail {
+    status: ScreenImplementationReadiness;
+    reasons: string[];
+    blockingCount: number;
+    reviewCount: number;
+}
+
+export interface ScreenImplementationHandoff {
+    screenId: string;
+    screenTitle: string;
+    priority?: string;
+    readiness: ScreenImplementationReadinessDetail;
+    route: HandoffRoute;
+    components: HandoffComponent[];
+    state: HandoffStateEntry[];
+    events: HandoffEvent[];
+    dataDependencies: HandoffDataDependency[];
+    mockupReferences: HandoffMockupReference[];
+    acceptanceCriteria: string[];
+    qaChecklist: HandoffQaItem[];
+    buildTasks: HandoffBuildTask[];
+    trace: HandoffTrace;
+}
+
+// --- Small helpers -----------------------------------------------------------
+
+const isP0 = (screen: ScreenItem): boolean =>
+    screen.priority === 'P0' || screen.priority === 'core';
+
+/** Primary = a screen users routinely land on (P0/P1). Route/component
+ * blockers only apply to primary screens; supporting UI can lack them. */
+const isPrimary = (screen: ScreenItem): boolean =>
+    isP0(screen) || screen.priority === 'P1' || screen.priority === 'secondary';
+
+const displayPriority = (screen: ScreenItem): string | undefined => {
+    switch (screen.priority) {
+        case 'P0': case 'core': return 'P0';
+        case 'P1': case 'secondary': return 'P1';
+        case 'P2': case 'supporting': return 'P2';
+        case 'P3': return 'P3';
+        default: return undefined;
+    }
+};
+
+const clean = (values: Array<string | undefined | null>): string[] => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const v of values) {
+        const t = v?.trim();
+        if (!t) continue;
+        const key = t.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(t);
+    }
+    return out;
+};
+
+const trimSentence = (text: string): string => text.trim().replace(/\.+$/, '');
+
+/** Turn a screen/UI label into a conventional PascalCase component name. */
+function toComponentName(label: string): string {
+    const cleaned = label.replace(/[^a-zA-Z0-9]+/g, ' ').trim();
+    if (!cleaned) return 'Component';
+    return cleaned
+        .split(/\s+/)
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join('');
+}
+
+/** Turn a label into a camelCase-ish handler name: onSelectRole, onSubmit… */
+function toEventName(base: string): string {
+    const parts = base.replace(/[^a-zA-Z0-9]+/g, ' ').trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return 'onEvent';
+    const pascal = parts.map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join('');
+    return `on${pascal}`;
+}
+
+// --- Route -------------------------------------------------------------------
+
+/** Small map of conventional routes for common screen names, so a derived route
+ * reads naturally (Landing → `/`, Settings → `/settings`). Not authoritative —
+ * every derived route is labeled `derived` and "confirm before building". */
+const KNOWN_ROUTE_KEYWORDS: Array<{ match: RegExp; path: string }> = [
+    { match: /\b(landing|home|welcome|role selection)\b/i, path: '/' },
+    { match: /\bdashboard\b/i, path: '/dashboard' },
+    { match: /\bsettings?\b/i, path: '/settings' },
+    { match: /\b(sign ?in|log ?in)\b/i, path: '/login' },
+    { match: /\b(sign ?up|register|onboarding)\b/i, path: '/signup' },
+    { match: /\bprofile\b/i, path: '/profile' },
+    { match: /\b(search|results?)\b/i, path: '/search' },
+];
+
+/** Derive the route/page a screen maps to. Prefers the generated handoff route
+ * (explicit); falls back to a small keyword map / slug of the title (derived).
+ * Never claims a derived route is final. */
+export function deriveHandoffRoute(screen: ScreenItem): HandoffRoute {
+    const explicit = screen.handoff?.route?.trim();
+    if (explicit) {
+        const params = clean(screen.handoff?.routeParams ?? []);
+        return {
+            path: explicit,
+            routeName: toComponentName(screen.name) + 'Page',
+            confidence: 'explicit',
+            notes: params.length > 0 ? [`Route params: ${params.join(', ')}`] : [],
+        };
+    }
+    const name = screen.name?.trim();
+    if (!name) {
+        return { confidence: 'missing', notes: ['No screen name to derive a route from.'] };
+    }
+    const known = KNOWN_ROUTE_KEYWORDS.find(k => k.match.test(name));
+    const path = known ? known.path : `/${slugifyScreenName(name)}`;
+    return {
+        path,
+        routeName: toComponentName(name) + 'Page',
+        confidence: 'derived',
+        notes: ['Derived from the screen name — confirm before building.'],
+    };
+}
+
+// --- Components ---------------------------------------------------------------
+
+/** Derive the components to build for a screen. Prefers the generated handoff
+ * `primaryComponents`; falls back to the spec's core UI regions, then to a
+ * single derived shell named from the title. Also folds in the mockup screen's
+ * own UI elements (source 'mockup') when they add coverage. */
+export function deriveHandoffComponents(
+    screen: ScreenItem,
+    mockupElements?: readonly string[],
+): HandoffComponent[] {
+    const out: HandoffComponent[] = [];
+    const seen = new Set<string>();
+    const push = (name: string, source: HandoffComponentSource, required: boolean) => {
+        const key = name.toLowerCase();
+        if (!name || seen.has(key)) return;
+        seen.add(key);
+        out.push({ name, source, required });
+    };
+
+    const handoffComponents = clean(screen.handoff?.primaryComponents ?? []);
+    for (const c of handoffComponents) push(toComponentName(c), 'handoff', true);
+
+    if (out.length === 0) {
+        const core = clean(
+            (screen.coreUIElements && screen.coreUIElements.length > 0)
+                ? screen.coreUIElements
+                : screen.components ?? [],
+        );
+        for (const c of core) push(toComponentName(c), 'core_ui', true);
+    }
+
+    for (const c of clean(mockupElements ?? [])) push(toComponentName(c), 'mockup', false);
+
+    if (out.length === 0 && screen.name?.trim()) {
+        push(toComponentName(screen.name), 'derived', true);
+    }
+    return out;
+}
+
+// --- State --------------------------------------------------------------------
+
+/** Derive the client state entries a screen implies. Prefers the generated
+ * handoff `stateVariables` (source 'handoff'); adds a state entry per documented
+ * required UI state (source 'screen_state'); when neither exists, a light
+ * derived selection/status entry for a primary screen. */
+export function deriveHandoffState(screen: ScreenItem): HandoffStateEntry[] {
+    const out: HandoffStateEntry[] = [];
+    const seen = new Set<string>();
+    const push = (name: string, source: HandoffStateSource, purpose?: string) => {
+        const key = name.toLowerCase();
+        if (!name || seen.has(key)) return;
+        seen.add(key);
+        out.push({ name, source, purpose });
+    };
+
+    for (const v of clean(screen.handoff?.stateVariables ?? [])) push(v, 'handoff');
+
+    for (const state of screen.states ?? []) {
+        const stateName = state.name?.trim();
+        if (!stateName) continue;
+        if (state.type === 'default') continue;
+        // A UI state usually maps to a status/flag rather than a data variable.
+        const varName = `${slugifyScreenName(stateName).replace(/-/g, '_')}_state`;
+        push(varName, 'screen_state', state.description?.trim() || state.trigger?.trim() || undefined);
+    }
+
+    if (out.length === 0 && isPrimary(screen)) {
+        push('viewStatus', 'derived', 'Loading / ready / error status for this screen (derived).');
+    }
+    return out;
+}
+
+// --- Events -------------------------------------------------------------------
+
+/** Derive the interaction events a screen needs. Prefers the generated handoff
+ * `events` (source 'handoff'); adds events derived from exit paths (source
+ * 'derived') and the flow user-actions referencing this screen (source 'flow'). */
+export function deriveHandoffEvents(
+    screen: ScreenItem,
+    flowUserActions: readonly string[] = [],
+): HandoffEvent[] {
+    const out: HandoffEvent[] = [];
+    const seen = new Set<string>();
+    const push = (event: HandoffEvent) => {
+        const key = event.name.toLowerCase();
+        if (!event.name || seen.has(key)) return;
+        seen.add(key);
+        out.push(event);
+    };
+
+    for (const e of screen.handoff?.events ?? []) {
+        const name = e.name?.trim();
+        if (!name) continue;
+        push({
+            name: name.startsWith('on') ? name : toEventName(name),
+            trigger: e.trigger?.trim() || undefined,
+            expectedOutcome: e.effect?.trim() || undefined,
+            source: 'handoff',
+        });
+    }
+
+    for (const exit of screen.exitPaths ?? []) {
+        const label = exit.label?.trim();
+        if (!label) continue;
+        push({
+            name: toEventName(label),
+            trigger: label,
+            expectedOutcome: exit.target?.trim() ? `Navigate to ${trimSentence(exit.target)}` : undefined,
+            source: 'derived',
+        });
+    }
+
+    for (const action of clean(flowUserActions)) {
+        // Flow user actions read like "User selects a role" — turn the verb
+        // phrase into a handler. Keep only the first few to avoid noise.
+        push({ name: toEventName(action), trigger: action, source: 'flow' });
+    }
+
+    return out.slice(0, 12);
+}
+
+// --- Data dependencies --------------------------------------------------------
+
+function classifyDataLabel(label: string): HandoffDataType {
+    const lower = label.toLowerCase();
+    if (/local ?storage|session ?storage|indexeddb|cache/.test(lower)) return 'storage';
+    if (/\bapi\b|endpoint|\/|https?:|graphql|rest/.test(lower)) return 'api';
+    if (/\bfield\b|column|attribute/.test(lower)) return 'field';
+    return 'entity';
+}
+
+/** Derive the data a screen reads/writes. Combines generated handoff
+ * data/api dependencies, the spec's outputData (writes), and entry inputs.
+ * When nothing can be found, returns [] — the caller surfaces the
+ * "No linked data model entities found" review warning. Everything is estimated
+ * (source labels say so); we never claim a real Data Model trace exists. */
+export function deriveHandoffDataDependencies(screen: ScreenItem): HandoffDataDependency[] {
+    const out: HandoffDataDependency[] = [];
+    const seen = new Set<string>();
+    const push = (dep: HandoffDataDependency) => {
+        const key = `${dep.label.toLowerCase()}|${dep.direction ?? ''}`;
+        if (!dep.label || seen.has(key)) return;
+        seen.add(key);
+        out.push(dep);
+    };
+
+    const h = screen.handoff;
+    for (const d of clean(h?.dataDependencies ?? [])) {
+        push({ label: d, type: classifyDataLabel(d), direction: 'read_write', source: 'handoff' });
+    }
+    for (const a of clean(h?.apiDependencies ?? [])) {
+        push({ label: a, type: 'api', direction: 'read_write', source: 'handoff' });
+    }
+    for (const o of clean(screen.outputData ?? [])) {
+        push({ label: o, type: classifyDataLabel(o), direction: 'write', source: 'screen_outputs' });
+    }
+    return out;
+}
+
+// --- Mockup references --------------------------------------------------------
+
+/** Project the derived variant grid into build-facing mockup references. Only
+ * variants that hold a real generated image (legacy / per-variant) or are
+ * user-accepted are listed as references; recommendedForBuild flags the default
+ * + generated variants a developer should look at first. */
+export function deriveHandoffMockupReferences(
+    variants: readonly DerivedMockupVariant[],
+): HandoffMockupReference[] {
+    const out: HandoffMockupReference[] = [];
+    for (const v of variants) {
+        const hasImage = v.source === 'legacy' || v.source === 'variant';
+        const accepted = v.status === 'accepted';
+        if (!hasImage && !accepted) continue;
+        out.push({
+            variantId: v.id,
+            label: formatVariantLabel(v),
+            viewport: v.viewport,
+            stateName: v.stateName,
+            freshness: v.freshness?.status,
+            coverage: v.coverageStatus,
+            recommendedForBuild: hasImage,
+        });
+    }
+    return out;
+}
+
+// --- QA checklist -------------------------------------------------------------
+
+export interface QaChecklistSignals {
+    acceptanceCriteria: readonly string[];
+    mobileMissing: boolean;
+    hasMockup: boolean;
+    /** Freshness concern on a generated mockup (stale / possibly / unknown). */
+    mockupFreshnessConcern: boolean;
+}
+
+/** Derive a practical QA checklist from the screen contract. Concise and
+ * grouped by category (rendering / interaction / state / data / accessibility /
+ * responsive / error handling / acceptance). Everything here is a restatement of
+ * a fact the spec already carries; nothing is invented. */
+export function deriveHandoffQaChecklist(
+    screen: ScreenItem,
+    signals: QaChecklistSignals,
+): HandoffQaItem[] {
+    const out: HandoffQaItem[] = [];
+    let n = 0;
+    const add = (
+        label: string, category: HandoffQaCategory, source: HandoffQaSource, required: boolean,
+    ) => {
+        out.push({ id: `qa-${n++}`, label, category, source, required });
+    };
+
+    // Rendering — always applicable.
+    add('Screen renders its primary layout without console errors.', 'rendering', 'derived', true);
+    const components = (screen.coreUIElements?.length ? screen.coreUIElements : screen.components) ?? [];
+    if (components.length > 0) {
+        add('Core UI regions are present and populated.', 'rendering', 'derived', true);
+    }
+
+    // Interaction — from the user intent + exits.
+    if (screen.userIntent?.trim()) {
+        add(`User can ${trimSentence(screen.userIntent).toLowerCase()}.`, 'interaction', 'derived', true);
+    }
+    for (const exit of screen.exitPaths ?? []) {
+        if (!exit.label?.trim() || !exit.target?.trim()) continue;
+        add(`"${trimSentence(exit.label)}" navigates to ${trimSentence(exit.target)}.`, 'interaction', 'derived', false);
+    }
+
+    // State + error handling — from documented states.
+    for (const state of screen.states ?? []) {
+        const stateName = state.name?.trim();
+        if (!stateName || state.type === 'default') continue;
+        const category: HandoffQaCategory = state.type === 'error' ? 'error_handling' : 'state';
+        const required = state.required === true;
+        add(`The "${trimSentence(stateName)}" state renders as specified.`, category, 'states', required);
+    }
+
+    // Data — from output data / risks touching data.
+    for (const out2 of clean(screen.outputData ?? [])) {
+        add(`${trimSentence(out2)} is persisted / read from the expected source.`, 'data', 'derived', false);
+    }
+
+    // Risks → error-handling checks.
+    const riskDescriptions = (screen.riskDetails && screen.riskDetails.length > 0)
+        ? screen.riskDetails.map(r => r.description)
+        : (screen.risks ?? []);
+    for (const risk of clean(riskDescriptions)) {
+        add(`Edge case handled: ${trimSentence(risk)}.`, 'error_handling', 'risks', false);
+    }
+
+    // Responsive / mockups.
+    if (signals.mobileMissing) {
+        add('Mobile layout remains usable (mobile mockup recommended).', 'responsive', 'mockups', false);
+    } else if (signals.hasMockup) {
+        add('Layout matches the generated mockup at desktop and mobile.', 'responsive', 'mockups', false);
+    }
+    if (signals.mockupFreshnessConcern) {
+        add('Confirm the mockup still matches the current screen spec before building.', 'rendering', 'mockups', false);
+    }
+
+    // Accessibility — from handoff notes, else a light default.
+    const a11y = clean(screen.handoff?.accessibilityNotes ?? []);
+    if (a11y.length > 0) {
+        for (const note of a11y) add(trimSentence(note) + '.', 'accessibility', 'derived', false);
+    } else {
+        add('Interactive elements are keyboard reachable and labeled.', 'accessibility', 'derived', false);
+    }
+
+    // Acceptance — the derived/generated criteria.
+    for (const c of signals.acceptanceCriteria) {
+        add(`Acceptance: ${trimSentence(c)}.`, 'acceptance', 'acceptance_criteria', true);
+    }
+
+    return out;
+}
+
+// --- Build tasks --------------------------------------------------------------
+
+export interface BuildTaskSignals {
+    route: HandoffRoute;
+    components: readonly HandoffComponent[];
+    state: readonly HandoffStateEntry[];
+    dataDependencies: readonly HandoffDataDependency[];
+    hasStateVariants: boolean;
+    hasMockup: boolean;
+    isP0: boolean;
+}
+
+/** Derive a small, hand-to-a-developer build-task list from the handoff pieces.
+ * Not a project manager — just the obvious steps, each with a `source` so the
+ * user understands why it exists. Priority: P0 / acceptance-critical → must;
+ * recommended states/mockup review → should; polish → could. */
+export function deriveHandoffBuildTasks(
+    screen: ScreenItem,
+    signals: BuildTaskSignals,
+): HandoffBuildTask[] {
+    const out: HandoffBuildTask[] = [];
+    let n = 0;
+    const add = (
+        title: string, description: string, category: HandoffTaskCategory,
+        priority: HandoffTaskPriority, source: string,
+    ) => {
+        out.push({ id: `task-${n++}`, title, description, category, priority, source });
+    };
+
+    const title = screen.name?.trim() || 'this screen';
+    const mustOrShould: HandoffTaskPriority = signals.isP0 ? 'must' : 'should';
+
+    // 1. Route / page shell.
+    add(
+        `Create the route and page shell for ${title}`,
+        signals.route.path
+            ? `Wire the ${signals.route.confidence === 'explicit' ? '' : 'derived '}route ${signals.route.path}.`
+            : 'Add the route and page shell.',
+        'route', mustOrShould,
+        signals.route.confidence === 'explicit' ? 'Generated handoff route' : 'Derived route',
+    );
+
+    // 2. Components.
+    if (signals.components.length > 0) {
+        const names = signals.components.slice(0, 4).map(c => c.name).join(', ');
+        add(
+            `Build the components for ${title}`,
+            `Implement ${names}${signals.components.length > 4 ? ', …' : ''}.`,
+            'component', mustOrShould, 'Screen UI regions / handoff components',
+        );
+    }
+
+    // 3. State.
+    if (signals.state.length > 0) {
+        add(
+            `Implement screen state for ${title}`,
+            `Wire ${signals.state.slice(0, 4).map(s => s.name).join(', ')}${signals.state.length > 4 ? ', …' : ''}.`,
+            'state', mustOrShould, 'Screen states / handoff state variables',
+        );
+    }
+
+    // 4. Data.
+    if (signals.dataDependencies.length > 0) {
+        add(
+            `Wire data dependencies for ${title}`,
+            `Read/write ${signals.dataDependencies.slice(0, 4).map(d => d.label).join(', ')}${signals.dataDependencies.length > 4 ? ', …' : ''}.`,
+            'data', 'should', 'Screen data dependencies',
+        );
+    }
+
+    // 5. States (empty / loading / error).
+    const nonDefaultStates = (screen.states ?? []).filter(s => s.name?.trim() && s.type !== 'default');
+    if (nonDefaultStates.length > 0) {
+        add(
+            `Add empty / loading / error states for ${title}`,
+            `Cover ${nonDefaultStates.slice(0, 4).map(s => s.name).join(', ')}${nonDefaultStates.length > 4 ? ', …' : ''}.`,
+            'state', 'should', 'Documented screen states',
+        );
+    }
+
+    // 6. Mockup review.
+    if (signals.hasMockup || signals.hasStateVariants) {
+        add(
+            `Verify desktop and mobile mockups for ${title}`,
+            'Check the implementation against the generated mockup variants.',
+            'mockup', 'should', 'Mockup variants',
+        );
+    }
+
+    // 7. Accessibility.
+    add(
+        `Confirm accessibility for ${title}`,
+        'Keyboard reachability, focus order, and labels for interactive elements.',
+        'accessibility', 'could', 'Accessibility review',
+    );
+
+    // 8. QA.
+    add(
+        `Add QA coverage for ${title}`,
+        'Cover the acceptance criteria and required states in tests.',
+        'qa', mustOrShould, 'Acceptance criteria',
+    );
+
+    return out;
+}
+
+// --- Readiness ----------------------------------------------------------------
+
+export interface HandoffReadinessSignals {
+    isP0: boolean;
+    isPrimary: boolean;
+    userStatus?: ScreenReviewStatus;
+    systemReadiness: SystemReadinessStatus;
+    blockingCount: number;
+    reviewCount: number;
+    reviewFreshness: ScreenReviewFreshnessStatus;
+    hasAcceptanceCriteria: boolean;
+    /** At least a route OR a component can be offered for this screen. */
+    hasRouteOrComponentGuidance: boolean;
+    /** Any generated mockup reads stale / possibly-stale / unknown. */
+    mockupFreshnessConcern: boolean;
+    /** A recommended Mobile default variant is missing. */
+    mobileMissing: boolean;
+    /** No data dependencies could be derived at all (missing trace). */
+    dataDependenciesMissing: boolean;
+    /** Developer handoff is thin (no route + no components + no events). */
+    handoffThin: boolean;
+    /** A blocking downstream implementation impact exists (Phase 4B). */
+    downstreamBlocking: boolean;
+}
+
+const signedOff = (status: ScreenReviewStatus | undefined): boolean =>
+    status === 'accepted' || status === 'implementation_ready';
+
+/**
+ * Derive the per-screen implementation-readiness verdict from the Phase 4A/4B
+ * signals plus the handoff completeness. Conservative and explainable — blocked
+ * only on the clear cases; review-recommended is the honest common state; ready
+ * requires sign-off + no blockers + minimal guidance.
+ */
+export function deriveHandoffReadiness(signals: HandoffReadinessSignals): ScreenImplementationReadinessDetail {
+    const reasons: string[] = [];
+    const blocked: string[] = [];
+
+    // --- Blocked ---
+    if (signals.systemReadiness === 'blocked' || signals.blockingCount > 0) {
+        blocked.push('This screen has unresolved blocking readiness issues.');
+    }
+    if (signals.isP0 && !signedOff(signals.userStatus)) {
+        blocked.push('This P0 screen has not been accepted yet.');
+    }
+    if (signals.isP0 && signedOff(signals.userStatus) && signals.reviewFreshness === 'outdated') {
+        blocked.push('This P0 screen changed after it was signed off — re-review before building.');
+    }
+    if (signals.isP0 && signals.downstreamBlocking) {
+        blocked.push('A blocking downstream implementation impact affects this P0 screen.');
+    }
+    if (!signals.hasAcceptanceCriteria) {
+        blocked.push('No acceptance criteria could be derived for this screen.');
+    }
+    if (signals.isPrimary && !signals.hasRouteOrComponentGuidance) {
+        blocked.push('No route or component guidance could be derived for this primary screen.');
+    }
+
+    if (blocked.length > 0) {
+        return {
+            status: 'blocked',
+            reasons: blocked,
+            blockingCount: blocked.length,
+            reviewCount: 0,
+        };
+    }
+
+    // --- Review recommended ---
+    if (signedOff(signals.userStatus) && signals.reviewCount > 0) {
+        reasons.push('Accepted, but Synapse still flags review items — confirm before building.');
+    }
+    if (!signedOff(signals.userStatus) && !signals.isP0) {
+        reasons.push('This supporting screen is not signed off yet.');
+    }
+    if (signals.mockupFreshnessConcern) {
+        reasons.push('One or more mockups may be out of date or unverified.');
+    }
+    if (signals.mobileMissing) {
+        reasons.push('A recommended mobile mockup is missing.');
+    }
+    if (signals.dataDependenciesMissing) {
+        reasons.push('No linked data model entities found — review data dependencies before implementation.');
+    }
+    if (signals.handoffThin) {
+        reasons.push('Developer handoff detail (route, components, events) is thin.');
+    }
+    if (signals.reviewFreshness === 'outdated') {
+        reasons.push('This screen changed after it was reviewed.');
+    }
+
+    if (reasons.length > 0) {
+        return {
+            status: 'review_recommended',
+            reasons,
+            blockingCount: 0,
+            reviewCount: reasons.length,
+        };
+    }
+
+    return { status: 'ready', reasons: [], blockingCount: 0, reviewCount: 0 };
+}
+
+// --- Composite builder --------------------------------------------------------
+
+export interface ScreenHandoffInput {
+    item: ScreenExperienceItem;
+    reviewModel: ScreenReviewModel;
+    variants: readonly DerivedMockupVariant[];
+    downstream?: ScreenDownstreamImpact;
+    features?: readonly Feature[];
+}
+
+/** Build the full implementation handoff for one joined screen. Derives every
+ * section from the existing layers (screen contract, review model, variant grid,
+ * downstream impact) — pure, read-time, never persisted. */
+export function buildScreenImplementationHandoff(input: ScreenHandoffInput): ScreenImplementationHandoff {
+    const { item, reviewModel, variants, downstream, features } = input;
+    const screen = item.screen;
+
+    const flowUserActions = item.relatedFlows
+        .map(ref => ref.step.userAction)
+        .filter((a): a is string => Boolean(a?.trim()));
+
+    const route = deriveHandoffRoute(screen);
+    const components = deriveHandoffComponents(screen, item.mockupScreen?.coreUIElements);
+    const state = deriveHandoffState(screen);
+    const events = deriveHandoffEvents(screen, flowUserActions);
+    const dataDependencies = deriveHandoffDataDependencies(screen);
+    const mockupReferences = deriveHandoffMockupReferences(variants);
+    const { criteria: acceptanceCriteria } = resolveAcceptanceCriteria(screen);
+
+    const mobileMissing = variants.some(
+        v => v.viewport === 'mobile' && v.stateType === 'default' && v.status === 'missing',
+    );
+    const hasMockup = variants.some(v => v.source === 'legacy' || v.source === 'variant');
+    const mockupFreshnessConcern = variants.some(
+        v => v.freshness && (v.freshness.status === 'stale' || v.freshness.status === 'possibly_stale'
+            || v.freshness.status === 'unknown'),
+    );
+    const hasStateVariants = variants.some(v => v.stateType !== 'default');
+
+    const qaChecklist = deriveHandoffQaChecklist(screen, {
+        acceptanceCriteria,
+        mobileMissing,
+        hasMockup,
+        mockupFreshnessConcern,
+    });
+
+    const buildTasks = deriveHandoffBuildTasks(screen, {
+        route,
+        components,
+        state,
+        dataDependencies,
+        hasStateVariants,
+        hasMockup,
+        isP0: isP0(screen),
+    });
+
+    // Trace — reuse the existing traceability resolver so ids/confidence match
+    // the Overview tab.
+    const traceability = buildScreenTraceability(item, features);
+    const traceFeatures = traceability.features
+        .map(l => l.feature ? `${l.feature.id} ${l.feature.name}` : l.raw)
+        .filter(Boolean);
+    const traceWarnings: string[] = [];
+    if (traceability.confidence === 'missing') {
+        traceWarnings.push('No PRD features are linked to this screen.');
+    } else if (traceability.invalidRefIds.length > 0) {
+        traceWarnings.push(`Some linked feature ids no longer match the PRD: ${traceability.invalidRefIds.join(', ')}.`);
+    }
+    if (dataDependencies.length === 0) {
+        traceWarnings.push('No linked data model entities found. Review recommended before implementation.');
+    }
+
+    const downstreamBlocking = downstream?.summary.hasBlockingImpact ?? false;
+    const handoffThin = !route.path && components.length === 0 && events.length === 0;
+
+    const readiness = deriveHandoffReadiness({
+        isP0: isP0(screen),
+        isPrimary: isPrimary(screen),
+        userStatus: reviewModel.userStatus,
+        systemReadiness: reviewModel.systemReadiness,
+        blockingCount: reviewModel.blockingCount,
+        reviewCount: reviewModel.reviewCount,
+        reviewFreshness: reviewModel.freshness,
+        hasAcceptanceCriteria: acceptanceCriteria.length > 0,
+        hasRouteOrComponentGuidance: Boolean(route.path) || components.length > 0,
+        mockupFreshnessConcern,
+        mobileMissing,
+        dataDependenciesMissing: dataDependencies.length === 0,
+        handoffThin,
+        downstreamBlocking,
+    });
+
+    return {
+        screenId: item.id,
+        screenTitle: screen.name || item.id,
+        priority: displayPriority(screen),
+        readiness,
+        route,
+        components,
+        state,
+        events,
+        dataDependencies,
+        mockupReferences,
+        acceptanceCriteria,
+        qaChecklist,
+        buildTasks,
+        trace: {
+            prdFeatures: traceFeatures,
+            userFlows: traceability.flows,
+            relatedArtifacts: mockupReferences.length > 0 ? ['mockups'] : [],
+            estimated: true,
+            warnings: traceWarnings,
+        },
+    };
+}
+
+// --- Artifact-level rollup ----------------------------------------------------
+
+export interface ScreensHandoffRollup {
+    total: number;
+    ready: number;
+    reviewRecommended: number;
+    blocked: number;
+    /** P0 screens whose handoff is ready. */
+    p0Ready: number;
+    p0Total: number;
+    /** Overall verdict: ready only when every P0 screen's handoff is ready. */
+    status: ScreenImplementationReadiness;
+    message: string;
+}
+
+export function buildScreensHandoffRollup(
+    handoffs: readonly ScreenImplementationHandoff[],
+    p0Ids: ReadonlySet<string>,
+): ScreensHandoffRollup {
+    let ready = 0;
+    let reviewRecommended = 0;
+    let blocked = 0;
+    let p0Ready = 0;
+    let p0Total = 0;
+    let p0Blocked = 0;
+
+    for (const h of handoffs) {
+        if (h.readiness.status === 'ready') ready += 1;
+        else if (h.readiness.status === 'review_recommended') reviewRecommended += 1;
+        else blocked += 1;
+        if (p0Ids.has(h.screenId)) {
+            p0Total += 1;
+            if (h.readiness.status === 'ready') p0Ready += 1;
+            if (h.readiness.status === 'blocked') p0Blocked += 1;
+        }
+    }
+
+    let status: ScreenImplementationReadiness;
+    if (p0Blocked > 0 || (p0Total > 0 && p0Ready < p0Total && blocked > 0)) status = 'blocked';
+    else if (p0Total > 0 && p0Ready === p0Total && reviewRecommended === 0 && blocked === 0) status = 'ready';
+    else status = 'review_recommended';
+
+    let message: string;
+    if (handoffs.length === 0) message = 'No screens to hand off yet.';
+    else if (status === 'ready') {
+        message = 'All P0 screens have accepted specs and build-ready handoff packages.';
+    } else if (status === 'blocked') {
+        message = 'Resolve P0 blockers before using these screens as build source.';
+    } else {
+        message = 'Some screens need review before their handoff packages are build-ready.';
+    }
+
+    return {
+        total: handoffs.length,
+        ready,
+        reviewRecommended,
+        blocked,
+        p0Ready,
+        p0Total,
+        status,
+        message,
+    };
+}
+
+// --- Preflight contribution ---------------------------------------------------
+
+/** Handoff-derived additions to the Phase 4B implementation preflight. Kept in
+ * this module (not screenDownstreamImpact) so the downstream layer never depends
+ * on the handoff layer — the caller passes this into buildScreensPreflight. */
+export interface HandoffPreflightContribution {
+    blocking: string[];
+    review: string[];
+    info: string[];
+    recommendedNextActions: string[];
+}
+
+export function buildHandoffPreflightContribution(
+    handoffs: readonly ScreenImplementationHandoff[],
+    p0Ids: ReadonlySet<string>,
+): HandoffPreflightContribution {
+    const blocking: string[] = [];
+    const review: string[] = [];
+    const info: string[] = [];
+    const recommendedNextActions: string[] = [];
+
+    for (const h of handoffs) {
+        const isScreenP0 = p0Ids.has(h.screenId);
+        if (h.readiness.status === 'blocked') {
+            const reason = h.readiness.reasons[0] ?? 'handoff is blocked';
+            blocking.push(`${h.screenTitle} handoff is blocked: ${reason.toLowerCase()}`);
+        } else if (h.readiness.status === 'review_recommended' && isScreenP0) {
+            const reason = h.readiness.reasons[0];
+            if (reason) review.push(`${h.screenTitle}: ${reason.toLowerCase()}`);
+        }
+        if (h.route.confidence !== 'explicit' && isScreenP0) {
+            info.push(`${h.screenTitle} uses a derived route — confirm before building.`);
+        }
+    }
+
+    // Prioritized next steps (capped to 5, deduped).
+    const push = (a: string) => { if (a && !recommendedNextActions.includes(a)) recommendedNextActions.push(a); };
+    for (const h of handoffs) {
+        if (p0Ids.has(h.screenId) && h.readiness.status === 'blocked') {
+            push(`Resolve the handoff blockers on ${h.screenTitle}.`);
+        }
+    }
+    for (const h of handoffs) {
+        if (p0Ids.has(h.screenId) && h.readiness.status === 'review_recommended') {
+            push(`Review the handoff for ${h.screenTitle} before building.`);
+        }
+    }
+    if (handoffs.some(h => p0Ids.has(h.screenId)) && blocking.length === 0) {
+        push('Copy the handoff for each P0 screen once its package is ready.');
+    }
+
+    return {
+        blocking: blocking.slice(0, 6),
+        review: review.slice(0, 6),
+        info: info.slice(0, 4),
+        recommendedNextActions: recommendedNextActions.slice(0, 5),
+    };
+}
+
+// --- Markdown export ----------------------------------------------------------
+
+const DATA_DIRECTION_LABELS: Record<HandoffDataDirection, string> = {
+    read: 'read',
+    write: 'write',
+    read_write: 'read/write',
+};
+
+/** Render a copy-ready markdown handoff package for one screen. Covers the main
+ * implementation sections; missing/estimated data is labeled, never fabricated. */
+export function renderHandoffMarkdown(handoff: ScreenImplementationHandoff): string {
+    const lines: string[] = [];
+    const priority = handoff.priority ? ` (${handoff.priority})` : '';
+    lines.push(`# ${handoff.screenTitle}${priority} — Implementation Handoff`);
+    lines.push('');
+    lines.push(`Status: ${IMPLEMENTATION_READINESS_LABELS[handoff.readiness.status]}`);
+    if (handoff.readiness.reasons.length > 0) {
+        for (const r of handoff.readiness.reasons) lines.push(`- ${r}`);
+    }
+    lines.push('');
+
+    // Route
+    lines.push('## Route');
+    if (handoff.route.path) {
+        const suffix = handoff.route.confidence === 'explicit'
+            ? ''
+            : ` — ${handoff.route.confidence} from screen (confirm before building)`;
+        lines.push(`- \`${handoff.route.path}\`${suffix}`);
+    } else {
+        lines.push('- Not specified');
+    }
+    for (const note of handoff.route.notes) lines.push(`  - ${note}`);
+    lines.push('');
+
+    // Components
+    lines.push('## Components');
+    if (handoff.components.length > 0) {
+        for (const c of handoff.components) lines.push(`- ${c.name}${c.required ? '' : ' (optional)'}`);
+    } else {
+        lines.push('- Not specified');
+    }
+    lines.push('');
+
+    // State
+    lines.push('## State');
+    if (handoff.state.length > 0) {
+        for (const s of handoff.state) lines.push(`- ${s.name}${s.purpose ? ` — ${s.purpose}` : ''}`);
+    } else {
+        lines.push('- Not specified');
+    }
+    lines.push('');
+
+    // Events
+    lines.push('## Events');
+    if (handoff.events.length > 0) {
+        for (const e of handoff.events) {
+            const detail = [e.trigger, e.expectedOutcome].filter(Boolean).join(' → ');
+            lines.push(`- ${e.name}${detail ? ` (${detail})` : ''}`);
+        }
+    } else {
+        lines.push('- Not specified');
+    }
+    lines.push('');
+
+    // Data dependencies
+    lines.push('## Data Dependencies');
+    if (handoff.dataDependencies.length > 0) {
+        for (const d of handoff.dataDependencies) {
+            const dir = d.direction ? ` — ${DATA_DIRECTION_LABELS[d.direction]}` : '';
+            lines.push(`- ${d.label}${dir}`);
+        }
+    } else {
+        lines.push('- No linked data model entities found. Review recommended before implementation.');
+    }
+    lines.push('');
+
+    // Mockups
+    lines.push('## Mockups to Reference');
+    if (handoff.mockupReferences.length > 0) {
+        for (const m of handoff.mockupReferences) {
+            const bits: string[] = [];
+            if (m.freshness) bits.push(`freshness: ${m.freshness}`);
+            if (m.coverage) bits.push(`coverage: ${m.coverage}`);
+            lines.push(`- ${m.label}${bits.length ? ` (${bits.join(', ')})` : ''}`);
+        }
+    } else {
+        lines.push('- No generated mockups to reference yet.');
+    }
+    lines.push('');
+
+    // Acceptance criteria
+    lines.push('## Acceptance Criteria');
+    if (handoff.acceptanceCriteria.length > 0) {
+        for (const c of handoff.acceptanceCriteria) lines.push(`- ${c}`);
+    } else {
+        lines.push('- Not specified');
+    }
+    lines.push('');
+
+    // QA checklist
+    lines.push('## QA Checklist');
+    if (handoff.qaChecklist.length > 0) {
+        for (const q of handoff.qaChecklist) lines.push(`- ${q.label}`);
+    } else {
+        lines.push('- Not specified');
+    }
+    lines.push('');
+
+    // Build tasks
+    lines.push('## Build Tasks');
+    if (handoff.buildTasks.length > 0) {
+        handoff.buildTasks.forEach((t, i) => {
+            lines.push(`${i + 1}. ${t.title} — ${t.description}`);
+        });
+    } else {
+        lines.push('- Not specified');
+    }
+    lines.push('');
+
+    // Trace
+    lines.push('## Trace / Confidence');
+    lines.push(`- PRD features: ${handoff.trace.prdFeatures.length > 0 ? handoff.trace.prdFeatures.join(', ') : 'none linked'}`);
+    lines.push(`- User flows: ${handoff.trace.userFlows.length > 0 ? handoff.trace.userFlows.join(', ') : 'none'}`);
+    for (const w of handoff.trace.warnings) lines.push(`- ${w}`);
+    lines.push('- All fields are estimated from the generated spec — confirm before building.');
+
+    return lines.join('\n');
+}

--- a/src/lib/screenReadiness.ts
+++ b/src/lib/screenReadiness.ts
@@ -925,6 +925,8 @@ export type ScreenListFilter =
     | 'review_recommended'
     | 'outdated_review'
     | 'downstream_review'
+    | 'handoff_ready'
+    | 'handoff_blocked'
     | 'missing_mockups'
     | 'has_risks';
 
@@ -941,6 +943,9 @@ export const SCREEN_LIST_FILTERS: Array<{ id: ScreenListFilter; label: string }>
     // existing review filters so the review-focused controls stay together.
     { id: 'outdated_review', label: 'Outdated review' },
     { id: 'downstream_review', label: 'Downstream review' },
+    // Phase 5A: implementation-handoff readiness filters.
+    { id: 'handoff_ready', label: 'Handoff ready' },
+    { id: 'handoff_blocked', label: 'Handoff blocked' },
     { id: 'missing_mockups', label: 'Missing mockups' },
     { id: 'has_risks', label: 'Has risks' },
 ];
@@ -957,6 +962,8 @@ export interface ScreenFilterReview {
     reviewFreshness?: 'current' | 'outdated' | 'unknown';
     /** Phase 4B: true when this screen has a blocking/review downstream impact. */
     downstreamReviewNeeded?: boolean;
+    /** Phase 5A: implementation-handoff readiness for this screen. */
+    handoffReadiness?: 'ready' | 'review_recommended' | 'blocked';
 }
 
 export function screenMatchesFilter(
@@ -991,6 +998,10 @@ export function screenMatchesFilter(
             return review?.reviewFreshness === 'outdated';
         case 'downstream_review':
             return review?.downstreamReviewNeeded === true;
+        case 'handoff_ready':
+            return review?.handoffReadiness === 'ready';
+        case 'handoff_blocked':
+            return review?.handoffReadiness === 'blocked';
         case 'missing_mockups':
             return !item.mockupScreen;
         case 'has_risks':


### PR DESCRIPTION
## Summary

Phase 5A turns each accepted screen into a **developer-ready build contract**, layered on top of the Phase 4A review workflow and Phase 4B downstream/preflight layers (never changing them). It answers, per screen: what route/components/state/events/data are needed, which mockups to reference, what acceptance criteria and QA checks must pass, which build tasks fall out, and whether the screen is ready to hand off.

Everything is **derived, read-time, and never persisted** — no schema, prompt, pipeline, sync, or snapshot changes; no downstream artifact is mutated; legacy/sparse screens degrade to "Not specified" / review warnings and never crash.

## Implementation handoff model (`src/lib/screenImplementationHandoff.ts`, pure)

`buildScreenImplementationHandoff({ item, reviewModel, variants, downstream?, features? })` → `ScreenImplementationHandoff`:

- **Route** — explicit generated `handoff.route` → small keyword map (Landing → `/`, Settings → `/settings`) → slugified title; tagged `explicit` / `derived` / `missing`.
- **Components / State / Events** — prefer the generated handoff contract, fall back to core UI regions / documented states / exit paths + flow user actions. PascalCased components, `on…`-named handlers.
- **Data dependencies** — handoff data/api deps + `outputData`, keyword-classified (entity / api / storage / …). When none exist, a **"No linked data model entities found"** review warning — there is no real Data Model trace, so everything is labeled estimated, never "verified".
- **Mockup references** — variants holding a real image / accepted, with Phase 3C freshness + coverage.
- **Acceptance criteria** — reuses `resolveAcceptanceCriteria`.
- **QA checklist** — categorized (rendering / interaction / state / data / accessibility / responsive / error handling / acceptance), restated from the spec.
- **Build tasks** — small route/component/state/data/mockup/qa/accessibility list, each with a `priority` (`must`/`should`/`could`) and a `source` explaining why it exists.
- **Trace** — PRD features + flows (via `buildScreenTraceability`), warnings, `estimated: true`.

## Readiness logic (`deriveHandoffReadiness`)

`ready` | `review_recommended` | `blocked`:
- **Blocked** only on clear cases: system-readiness blockers, unsigned/outdated/downstream-blocking P0, no acceptance criteria, or no route/component guidance on a primary screen.
- **Review recommended** (the honest common state): accepted-with-review-items, stale/unknown mockups, missing mobile, missing data trace, thin handoff.
- **Ready** requires sign-off + no blockers + minimal guidance.

`buildScreensHandoffRollup` rolls ready/review/blocked up **gated on P0**.

## Copy-to-markdown

`renderHandoffMarkdown` produces a copy-ready package covering Route / Components / State / Events / Data / Acceptance / QA / Build Tasks / Trace. The Handoff tab's **Copy handoff** action uses the shared `copyToClipboard` (Clipboard API → hidden-textarea fallback); if the clipboard is unavailable it reveals the markdown in a read-only textarea.

## UI integration

- **Screen Detail Handoff tab** (`ScreenHandoffView`, `ScreenDetailTab` gains `handoff`, URL-addressable via `?screenTab=handoff`) with a readiness-colored tab dot and compact card sections.
- **Handoff readiness chip** on `ScreenListView` cards.
- **Handoff ready / Handoff blocked** list filters (`SCREEN_LIST_FILTERS` + `ScreenFilterReview.handoffReadiness`).
- **Implementation handoff rollup** section in `ScreenCoveragePanel`.
- **Preflight integration** — handoff issues fold into the Phase 4B implementation preflight via a structural `PreflightContribution` param on `buildScreensPreflight` / `analyzeScreensDownstream` (screenDownstreamImpact **never imports** the handoff module — that would cycle; the caller passes the contribution in). A handoff blocker pushes the preflight to `not_ready`.

## Implementation Plan bridge — intentionally skipped

Deliberately deferred to Phase 5B. Phase 5A does not mutate or couple the Implementation Plan artifact; the local Handoff tab + copy action is the decision surface, mirroring the Phase 4B rationale.

## Backward compatibility

No persisted state added; no schema/prompt/pipeline change. Legacy screens (no handoff contract, no review data) still render — every field shows "Not specified" or a calm review warning, never a crash or a fabricated value. All PRD features remain optional inputs.

## Tests

- `src/lib/__tests__/screenImplementationHandoff.test.ts` — 23 pure tests (route/component/state/event/data derivation, QA checklist, build tasks, readiness blocked/review/ready, rollup, markdown export, legacy safety, preflight contribution).
- `src/components/__tests__/ScreenExperienceViews.test.tsx` — 6 new component tests (Handoff tab renders, blocked/accepted states, copy→markdown, card chip, coverage rollup, preflight includes handoff issues).
- Full suite: **1364 tests pass**; `npm run build` and `npm run lint` both clean.

## Known limitations / Phase 5B follow-up

- Data dependencies and route/component guidance are **estimated** from the screen spec — there is no trace-backed Data Model / Implementation Plan correlation yet.
- No read-only Implementation Plan bridge (deferred).
- No Screens-specific export/finalization hook (consistent with Phase 4B) — the Handoff tab + copy is the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RF1rd3BUnZq3ZZwSfoNZeq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF1rd3BUnZq3ZZwSfoNZeq)_