### PR TITLE
Fix user-flows ↔ screens naming disconnect from spine seed ids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1502,6 +1502,21 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   match by `sourceScreenId` first, then slugified `MockupScreen.name` (legacy
   fallback). Flow steps are markdown and only know names, so they match by
   exact slug of the parsed `[Screen Name]` step title (`stepScreenSlug`).
+  **`stepScreenSlug` canonicalizes the `scr-` screen-seed prefix**
+  (`stripScreenSeedPrefix` in `journeyNode.ts`) so a step whose bracket carries
+  the canonical spine seed id (`[scr-infographic-library]` — a form the
+  user_flows model sometimes emits instead of the human name, since the spine
+  prompt tells it to "reuse screen seed ids") still joins to the
+  `infographic-library` screen at read time (fixing already-final artifacts
+  without regeneration). Because it is the single shared key for the
+  flow→screen join, journey grouping, AND flow-node navigation, normalizing it
+  there keeps all three consistent. The display mirrors this:
+  `prettyScreenTitle` (also `journeyNode.ts`) renders a seed-id step title as
+  its human name ("Infographic Library") in the flow renderer. The user_flows
+  prompt was also tightened to write the human display name in the bracket, so
+  new generations avoid the drift at the source. Only the `scr-` prefix (with a
+  `-`/`_` separator) is stripped, so a real name like "Scribble Pad" is never
+  touched.
   Screen selection/navigation uses the **id**; per-screen images stay keyed by
   the slug of the *stored* (generated) name, so both survive display renames.
   Missing artifacts degrade gracefully; a missing inventory returns the

--- a/src/components/renderers/userFlows/StepCard.tsx
+++ b/src/components/renderers/userFlows/StepCard.tsx
@@ -5,9 +5,10 @@ import type { FeatureRef, FlowIssue, ParsedStep } from './types';
 import { ISSUE_KIND_META } from './issueMeta';
 import { inlineWithFeatures } from './inlineWithFeatures';
 import { inlineMd } from './markdown';
+import { prettyScreenTitle } from './journeyNode';
 
-/** Strip surrounding markdown code backticks from a short label (e.g. a
- * screen name like `` `Import Dashboard` `` → "Import Dashboard"). */
+/** Strip surrounding markdown code backticks from a short label (e.g. an API
+ * ref like `` `POST /v1/import` `` → "POST /v1/import"). */
 function stripBackticks(text: string): string {
     return text.replace(/^`+|`+$/g, '').trim();
 }
@@ -60,7 +61,7 @@ export function StepCard({
                 {hasStructured ? (
                     step.title ? (
                         <h4 className="min-w-0 flex-1 text-sm font-semibold text-neutral-900 leading-snug">
-                            {inlineMd(stripBackticks(step.title))}
+                            {inlineMd(prettyScreenTitle(step.title))}
                         </h4>
                     ) : (
                         <h4 className="min-w-0 flex-1 text-sm font-semibold text-neutral-400 leading-snug">

--- a/src/components/renderers/userFlows/journeyNode.ts
+++ b/src/components/renderers/userFlows/journeyNode.ts
@@ -1,5 +1,45 @@
 import type { FlowJourneyNode, FlowJourneyNodeKind, ParsedStep } from './types';
 
+/**
+ * The canonical PRD spine stamps every screen with a deterministic seed id of
+ * the form `scr-<slug>` (see src/lib/canonicalPrdSpine.ts). The model that
+ * writes the user_flows artifact sometimes echoes that seed id into a step's
+ * `[Screen Name]` bracket instead of the human-readable name — e.g. it writes
+ * `[scr-infographic-library]` for the screen named "Infographic Library". Left
+ * as-is this detaches the step from its screen: the join key slugs to
+ * `scr-infographic-library` while the screen's slug is `infographic-library`,
+ * so the Screens view warns "No user flow references this screen" and the flow
+ * renders the raw id. These helpers canonicalize that reference so existing
+ * (already-final) artifacts join and read correctly at render time. Only the
+ * `scr-` screen-seed prefix is handled — `ent-`/other prefixes are unrelated
+ * to screen references, and the `scr-` requires a `-`/`_` separator so a real
+ * name like "Scribble Pad" (slug `scribble-pad`) is never touched. */
+const SCREEN_SEED_PREFIX_RE = /^scr[-_]/i;
+const SCREEN_SEED_ID_RE = /^scr[-_][a-z0-9]+(?:[-_][a-z0-9]+)*$/i;
+
+/** True when a flow-step title is a bare screen seed id (`scr-…`) the model
+ * echoed instead of a real screen name. */
+export function looksLikeScreenSeedId(title: string): boolean {
+    return SCREEN_SEED_ID_RE.test(title.trim());
+}
+
+/** Strip the `scr-`/`scr_` screen-seed prefix from an already-slugified value
+ * so a `scr-infographic-library` step reference matches the `infographic-library`
+ * screen slug. A non-seed slug is returned unchanged. */
+export function stripScreenSeedPrefix(slug: string): string {
+    return slug.replace(SCREEN_SEED_PREFIX_RE, '') || slug;
+}
+
+/** Human label for a flow-step screen title: a seed id like
+ * `scr-infographic-library` becomes "Infographic Library"; a real name is
+ * returned unchanged (only surrounding backticks trimmed). */
+export function prettyScreenTitle(title: string): string {
+    const trimmed = title.replace(/^`+|`+$/g, '').trim();
+    if (!looksLikeScreenSeedId(trimmed)) return trimmed;
+    const words = trimmed.replace(SCREEN_SEED_PREFIX_RE, '').replace(/[-_]+/g, ' ').trim();
+    return words ? words.replace(/\b\w/g, c => c.toUpperCase()) : trimmed;
+}
+
 const STATE_HINTS = /\b(state|loading|importing|saving|syncing|fetching|processing|computing|pending|in[-\s]?progress|generating)\b/i;
 const ACTION_HINTS = /\b(save|submit|click|tap|send|post|create|delete|remove|export|import|share|invite|publish|copy|paste|drag|drop|upload|download|trigger|run)\b/i;
 const SCREEN_HINTS = /\b(screen|page|view|dashboard|panel|modal|drawer|sheet|inbox|library|settings|home|landing|profile)\b/i;
@@ -110,7 +150,7 @@ export function buildJourneyGroups(
         } else {
             groups.push({
                 screenSlug: key,
-                screenLabel: (step.title?.trim() || node.label).replace(BACKTICKS, '').trim(),
+                screenLabel: prettyScreenTitle(step.title?.trim() || node.label),
                 nodes: [node],
                 firstStepIndex: step.index,
                 lastStepIndex: step.index,

--- a/src/lib/__tests__/__snapshots__/promptSurfaces.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/promptSurfaces.test.ts.snap
@@ -265,6 +265,8 @@ For each flow, use this exact format:
 
 You may also include any of these optional sections when relevant, using the same bold-label format: **Entry Points:** (where the flow can be started from), **Assumptions:**, and **Open Questions:**. Keep step lines in the exact "[Screen Name] — User action → System response" form so each step parses into screen, action, and response.
 
+In the "[Screen Name]" bracket, always write the screen's human-readable display name exactly as it appears in the screen inventory / PRD (e.g. "[Infographic Library]"). Never put a screen seed id or slug there (e.g. NOT "[scr-infographic-library]") — the flow steps are joined to screens by that display name, so a seed id detaches the step from its screen.
+
 Cover at minimum: first-time user onboarding, the core value workflow, and one administrative/settings flow.
 
 Begin your response directly with the first section heading. Do NOT include any preamble, introduction, or conversational text (e.g. "Of course", "Here are", "As a UX expert")."

--- a/src/lib/__tests__/screenExperience.test.ts
+++ b/src/lib/__tests__/screenExperience.test.ts
@@ -93,6 +93,20 @@ describe('stepScreenSlug', () => {
         // false-match a screen literally slugged "screen".
         expect(stepScreenSlug({ title: '``' })).toBeNull();
     });
+
+    it('normalizes a canonical spine screen seed id to the screen slug', () => {
+        // The user_flows model sometimes echoes the `scr-<slug>` seed id from
+        // the canonical PRD spine instead of the human name; it must still
+        // resolve to the same screen slug as the plain name.
+        expect(stepScreenSlug({ title: 'scr-infographic-library' })).toBe('infographic-library');
+        expect(stepScreenSlug({ title: '`scr-side-by-side-editor`' })).toBe('side-by-side-editor');
+        expect(stepScreenSlug({ title: 'Infographic Library' })).toBe('infographic-library');
+    });
+
+    it('does not strip a real name that merely starts with "scr"', () => {
+        // No `-`/`_` separator after `scr`, so this is a genuine name, not a seed id.
+        expect(stepScreenSlug({ title: 'Scribble Pad' })).toBe('scribble-pad');
+    });
 });
 
 describe('buildScreenIndex', () => {
@@ -127,6 +141,25 @@ describe('buildScreenIndex', () => {
             'landing-page', 'sign-in', 'sign-in-confirmation',
         ]);
         expect(index.sections[0].flowSummary).toBe('Landing Page → Sign In → Dashboard');
+    });
+
+    it('joins a flow step that references a screen by its spine seed id', () => {
+        // A flow whose steps carry the `scr-<slug>` seed id (the drift this
+        // fix targets) must still attach to its screen and NOT surface an
+        // "unmatched flow step" reference warning.
+        const seedIdFlow = `### Flow: Onboarding
+**Goal:** Land on the dashboard.
+**Preconditions:** None.
+**Steps:**
+1. [scr-landing-page] — User taps Get started → System routes to sign-in
+2. [scr-dashboard] — User lands → System loads workspace
+**Success Outcome:** Dashboard reached.`;
+        const flows = parseFlows(seedIdFlow);
+        const index = buildScreenIndex(INVENTORY, flows, null);
+
+        expect(index.bySlug.get('landing-page')?.relatedFlows).toHaveLength(1);
+        expect(index.bySlug.get('dashboard')?.relatedFlows).toHaveLength(1);
+        expect(index.issues.filter(i => i.kind === 'unmatched_flow_step')).toEqual([]);
     });
 
     it('does not cross-match screens with similar names', () => {

--- a/src/lib/screenExperience.ts
+++ b/src/lib/screenExperience.ts
@@ -30,7 +30,7 @@ import type {
     ParsedFlow,
     ParsedStep,
 } from '../components/renderers/userFlows/types';
-import { inferNodeKind } from '../components/renderers/userFlows/journeyNode';
+import { inferNodeKind, stripScreenSeedPrefix } from '../components/renderers/userFlows/journeyNode';
 
 /**
  * User edit overlay for one screen, keyed by the canonical screen id and
@@ -391,11 +391,18 @@ const stripBackticks = (text: string): string => text.replace(/^`+|`+$/g, '').tr
  * no usable title. Guarding the empty title matters because
  * `slugifyScreenName('')` falls back to the literal `'screen'`, which could
  * otherwise false-match a real screen that slugs to the same value.
+ *
+ * The `scr-` screen-seed prefix is stripped (`stripScreenSeedPrefix`) so a step
+ * whose bracket carries the canonical spine seed id (`[scr-infographic-library]`
+ * — a form the user_flows model sometimes emits instead of the human name)
+ * still joins to the `infographic-library` screen. Because this is the single
+ * shared key for the flow→screen join, journey grouping, AND flow-node
+ * navigation, normalizing it here keeps all three consistent.
  */
 export function stepScreenSlug(step: Pick<ParsedStep, 'title'>): string | null {
     const title = step.title ? stripBackticks(step.title) : '';
     if (!title) return null;
-    return slugifyScreenName(title);
+    return stripScreenSeedPrefix(slugifyScreenName(title));
 }
 
 /**

--- a/src/lib/services/coreArtifactService.ts
+++ b/src/lib/services/coreArtifactService.ts
@@ -99,6 +99,8 @@ For each flow, use this exact format:
 
 You may also include any of these optional sections when relevant, using the same bold-label format: **Entry Points:** (where the flow can be started from), **Assumptions:**, and **Open Questions:**. Keep step lines in the exact "[Screen Name] — User action → System response" form so each step parses into screen, action, and response.
 
+In the "[Screen Name]" bracket, always write the screen's human-readable display name exactly as it appears in the screen inventory / PRD (e.g. "[Infographic Library]"). Never put a screen seed id or slug there (e.g. NOT "[scr-infographic-library]") — the flow steps are joined to screens by that display name, so a seed id detaches the step from its screen.
+
 Cover at minimum: first-time user onboarding, the core value workflow, and one administrative/settings flow.
 
 ${ANTI_PREAMBLE_RULE}`,


### PR DESCRIPTION
## Problem

The User Flows artifact referenced screens with slug-like names such as `scr-infographic-library`, while the Screens view showed "**No user flow currently references this screen**" and reference warnings like "**Unknown screen reference: Infographic Library**".

**Root cause:** the canonical PRD spine (`canonicalPrdSpine.ts`) instructs the model to "reuse screen seed ids" — the deterministic `scr-<slug>` ids it stamps on each screen. The user_flows model sometimes echoes that seed id into a step's `[Screen Name]` bracket (`[scr-infographic-library]`) instead of the human name. The join layer then slugged that to `scr-infographic-library`, which never matched the actual screen slug `infographic-library`, so:

- flow steps didn't attach to their screens (Screens Overview reported no referencing flow),
- those steps surfaced as "Unknown screen reference" warnings, and
- User Flows rendered the raw `scr-…` id instead of the screen name.

## Fix

Layered so **existing already-final artifacts heal at read time, without regeneration**:

1. **Join normalization** — `stepScreenSlug` canonicalizes the `scr-` seed prefix via the new `stripScreenSeedPrefix` (`journeyNode.ts`). This is the single shared key for the flow→screen join, journey grouping, and flow-node navigation, so all three stay consistent. Only `scr-` with a `-`/`_` separator is stripped, so a genuine name like "Scribble Pad" is never touched.
2. **Display** — `prettyScreenTitle` (`journeyNode.ts`) renders a seed-id step title as its human name ("Infographic Library") in both the Flow Journey group headers and the step cards.
3. **Prevent recurrence** — the user_flows prompt now requires the human display name in the `[Screen Name]` bracket (and explicitly forbids a `scr-…` id), so new generations avoid the drift at the source. This also keeps the raw exported/handoff markdown clean. Snapshot updated.

## Tests

- New regression tests in `screenExperience.test.ts`: a `scr-`-prefixed flow step now joins to its screen and produces no `unmatched_flow_step` issue; `stepScreenSlug` normalizes seed ids while leaving real "scr…" names alone.
- Full suite green (1429 passed); `npm run build` and `npm run lint` pass.

## Docs

- Documented the seed-prefix normalization in the Experience-workspace "Join layer" section of `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjdphS4S5eZh9nNP7T2hVk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjdphS4S5eZh9nNP7T2hVk)_