### PR TITLE
Reframe mockup variants as optional enhancement, not a readiness deficiency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1560,7 +1560,20 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   risks without recorded handling, **flow decisions without parseable branch
   outcomes**, no flow refs) rolls into a
   per-screen **readiness status** (`deriveScreenReadiness` → draft /
-  needs_review / accepted / implementation_ready). A **user-set status** —
+  needs_review / accepted / implementation_ready).
+  **Mockup variants are an optional enhancement, never a readiness
+  requirement.** Synapse deliberately generates ONE primary
+  implementation-quality mockup per screen (a missing P0 primary mockup is
+  still `missing_mockup_p0`, review-triggering) and offers the extra viewport ×
+  state variants on demand. So `OPTIONAL_ENHANCEMENT_GAPS`
+  (`missing_state_variants`) is **excluded from status scoring**:
+  `deriveScreenReadiness` scores off `gaps.filter(g => !OPTIONAL_ENHANCEMENT_GAPS.has(g.kind))`
+  while still returning the full gap list (incl. the optional variant gap) so
+  the detail view can surface it as an opportunity. A screen with every
+  required asset is `implementation_ready` even when its optional variants are
+  ungenerated. `missing_state_variants` is NOT in `REVIEW_TRIGGER_GAPS`. Never
+  re-add variant gaps to readiness scoring — they are additive documentation.
+  A **user-set status** —
   the optional `reviewStatus` field on the existing `ScreenMetadataEdit`
   overlay — always wins (`source: 'user'`) but never hides derived warnings
   (an `accepted_with_warnings` gap is appended); a derived status is always
@@ -1616,10 +1629,14 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   Blocking = missing purpose, missing traceability/navigation on a **primary**
   (P0/P1) screen, P0 without a default mockup, a required state with no behavior,
   no derivable acceptance criteria, an unresolved high-severity risk on a P0
-  screen. Review = missing mobile mockup, stale mockups, unresolved risks,
-  decisions without branch outcomes, thin handoff, missing state variants, stale
+  screen. Review = stale mockups, unresolved risks,
+  decisions without branch outcomes, thin handoff, stale
   PRD refs. Info = freshness/coverage unknown (legacy metadata — NEVER a
-  blocker), no flow refs. `buildScreenReviewModel`/`buildScreenReviewModelForItem`/
+  blocker), no flow refs, **and the optional mockup-variant nudges (`mockup_mobile_missing`,
+  `mockup_state_variants_missing`)** — additional viewport/state variants are
+  generated on demand, so a missing one is `info` (discoverable) and must NEVER
+  be `review`/`blocking` (that would let optional design coverage reduce a
+  screen's system readiness). Only the P0 *primary* mockup gates. `buildScreenReviewModel`/`buildScreenReviewModelForItem`/
   `buildScreenReviewIndex` assemble the per-screen `ScreenReviewModel` (status +
   systemReadiness + issues + counts + `acceptedOverWarnings` + freshness +
   checklist progress); the views use the `-ForItem`/`-Index` wrappers (which build
@@ -1894,9 +1911,11 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     **`mockupVariantStatus`** map (`'accepted' | 'not_needed'`) on
     `ScreenMetadataEdit`. A missing **state** row (never the default row —
     that's `missing_mockup_p0`'s job, and counting it would downgrade legacy
-    mockup-less P2/P3 screens) left `missing` while `required` is the
-    `missing_state_variants` readiness gap; `accepted`/`not_needed` resolve it.
-    This layer alone drives review status.
+    mockup-less P2/P3 screens) left `missing` while `required` produces the
+    `missing_state_variants` gap; `accepted`/`not_needed` resolve it. **That gap
+    is OPTIONAL (`OPTIONAL_ENHANCEMENT_GAPS`) — it is surfaced for discovery but
+    excluded from readiness scoring, so it never downgrades a screen's status**
+    (see the Readiness & coverage layer above).
   - **Phase 3A discovery layer (`src/lib/mockupVariants.ts`, pure,
     unit-tested)** — `buildScreenMockupVariants(item, {platform, mobileRelevant})`
     adds a **viewport dimension** (desktop / mobile / tablet) on top of states,
@@ -1919,8 +1938,21 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     layer); only the secondary-viewport default introduces `${viewport}:default`.
     `summarizeScreenVariants` (per-screen card) and
     `buildMockupVariantCoverageSummary` (artifact rollup: recommended
-    generated/total, P0 mobile coverage, legacy-unknown count) drive the UI.
+    generated/total, **`additionalGenerated`/`additionalTotal`** — recommended
+    variants EXCLUDING each screen's primary Default row, i.e. the optional
+    "expanded coverage" pool the panel shows separately from required primary
+    mockups — P0 mobile coverage, legacy-unknown count) drive the UI.
     This layer is **display/discovery only — it never changes review status.**
+    The **Screen Coverage & Readiness panel (`ScreenCoveragePanel`) presents
+    these variants as optional, NOT a checklist**: a green "Ready for
+    Development" section lists the required implementation assets (PRD links,
+    flows, primary mockups, states, open risks, ready count) with a progress
+    bar, and a separate neutral "Expanded Design Coverage" section frames the
+    additional variants positively ("N generated · M available on demand", an
+    "Optional" bar, a discovery card pointing at the per-screen Mockups tab) —
+    no warning color, no "recommended" ratio. Keep required vs. optional split;
+    orange/amber is reserved for genuine implementation risk (uncovered PRD
+    features, a P0 without its primary mockup, unhandled risks).
   - **Phase 3B single-variant generation (`src/lib/mockupVariantRequest.ts`
     pure + `src/lib/mockupVariantImageStore.ts` IDB +
     `src/store/mockupVariantImageStore.ts` Zustand +

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -113,6 +113,32 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
         expect(getByText(/Sharing/)).toBeTruthy();
     });
 
+    it('frames mockup variants as optional Expanded Design Coverage, not a deficiency', () => {
+        const { index, readiness, coverage } = buildFixtures();
+        const { getByText, queryByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                coverage={coverage}
+                variantCoverage={{
+                    recommendedGenerated: 7, recommendedTotal: 17,
+                    additionalGenerated: 6, additionalTotal: 17,
+                    p0WithMobile: 0, p0Total: 2,
+                    legacyUnknownMockups: 0, manifestBackedGenerated: 0,
+                    freshness: { total: 0, current: 0, review: 0, unknown: 0 },
+                }}
+                onSelectScreen={() => {}}
+            />,
+        );
+        // Required work sits under a positive "Ready for Development" header.
+        expect(getByText('Ready for Development')).toBeTruthy();
+        // Variants are reframed as optional, opportunity-oriented coverage.
+        expect(getByText('Expanded Design Coverage')).toBeTruthy();
+        expect(getByText(/available on demand/)).toBeTruthy();
+        // The old mandatory-sounding "N / M recommended" ratio is gone.
+        expect(queryByText(/17 recommended/)).toBeNull();
+    });
+
     it('filters screens (Has risks shows only the risky screen)', () => {
         const { index, readiness, coverage } = buildFixtures();
         const { getByText, queryByText } = render(

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -8,23 +8,14 @@
 
 import { useState } from 'react';
 import {
-    AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, ClipboardCheck, Gauge, Image as ImageIcon,
+    AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, Circle, ClipboardCheck, Gauge,
+    Image as ImageIcon, Sparkles,
 } from 'lucide-react';
 import type { ScreenCoverageSummary } from '../../lib/screenReadiness';
 import type { ScreenArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
 import type { ScreensDownstreamImpactRollup } from '../../lib/screenDownstreamImpact';
 import type { ScreensHandoffRollup } from '../../lib/screenImplementationHandoff';
 import type { MockupVariantCoverageSummary } from '../../lib/mockupVariants';
-import type { VariantFreshnessRollup } from '../../lib/mockupVariantTrust';
-
-/** "8 current · 2 review · 3 unknown" (omits zero segments). */
-function freshnessLabel(f: VariantFreshnessRollup): string {
-    const parts: string[] = [];
-    if (f.current > 0) parts.push(`${f.current} current`);
-    if (f.review > 0) parts.push(`${f.review} review`);
-    if (f.unknown > 0) parts.push(`${f.unknown} unknown`);
-    return parts.length ? parts.join(' · ') : 'None generated';
-}
 
 interface Props {
     summary: ScreenCoverageSummary;
@@ -45,23 +36,52 @@ interface Props {
     onGenerateMissingMockups?: () => void;
 }
 
-function MetricRow({
-    label, value, hint, tone = 'neutral',
-}: {
+type RowTone = 'good' | 'todo' | 'risk';
+
+/** One row in the "Ready for Development" required checklist. `good` = a green
+ * check (done), `risk` = a genuine implementation risk (amber), `todo` = still
+ * in progress but NOT alarming (neutral). Only genuine risk ever uses warning
+ * color — an unmet-but-optional item is never amber. */
+function RequiredRow({ label, value, tone, hint }: {
     label: string;
     value: string;
+    tone: RowTone;
     hint?: string;
-    tone?: 'neutral' | 'good' | 'warn';
 }) {
-    const valueColor = tone === 'good'
-        ? 'text-emerald-700'
-        : tone === 'warn'
-            ? 'text-amber-700'
-            : 'text-neutral-800';
+    const Icon = tone === 'good' ? CheckCircle2 : tone === 'risk' ? AlertTriangle : Circle;
+    const iconColor = tone === 'good'
+        ? 'text-emerald-500'
+        : tone === 'risk' ? 'text-amber-500' : 'text-neutral-300';
+    const valueColor = tone === 'risk' ? 'text-amber-700' : 'text-neutral-700';
     return (
-        <div className="flex items-baseline justify-between gap-3 py-1.5" title={hint}>
-            <span className="text-xs text-neutral-600">{label}</span>
-            <span className={`text-xs font-semibold tabular-nums text-right ${valueColor}`}>{value}</span>
+        <div className="flex items-center justify-between gap-3 py-1" title={hint}>
+            <span className="flex items-center gap-1.5 text-xs text-neutral-700 min-w-0">
+                <Icon size={13} className={`shrink-0 ${iconColor}`} aria-hidden />
+                <span className="truncate">{label}</span>
+            </span>
+            <span className={`text-xs font-medium tabular-nums text-right shrink-0 ${valueColor}`}>{value}</span>
+        </div>
+    );
+}
+
+/** Slim progress meter. `good` fills emerald; `neutral` fills indigo and is
+ * never a warning color (used for the optional expanded-coverage bar). */
+function ProgressBar({ pct, tone, trailingLabel }: {
+    pct: number;
+    tone: 'good' | 'neutral';
+    trailingLabel?: string;
+}) {
+    const clamped = Math.max(0, Math.min(1, pct));
+    const track = tone === 'good' ? 'bg-emerald-100' : 'bg-indigo-100';
+    const fill = tone === 'good' ? 'bg-emerald-500' : 'bg-indigo-400';
+    return (
+        <div className="flex items-center gap-2">
+            <div className={`h-2 flex-1 rounded-full overflow-hidden ${track}`}>
+                <div className={`h-full rounded-full ${fill}`} style={{ width: `${Math.round(clamped * 100)}%` }} />
+            </div>
+            {trailingLabel && (
+                <span className="text-[10px] font-medium text-neutral-500 tabular-nums shrink-0">{trailingLabel}</span>
+            )}
         </div>
     );
 }
@@ -69,22 +89,91 @@ function MetricRow({
 export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, downstreamRollup, handoffRollup, onGenerateMissingMockups }: Props) {
     const [showUncovered, setShowUncovered] = useState(false);
     const {
-        totalScreens, prdFeatures, stateVariants, flows, p0, states, mockups, openRisks,
+        totalScreens, prdFeatures, flows, p0, states, openRisks,
         ready, readyWithWarnings, message,
     } = summary;
     if (totalScreens === 0) return null;
 
-    // "All clear" only when every screen is ready AND none of those are
-    // user-overridden while derived warnings remain — otherwise the green
-    // all-clear treatment would hide unresolved warnings at the artifact level.
-    const allReady = ready === totalScreens && readyWithWarnings === 0;
-    const missingMockups = mockups.total - mockups.covered;
+    // Clean-ready screens: implementation-ready and NOT a user override that
+    // still carries derived warnings. When every screen is clean-ready the core
+    // implementation assets are complete (mockup variants never factor in).
+    const readyClean = Math.max(0, ready - readyWithWarnings);
+    const coreComplete = readyClean === totalScreens;
+
+    // --- Required (implementation-critical) checklist -----------------------
+    // Only genuine implementation risk (missing PRD coverage, a P0 without its
+    // primary mockup, unhandled risks) is styled amber. Everything else that is
+    // simply not-yet-done reads as a calm "in progress", never a failure.
+    const required: Array<{ key: string; label: string; value: string; tone: RowTone; hint?: string }> = [];
+    if (prdFeatures) {
+        const done = prdFeatures.covered === prdFeatures.total;
+        required.push({
+            key: 'prd', label: 'PRD features linked',
+            value: `${prdFeatures.covered} / ${prdFeatures.total}`,
+            tone: done ? 'good' : 'risk',
+            hint: 'PRD features referenced by at least one screen — estimated from feature ids, not a full PRD validation',
+        });
+    } else {
+        required.push({ key: 'prd', label: 'PRD features linked', value: 'No feature list', tone: 'todo' });
+    }
+    if (flows) {
+        const done = flows.represented === flows.total;
+        required.push({
+            key: 'flows', label: 'User flows represented',
+            value: `${flows.represented} / ${flows.total}`,
+            tone: done ? 'good' : 'todo',
+            hint: 'User flows with at least one step matched to a screen',
+        });
+    } else {
+        required.push({ key: 'flows', label: 'User flows represented', value: 'No flows yet', tone: 'todo' });
+    }
+    {
+        const usesP0 = p0.total > 0;
+        const done = usesP0 ? p0.withMockup === p0.total : summary.mockups.covered === summary.mockups.total;
+        required.push({
+            key: 'primary', label: 'Primary mockups',
+            value: usesP0 ? `${p0.withMockup} / ${p0.total} key screens` : `${summary.mockups.covered} / ${summary.mockups.total} screens`,
+            // A P0 (key) screen without its one primary mockup is genuine risk;
+            // a non-critical screen still awaiting its mockup is just in progress.
+            tone: done ? 'good' : usesP0 ? 'risk' : 'todo',
+            hint: 'Every key screen should have one primary implementation-quality mockup. Extra variants are optional (see Expanded Design Coverage).',
+        });
+    }
+    {
+        const done = states.screensWithStates === totalScreens;
+        required.push({
+            key: 'states', label: 'Screen states documented',
+            value: `${states.screensWithStates} / ${totalScreens}`,
+            tone: done ? 'good' : 'todo',
+            hint: states.totalStates > 0
+                ? `${states.statesWithBehavior} of ${states.totalStates} documented states describe a trigger or behavior`
+                : undefined,
+        });
+    }
+    required.push({
+        key: 'risks', label: 'Open risks',
+        value: openRisks === 0 ? 'None noted' : `${openRisks} to review`,
+        tone: openRisks === 0 ? 'good' : 'risk',
+        hint: 'Risk notes in the spec with no recorded handling yet — review them per screen',
+    });
+    required.push({
+        key: 'ready', label: 'Ready for implementation',
+        value: `${readyClean} / ${totalScreens} screens`,
+        tone: coreComplete ? 'good' : 'todo',
+    });
+
+    const headline = coreComplete
+        ? 'Implementation coverage is complete. Every screen has its required assets — optional design documentation can be generated whenever you like.'
+        : message;
+
+    const missingMockups = summary.mockups.total - summary.mockups.covered;
+    const hasExpanded = Boolean(variantCoverage && variantCoverage.additionalTotal > 0);
 
     return (
         <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
             <div className="flex items-start gap-3">
-                <div className={`mt-0.5 h-8 w-8 shrink-0 rounded-lg flex items-center justify-center ${allReady ? 'bg-emerald-50' : 'bg-indigo-50'}`}>
-                    <Gauge size={16} className={allReady ? 'text-emerald-600' : 'text-indigo-600'} />
+                <div className={`mt-0.5 h-8 w-8 shrink-0 rounded-lg flex items-center justify-center ${coreComplete ? 'bg-emerald-50' : 'bg-indigo-50'}`}>
+                    <Gauge size={16} className={coreComplete ? 'text-emerald-600' : 'text-indigo-600'} />
                 </div>
                 <div className="min-w-0 flex-1">
                     <div className="flex items-baseline justify-between gap-2 flex-wrap">
@@ -93,101 +182,28 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
                             Estimated from the generated spec
                         </span>
                     </div>
-                    <p className="mt-1 text-xs leading-relaxed text-neutral-600">{message}</p>
+                    <p className="mt-1 text-xs leading-relaxed text-neutral-600">{headline}</p>
 
-                    <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-x-6 divide-y divide-neutral-100 sm:divide-y-0 text-xs">
-                        <div className="divide-y divide-neutral-100">
-                            {prdFeatures ? (
-                                <MetricRow
-                                    label="PRD features linked"
-                                    value={`${prdFeatures.covered} / ${prdFeatures.total}`}
-                                    hint="PRD features referenced by at least one screen's linked features — estimated from feature ids, not a full PRD validation"
-                                    tone={prdFeatures.covered === prdFeatures.total ? 'good' : 'warn'}
-                                />
-                            ) : (
-                                <MetricRow label="PRD features linked" value="No feature list to compare" />
-                            )}
-                            {flows ? (
-                                <MetricRow
-                                    label="User flows represented"
-                                    value={`${flows.represented} / ${flows.total}`}
-                                    hint="User flows with at least one step matched to a screen"
-                                    tone={flows.represented === flows.total ? 'good' : 'warn'}
-                                />
-                            ) : (
-                                <MetricRow label="User flows represented" value="No flows generated yet" />
-                            )}
-                            <MetricRow
-                                label="P0 screens with mockups"
-                                value={p0.total === 0 ? 'No P0 screens' : `${p0.withMockup} / ${p0.total}`}
-                                tone={p0.total > 0 && p0.withMockup < p0.total ? 'warn' : p0.total > 0 ? 'good' : 'neutral'}
-                            />
+                    {/* --- Ready for Development (required implementation assets) --- */}
+                    <div className="mt-3">
+                        <div className="flex items-baseline justify-between gap-2 mb-1.5">
+                            <h4 className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                                {coreComplete && <CheckCircle2 size={13} className="text-emerald-500" aria-hidden />}
+                                Ready for Development
+                            </h4>
+                            <span className="text-[11px] font-medium text-neutral-500 tabular-nums">
+                                {readyClean} / {totalScreens} screens
+                            </span>
                         </div>
-                        <div className="divide-y divide-neutral-100">
-                            <MetricRow
-                                label="Screens documenting states"
-                                value={`${states.screensWithStates} / ${totalScreens}`}
-                                hint={states.totalStates > 0
-                                    ? `${states.statesWithBehavior} of ${states.totalStates} documented states describe a trigger or behavior`
-                                    : undefined}
-                                tone={states.screensWithStates < totalScreens ? 'warn' : 'good'}
-                            />
-                            <MetricRow
-                                label="Mockups"
-                                value={`${mockups.covered} / ${mockups.total} screens`}
-                                tone={missingMockups > 0 ? 'neutral' : 'good'}
-                            />
-                            {variantCoverage && variantCoverage.recommendedTotal > 0 && (
-                                <MetricRow
-                                    label="Mockup variants"
-                                    value={`${variantCoverage.recommendedGenerated} / ${variantCoverage.recommendedTotal} recommended`}
-                                    hint="Recommended viewport × state variants generated or accepted across all screens — tracked from mockup metadata and your marks, never from inspecting images"
-                                    tone={variantCoverage.recommendedGenerated < variantCoverage.recommendedTotal ? 'warn' : 'good'}
-                                />
-                            )}
-                            {variantCoverage && variantCoverage.p0Total > 0 && (
-                                <MetricRow
-                                    label="Mobile coverage (P0)"
-                                    value={`${variantCoverage.p0WithMobile} / ${variantCoverage.p0Total} P0 screens`}
-                                    hint="P0 screens whose Mobile default variant is generated, accepted, or marked not needed"
-                                    tone={variantCoverage.p0WithMobile < variantCoverage.p0Total ? 'warn' : 'good'}
-                                />
-                            )}
-                            {variantCoverage && variantCoverage.freshness.total > 0 && (
-                                <MetricRow
-                                    label="Mockup freshness"
-                                    value={freshnessLabel(variantCoverage.freshness)}
-                                    hint="Generated mockup variants compared to the current screen spec, design system, and PRD — from stored generation metadata, never a visual check. Unknown = an older mockup with no source metadata."
-                                    tone={variantCoverage.freshness.review > 0 ? 'warn' : 'good'}
-                                />
-                            )}
-                            {variantCoverage && variantCoverage.legacyUnknownMockups > 0 && (
-                                <MetricRow
-                                    label="Legacy mockups (coverage unknown)"
-                                    value={`${variantCoverage.legacyUnknownMockups}`}
-                                    hint="Mockups generated before coverage metadata was captured — visually useful, but Synapse can't confirm which spec items they represent"
-                                    tone="neutral"
-                                />
-                            )}
-                            {stateVariants && (
-                                <MetricRow
-                                    label="Recommended state variants"
-                                    value={`${stateVariants.covered} / ${stateVariants.required}`}
-                                    hint="State mockup variants the generated spec recommends — tracked from mockup metadata and your accepted/not-needed marks, never from inspecting images"
-                                    tone={stateVariants.covered < stateVariants.required ? 'warn' : 'good'}
-                                />
-                            )}
-                            <MetricRow
-                                label="Open risks"
-                                value={openRisks === 0 ? 'None noted' : `${openRisks} to review`}
-                                hint="Risk notes in the spec have no recorded handling yet — review them per screen"
-                                tone={openRisks > 0 ? 'warn' : 'good'}
-                            />
-                            <MetricRow
-                                label="Ready for implementation"
-                                value={`${ready} / ${totalScreens} screens`}
-                                tone={allReady ? 'good' : 'neutral'}
-                            />
+                        <ProgressBar
+                            pct={totalScreens > 0 ? readyClean / totalScreens : 0}
+                            tone="good"
+                            trailingLabel={totalScreens > 0 ? `${Math.round((readyClean / totalScreens) * 100)}%` : undefined}
+                        />
+                        <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-6">
+                            {required.map(r => (
+                                <RequiredRow key={r.key} label={r.label} value={r.value} tone={r.tone} hint={r.hint} />
+                            ))}
                         </div>
                     </div>
 
@@ -242,9 +258,15 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
                             </span>
                         </div>
                     )}
-                    {allReady && (
+
+                    {/* --- Expanded Design Coverage (optional enhancement) --- */}
+                    {hasExpanded && variantCoverage && (
+                        <ExpandedCoverageSection variant={variantCoverage} />
+                    )}
+
+                    {coreComplete && (
                         <p className="mt-3 inline-flex items-center gap-1.5 text-[11px] text-emerald-700">
-                            <CheckCircle2 size={12} /> Derived checks pass — statuses are estimates, so give screens a final review.
+                            <CheckCircle2 size={12} /> Core assets complete — statuses are estimates, so give screens a final review before building.
                         </p>
                     )}
 
@@ -260,6 +282,86 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
                         <HandoffReadinessSection rollup={handoffRollup} />
                     )}
                 </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Optional "Expanded Design Coverage" — the additional viewport × state mockup
+ * variants a user can generate on demand. This is deliberately framed as a
+ * premium enhancement, NOT a checklist to complete: no warning color, positive
+ * "N generated · M available on demand" messaging, an "Optional" progress bar,
+ * and a discovery card pointing at the per-screen Mockups tab (where the actual
+ * on-demand variant generation lives). Additional variants never affect a
+ * screen's readiness — see src/lib/screenReadiness.ts.
+ */
+function ExpandedCoverageSection({ variant }: { variant: MockupVariantCoverageSummary }) {
+    const total = variant.additionalTotal;
+    const generated = variant.additionalGenerated;
+    const remaining = Math.max(0, total - generated);
+    const pct = total > 0 ? generated / total : 0;
+    const statLine = generated === 0
+        ? `${total} available on demand`
+        : remaining === 0
+            ? `All ${total} generated`
+            : `${generated} generated · ${remaining} available on demand`;
+
+    return (
+        <div className="mt-4 pt-4 border-t border-neutral-100">
+            <div className="flex items-center justify-between gap-2 mb-1">
+                <div className="flex items-center gap-1.5">
+                    <Sparkles size={13} className="text-indigo-400" aria-hidden />
+                    <h4 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+                        Expanded Design Coverage
+                    </h4>
+                </div>
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Optional</span>
+            </div>
+            <p className="text-[11px] leading-relaxed text-neutral-500">
+                Primary screens are prioritized first. Additional variants — empty, loading, error, and
+                responsive layouts — are generated only when you request them, to keep projects fast.
+            </p>
+
+            <div className="mt-2.5 space-y-1.5">
+                <div className="flex items-baseline justify-between gap-3">
+                    <span className="text-xs text-neutral-700">Expanded coverage</span>
+                    <span className="text-xs font-medium text-neutral-700 tabular-nums">{statLine}</span>
+                </div>
+                <ProgressBar pct={pct} tone="neutral" trailingLabel="Optional" />
+
+                {variant.p0Total > 0 && (
+                    <div className="flex items-baseline justify-between gap-3">
+                        <span className="text-xs text-neutral-500">Mobile previews (key screens)</span>
+                        <span className="text-xs text-neutral-500 tabular-nums">
+                            {variant.p0WithMobile} / {variant.p0Total} · optional
+                        </span>
+                    </div>
+                )}
+                {variant.freshness.review > 0 && (
+                    <p className="text-[11px] text-neutral-500">
+                        {variant.freshness.review} generated {variant.freshness.review === 1 ? 'variant' : 'variants'}
+                        {' '}may be worth refreshing after recent spec changes.
+                    </p>
+                )}
+                {variant.legacyUnknownMockups > 0 && (
+                    <p className="text-[11px] text-neutral-400">
+                        {variant.legacyUnknownMockups} older {variant.legacyUnknownMockups === 1 ? 'mockup' : 'mockups'}
+                        {' '}predate coverage metadata.
+                    </p>
+                )}
+            </div>
+
+            <div className="mt-3 rounded-lg border border-indigo-100 bg-indigo-50/40 p-3">
+                <p className="flex items-center gap-1.5 text-xs font-medium text-neutral-800">
+                    <Sparkles size={12} className="text-indigo-500" aria-hidden />
+                    Expand coverage when you need it
+                </p>
+                <p className="text-[11px] text-neutral-600 mt-1">
+                    Open a screen&rsquo;s <span className="font-medium text-neutral-700">Mockups</span> tab to generate
+                    additional variants — empty, loading, error, and success states, plus mobile and alternate
+                    layouts — on demand.
+                </p>
             </div>
         </div>
     );

--- a/src/lib/__tests__/screenReadiness.test.ts
+++ b/src/lib/__tests__/screenReadiness.test.ts
@@ -566,7 +566,7 @@ describe('buildMockupVariantRows', () => {
         expect(byId.get('state:empty-history')!.status).toBe('missing');
     });
 
-    it('feeds readiness: missing recommended variants → needs_review; not_needed resolves it', () => {
+    it('missing recommended variants are optional — surfaced as a gap but never downgrade readiness', () => {
         const flows = parseFlows(`### Flow: Submit
 **Goal:** Submit
 **Steps:**
@@ -574,7 +574,10 @@ describe('buildMockupVariantRows', () => {
 `);
         const open = buildReadinessIndex(buildScreenIndex(inventory, flows, payload), FEATURES);
         const r1 = open.get('scr-submission')!;
-        expect(r1.status).toBe('needs_review');
+        // Additional mockup variants are optional design enrichment: the screen
+        // is implementation-ready even though its state variants are ungenerated.
+        expect(r1.status).toBe('implementation_ready');
+        // The gap is still surfaced for discovery, it just doesn't score.
         expect(r1.gaps.map(g => g.kind)).toContain('missing_state_variants');
 
         const resolved = buildReadinessIndex(buildScreenIndex(inventory, flows, payload, {

--- a/src/lib/__tests__/screenReviewWorkflow.test.ts
+++ b/src/lib/__tests__/screenReviewWorkflow.test.ts
@@ -64,11 +64,14 @@ describe('deriveScreenReviewIssues', () => {
         expect(issues.find(i => i.id === 'mockup_missing_p0')?.severity).toBe('blocking');
     });
 
-    it('a missing mobile mockup is a review warning, not a blocker', () => {
+    it('a missing mobile mockup is optional info — never reduces readiness', () => {
         const issues = deriveScreenReviewIssues(cleanSignals({ mobileMockupMissing: true }));
         const mobile = issues.find(i => i.id === 'mockup_mobile_missing');
-        expect(mobile?.severity).toBe('review');
-        expect(issues.some(i => i.severity === 'blocking')).toBe(false);
+        // Additional mockup variants (mobile / responsive) are optional design
+        // enrichment — they surface as info and must not push the screen to
+        // blocking OR review-recommended.
+        expect(mobile?.severity).toBe('info');
+        expect(issues.some(i => i.severity === 'blocking' || i.severity === 'review')).toBe(false);
     });
 
     it('a stale mockup creates a review issue', () => {

--- a/src/lib/mockupVariants.ts
+++ b/src/lib/mockupVariants.ts
@@ -483,6 +483,16 @@ export interface MockupVariantCoverageSummary {
     recommendedGenerated: number;
     /** Recommended variants across all screens. */
     recommendedTotal: number;
+    /** ADDITIONAL (non-primary) variants generated/accepted — i.e. excluding
+     * each screen's primary Default mockup (which is the required implementation
+     * asset, counted under primary mockup coverage). These are the optional
+     * "expanded design coverage" enhancements (mobile / responsive / per-state
+     * layouts). */
+    additionalGenerated: number;
+    /** ADDITIONAL (non-primary) recommended variants across all screens. The
+     * pool a user can expand into on demand; `additionalTotal - additionalGenerated`
+     * are available to generate. */
+    additionalTotal: number;
     /** P0 screens whose Mobile default is generated/accepted. */
     p0WithMobile: number;
     /** Total P0 screens. */
@@ -514,6 +524,8 @@ export function buildMockupVariantCoverageSummary(
     if (index.items.length === 0) return null;
     let recommendedGenerated = 0;
     let recommendedTotal = 0;
+    let additionalGenerated = 0;
+    let additionalTotal = 0;
     let p0WithMobile = 0;
     let p0Total = 0;
     let legacyUnknownMockups = 0;
@@ -538,8 +550,15 @@ export function buildMockupVariantCoverageSummary(
             // A not_needed variant is deliberately skipped — drop it from the
             // denominator so a resolved gap never keeps the panel warning.
             if (v.required && v.status !== 'not_needed') {
+                const generated = isGeneratedOrAccepted(v.status);
                 recommendedTotal += 1;
-                if (isGeneratedOrAccepted(v.status)) recommendedGenerated += 1;
+                if (generated) recommendedGenerated += 1;
+                // Everything except the primary Default row is optional expanded
+                // coverage (the Default row is the required implementation asset).
+                if (v.id !== DEFAULT_VARIANT_ID) {
+                    additionalTotal += 1;
+                    if (generated) additionalGenerated += 1;
+                }
             }
             // "Handled" = generated, accepted, or explicitly not needed, so a
             // deliberately-skipped mobile default doesn't read as a gap.
@@ -560,6 +579,8 @@ export function buildMockupVariantCoverageSummary(
     return {
         recommendedGenerated,
         recommendedTotal,
+        additionalGenerated,
+        additionalTotal,
         p0WithMobile,
         p0Total,
         legacyUnknownMockups,

--- a/src/lib/screenReadiness.ts
+++ b/src/lib/screenReadiness.ts
@@ -82,9 +82,22 @@ const REVIEW_TRIGGER_GAPS: ReadonlySet<ScreenGapKind> = new Set([
     'missing_traceability',
     'invalid_traceability',
     'missing_mockup_p0',
-    'missing_state_variants',
     'states_without_behavior',
     'decision_missing_branches',
+]);
+
+/**
+ * Gaps that describe OPTIONAL design enrichment (additional mockup variants for
+ * states / viewports) rather than implementation-critical work. Synapse
+ * deliberately generates one primary implementation-quality mockup per screen
+ * and offers the extra variants on demand — so a missing variant is expanded
+ * coverage a user CAN generate, never a failure. These gaps are still surfaced
+ * for discovery (they stay in ScreenReadiness.gaps) but must NEVER reduce a
+ * screen's readiness status: a screen with every required asset is
+ * implementation-ready even when its optional variants are ungenerated.
+ */
+const OPTIONAL_ENHANCEMENT_GAPS: ReadonlySet<ScreenGapKind> = new Set([
+    'missing_state_variants',
 ]);
 
 export interface ScreenReadiness {
@@ -265,9 +278,15 @@ function reasonsFromGaps(gaps: ScreenGap[]): string[] {
  */
 export function deriveScreenReadiness(input: ReadinessInput): ScreenReadiness {
     const gaps = detectScreenGaps(input);
+    // Optional design-enrichment gaps (extra mockup variants) are additive
+    // documentation — they must never reduce readiness. Score status off the
+    // implementation-critical gaps only, while still returning the full gap
+    // list (incl. optional ones) so the detail view can surface them as
+    // opportunities.
+    const scoringGaps = gaps.filter(g => !OPTIONAL_ENHANCEMENT_GAPS.has(g.kind));
     if (input.userStatus) {
         const masked = (input.userStatus === 'accepted' || input.userStatus === 'implementation_ready')
-            && gaps.some(g => REVIEW_TRIGGER_GAPS.has(g.kind));
+            && scoringGaps.some(g => REVIEW_TRIGGER_GAPS.has(g.kind));
         const allGaps = masked
             ? [...gaps, {
                 kind: 'accepted_with_warnings' as const,
@@ -281,13 +300,13 @@ export function deriveScreenReadiness(input: ReadinessInput): ScreenReadiness {
             gaps: allGaps,
         };
     }
-    if (gaps.length === 0) {
+    if (scoringGaps.length === 0) {
         return { status: 'implementation_ready', source: 'derived', reasons: [], gaps };
     }
-    const status: ScreenReviewStatus = gaps.some(g => REVIEW_TRIGGER_GAPS.has(g.kind))
+    const status: ScreenReviewStatus = scoringGaps.some(g => REVIEW_TRIGGER_GAPS.has(g.kind))
         ? 'needs_review'
         : 'draft';
-    return { status, source: 'derived', reasons: reasonsFromGaps(gaps), gaps };
+    return { status, source: 'derived', reasons: reasonsFromGaps(scoringGaps), gaps };
 }
 
 /** Readiness for every screen in the index, keyed by canonical screen id.

--- a/src/lib/screenReviewWorkflow.ts
+++ b/src/lib/screenReviewWorkflow.ts
@@ -259,24 +259,29 @@ export function deriveScreenReviewIssues(signals: ScreenReviewSignals): ScreenRe
             recommendedAction: 'Generate or upload a mockup for this screen.',
         });
     }
+    // Additional mockup variants (mobile / responsive / per-state layouts) are
+    // OPTIONAL design enrichment, generated on demand — never implementation-
+    // critical. They surface as INFO so they stay discoverable without ever
+    // reducing a screen's system readiness (a missing variant must not make an
+    // otherwise-complete screen read as "needs review").
     if (signals.mobileMockupMissing) {
         issues.push({
             id: 'mockup_mobile_missing',
-            severity: 'review',
+            severity: 'info',
             category: 'mobile',
-            title: 'Mobile mockup recommended',
-            description: 'A mobile variant is recommended for this screen but has not been generated.',
-            recommendedAction: 'Generate a mobile variant, or mark it not needed if the screen is desktop-only.',
+            title: 'Mobile variant available on demand',
+            description: 'A mobile variant can be generated for this screen — an optional enhancement, not required to build.',
+            recommendedAction: 'Generate a mobile variant from the screen’s Mockups tab if you want one.',
         });
     }
     if (gapKinds.has('missing_state_variants')) {
         issues.push({
             id: 'mockup_state_variants_missing',
-            severity: 'review',
+            severity: 'info',
             category: 'mockups',
-            title: 'Recommended state mockups missing',
+            title: 'Additional state mockups available',
             description: gapMessage('missing_state_variants')
-                ?? 'Some recommended state mockup variants have not been generated.',
+                ?? 'Extra state mockup variants can be generated on demand — optional design coverage, not required to build.',
         });
     }
     if ((signals.freshnessStale ?? 0) > 0) {


### PR DESCRIPTION
## Problem

The **Screen Coverage & Readiness** panel unintentionally implied that ungenerated mockup variants were failures — orange "N / M recommended" ratios that looked identical to errors — even though Synapse behaves exactly as designed: it generates **one primary implementation-quality mockup per screen** and offers the extra variants (empty / loading / error / mobile / alternate layouts) **on demand** to keep projects fast. A correctly-behaving product read as incomplete.

## Design principle applied

Core implementation assets = project readiness. Variant mockups = optional design depth. The UI now celebrates completion first and presents expanded coverage as a premium enhancement users can generate whenever they choose.

## Changes

**Readiness scoring (the correctness fix — variants never block readiness)**
- New `OPTIONAL_ENHANCEMENT_GAPS` in `screenReadiness.ts`: `missing_state_variants` is still surfaced for discovery but **excluded from status scoring**. A screen with every required asset reaches `implementation_ready` even with ungenerated variants. Removed it from `REVIEW_TRIGGER_GAPS`.
- Review workflow: demoted `mockup_mobile_missing` and `mockup_state_variants_missing` from `review` → `info`, so optional variants never reduce a screen's system readiness. A **P0 primary mockup** (`missing_mockup_p0`) stays blocking — that's a genuine requirement, not a variant.

**Coverage rollup**
- Added `additionalGenerated` / `additionalTotal` to `MockupVariantCoverageSummary` (recommended variants excluding each screen's primary Default row) so the panel can separate required primary mockups from optional expanded coverage.

**Panel UI reframe (`ScreenCoveragePanel`)**
- Split into a green **"Ready for Development"** section — required assets (PRD links, flows, primary mockups, states, open risks, ready count) with check icons and a progress bar — and a separate neutral **"Expanded Design Coverage"** section.
- Expanded coverage is framed as opportunity: "N generated · M available on demand", an **Optional** progress bar, helper text explaining that primary screens are prioritized and variants are generated on request, and a discovery card pointing at the per-screen Mockups tab.
- Warning color is now reserved for **genuine implementation risk only** (uncovered PRD features, a P0 without its primary mockup, open risks). The mandatory-sounding "recommended" ratios and amber variant metrics are gone.
- Celebratory summary when core assets are complete.

## Testing

- `npm run build` (tsc -b + vite build) — passes
- `npm run lint` — passes
- `npm test` — 1427 passed (158 files), including updated readiness/review assertions and a new render test asserting the panel frames variants as optional "Expanded Design Coverage".

CLAUDE.md updated in the same change to document the optional-variant rule and the panel's required-vs-optional split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsevRsfNnhUuFNXALEy8im

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsevRsfNnhUuFNXALEy8im)_