### PR TITLE
Redesign Screens artifact list with a flow-first information architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1524,11 +1524,9 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   Selector-stability rule). Slug collisions keep **all** screens as items
   (unique ids), resolve `bySlug` to the first, and are surfaced via
   `index.collisions` (warning banner in the list).
-- **Views** — `src/components/experience/`: `ScreenListView` (sectioned,
-  filterable list of all inventory screens topped by the **Screen Coverage &
-  Readiness** panel — `ScreenCoveragePanel`; per-card readiness badge,
-  linked-feature/risk chips, state/mockup/flow metadata and
-  "N incoming · N outgoing" navigation labels), `ScreenDetailView` +
+- **Views** — `src/components/experience/`: `ScreenListView` (a **flow-first**
+  list — screens are the primary focus, implementation/traceability/readiness
+  data is kept but visually secondary), `ScreenDetailView` +
   `ScreenDetailTabs` (per-screen **Overview / Flow / Mockups** tabs). They
   reuse existing pieces rather than duplicating them: Overview = the
   structured `ScreenOverviewPanel` (screen contract — see the readiness
@@ -1566,6 +1564,35 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   `src/components/renderers/screenPriority.ts`
   (own module — the react-refresh/only-export-components rule forbids constant
   exports from component files).
+- **Flow-first list IA (`ScreenListView` + `src/lib/screenFlowView.ts`, pure,
+  unit-tested).** The Screens list leads with the product experience — what
+  screens exist, how they connect, and which flow they belong to — and keeps
+  every implementation/traceability/readiness/review signal reachable but
+  visually secondary. `screenFlowView.ts` is the pure presentation layer:
+  `deriveScreenConnections(item)` reads a screen's own contract for connection
+  **names, not counts** (outgoing = `exitPaths[].target`, incoming =
+  `entryPoints`, plus joined `relatedFlows` titles); `buildScreenGroups(index,
+  mode)` groups screens `'flow'` (primary-flow assignment — the flow where a
+  screen appears earliest — with a trailing "Other screens" bucket for
+  flow-less screens, screens ordered by step within a flow), `'section'`, or
+  `'priority'`; `hasFlowGrouping`/`flowFilterOptions` drive the defaults. The
+  view replaces the old **14 filter chips** with one compact control row
+  (search + Priority/Flow/Status/Sort/Group selects + an **Advanced** drawer
+  holding the long-tail filters — has_blockers / review_recommended /
+  outdated_review / downstream_review / handoff_ready / handoff_blocked /
+  missing_mockups / has_risks, still resolved through `screenMatchesFilter` so
+  the filter semantics are unchanged). Each card shows **one prominent badge
+  (priority)** + title + purpose + a mini flow strip ("Next → …" from
+  `deriveScreenConnections`, else "Part of <flow>") + a single muted readiness
+  badge; **all other metadata** (review, traceability, handoff, mockup
+  coverage, states, risks, downstream impact) moves behind a per-card **"Show
+  details"** disclosure. Color is reserved for priority + genuine warnings
+  (blockers/risks/stale/blocked). The **Screen Coverage & Readiness**,
+  implementation-preflight, and handoff-export panels are collapsed by default
+  under a single "Project readiness & metadata" section (kept mounted, hidden
+  via CSS) so the screens stay the focus. This is presentation-only over the
+  existing join/readiness/review/handoff/downstream layers — no schema, prompt,
+  pipeline, or persistence change.
 - **Readiness & coverage layer (`src/lib/screenReadiness.ts`, pure,
   unit-tested — no store/LLM/persistence).** Computed at read time over the
   join layer: per-screen **gap detection** (`detectScreenGaps`: missing
@@ -1676,7 +1703,8 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   line, Accept / Request changes / Mark ready-to-build actions with an inline
   override-reason capture when blockers exist, readiness-issue list, review
   checklist, a calm "review may be outdated" banner + Re-review), review status +
-  issue counts on `ScreenListView` cards, and a "Review readiness" rollup + gate
+  issue counts in each `ScreenListView` card's "Show details" disclosure, and a
+  "Review readiness" rollup + gate
   callout in `ScreenCoveragePanel`. Persistence flows through the existing
   `handleSaveScreenEdit` → `updateArtifactVersionMetadata` overlay path
   (timestamps/signatures stamped in `ScreenDetailView`, not the pure module).
@@ -1716,13 +1744,16 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   entry point the workspace calls. **UI:** `ScreenDownstreamImpactSection`
   (Screen Detail, below the review panel — impacted-artifact list, or a calm
   "No downstream impact detected" / "cannot be fully confirmed for this older
-  review" empty state), a compact `DownstreamChip` on `ScreenListView` cards
-  (only when a blocking/review impact exists — info-only shows nothing), a
+  review" empty state), a compact downstream note in each `ScreenListView`
+  card's "Show details" disclosure (only when a blocking/review impact exists —
+  info-only shows nothing), a
   **Downstream readiness** section in `ScreenCoveragePanel`, and a collapsible
-  **`ScreenPreflightPanel`** ("Implementation preflight") above the screen list.
-  Two new list filters — **Outdated review** (`reviewFreshness === 'outdated'`)
+  **`ScreenPreflightPanel`** ("Implementation preflight") in the collapsed
+  project-metadata section. Two list filters — **Outdated review**
+  (`reviewFreshness === 'outdated'`)
   and **Downstream review** (`downstreamReviewNeeded`) — extend
-  `SCREEN_LIST_FILTERS` / `ScreenFilterReview` (the caller supplies the new
+  `SCREEN_LIST_FILTERS` / `ScreenFilterReview` (surfaced in the Advanced filter
+  drawer) (the caller supplies the new
   signals; `screenReadiness.ts` must NOT import `screenDownstreamImpact` — that
   would cycle). **No export/finalization hook was added**: there is no
   Screens-specific export/share/finalize action today (the PRD Mark-as-Final /
@@ -1768,8 +1799,9 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   Screen Detail **Handoff tab** (`ScreenHandoffView` + a `handoff` value on
   `ScreenDetailTab`, URL-addressable via `?screenTab=handoff`) with a
   readiness-colored tab dot, compact sections, and a Copy-handoff action
-  (clipboard → textarea fallback); a compact **handoff readiness chip** on
-  `ScreenListView` cards; **Handoff ready / Handoff blocked** list filters
+  (clipboard → textarea fallback); a **handoff readiness** row in each
+  `ScreenListView` card's "Show details" disclosure; **Handoff ready / Handoff
+  blocked** Advanced-drawer filters
   (`SCREEN_LIST_FILTERS` + `ScreenFilterReview.handoffReadiness`); and an
   **Implementation handoff** rollup section in `ScreenCoveragePanel`. Everything
   stays **advisory** — nothing gates rendering or generation, and legacy/sparse
@@ -1834,10 +1866,11 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
     Model support** matches (entity + confidence + fields + reason, or a calm
     "No linked Data Model entities found" empty state), a **Related implementation
     plan items** section, per-dependency trace tags, and trace notes.
-    `ScreenListView` cards carry a compact `TraceChip` (only on a real concern —
-    "No plan match" / "Trace needs review", never on a strong trace);
+    each `ScreenListView` card's "Show details" disclosure surfaces a trace
+    concern (only on a real concern — "No plan match" / "Trace needs review",
+    never on a strong trace);
     `ScreenCoveragePanel`'s handoff section shows the trace rollup. **No new list
-    filters** were added (the filter bar is already crowded — chips + preflight
+    filters** were added (the details disclosure + preflight
     carry the signal). Everything stays **advisory**; nothing gates rendering or
     generation, and screens with no downstream artifacts degrade to `missing`
     with an info note, never a crash. **No downstream artifact is mutated and no
@@ -1879,8 +1912,9 @@ pipeline, sync, or snapshot change. Do not add persisted state for this view.
   (`JSON.stringify(pkg, null, 2)`) are the two export formats;
   `screensHandoffExportFilename` builds the download name. **UI:**
   `ScreensHandoffExportPanel` (`src/components/experience/`) — a local,
-  collapsible panel rendered by `ScreenListView` directly below
-  `ScreenPreflightPanel`: an export-readiness header + status banner (calm,
+  collapsible panel rendered by `ScreenListView` inside the collapsed
+  project-metadata section, below `ScreenPreflightPanel`: an export-readiness
+  header + status banner (calm,
   **non-blocking** even when `not_ready` — it still exports, mirroring the
   Phase 4B "decision surface, never a gate" rule), summary stat tiles, Copy /
   Download for Markdown and JSON (clipboard → textarea fallback, Phase 5A

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -104,8 +104,8 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
         expect(getByText('Screen Coverage & Readiness')).toBeTruthy();
         expect(getByText('PRD features linked')).toBeTruthy();
         expect(getAllByText('1 / 2').length).toBeGreaterThan(0);
-        // Clearer navigation label replaces "2 in · 2 out".
-        expect(getByText(/incoming · .*outgoing/)).toBeTruthy();
+        // Flow-first: the card visualizes the next screen by name, not counts.
+        expect(getByText('Item Detail')).toBeTruthy();
         // Both screens have review-worthy gaps → needs-review badges present.
         expect(getAllByText('Needs review').length).toBeGreaterThan(0);
         // Uncovered-feature disclosure names the missing feature.
@@ -149,6 +149,8 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
                 onSelectScreen={() => {}}
             />,
         );
+        // "Has risks" now lives in the Advanced filter drawer, not a top-level chip.
+        fireEvent.click(getByText('Advanced'));
         fireEvent.click(getByText('Has risks'));
         expect(getByText('Home Dashboard')).toBeTruthy();
         expect(queryByText('Bare Legacy Screen')).toBeNull();
@@ -156,7 +158,7 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
 
     it('renders an empty-filter state instead of nothing', () => {
         const { index, readiness, coverage } = buildFixtures();
-        const { getByText } = render(
+        const { getByText, getByLabelText } = render(
             <ScreenListView
                 index={index}
                 readiness={readiness}
@@ -164,7 +166,8 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
                 onSelectScreen={() => {}}
             />,
         );
-        fireEvent.click(getByText('Ready'));
+        // Status is now a compact select rather than a filter chip.
+        fireEvent.change(getByLabelText('Status'), { target: { value: 'ready' } });
         expect(getByText('No screens match this filter.')).toBeTruthy();
     });
 });
@@ -464,7 +467,8 @@ describe('Phase 4A Screens list + coverage panel', () => {
                 onSelectScreen={() => {}}
             />,
         );
-        // Both screens are unreviewed → each card shows the review status line.
+        // Review status is now secondary metadata behind each card's "Details".
+        getAllByText('Show details').forEach(btn => fireEvent.click(btn));
         expect(getAllByText('Not reviewed').length).toBeGreaterThan(0);
     });
 
@@ -480,6 +484,8 @@ describe('Phase 4A Screens list + coverage panel', () => {
                 onSelectScreen={() => {}}
             />,
         );
+        // "Has blockers" is now an Advanced filter.
+        fireEvent.click(getByText('Advanced'));
         fireEvent.click(getByText('Has blockers'));
         // The bare legacy screen (no purpose / acceptance) has blockers; the
         // full P0 dashboard does not.
@@ -675,7 +681,7 @@ describe('Phase 4B downstream impact section', () => {
 describe('Phase 4B list card + coverage panel', () => {
     it('13. a card shows a downstream review chip only when relevant', () => {
         const { index, readiness, coverage, reviewModels, artifactReview } = buildDownstreamFixtures();
-        const { getByText, queryAllByText } = render(
+        const { getByText, queryAllByText, getAllByText } = render(
             <ScreenListView
                 index={index}
                 readiness={readiness}
@@ -685,9 +691,11 @@ describe('Phase 4B list card + coverage panel', () => {
                 onSelectScreen={() => {}}
             />,
         );
-        // The accepted-but-outdated P0 dashboard surfaces a downstream chip…
+        // The accepted-but-outdated P0 dashboard surfaces a downstream note in
+        // its (now secondary) Details section…
+        getAllByText('Show details').forEach(btn => fireEvent.click(btn));
         expect(queryAllByText(/Downstream review/).length).toBeGreaterThan(0);
-        // …but the header still renders normally.
+        // …but the coverage panel still renders normally.
         expect(getByText('Screen Coverage & Readiness')).toBeTruthy();
     });
 
@@ -800,8 +808,10 @@ describe('Phase 5A handoff tab', () => {
                 onSelectScreen={() => {}}
             />,
         );
+        // Handoff readiness is now secondary metadata behind each card's Details.
+        getAllByText('Show details').forEach(btn => fireEvent.click(btn));
         // The unsigned P0 Home Dashboard has a blocked handoff.
-        expect(getAllByText('Handoff blocked').length).toBeGreaterThan(0);
+        expect(getAllByText('Blocked').length).toBeGreaterThan(0);
     });
 
     it('23. the coverage panel shows the handoff rollup', () => {

--- a/src/components/experience/ScreenListView.tsx
+++ b/src/components/experience/ScreenListView.tsx
@@ -1,18 +1,26 @@
-// Canonical screen list for the Experience workspace. Read-only: every row is
-// derived from the screen_inventory artifact via the pure join layer
-// (src/lib/screenExperience.ts) plus the derived readiness layer
-// (src/lib/screenReadiness.ts) — nothing here writes to the store. Rows show
-// what the other experience artifacts say about each screen (flow refs,
-// mockup coverage), the derived/user-set review status, and click through to
-// the Screen Detail view. The Screen Coverage & Readiness panel at the top
-// replaces the old mockup-only coverage card.
+// Canonical screen list for the Experience workspace — redesigned "flow-first".
+//
+// Read-only: every row is derived from the screen_inventory artifact via the
+// pure join layer (src/lib/screenExperience.ts), the flow-view helpers
+// (src/lib/screenFlowView.ts), and the derived readiness / review / handoff /
+// downstream layers. Nothing here writes to the store.
+//
+// The information architecture leads with the product experience — what screens
+// exist, how they connect, and which flow they belong to — and keeps
+// implementation, traceability, readiness, and review data available but
+// visually secondary (a per-card "Details" disclosure + a collapsed
+// project-metadata section). A single compact control row replaces the old
+// 14-chip filter explosion.
 
-import { AlertTriangle, AppWindow, ChevronRight, Image as ImageIcon, Layers, Workflow } from 'lucide-react';
+import {
+    AlertTriangle, ArrowRight, ChevronDown, ChevronRight, Image as ImageIcon,
+    Layers, Search, SlidersHorizontal, Workflow, X,
+} from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { DataModelContent, Feature, MockupPlatform, StructuredImplementationPlan } from '../../types';
 import type { ScreenExperienceIndex, ScreenExperienceItem } from '../../lib/screenExperience';
 import {
-    SCREEN_LIST_FILTERS, screenMatchesFilter,
+    screenMatchesFilter,
     type ScreenCoverageSummary, type ScreenFilterReview, type ScreenListFilter, type ScreenReadiness,
 } from '../../lib/screenReadiness';
 import {
@@ -31,6 +39,10 @@ import {
     buildScreenMockupVariants, summarizeScreenVariants,
     type GeneratedVariantMap, type MockupVariantCoverageSummary,
 } from '../../lib/mockupVariants';
+import {
+    buildScreenGroups, deriveScreenConnections, flowFilterOptions, hasFlowGrouping,
+    type ScreenGroupMode,
+} from '../../lib/screenFlowView';
 import type { VariantTrustContext } from '../../lib/mockupVariantTrust';
 import { PRIORITY_STYLES, stylablePriority } from '../renderers/screenPriority';
 import type { ScreensHandoffExportManifestInput } from '../../lib/screenHandoffExport';
@@ -84,6 +96,27 @@ interface Props {
     onGenerateMissingMockups?: () => void;
 }
 
+type PriorityFilter = 'all' | 'P0' | 'P1' | 'P2' | 'P3';
+type StatusFilter = 'all' | 'draft' | 'needs_review' | 'accepted' | 'ready';
+type SortMode = 'group' | 'priority' | 'name' | 'readiness';
+
+/** Advanced (power-user) filters — the long tail that used to be top-level chips. */
+const ADVANCED_FILTERS: Array<{ id: ScreenListFilter; label: string }> = [
+    { id: 'has_blockers', label: 'Has blockers' },
+    { id: 'review_recommended', label: 'Review recommended' },
+    { id: 'outdated_review', label: 'Outdated review' },
+    { id: 'downstream_review', label: 'Downstream review' },
+    { id: 'handoff_ready', label: 'Handoff ready' },
+    { id: 'handoff_blocked', label: 'Handoff blocked' },
+    { id: 'missing_mockups', label: 'Missing mockups' },
+    { id: 'has_risks', label: 'Has risks' },
+];
+
+const READINESS_RANK: Record<ScreenReadiness['status'], number> = {
+    implementation_ready: 0, accepted: 1, needs_review: 2, draft: 3,
+};
+const PRIORITY_RANK: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
+
 export function ScreenListView({
     index, readiness, reviewModels = EMPTY_REVIEW_MODELS, artifactReview, coverage,
     variantCoverage, mockupPlatform, mobileRelevant,
@@ -91,20 +124,26 @@ export function ScreenListView({
     projectName, exportManifest,
     onSelectScreen, onGenerateMissingMockups,
 }: Props) {
-    const [filter, setFilter] = useState<ScreenListFilter>('all');
+    const flowsAvailable = useMemo(() => hasFlowGrouping(index), [index]);
+    const [search, setSearch] = useState('');
+    const [priority, setPriority] = useState<PriorityFilter>('all');
+    const [flow, setFlow] = useState<string>('all');
+    const [status, setStatus] = useState<StatusFilter>('all');
+    const [sort, setSort] = useState<SortMode>('group');
+    const [group, setGroup] = useState<ScreenGroupMode>(flowsAvailable ? 'flow' : 'section');
+    const [advanced, setAdvanced] = useState<ReadonlySet<ScreenListFilter>>(() => new Set());
+    const [advancedOpen, setAdvancedOpen] = useState(false);
+    const [metadataOpen, setMetadataOpen] = useState(false);
 
-    // Phase 4B: downstream impact analysis — per-screen impacts (row chips +
+    // Phase 4B: downstream impact analysis — per-screen impacts (detail chips +
     // filters), the artifact-level rollup, and the implementation preflight.
-    // Derived once from the review models; pure & memoized, never persisted.
     const downstream = useMemo(
         () => analyzeScreensDownstream(index, reviewModels, artifactReview),
         [index, reviewModels, artifactReview],
     );
     const downstreamByScreen = downstream.impactsByScreen;
 
-    // Phase 5A: per-screen implementation handoff packages (route/components/
-    // state/events/data/mockups/QA/build tasks + readiness). Derived from the
-    // review model + variant grid + downstream impact — pure & memoized.
+    // Phase 5A: per-screen implementation handoff packages.
     const handoffByScreen = useMemo(() => {
         const map = new Map<string, ScreenImplementationHandoff>();
         for (const item of index.items) {
@@ -131,8 +170,6 @@ export function ScreenListView({
         () => buildScreensHandoffRollup([...handoffByScreen.values()], p0Ids),
         [handoffByScreen, p0Ids],
     );
-    // Fold handoff issues into the Phase 4B preflight (handoff contributions are
-    // structural — screenDownstreamImpact never imports the handoff module).
     const preflight = useMemo(() => {
         const contribution = buildHandoffPreflightContribution([...handoffByScreen.values()], p0Ids);
         return buildScreensPreflight(downstream.inputs, artifactReview, contribution);
@@ -154,22 +191,72 @@ export function ScreenListView({
         };
     };
 
-    // Per-filter match counts so empty filters are obvious before clicking.
-    const filterCounts = useMemo(() => {
-        const counts = new Map<ScreenListFilter, number>();
-        for (const { id } of SCREEN_LIST_FILTERS) {
-            counts.set(id, index.items.filter(item =>
-                screenMatchesFilter(item, readiness.get(item.id), id, filterReviewFor(item))).length);
+    const flowOptions = useMemo(() => flowFilterOptions(index), [index]);
+
+    // Combined predicate over the compact controls: search ∧ priority ∧ flow ∧
+    // status ∧ every active advanced filter.
+    const matches = (item: ScreenExperienceItem): boolean => {
+        if (search.trim()) {
+            const needle = search.trim().toLowerCase();
+            const haystack = `${item.screen.name} ${item.screen.purpose ?? ''} ${item.relatedFlows.map(r => r.flow.title).join(' ')}`.toLowerCase();
+            if (!haystack.includes(needle)) return false;
         }
-        return counts;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [index, readiness, reviewModels, downstreamByScreen, handoffByScreen]);
+        if (priority !== 'all' && stylablePriority(item.screen.priority) !== priority) return false;
+        if (flow !== 'all' && !item.relatedFlows.some(r => r.flow.title === flow)) return false;
+        const review = filterReviewFor(item);
+        const rd = readiness.get(item.id);
+        if (status !== 'all' && !screenMatchesFilter(item, rd, status, review)) return false;
+        for (const adv of advanced) {
+            if (!screenMatchesFilter(item, rd, adv, review)) return false;
+        }
+        return true;
+    };
+
+    const sortItems = (items: readonly ScreenExperienceItem[]): ScreenExperienceItem[] => {
+        if (sort === 'group') return [...items];
+        const copy = [...items];
+        copy.sort((a, b) => {
+            if (sort === 'name') return a.screen.name.localeCompare(b.screen.name);
+            if (sort === 'priority') {
+                return (PRIORITY_RANK[stylablePriority(a.screen.priority)] ?? 9)
+                    - (PRIORITY_RANK[stylablePriority(b.screen.priority)] ?? 9);
+            }
+            // readiness
+            const ra = readiness.get(a.id)?.status ?? 'draft';
+            const rb = readiness.get(b.id)?.status ?? 'draft';
+            return READINESS_RANK[ra] - READINESS_RANK[rb];
+        });
+        return copy;
+    };
+
+    const groups = useMemo(() => buildScreenGroups(index, group), [index, group]);
+
+    const filteredGroups = groups
+        .map(g => ({ ...g, items: sortItems(g.items.filter(matches)) }))
+        .filter(g => g.items.length > 0);
+
+    const totalMatches = filteredGroups.reduce((sum, g) => sum + g.items.length, 0);
+    const advancedCount = advanced.size;
+    const anyFilterActive = Boolean(search.trim()) || priority !== 'all' || flow !== 'all'
+        || status !== 'all' || advancedCount > 0;
+
+    const toggleAdvanced = (id: ScreenListFilter) => {
+        setAdvanced(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id); else next.add(id);
+            return next;
+        });
+    };
+    const clearFilters = () => {
+        setSearch(''); setPriority('all'); setFlow('all'); setStatus('all');
+        setAdvanced(new Set());
+    };
 
     if (index.items.length === 0) {
         return (
             <div className="max-w-xl mx-auto bg-white rounded-xl border border-dashed border-neutral-300 p-10 text-center">
                 <div className="w-12 h-12 rounded-full bg-indigo-50 flex items-center justify-center mx-auto mb-3">
-                    <AppWindow size={20} className="text-indigo-500" />
+                    <Layers size={20} className="text-indigo-500" />
                 </div>
                 <h3 className="text-sm font-semibold text-neutral-800">No screens yet</h3>
                 <p className="text-xs text-neutral-500 mt-1">
@@ -179,68 +266,111 @@ export function ScreenListView({
         );
     }
 
-    const filteredSections = index.sections
-        .map(section => ({
-            ...section,
-            items: section.items.filter(item =>
-                screenMatchesFilter(item, readiness.get(item.id), filter, filterReviewFor(item))),
-        }))
-        .filter(section => section.items.length > 0);
-
     return (
-        <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-6">
-            <ScreenCoveragePanel
-                summary={coverage}
-                variantCoverage={variantCoverage}
-                artifactReview={artifactReview}
-                downstreamRollup={downstream.rollup}
-                handoffRollup={handoffRollup}
-                onGenerateMissingMockups={onGenerateMissingMockups}
-            />
+        <div className="max-w-3xl xl:max-w-5xl mx-auto space-y-5">
+            {/* Compact control row — replaces the old 14-chip filter explosion. */}
+            <div className="bg-white rounded-xl border border-neutral-200 p-3 space-y-3 sticky top-0 z-10">
+                <div className="flex flex-wrap items-center gap-2">
+                    <label className="relative flex-1 min-w-[10rem]">
+                        <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-neutral-400" aria-hidden />
+                        <input
+                            type="search"
+                            value={search}
+                            onChange={e => setSearch(e.target.value)}
+                            placeholder="Search screens…"
+                            aria-label="Search screens"
+                            className="w-full pl-8 pr-2 py-1.5 text-sm rounded-lg border border-neutral-200 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-300"
+                        />
+                    </label>
+                    <SelectControl label="Priority" value={priority} onChange={v => setPriority(v as PriorityFilter)}
+                        options={[
+                            { value: 'all', label: 'All priorities' },
+                            { value: 'P0', label: 'P0' }, { value: 'P1', label: 'P1' },
+                            { value: 'P2', label: 'P2' }, { value: 'P3', label: 'P3' },
+                        ]} />
+                    <SelectControl label="Flow" value={flow} onChange={setFlow}
+                        options={[
+                            { value: 'all', label: 'All flows' },
+                            ...flowOptions.map(f => ({ value: f, label: f })),
+                        ]} />
+                    <SelectControl label="Status" value={status} onChange={v => setStatus(v as StatusFilter)}
+                        options={[
+                            { value: 'all', label: 'Any status' },
+                            { value: 'draft', label: 'Draft' },
+                            { value: 'needs_review', label: 'Needs review' },
+                            { value: 'accepted', label: 'Accepted' },
+                            { value: 'ready', label: 'Ready' },
+                        ]} />
+                    <SelectControl label="Sort" value={sort} onChange={v => setSort(v as SortMode)}
+                        options={[
+                            { value: 'group', label: 'Flow order' },
+                            { value: 'priority', label: 'Priority' },
+                            { value: 'name', label: 'Name' },
+                            { value: 'readiness', label: 'Readiness' },
+                        ]} />
+                    <SelectControl label="Group" value={group} onChange={v => setGroup(v as ScreenGroupMode)}
+                        options={[
+                            ...(flowsAvailable ? [{ value: 'flow', label: 'By flow' }] : []),
+                            { value: 'section', label: 'By section' },
+                            { value: 'priority', label: 'By priority' },
+                        ]} />
+                    <button
+                        type="button"
+                        onClick={() => setAdvancedOpen(o => !o)}
+                        aria-expanded={advancedOpen}
+                        className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition ${
+                            advancedCount > 0
+                                ? 'border-indigo-300 text-indigo-700 bg-indigo-50'
+                                : 'border-neutral-200 text-neutral-600 hover:border-indigo-300 hover:text-indigo-700'
+                        }`}
+                    >
+                        <SlidersHorizontal size={13} aria-hidden />
+                        Advanced
+                        {advancedCount > 0 && (
+                            <span className="tabular-nums bg-indigo-600 text-white rounded-full px-1.5">{advancedCount}</span>
+                        )}
+                    </button>
+                </div>
 
-            <ScreenPreflightPanel preflight={preflight} />
+                {advancedOpen && (
+                    <div className="flex flex-wrap items-center gap-1.5 border-t border-neutral-100 pt-2.5">
+                        <span className="text-[11px] uppercase tracking-wide text-neutral-400 mr-1">Advanced filters</span>
+                        {ADVANCED_FILTERS.map(f => {
+                            const active = advanced.has(f.id);
+                            return (
+                                <button
+                                    key={f.id}
+                                    type="button"
+                                    aria-pressed={active}
+                                    onClick={() => toggleAdvanced(f.id)}
+                                    className={`px-2.5 py-1 rounded-full text-xs font-medium transition ${
+                                        active
+                                            ? 'bg-indigo-600 text-white'
+                                            : 'bg-white text-neutral-600 ring-1 ring-neutral-200 hover:ring-indigo-300 hover:text-indigo-700'
+                                    }`}
+                                >
+                                    {f.label}
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
 
-            {/* Phase 5C: trace-aware implementation-handoff export surface. */}
-            <ScreensHandoffExportPanel
-                input={{
-                    projectName,
-                    handoffs: [...handoffByScreen.values()],
-                    reviewModels,
-                    preflight,
-                    handoffRollup,
-                    p0Ids,
-                    manifest: exportManifest,
-                }}
-            />
-
-            <div className="flex items-center gap-1.5 flex-wrap" role="group" aria-label="Filter screens">
-                {SCREEN_LIST_FILTERS.map(f => {
-                    const active = f.id === filter;
-                    const count = filterCounts.get(f.id) ?? 0;
-                    return (
+                <div className="flex items-center gap-2 text-[11px] text-neutral-400">
+                    <span className="tabular-nums">{totalMatches} of {index.items.length} screens</span>
+                    {anyFilterActive && (
                         <button
-                            key={f.id}
                             type="button"
-                            aria-pressed={active}
-                            onClick={() => setFilter(f.id)}
-                            className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition ${
-                                active
-                                    ? 'bg-indigo-600 text-white'
-                                    : 'bg-white text-neutral-600 ring-1 ring-neutral-200 hover:ring-indigo-300 hover:text-indigo-700'
-                            }`}
+                            onClick={clearFilters}
+                            className="inline-flex items-center gap-1 text-indigo-600 hover:text-indigo-800"
                         >
-                            {f.label}
-                            {f.id !== 'all' && (
-                                <span className={`tabular-nums ${active ? 'text-indigo-200' : 'text-neutral-400'}`}>
-                                    {count}
-                                </span>
-                            )}
+                            <X size={11} aria-hidden /> Clear filters
                         </button>
-                    );
-                })}
+                    )}
+                </div>
             </div>
 
-            {filteredSections.length === 0 && (
+            {filteredGroups.length === 0 && (
                 <div className="bg-white rounded-xl border border-dashed border-neutral-300 p-8 text-center">
                     <Layers size={18} className="text-neutral-300 mx-auto mb-2" />
                     <p className="text-sm text-neutral-600">
@@ -249,24 +379,25 @@ export function ScreenListView({
                 </div>
             )}
 
-            {filteredSections.map((section, sectionIdx) => (
-                <section key={section.title + sectionIdx}>
-                    <header className="mb-3">
-                        <h3 className="text-base font-semibold text-neutral-800">
-                            {section.title}
-                        </h3>
-                        {section.description && (
-                            <p className="text-xs text-neutral-500 mt-1">{section.description}</p>
+            {filteredGroups.map((section) => (
+                <section key={section.id}>
+                    <header className="mb-2.5 flex items-baseline gap-2">
+                        {group === 'flow' && section.id !== '__other__' && (
+                            <Workflow size={15} className="text-indigo-400 shrink-0 self-center" aria-hidden />
                         )}
-                        <div className="mt-1 text-[11px] uppercase tracking-wide text-neutral-400">
-                            {section.items.length} {section.items.length === 1 ? 'screen' : 'screens'}
-                            {filter !== 'all' && ' matching'}
-                        </div>
+                        <h3 className="text-base font-semibold text-neutral-800">{section.title}</h3>
+                        <span className="text-[11px] text-neutral-400">
+                            {section.items.length}{filteredGroups.length !== groups.length || totalMatches !== index.items.length ? ' matching' : ''}
+                        </span>
+                        {section.subtitle && group !== 'flow' && (
+                            <span className="text-xs text-neutral-400 truncate">· {section.subtitle}</span>
+                        )}
                     </header>
                     <ul className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-                        {section.items.map(item => (
+                        {section.items.map((item, i) => (
                             <li key={item.id}>
-                                <ScreenRow
+                                <ScreenCard
+                                    ordinal={sort === 'group' && group === 'flow' && section.id !== '__other__' ? i + 1 : undefined}
                                     item={item}
                                     readiness={readiness.get(item.id)}
                                     reviewModel={reviewModels.get(item.id)}
@@ -283,9 +414,106 @@ export function ScreenListView({
                     </ul>
                 </section>
             ))}
+
+            {/* Secondary: project readiness & metadata — collapsed by default so
+                the screens themselves stay the primary focus. Kept mounted. */}
+            <CollapsibleSection
+                title="Project readiness & metadata"
+                subtitle="Coverage, review readiness, implementation preflight & export"
+                open={metadataOpen}
+                onToggle={() => setMetadataOpen(o => !o)}
+            >
+                <div className="space-y-4">
+                    <ScreenCoveragePanel
+                        summary={coverage}
+                        variantCoverage={variantCoverage}
+                        artifactReview={artifactReview}
+                        downstreamRollup={downstream.rollup}
+                        handoffRollup={handoffRollup}
+                        onGenerateMissingMockups={onGenerateMissingMockups}
+                    />
+                    <ScreenPreflightPanel preflight={preflight} />
+                    <ScreensHandoffExportPanel
+                        input={{
+                            projectName,
+                            handoffs: [...handoffByScreen.values()],
+                            reviewModels,
+                            preflight,
+                            handoffRollup,
+                            p0Ids,
+                            manifest: exportManifest,
+                        }}
+                    />
+                </div>
+            </CollapsibleSection>
         </div>
     );
 }
+
+// --- Compact select control ---------------------------------------------------
+
+function SelectControl({
+    label, value, onChange, options,
+}: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    options: Array<{ value: string; label: string }>;
+}) {
+    return (
+        <label className="inline-flex items-center gap-1 text-xs text-neutral-500">
+            <span className="sr-only">{label}</span>
+            <select
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                aria-label={label}
+                className="py-1.5 pl-2 pr-6 rounded-lg border border-neutral-200 text-neutral-700 bg-white text-xs focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-300"
+            >
+                {options.map(o => (
+                    <option key={o.value} value={o.value}>{label}: {o.label}</option>
+                ))}
+            </select>
+        </label>
+    );
+}
+
+// --- Collapsible metadata section --------------------------------------------
+
+function CollapsibleSection({
+    title, subtitle, open, onToggle, children,
+}: {
+    title: string;
+    subtitle?: string;
+    open: boolean;
+    onToggle: () => void;
+    children: React.ReactNode;
+}) {
+    return (
+        <section className="bg-white rounded-xl border border-neutral-200">
+            <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={open}
+                className="w-full flex items-center gap-3 px-4 py-3 text-left"
+            >
+                <ChevronDown
+                    size={16}
+                    className={`text-neutral-400 transition-transform ${open ? '' : '-rotate-90'}`}
+                    aria-hidden
+                />
+                <span className="flex-1 min-w-0">
+                    <span className="block text-sm font-semibold text-neutral-800">{title}</span>
+                    {subtitle && <span className="block text-xs text-neutral-400 truncate">{subtitle}</span>}
+                </span>
+            </button>
+            {/* Kept mounted (hidden, not unmounted) so panel state survives a
+                collapse and derived content is always present. */}
+            <div className={open ? 'px-4 pb-4' : 'hidden'}>{children}</div>
+        </section>
+    );
+}
+
+// --- Screen card -------------------------------------------------------------
 
 const SYSTEM_READINESS_TONE: Record<ScreenReviewModel['systemReadiness'], string> = {
     ready: 'text-emerald-600',
@@ -293,9 +521,10 @@ const SYSTEM_READINESS_TONE: Record<ScreenReviewModel['systemReadiness'], string
     blocked: 'text-red-600',
 };
 
-function ScreenRow({
-    item, readiness, reviewModel, downstreamImpact, handoff, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
+function ScreenCard({
+    ordinal, item, readiness, reviewModel, downstreamImpact, handoff, mockupPlatform, mobileRelevant, generatedVariants, trustContext, onSelect,
 }: {
+    ordinal?: number;
     item: ScreenExperienceItem;
     readiness?: ScreenReadiness;
     reviewModel?: ScreenReviewModel;
@@ -307,172 +536,127 @@ function ScreenRow({
     trustContext?: VariantTrustContext;
     onSelect: () => void;
 }) {
+    const [detailsOpen, setDetailsOpen] = useState(false);
     const { screen } = item;
     const priority = stylablePriority(screen.priority);
-    const flowCount = item.relatedFlows.length;
-    const entryCount = screen.entryPoints?.length ?? 0;
-    const exitCount = screen.exitPaths?.length ?? 0;
-    const stateCount = screen.states?.length ?? 0;
-    const riskCount = screen.risks?.length ?? 0;
-    const featureRefs = screen.featureRefs ?? [];
+    const connections = deriveScreenConnections(item);
     const variants = buildScreenMockupVariants(item, {
         platform: mockupPlatform, mobileRelevant, generatedVariants, trustContext,
     });
     const variantSummary = summarizeScreenVariants(variants);
-    // Compact freshness signal — count generated variants worth a review.
-    const freshReview = variants.filter(
-        v => v.freshness && (v.freshness.status === 'stale' || v.freshness.status === 'possibly_stale'),
-    ).length;
 
+    // A single, muted status indicator (readiness) is the only secondary signal
+    // shown by default — the badge already distinguishes derived vs. user-set.
+    // Everything else lives behind "Details".
     return (
-        <button
-            type="button"
-            onClick={onSelect}
-            className="w-full h-full text-left bg-white rounded-lg border border-neutral-200 p-4 hover:border-indigo-300 hover:shadow-sm transition group flex flex-col"
-        >
-            <div className="flex items-start justify-between gap-2">
-                <h4 className="font-semibold text-neutral-800 text-sm leading-tight group-hover:text-indigo-700 transition-colors">
-                    {screen.name}
-                </h4>
-                <div className="flex items-center gap-1.5 shrink-0">
-                    {item.isEdited && (
-                        <span className="text-[10px] uppercase tracking-wide text-violet-700 bg-violet-50 ring-1 ring-violet-200 px-1.5 py-0.5 rounded">
-                            Edited
+        <div className="h-full bg-white rounded-lg border border-neutral-200 hover:border-indigo-300 hover:shadow-sm transition flex flex-col">
+            <button
+                type="button"
+                onClick={onSelect}
+                className="w-full text-left p-4 flex flex-col gap-2.5 group flex-1"
+            >
+                <div className="flex items-start gap-2.5">
+                    {ordinal !== undefined && (
+                        <span className="shrink-0 mt-0.5 w-5 h-5 rounded-full bg-neutral-100 text-neutral-500 text-[11px] font-semibold flex items-center justify-center tabular-nums">
+                            {ordinal}
                         </span>
                     )}
-                    {screen.type && screen.type !== 'screen' && (
-                        <span className="text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded">
-                            {screen.type}
+                    <div className="flex-1 min-w-0">
+                        <h4 className="font-semibold text-neutral-800 text-sm leading-tight group-hover:text-indigo-700 transition-colors">
+                            {screen.name}
+                        </h4>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                        {item.isEdited && (
+                            <span className="text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-100 px-1.5 py-0.5 rounded">
+                                Edited
+                            </span>
+                        )}
+                        <span className={`text-xs px-2 py-0.5 rounded-full font-semibold ${PRIORITY_STYLES[priority]}`}>
+                            {priority}
                         </span>
-                    )}
-                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PRIORITY_STYLES[priority]}`}>
-                        {priority}
-                    </span>
+                    </div>
                 </div>
-            </div>
 
-            {screen.purpose && (
-                <p className="text-xs leading-relaxed text-neutral-600 mt-2 line-clamp-2">
-                    {screen.purpose}
-                </p>
-            )}
+                {screen.purpose && (
+                    <p className="text-xs leading-relaxed text-neutral-600 line-clamp-2">
+                        {screen.purpose}
+                    </p>
+                )}
 
-            <div className="mt-2.5 flex items-center gap-1.5 flex-wrap">
-                {readiness && <ReadinessBadge readiness={readiness} />}
-                {featureRefs.length > 0 ? (
-                    <span
-                        className="text-[10px] text-violet-700 bg-violet-50 ring-1 ring-violet-200 px-1.5 py-0.5 rounded-full"
-                        title={`Linked PRD features: ${featureRefs.join(', ')}`}
-                    >
-                        Covers {featureRefs.length} {featureRefs.length === 1 ? 'feature' : 'features'}
-                    </span>
-                ) : (
-                    <span
-                        className="text-[10px] text-neutral-400 bg-neutral-50 ring-1 ring-neutral-200 px-1.5 py-0.5 rounded-full"
-                        title="No linked PRD features found — review recommended"
-                    >
-                        No PRD links
-                    </span>
-                )}
-                {riskCount > 0 && (
-                    <span className="inline-flex items-center gap-1 text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full">
-                        <AlertTriangle size={9} aria-hidden />
-                        {riskCount} {riskCount === 1 ? 'risk' : 'risks'} to review
-                    </span>
-                )}
-                {variantSummary.mobileMissing && (
-                    <span
-                        className="text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full"
-                        title="No mobile mockup variant yet"
-                    >
-                        Mobile: missing
-                    </span>
-                )}
-                {freshReview > 0 && (
-                    <span
-                        className="text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full"
-                        title="One or more generated mockup variants may be stale — the screen spec, design system, or PRD changed after generation"
-                    >
-                        Freshness: {freshReview} to review
-                    </span>
-                )}
-                {variantSummary.coverageUnknown && (
-                    <span
-                        className="text-[10px] text-neutral-500 bg-neutral-50 ring-1 ring-neutral-200 px-1.5 py-0.5 rounded-full"
-                        title="This mockup was generated before coverage metadata was captured"
-                    >
-                        Coverage: unknown
-                    </span>
-                )}
-                {reviewModel?.freshness === 'outdated' && (
-                    <span
-                        className="text-[10px] text-amber-700 bg-amber-50 ring-1 ring-amber-200 px-1.5 py-0.5 rounded-full"
-                        title="This screen changed after it was reviewed — re-review recommended"
-                    >
-                        Review may be outdated
-                    </span>
-                )}
-                {downstreamImpact && <DownstreamChip impact={downstreamImpact} />}
-                {handoff && <HandoffChip status={handoff.readiness.status} />}
-                {handoff?.traceBridge && <TraceChip bridge={handoff.traceBridge} />}
-            </div>
+                {/* Flow connection — the hero. Names, not counts. */}
+                <FlowStrip name={screen.name} connections={connections} />
 
-            {reviewModel && (
-                <div className="mt-2 flex items-center gap-2 flex-wrap text-[11px]">
-                    <span className="text-neutral-400 uppercase tracking-wide text-[10px]">Review</span>
-                    <span className="font-medium text-neutral-700">
-                        {reviewModel.userStatus ? REVIEW_STATUS_LABELS[reviewModel.userStatus] : 'Not reviewed'}
+                {/* One-line, low-color footer: mockup availability + readiness. */}
+                <div className="mt-auto pt-2 flex items-center gap-3 flex-wrap text-[11px] text-neutral-500">
+                    <span className="inline-flex items-center gap-1" title="Mockup availability for this screen">
+                        <ImageIcon size={12} className={variantSummary.hasMockup ? 'text-emerald-500' : 'text-neutral-300'} />
+                        {variantSummary.hasMockup ? 'Mockup ready' : 'No mockup'}
                     </span>
-                    <span className="text-neutral-300" aria-hidden>·</span>
-                    <span className={SYSTEM_READINESS_TONE[reviewModel.systemReadiness]}>
-                        {reviewModel.blockingCount > 0
-                            ? `${reviewModel.blockingCount} ${reviewModel.blockingCount === 1 ? 'blocker' : 'blockers'}`
-                            : reviewModel.reviewCount > 0
-                                ? `${reviewModel.reviewCount} review ${reviewModel.reviewCount === 1 ? 'item' : 'items'}`
-                                : SYSTEM_READINESS_LABELS[reviewModel.systemReadiness]}
-                    </span>
-                    {reviewModel.blockingCount > 0 && reviewModel.reviewCount > 0 && (
-                        <span className="text-amber-600">
-                            + {reviewModel.reviewCount} review {reviewModel.reviewCount === 1 ? 'item' : 'items'}
-                        </span>
-                    )}
+                    {readiness && <ReadinessBadge readiness={readiness} />}
+                    <ChevronRight size={13} className="ml-auto text-neutral-300 group-hover:text-indigo-400 transition-colors" aria-hidden />
                 </div>
-            )}
+            </button>
 
-            <div className="mt-auto pt-3 flex items-center gap-3 flex-wrap text-[11px] text-neutral-500">
-                <span
-                    className="inline-flex items-center gap-1"
-                    title="States documented in the spec (empty / loading / error variants)"
+            {/* Progressive disclosure — implementation / traceability / review /
+                risk / handoff / downstream, none of it competing by default. */}
+            <div className="px-4 pb-3">
+                <button
+                    type="button"
+                    onClick={() => setDetailsOpen(o => !o)}
+                    aria-expanded={detailsOpen}
+                    className="inline-flex items-center gap-1 text-[11px] font-medium text-neutral-500 hover:text-indigo-600 transition"
                 >
-                    <Layers size={11} className={stateCount > 0 ? 'text-sky-500' : 'text-neutral-300'} />
-                    {stateCount > 0 ? `${stateCount} ${stateCount === 1 ? 'state' : 'states'}` : 'No states'}
-                </span>
-                <span
-                    className="inline-flex items-center gap-1"
-                    title="Mockup variant coverage — generated vs. recommended (viewport × state), tracked from mockup metadata"
-                >
-                    <ImageIcon size={11} className={variantSummary.hasMockup ? 'text-emerald-500' : 'text-neutral-300'} />
-                    {variantSummary.hasMockup
-                        ? `Mockups: ${variantSummary.label}`
-                        : 'No mockup'}
-                </span>
-                <span
-                    className="inline-flex items-center gap-1"
-                    title="User-flow steps referencing this screen"
-                >
-                    <Workflow size={11} className={flowCount > 0 ? 'text-indigo-500' : 'text-neutral-300'} />
-                    {flowCount > 0
-                        ? `${flowCount} flow ${flowCount === 1 ? 'step' : 'steps'}`
-                        : 'No flow refs'}
-                </span>
-                {(entryCount > 0 || exitCount > 0) && (
-                    <span title="Ways users arrive at this screen (incoming) and leave it (outgoing)">
-                        {entryCount} incoming · {exitCount} outgoing
-                    </span>
+                    <ChevronDown size={12} className={`transition-transform ${detailsOpen ? '' : '-rotate-90'}`} aria-hidden />
+                    {detailsOpen ? 'Hide details' : 'Show details'}
+                </button>
+                {detailsOpen && (
+                    <CardDetails
+                        item={item}
+                        connections={connections}
+                        reviewModel={reviewModel}
+                        downstreamImpact={downstreamImpact}
+                        handoff={handoff}
+                        variantSummary={variantSummary}
+                    />
                 )}
-                <ChevronRight size={13} className="ml-auto text-neutral-300 group-hover:text-indigo-400 transition-colors" aria-hidden />
             </div>
-        </button>
+        </div>
+    );
+}
+
+/** The mini flow visualization: This screen → next screens (by exit-path
+ * target). Falls back to the flow it belongs to when there are no exit paths. */
+function FlowStrip({ name, connections }: { name: string; connections: ReturnType<typeof deriveScreenConnections> }) {
+    if (connections.outgoing.length > 0) {
+        return (
+            <div className="flex items-center gap-1.5 flex-wrap text-[11px]" title={`${name} leads to ${connections.outgoing.join(', ')}`}>
+                <span className="text-[10px] uppercase tracking-wide text-neutral-400">Next</span>
+                {connections.outgoing.slice(0, 3).map((target, i) => (
+                    <span key={i} className="inline-flex items-center gap-1 text-neutral-600">
+                        <ArrowRight size={11} className="text-neutral-300" aria-hidden />
+                        <span className="max-w-[8rem] truncate">{target}</span>
+                    </span>
+                ))}
+                {connections.outgoing.length > 3 && (
+                    <span className="text-neutral-400">+{connections.outgoing.length - 3}</span>
+                )}
+            </div>
+        );
+    }
+    if (connections.flowTitles.length > 0) {
+        return (
+            <div className="flex items-center gap-1.5 text-[11px] text-neutral-500">
+                <Workflow size={11} className="text-indigo-300" aria-hidden />
+                <span className="text-neutral-400">Part of</span>
+                <span className="font-medium text-neutral-600 truncate" title={connections.flowTitles.join(', ')}>
+                    {connections.flowTitles.join(', ')}
+                </span>
+            </div>
+        );
+    }
+    return (
+        <div className="text-[11px] text-neutral-400">Not yet connected to a flow</div>
     );
 }
 
@@ -486,77 +670,132 @@ const DOWNSTREAM_LABELS: Record<string, string> = {
     export: 'Export',
 };
 
-/** Compact downstream-impact chip — shown only when a change/blocker actually
- * impacts a downstream artifact (info-only impacts show no chip, to avoid
- * cluttering every legacy card). */
-function DownstreamChip({ impact }: { impact: ScreenDownstreamImpact }) {
-    const actionable = impact.impactedArtifacts.filter(a => a.severity !== 'info');
-    if (actionable.length === 0) return null;
-    const blocking = impact.summary.hasBlockingImpact;
-    const names = actionable.slice(0, 2).map(a => DOWNSTREAM_LABELS[a.kind] ?? a.kind);
-    const label = blocking
-        ? 'Implementation not ready'
-        : `Downstream review: ${names.join(', ')}${actionable.length > names.length ? '…' : ''}`;
-    const tone = blocking
-        ? 'text-red-700 bg-red-50 ring-red-200'
-        : 'text-amber-700 bg-amber-50 ring-amber-200';
+/** Secondary metadata, revealed on demand. Neutral typography with warning
+ * color reserved for genuine issues (blockers, risks, stale/blocked states). */
+function CardDetails({
+    item, connections, reviewModel, downstreamImpact, handoff, variantSummary,
+}: {
+    item: ScreenExperienceItem;
+    connections: ReturnType<typeof deriveScreenConnections>;
+    reviewModel?: ScreenReviewModel;
+    downstreamImpact?: ScreenDownstreamImpact;
+    handoff?: ScreenImplementationHandoff;
+    variantSummary: ReturnType<typeof summarizeScreenVariants>;
+}) {
+    const { screen } = item;
+    const featureRefs = screen.featureRefs ?? [];
+    const riskCount = screen.risks?.length ?? 0;
+    const stateCount = screen.states?.length ?? 0;
+    const downstreamActionable = downstreamImpact?.impactedArtifacts.filter(a => a.severity !== 'info') ?? [];
+
     return (
-        <span
-            className={`text-[10px] px-1.5 py-0.5 rounded-full ring-1 ${tone}`}
-            title={blocking
-                ? 'This screen has blocking readiness issues — downstream implementation is affected'
-                : 'This screen changed or needs review — the named downstream artifacts may be worth re-checking'}
-        >
-            {label}
-        </span>
+        <dl className="mt-2.5 pt-2.5 border-t border-neutral-100 space-y-2 text-[11px]">
+            {/* Connections */}
+            {(connections.incoming.length > 0 || connections.outgoing.length > 0) && (
+                <DetailRow label="Connected to">
+                    {connections.outgoing.length > 0 ? connections.outgoing.join(', ') : '—'}
+                    {connections.incoming.length > 0 && (
+                        <span className="block text-neutral-400 mt-0.5">
+                            Reached from: {connections.incoming.join(', ')}
+                        </span>
+                    )}
+                </DetailRow>
+            )}
+
+            {/* Review */}
+            {reviewModel && (
+                <DetailRow label="Review">
+                    <span className="text-neutral-700">
+                        {reviewModel.userStatus ? REVIEW_STATUS_LABELS[reviewModel.userStatus] : 'Not reviewed'}
+                    </span>
+                    <span className="text-neutral-300 mx-1" aria-hidden>·</span>
+                    <span className={SYSTEM_READINESS_TONE[reviewModel.systemReadiness]}>
+                        {reviewModel.blockingCount > 0
+                            ? `${reviewModel.blockingCount} ${reviewModel.blockingCount === 1 ? 'blocker' : 'blockers'}`
+                            : reviewModel.reviewCount > 0
+                                ? `${reviewModel.reviewCount} review ${reviewModel.reviewCount === 1 ? 'item' : 'items'}`
+                                : SYSTEM_READINESS_LABELS[reviewModel.systemReadiness]}
+                    </span>
+                    {reviewModel.freshness === 'outdated' && (
+                        <span className="block text-amber-600 mt-0.5">Review may be outdated — the screen changed after sign-off.</span>
+                    )}
+                </DetailRow>
+            )}
+
+            {/* Traceability */}
+            <DetailRow label="Traceability">
+                {featureRefs.length > 0
+                    ? `Covers ${featureRefs.length} PRD ${featureRefs.length === 1 ? 'feature' : 'features'}: ${featureRefs.join(', ')}`
+                    : <span className="text-neutral-400">No linked PRD features — review recommended</span>}
+            </DetailRow>
+
+            {/* Implementation / handoff */}
+            {handoff && (
+                <DetailRow label="Handoff">
+                    <span className={
+                        handoff.readiness.status === 'blocked' ? 'text-red-600'
+                            : handoff.readiness.status === 'review_recommended' ? 'text-amber-600'
+                                : 'text-emerald-600'
+                    }>
+                        {HANDOFF_STATUS_LABELS[handoff.readiness.status]}
+                    </span>
+                    {handoff.traceBridge && (handoff.traceBridge.implementationPlan.confidence === 'missing'
+                        || ['weak', 'estimated', 'missing'].includes(handoff.traceBridge.overall.confidence)) && (
+                        <span className="block text-amber-600 mt-0.5">
+                            Downstream trace estimated or missing — confirm before building.
+                        </span>
+                    )}
+                </DetailRow>
+            )}
+
+            {/* Mockup coverage detail */}
+            <DetailRow label="Mockups">
+                {variantSummary.hasMockup ? variantSummary.label : 'Not generated yet'}
+                {variantSummary.coverageUnknown && (
+                    <span className="block text-neutral-400 mt-0.5">Coverage unknown — generated before coverage metadata was captured.</span>
+                )}
+            </DetailRow>
+
+            {/* States */}
+            <DetailRow label="States">
+                {stateCount > 0 ? `${stateCount} documented` : <span className="text-neutral-400">None documented</span>}
+            </DetailRow>
+
+            {/* Risks */}
+            {riskCount > 0 && (
+                <DetailRow label="Risks">
+                    <span className="inline-flex items-center gap-1 text-amber-700">
+                        <AlertTriangle size={10} aria-hidden />
+                        {riskCount} to review
+                    </span>
+                </DetailRow>
+            )}
+
+            {/* Downstream impact */}
+            {downstreamActionable.length > 0 && (
+                <DetailRow label="Downstream">
+                    <span className={downstreamImpact?.summary.hasBlockingImpact ? 'text-red-600' : 'text-amber-600'}>
+                        {downstreamImpact?.summary.hasBlockingImpact
+                            ? 'Implementation not ready'
+                            : `Downstream review: ${downstreamActionable.slice(0, 2).map(a => DOWNSTREAM_LABELS[a.kind] ?? a.kind).join(', ')}`}
+                    </span>
+                </DetailRow>
+            )}
+        </dl>
     );
 }
 
-const HANDOFF_CHIP_META: Record<ScreenImplementationHandoff['readiness']['status'], {
-    label: string; tone: string; title: string;
-}> = {
-    ready: {
-        label: 'Handoff ready',
-        tone: 'text-emerald-700 bg-emerald-50 ring-emerald-200',
-        title: 'This screen has an accepted spec and a build-ready handoff package',
-    },
-    review_recommended: {
-        label: 'Handoff needs review',
-        tone: 'text-amber-700 bg-amber-50 ring-amber-200',
-        title: 'The handoff package is usable but has review items — confirm before building',
-    },
-    blocked: {
-        label: 'Handoff blocked',
-        tone: 'text-red-700 bg-red-50 ring-red-200',
-        title: 'Resolve the blockers before using this screen as a build source',
-    },
+const HANDOFF_STATUS_LABELS: Record<ScreenImplementationHandoff['readiness']['status'], string> = {
+    ready: 'Ready',
+    review_recommended: 'Needs review',
+    blocked: 'Blocked',
 };
 
-/** Compact implementation-handoff readiness chip (Phase 5A). */
-function HandoffChip({ status }: { status: ScreenImplementationHandoff['readiness']['status'] }) {
-    const meta = HANDOFF_CHIP_META[status];
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
     return (
-        <span className={`text-[10px] px-1.5 py-0.5 rounded-full ring-1 ${meta.tone}`} title={meta.title}>
-            {meta.label}
-        </span>
-    );
-}
-
-/** Compact downstream-trace chip (Phase 5B) — shown only when a trace concern
- * exists (no plan match, or an estimated/missing overall trace), to avoid
- * cluttering cards whose trace is already strong. */
-function TraceChip({ bridge }: { bridge: NonNullable<ScreenImplementationHandoff['traceBridge']> }) {
-    const planMissing = bridge.implementationPlan.confidence === 'missing';
-    const overall = bridge.overall.confidence;
-    const weak = overall === 'weak' || overall === 'estimated' || overall === 'missing';
-    if (!planMissing && !weak) return null; // strong trace → no chip
-    const label = planMissing ? 'No plan match' : 'Trace needs review';
-    return (
-        <span
-            className="text-[10px] px-1.5 py-0.5 rounded-full ring-1 text-amber-700 bg-amber-50 ring-amber-200"
-            title="Downstream trace to the Data Model / Implementation Plan is estimated or missing — confirm before building"
-        >
-            {label}
-        </span>
+        <div className="flex gap-2">
+            <dt className="w-20 shrink-0 text-neutral-400 uppercase tracking-wide text-[10px] pt-0.5">{label}</dt>
+            <dd className="flex-1 min-w-0 text-neutral-600">{children}</dd>
+        </div>
     );
 }

--- a/src/lib/__tests__/screenFlowView.test.ts
+++ b/src/lib/__tests__/screenFlowView.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import type { MockupPayload, ScreenInventoryContent } from '../../types';
+import { buildScreenIndex } from '../screenExperience';
+import { parseFlows } from '../../components/renderers/userFlows/parseFlow';
+import {
+    buildScreenGroups, deriveScreenConnections, flowFilterOptions, hasFlowGrouping,
+} from '../screenFlowView';
+
+const inventory: ScreenInventoryContent = {
+    sections: [{
+        title: 'Main',
+        screens: [
+            {
+                id: 'scr-upload', name: 'Upload', priority: 'P0', purpose: 'Upload images',
+                entryPoints: ['App launch'],
+                exitPaths: [{ label: 'Continue', target: 'Verification' }],
+            },
+            {
+                id: 'scr-verification', name: 'Verification', priority: 'P1', purpose: 'Verify',
+                exitPaths: [{ label: 'Next', target: 'Review' }, { label: 'Back', target: 'Upload' }],
+            },
+            { id: 'scr-review', name: 'Review', priority: 'P1', purpose: 'Review results' },
+            { id: 'scr-settings', name: 'Settings', priority: 'P2', purpose: 'Configure' },
+        ],
+    }],
+};
+
+const FLOWS_MD = `### Flow: Content Ingestion
+**Goal:** Ingest content
+**Steps:**
+1. [Upload] — User uploads → System accepts
+2. [Verification] — User verifies → System checks
+3. [Review] — User reviews → System stores
+`;
+
+function build() {
+    const flows = parseFlows(FLOWS_MD);
+    return buildScreenIndex(inventory, flows, null as unknown as MockupPayload);
+}
+
+describe('deriveScreenConnections', () => {
+    it('derives outgoing target names and flow titles', () => {
+        const index = build();
+        const upload = index.byId.get('scr-upload')!;
+        const c = deriveScreenConnections(upload);
+        expect(c.outgoing).toEqual(['Verification']);
+        expect(c.incoming).toEqual(['App launch']);
+        expect(c.flowTitles).toEqual(['Content Ingestion']);
+    });
+
+    it('dedupes and preserves order', () => {
+        const index = build();
+        const verification = index.byId.get('scr-verification')!;
+        const c = deriveScreenConnections(verification);
+        expect(c.outgoing).toEqual(['Review', 'Upload']);
+    });
+
+    it('returns empty connections for an unconnected screen', () => {
+        const index = build();
+        const settings = index.byId.get('scr-settings')!;
+        const c = deriveScreenConnections(settings);
+        expect(c.outgoing).toEqual([]);
+        expect(c.flowTitles).toEqual([]);
+    });
+});
+
+describe('buildScreenGroups', () => {
+    it('groups flow screens by their flow, in step order, with an Other bucket', () => {
+        const index = build();
+        const groups = buildScreenGroups(index, 'flow');
+        expect(groups[0].title).toBe('Content Ingestion');
+        expect(groups[0].items.map(i => i.screen.name)).toEqual(['Upload', 'Verification', 'Review']);
+        // Settings is in no flow → trailing "Other screens" group.
+        const other = groups.find(g => g.id === '__other__');
+        expect(other?.items.map(i => i.screen.name)).toEqual(['Settings']);
+    });
+
+    it('groups by section', () => {
+        const index = build();
+        const groups = buildScreenGroups(index, 'section');
+        expect(groups).toHaveLength(1);
+        expect(groups[0].title).toBe('Main');
+        expect(groups[0].items).toHaveLength(4);
+    });
+
+    it('groups by priority, highest tier first', () => {
+        const index = build();
+        const groups = buildScreenGroups(index, 'priority');
+        expect(groups.map(g => g.id)).toEqual(['priority:P0', 'priority:P1', 'priority:P2']);
+        expect(groups[0].items.map(i => i.screen.name)).toEqual(['Upload']);
+    });
+});
+
+describe('flow helpers', () => {
+    it('hasFlowGrouping is true when a screen is referenced by a flow', () => {
+        expect(hasFlowGrouping(build())).toBe(true);
+    });
+
+    it('flowFilterOptions lists distinct flow titles', () => {
+        expect(flowFilterOptions(build())).toEqual(['Content Ingestion']);
+    });
+});

--- a/src/lib/screenFlowView.ts
+++ b/src/lib/screenFlowView.ts
@@ -1,0 +1,194 @@
+// Flow-first presentation helpers for the Screens (Experience) list view.
+//
+// Pure & framework-free (no store / React / IDB) so it can be unit-tested in
+// isolation. This module answers the two questions the redesigned Screens list
+// leads with — "what flow does a screen belong to?" and "where does the user go
+// next?" — by deriving grouping and connection data from the already-joined
+// ScreenExperienceIndex. It never mutates the index and never invents a
+// connection the artifacts don't already describe.
+
+import type { ScreenExperienceIndex, ScreenExperienceItem } from './screenExperience';
+import { stylablePriority } from '../components/renderers/screenPriority';
+
+/** Connections a single screen participates in, derived from its own spec. */
+export interface ScreenConnections {
+    /** Ways users arrive (entry-point labels from the screen contract). */
+    incoming: string[];
+    /** Where users go next — exit-path target screen names (deduped, in order). */
+    outgoing: string[];
+    /** Titles of the user flows this screen appears in (deduped, flow order). */
+    flowTitles: string[];
+}
+
+const dedupe = (values: Iterable<string>): string[] => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const raw of values) {
+        const value = raw.trim();
+        if (!value || seen.has(value)) continue;
+        seen.add(value);
+        out.push(value);
+    }
+    return out;
+};
+
+/**
+ * Derive the human-readable connections for one screen — names, not counts.
+ * Outgoing comes from `exitPaths[].target` (usually a screen name), incoming
+ * from `entryPoints` (arrival triggers / origins), and the flow titles from the
+ * joined `relatedFlows`. Everything is deduped and order-preserving.
+ */
+export function deriveScreenConnections(item: ScreenExperienceItem): ScreenConnections {
+    const { screen } = item;
+    const outgoing = dedupe((screen.exitPaths ?? []).map(p => p.target ?? '').filter(Boolean));
+    const incoming = dedupe((screen.entryPoints ?? []).filter(Boolean));
+    const flowTitles = dedupe(item.relatedFlows.map(ref => ref.flow.title).filter(Boolean));
+    return { incoming, outgoing, flowTitles };
+}
+
+// --- Grouping -----------------------------------------------------------------
+
+export type ScreenGroupMode = 'flow' | 'section' | 'priority';
+
+/** One display group of screens for the list (a flow, a section, or a tier). */
+export interface ScreenDisplayGroup {
+    /** Stable key for React lists / group state. */
+    id: string;
+    title: string;
+    subtitle?: string;
+    items: ScreenExperienceItem[];
+}
+
+/** The primary flow a screen belongs to — the flow where it appears earliest.
+ * Ties break on flow order, then step order, so the assignment is stable. */
+function primaryFlowRef(item: ScreenExperienceItem): { flowIndex: number; stepIndex: number; title: string } | null {
+    let best: { flowIndex: number; stepIndex: number; title: string } | null = null;
+    for (const ref of item.relatedFlows) {
+        if (!ref.flow.title) continue;
+        if (
+            !best
+            || ref.stepIndex < best.stepIndex
+            || (ref.stepIndex === best.stepIndex && ref.flowIndex < best.flowIndex)
+        ) {
+            best = { flowIndex: ref.flowIndex, stepIndex: ref.stepIndex, title: ref.flow.title };
+        }
+    }
+    return best;
+}
+
+const OTHER_GROUP_ID = '__other__';
+
+/** Group screens by their primary user flow, ordered by flow appearance. Screens
+ * not referenced by any flow collect in a trailing "Other screens" group so
+ * nothing is dropped. Within a flow, screens follow their step order. */
+function groupByFlow(index: ScreenExperienceIndex): ScreenDisplayGroup[] {
+    interface Bucket {
+        flowIndex: number;
+        title: string;
+        entries: Array<{ item: ScreenExperienceItem; stepIndex: number; order: number }>;
+    }
+    const buckets = new Map<number, Bucket>();
+    const other: ScreenExperienceItem[] = [];
+
+    index.items.forEach((item, order) => {
+        const primary = primaryFlowRef(item);
+        if (!primary) {
+            other.push(item);
+            return;
+        }
+        let bucket = buckets.get(primary.flowIndex);
+        if (!bucket) {
+            bucket = { flowIndex: primary.flowIndex, title: primary.title, entries: [] };
+            buckets.set(primary.flowIndex, bucket);
+        }
+        bucket.entries.push({ item, stepIndex: primary.stepIndex, order });
+    });
+
+    const groups: ScreenDisplayGroup[] = [...buckets.values()]
+        .sort((a, b) => a.flowIndex - b.flowIndex)
+        .map(bucket => {
+            const items = bucket.entries
+                .sort((a, b) => (a.stepIndex - b.stepIndex) || (a.order - b.order))
+                .map(e => e.item);
+            return {
+                id: `flow:${bucket.flowIndex}`,
+                title: bucket.title,
+                subtitle: `${items.length} ${items.length === 1 ? 'screen' : 'screens'}`,
+                items,
+            };
+        });
+
+    if (other.length > 0) {
+        groups.push({
+            id: OTHER_GROUP_ID,
+            title: 'Other screens',
+            subtitle: 'Not referenced by a user flow yet',
+            items: other,
+        });
+    }
+    return groups;
+}
+
+/** Group screens by the inventory section they were generated under. */
+function groupBySection(index: ScreenExperienceIndex): ScreenDisplayGroup[] {
+    return index.sections.map((section, i) => ({
+        id: `section:${i}`,
+        title: section.title,
+        subtitle: section.description,
+        items: section.items,
+    }));
+}
+
+const PRIORITY_ORDER = ['P0', 'P1', 'P2', 'P3'] as const;
+const PRIORITY_TITLES: Record<string, string> = {
+    P0: 'P0 · Critical',
+    P1: 'P1 · Important',
+    P2: 'P2 · Secondary',
+    P3: 'P3 · Nice to have',
+};
+
+/** Group screens by priority tier, highest first. */
+function groupByPriority(index: ScreenExperienceIndex): ScreenDisplayGroup[] {
+    const byTier = new Map<string, ScreenExperienceItem[]>();
+    for (const item of index.items) {
+        const tier = stylablePriority(item.screen.priority);
+        const list = byTier.get(tier) ?? [];
+        list.push(item);
+        byTier.set(tier, list);
+    }
+    return PRIORITY_ORDER
+        .filter(tier => byTier.has(tier))
+        .map(tier => {
+            const items = byTier.get(tier)!;
+            return {
+                id: `priority:${tier}`,
+                title: PRIORITY_TITLES[tier],
+                subtitle: `${items.length} ${items.length === 1 ? 'screen' : 'screens'}`,
+                items,
+            };
+        });
+}
+
+/** Build the display groups for the given grouping mode. */
+export function buildScreenGroups(index: ScreenExperienceIndex, mode: ScreenGroupMode): ScreenDisplayGroup[] {
+    switch (mode) {
+        case 'flow':
+            return groupByFlow(index);
+        case 'priority':
+            return groupByPriority(index);
+        case 'section':
+        default:
+            return groupBySection(index);
+    }
+}
+
+/** True when at least one screen is referenced by a user flow — the signal for
+ * defaulting the list to flow grouping. */
+export function hasFlowGrouping(index: ScreenExperienceIndex): boolean {
+    return index.items.some(item => primaryFlowRef(item) !== null);
+}
+
+/** Distinct flow titles across the index, for the Flow filter dropdown. */
+export function flowFilterOptions(index: ScreenExperienceIndex): string[] {
+    return dedupe(index.items.flatMap(item => item.relatedFlows.map(ref => ref.flow.title)));
+}


### PR DESCRIPTION
## Why

The Screens artifact had drifted into a project-management dashboard: a **14-chip filter row** across the top and cards carrying up to a dozen colored status / traceability / handoff / downstream / freshness pills. The product experience — what screens exist, how they connect, and which flow they belong to — was buried under implementation metadata.

This PR re-centers the Screens list on a **flow-first philosophy**: the screens and their connections are the primary focus; implementation, traceability, readiness, and review data stay fully available but visually secondary.

**This is an information-architecture / UX redesign, not a feature removal.** It is presentation-only over the existing join / readiness / review / handoff / downstream layers — no schema, prompt, pipeline, sync, or persistence change. Every filter, badge, and signal that existed before is still reachable.

## What changed

- **New pure helper `src/lib/screenFlowView.ts`** (unit-tested):
  - `deriveScreenConnections(item)` — connection **names, not counts** (outgoing = `exitPaths[].target`, incoming = `entryPoints`, plus joined flow titles).
  - `buildScreenGroups(index, mode)` — group by `flow` (primary-flow assignment where a screen appears earliest, with a trailing "Other screens" bucket), `section`, or `priority`.
  - `hasFlowGrouping` / `flowFilterOptions` drive the defaults.
- **Compact control row replaces the 14 filter chips**: search + Priority / Flow / Status / Sort / Group selects + an **Advanced** drawer holding the long-tail filters (has_blockers, review_recommended, outdated_review, downstream_review, handoff_ready, handoff_blocked, missing_mockups, has_risks). Filter semantics are unchanged — still resolved through `screenMatchesFilter`.
- **Screens grouped by user flow by default** (falls back to section grouping when no flow references exist).
- **Redesigned card**: one prominent badge (priority) + title + purpose + a **mini flow strip** ("Next → …", else "Part of &lt;flow&gt;") + a single muted readiness badge. All other metadata (review, traceability, handoff, mockup coverage, states, risks, downstream impact) moves behind a per-card **"Show details"** disclosure.
- **Reduced color**: reserved for priority and genuine warnings (blockers / risks / stale / blocked); neutral typography elsewhere.
- **Coverage & Readiness / preflight / export panels** collapsed under one **"Project readiness & metadata"** section (kept mounted, hidden via CSS) so the screens stay the focus.

## Tests

- Updated `ScreenExperienceViews` tests to exercise the new controls (selects + Advanced drawer) and the per-card "Show details" disclosure.
- Added `src/lib/__tests__/screenFlowView.test.ts` for connection derivation and grouping.
- Full suite green: **1438 tests pass**, `npm run build` and `npm run lint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G3T2aieUK6RSDb4me4gdr

---
_Generated by [Claude Code](https://claude.ai/code/session_019G3T2aieUK6RSDb4me4gdr)_