### PR TITLE
Fix two review findings from the readiness-reframe panel

### DIFF
--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -154,12 +154,18 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
             mockups: { covered: 2, total: 2 },
             openRisks: 0,
             ready: 2, readyWithWarnings: 0, needsReview: 0,
-            message: 'Review the uncovered PRD feature before implementation.',
+            // Per-screen readiness sentence reads all-clear — it must NOT be
+            // used as the headline while an artifact-level risk remains.
+            message: 'All 2 screens pass the derived readiness checks. Review them once more before implementation.',
         };
         const { queryByText, getByText } = render(
             <ScreenListView index={index} readiness={readiness} coverage={coverage} onSelectScreen={() => {}} />,
         );
+        // Neither the green all-clear nor the celebratory per-screen message.
         expect(queryByText(/Implementation coverage is complete/)).toBeNull();
+        expect(queryByText(/All 2 screens pass the derived readiness checks/)).toBeNull();
+        // A dedicated risk-aware headline is shown instead.
+        expect(getByText(/some required coverage still needs review/)).toBeTruthy();
         expect(getByText(/1 PRD feature not linked to any screen/)).toBeTruthy();
     });
 

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import type { Feature, MockupPayload, ScreenInventoryContent, ScreenItem } from '../../types';
 import { buildScreenIndex, type ScreenMetadataEdit } from '../../lib/screenExperience';
-import { buildReadinessIndex, buildScreenCoverageSummary } from '../../lib/screenReadiness';
+import { buildReadinessIndex, buildScreenCoverageSummary, type ScreenCoverageSummary } from '../../lib/screenReadiness';
 import { buildScreenReviewIndex, summarizeArtifactReviewReadiness } from '../../lib/screenReviewWorkflow';
 import { parseFlows } from '../renderers/userFlows/parseFlow';
 import { ScreenListView } from '../experience/ScreenListView';
@@ -137,6 +137,56 @@ describe('ScreenListView (coverage panel + filters + cards)', () => {
         expect(getByText(/available on demand/)).toBeTruthy();
         // The old mandatory-sounding "N / M recommended" ratio is gone.
         expect(queryByText(/17 recommended/)).toBeNull();
+    });
+
+    it('withholds the green all-clear when a PRD feature is uncovered, even if every screen is ready', () => {
+        const { index, readiness } = buildFixtures();
+        // Every screen ready, no warnings — but one PRD feature links to no
+        // screen, which is genuine implementation risk. The all-clear headline
+        // must NOT fire (it would contradict the amber uncovered-feature row).
+        const coverage: ScreenCoverageSummary = {
+            totalScreens: 2,
+            prdFeatures: { covered: 1, total: 2, uncovered: [{ id: 'F2', name: 'Sharing' }], mustWithoutPrimaryScreen: [] },
+            stateVariants: null,
+            flows: { represented: 1, total: 1 },
+            p0: { total: 0, withMockup: 0 },
+            states: { screensWithStates: 2, totalStates: 2, statesWithBehavior: 2 },
+            mockups: { covered: 2, total: 2 },
+            openRisks: 0,
+            ready: 2, readyWithWarnings: 0, needsReview: 0,
+            message: 'Review the uncovered PRD feature before implementation.',
+        };
+        const { queryByText, getByText } = render(
+            <ScreenListView index={index} readiness={readiness} coverage={coverage} onSelectScreen={() => {}} />,
+        );
+        expect(queryByText(/Implementation coverage is complete/)).toBeNull();
+        expect(getByText(/1 PRD feature not linked to any screen/)).toBeTruthy();
+    });
+
+    it('surfaces stale/legacy primary-mockup signals even when no variants are recommended', () => {
+        const { index, readiness, coverage } = buildFixtures();
+        const { getByText, queryByText } = render(
+            <ScreenListView
+                index={index}
+                readiness={readiness}
+                coverage={coverage}
+                // Desktop/simple project: only primary mockups, no additional
+                // variants recommended — but one is stale and one is legacy.
+                variantCoverage={{
+                    recommendedGenerated: 2, recommendedTotal: 2,
+                    additionalGenerated: 0, additionalTotal: 0,
+                    p0WithMobile: 0, p0Total: 0,
+                    legacyUnknownMockups: 1, manifestBackedGenerated: 0,
+                    freshness: { total: 2, current: 1, review: 1, unknown: 0 },
+                }}
+                onSelectScreen={() => {}}
+            />,
+        );
+        // No optional-variant section (nothing to expand into)...
+        expect(queryByText('Expanded Design Coverage')).toBeNull();
+        // ...yet the freshness + legacy signals for existing mockups still show.
+        expect(getByText(/may be worth refreshing/)).toBeTruthy();
+        expect(getByText(/predate coverage metadata/)).toBeTruthy();
     });
 
     it('filters screens (Has risks shows only the risky screen)', () => {

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -95,10 +95,12 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
     if (totalScreens === 0) return null;
 
     // Clean-ready screens: implementation-ready and NOT a user override that
-    // still carries derived warnings. When every screen is clean-ready the core
-    // implementation assets are complete (mockup variants never factor in).
+    // still carries derived warnings. Every screen being clean-ready is
+    // necessary for the all-clear, but not sufficient — see `coreComplete`
+    // below, which also requires no genuine artifact-level risk (mockup
+    // variants never factor in either way).
     const readyClean = Math.max(0, ready - readyWithWarnings);
-    const coreComplete = readyClean === totalScreens;
+    const readyComplete = readyClean === totalScreens;
 
     // --- Required (implementation-critical) checklist -----------------------
     // Only genuine implementation risk (missing PRD coverage, a P0 without its
@@ -159,8 +161,18 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
     required.push({
         key: 'ready', label: 'Ready for implementation',
         value: `${readyClean} / ${totalScreens} screens`,
-        tone: coreComplete ? 'good' : 'todo',
+        tone: readyComplete ? 'good' : 'todo',
     });
+
+    // The green "all-clear" is shown only when every screen is clean-ready AND
+    // no genuine artifact-level implementation risk remains — an amber required
+    // row (uncovered PRD features, a P0 without its primary mockup, open risks)
+    // or a must-have feature owned only by a low-priority screen. Otherwise the
+    // celebratory headline would contradict the risk rows / uncovered-feature
+    // disclosure rendered directly below it.
+    const hasImplementationRisk = required.some(r => r.tone === 'risk')
+        || (prdFeatures?.mustWithoutPrimaryScreen.length ?? 0) > 0;
+    const coreComplete = readyComplete && !hasImplementationRisk;
 
     const headline = coreComplete
         ? 'Implementation coverage is complete. Every screen has its required assets — optional design documentation can be generated whenever you like.'
@@ -264,6 +276,30 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
                         <ExpandedCoverageSection variant={variantCoverage} />
                     )}
 
+                    {/* Freshness / legacy signals for EXISTING generated mockups
+                        (primary or variant). Rendered independently of the
+                        variants section so they still surface for desktop /
+                        simple projects that have only primary mockups
+                        (additionalTotal === 0, no Expanded section). Neutral —
+                        an out-of-date or metadata-less mockup is a nudge, not an
+                        implementation blocker. */}
+                    {variantCoverage && (variantCoverage.freshness.review > 0 || variantCoverage.legacyUnknownMockups > 0) && (
+                        <div className="mt-3 space-y-1">
+                            {variantCoverage.freshness.review > 0 && (
+                                <p className="text-[11px] text-neutral-500">
+                                    {variantCoverage.freshness.review} generated {variantCoverage.freshness.review === 1 ? 'mockup' : 'mockups'}
+                                    {' '}may be worth refreshing after recent spec, design-system, or PRD changes.
+                                </p>
+                            )}
+                            {variantCoverage.legacyUnknownMockups > 0 && (
+                                <p className="text-[11px] text-neutral-400">
+                                    {variantCoverage.legacyUnknownMockups} older {variantCoverage.legacyUnknownMockups === 1 ? 'mockup' : 'mockups'}
+                                    {' '}predate coverage metadata — visually useful, but their spec coverage is unconfirmed.
+                                </p>
+                            )}
+                        </div>
+                    )}
+
                     {coreComplete && (
                         <p className="mt-3 inline-flex items-center gap-1.5 text-[11px] text-emerald-700">
                             <CheckCircle2 size={12} /> Core assets complete — statuses are estimates, so give screens a final review before building.
@@ -337,18 +373,6 @@ function ExpandedCoverageSection({ variant }: { variant: MockupVariantCoverageSu
                             {variant.p0WithMobile} / {variant.p0Total} · optional
                         </span>
                     </div>
-                )}
-                {variant.freshness.review > 0 && (
-                    <p className="text-[11px] text-neutral-500">
-                        {variant.freshness.review} generated {variant.freshness.review === 1 ? 'variant' : 'variants'}
-                        {' '}may be worth refreshing after recent spec changes.
-                    </p>
-                )}
-                {variant.legacyUnknownMockups > 0 && (
-                    <p className="text-[11px] text-neutral-400">
-                        {variant.legacyUnknownMockups} older {variant.legacyUnknownMockups === 1 ? 'mockup' : 'mockups'}
-                        {' '}predate coverage metadata.
-                    </p>
                 )}
             </div>
 

--- a/src/components/experience/ScreenCoveragePanel.tsx
+++ b/src/components/experience/ScreenCoveragePanel.tsx
@@ -174,9 +174,16 @@ export function ScreenCoveragePanel({ summary, variantCoverage, artifactReview, 
         || (prdFeatures?.mustWithoutPrimaryScreen.length ?? 0) > 0;
     const coreComplete = readyComplete && !hasImplementationRisk;
 
+    // When every screen is clean-ready but an artifact-level risk remains
+    // (uncovered PRD feature, a must-have owned only by a low-priority screen),
+    // the per-screen `message` still reads "All N screens pass…" — an all-clear
+    // that would sit directly above the amber disclosure. Use a dedicated
+    // risk-aware headline for that case instead of reusing that message.
     const headline = coreComplete
         ? 'Implementation coverage is complete. Every screen has its required assets — optional design documentation can be generated whenever you like.'
-        : message;
+        : readyComplete
+            ? 'Every screen passes its readiness checks, but some required coverage still needs review before implementation — see the flagged items below.'
+            : message;
 
     const missingMockups = summary.mockups.total - summary.mockups.covered;
     const hasExpanded = Boolean(variantCoverage && variantCoverage.additionalTotal > 0);


### PR DESCRIPTION
Follow-up to #252 (merged), addressing two valid Codex review comments that landed on that PR after it merged.

## Fixes

**1. All-clear gate now includes artifact-level PRD coverage** (`ScreenCoveragePanel.tsx`)
`coreComplete` — which drives the green "Implementation coverage is complete" headline/icon and celebration line — checked only `readyClean === totalScreens`. So it could fire while the **PRD-features** required row was amber and the uncovered-feature disclosure flagged a genuine implementation risk right below it. It now also requires **no genuine implementation risk** (no amber required row — uncovered PRD features, a P0 without its primary mockup, open risks — and no must-have feature owned only by a low-priority screen). Split out `readyComplete` for the per-row "Ready for implementation" tone so that row still reflects pure screen readiness.

**2. Stale / legacy primary-mockup signals no longer vanish for variant-less projects** (`ScreenCoveragePanel.tsx`)
The mockup **freshness** and **legacy-unknown coverage** rows had been moved into the "Expanded Design Coverage" section, which only renders when `additionalTotal > 0`. Desktop / simple projects with only primary mockups (no recommended variants) therefore lost those signals entirely. They now render as their own neutral block, independent of the optional-variants section — so a stale or metadata-less **primary** mockup still surfaces. Kept neutral styling (a nudge, not an implementation blocker).

## Tests

Added two regression tests in `ScreenExperienceViews.test.tsx`:
- The green all-clear is withheld when a PRD feature is uncovered even if every screen is ready.
- Freshness / legacy-mockup signals still surface when `additionalTotal === 0`.

Full gate green on top of latest `main` (which now also includes #253's flow-first Screens changes): **build ✓, lint ✓, 1440 tests ✓**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsevRsfNnhUuFNXALEy8im

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsevRsfNnhUuFNXALEy8im)_