### PR TITLE
Fix PRD generation timeline layout on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2573,11 +2573,18 @@ component). It is driven directly by the live `prdSectionStatus` store slice
 - **`ProgressTimeline.tsx`** / `TimelineStep.tsx` / `ConcurrentGroup.tsx` —
   presentation. Status icons (completed/in-progress/queued/failed/pending — the
   amber `queued` ring is distinct from the plain `pending` ring), an
-  always-visible (truncating) model chip, a "Retried ×N" badge, and
+  always-visible model chip, a "Retried ×N" badge, and
   explicitly-labeled times (`Actual:`/`Est. ~`/`Elapsed:`). A 1s ticker injects
   live `Elapsed:` from `startedAt` (re-stamped on each `generating` transition,
-  so retries show fresh elapsed). Responsive rules (`min-w-0`, truncation, no
-  `whitespace-nowrap` on the model chip) keep narrow screens from overlapping.
+  so retries show fresh elapsed). **`StepBody` puts only the step title + timing
+  block on the header row and renders the description, `Waits on:` note, and
+  model chip full-width *below* it — so on a narrow phone the detail text and
+  model names use the whole card instead of being squeezed into a thin column
+  beside the timing block (the old single-row layout truncated model names to
+  "Gemini 3.1…" and wrapped descriptions into 2–3-word lines with an empty right
+  gutter). `ConcurrentGroup` also trims its nested indentation at `sm:` (dashed
+  padding, branch connector width, child gaps) to reclaim mobile width. Do not
+  move the description/model chip back beside the timing block.**
   Mobile collapses per-step detail behind chevrons and shows a `View full
   history >` link (navigates to the History stage); desktop shows
   description/model/status/est/actual/retry and concurrent groups without

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -1180,7 +1180,7 @@ export function ProjectWorkspace() {
                                 />
 
                                 {activeSpine ? (
-                                    <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-6 md:p-10 mb-8">
+                                    <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-4 sm:p-6 md:p-10 mb-8">
                                         {/* PRD generation progress timeline (initial gen, regen, or a
                                             settled run with a failed section awaiting retry). */}
                                         {(isGenerating || showProgressTimeline) && (
@@ -1341,7 +1341,7 @@ export function ProjectWorkspace() {
                                         )}
                                     </div>
                                 ) : (
-                                    <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-6 md:p-10 mb-8">
+                                    <div className="bg-white rounded-2xl shadow-sm border border-neutral-200/80 p-4 sm:p-6 md:p-10 mb-8">
                                         <ProgressTimeline
                                             steps={timelineSteps}
                                             messages={prdProgress?.messages}

--- a/src/components/progress/ConcurrentGroup.tsx
+++ b/src/components/progress/ConcurrentGroup.tsx
@@ -33,7 +33,7 @@ export function ConcurrentGroup({
                 {!isLast && <span className="w-px flex-1 bg-neutral-200 mt-1" />}
             </div>
             <div className={`${isLast ? 'pb-0' : 'pb-5'} flex-1 min-w-0`}>
-                <div className="rounded-xl border border-dashed border-indigo-300 bg-indigo-50/30 p-3">
+                <div className="rounded-xl border border-dashed border-indigo-300 bg-indigo-50/30 p-2.5 sm:p-3">
                     <div className="flex items-center gap-1.5 text-xs font-semibold text-indigo-700 mb-2">
                         <Info size={13} className="shrink-0" />
                         Running concurrently
@@ -42,15 +42,15 @@ export function ConcurrentGroup({
                         {children.map((child, i) => {
                             const isLastChild = i === children.length - 1;
                             return (
-                                <div key={child.id} className="flex gap-2">
-                                    <div className="relative w-5 shrink-0">
+                                <div key={child.id} className="flex gap-1.5 sm:gap-2">
+                                    <div className="relative w-3.5 sm:w-5 shrink-0">
                                         <span
                                             className={`absolute left-0 top-0 w-px bg-indigo-200 ${isLastChild ? 'h-3' : 'h-full'}`}
                                         />
-                                        <span className="absolute left-0 top-3 w-4 h-px bg-indigo-200" />
+                                        <span className="absolute left-0 top-3 w-3 sm:w-4 h-px bg-indigo-200" />
                                     </div>
                                     <div className={`${isLastChild ? '' : 'pb-3'} flex-1 min-w-0`}>
-                                        <div className="flex gap-2">
+                                        <div className="flex gap-1.5 sm:gap-2">
                                             <div className="pt-0.5">
                                                 <StatusIcon status={child.status} size="sm" />
                                             </div>

--- a/src/components/progress/TimelineStep.tsx
+++ b/src/components/progress/TimelineStep.tsx
@@ -115,32 +115,24 @@ export function StepBody({
 
     return (
         <div className="flex-1 min-w-0">
+            {/* Header row: title/number on the left, timing + toggle on the right.
+                Only the title shares this row with the timing block — the
+                description, dependency note, and model chip render full-width
+                below so they use the whole card and never get squeezed into a
+                narrow left column beside the timing text. */}
             <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-sm font-semibold text-neutral-800">
-                            <span className="text-neutral-400 font-medium mr-1.5">{step.label}.</span>
-                            {step.title}
+                <div className="flex items-center gap-2 flex-wrap min-w-0 flex-1">
+                    <span className="text-sm font-semibold text-neutral-800">
+                        <span className="text-neutral-400 font-medium mr-1.5">{step.label}.</span>
+                        {step.title}
+                    </span>
+                    {step.retryCount != null && step.retryCount > 0 && (
+                        <span className="inline-flex items-center rounded-full bg-amber-100 text-amber-700 text-[10px] font-semibold px-1.5 py-0.5">
+                            Retried ×{step.retryCount}
                         </span>
-                        {step.retryCount != null && step.retryCount > 0 && (
-                            <span className="inline-flex items-center rounded-full bg-amber-100 text-amber-700 text-[10px] font-semibold px-1.5 py-0.5">
-                                Retried ×{step.retryCount}
-                            </span>
-                        )}
-                    </div>
-                    {showDetails && step.description && (
-                        <p className="text-xs text-neutral-500 mt-0.5">{step.description}</p>
                     )}
-                    {(step.status === 'pending' || step.status === 'queued') && step.dependsOn && step.dependsOn.length > 0 && (
-                        <p className="text-xs text-neutral-400 mt-0.5 break-words">
-                            {step.status === 'queued' ? 'Ready — waiting for a slot' : `Waits on: ${step.dependsOn.join(', ')}`}
-                        </p>
-                    )}
-                    <div className="mt-1.5 min-w-0">
-                        <ModelChip model={step.modelName} />
-                    </div>
                 </div>
-                <div className="flex items-start gap-1.5">
+                <div className="flex items-start gap-1.5 shrink-0">
                     <TimeBlock step={step} />
                     {canToggle && (
                         <button
@@ -153,6 +145,18 @@ export function StepBody({
                         </button>
                     )}
                 </div>
+            </div>
+
+            {showDetails && step.description && (
+                <p className="text-xs text-neutral-500 mt-1">{step.description}</p>
+            )}
+            {(step.status === 'pending' || step.status === 'queued') && step.dependsOn && step.dependsOn.length > 0 && (
+                <p className="text-xs text-neutral-400 mt-1 break-words">
+                    {step.status === 'queued' ? 'Ready — waiting for a slot' : `Waits on: ${step.dependsOn.join(', ')}`}
+                </p>
+            )}
+            <div className="mt-1.5">
+                <ModelChip model={step.modelName} />
             </div>
 
             {step.status === 'failed' && (


### PR DESCRIPTION
## Problem

On mobile, the PRD generation progress timeline squeezed each step's description and model chip into a thin left column beside the timing block (`Waiting / Est. ~25s`). The result, visible on a phone:

- **Model names truncated** — e.g. `Gemini 3.1…` / `Gemini 3.…` instead of the full name.
- **Descriptions wrapped into 2–3-word lines** — "Creating the / product thesis / and value / proposition".
- **A strange empty right margin** — the wasted gutter next to the squished text column.

The root cause was `StepBody` laying the title, description, "Waits on:" note, and model chip all in one `min-w-0` column next to a fixed-width timing block, then compounded by the deep nesting of concurrent-group children on a narrow screen.

## Changes

- **`TimelineStep.tsx` (`StepBody`)** — keep only the step title + timing block on the header row; render the description, `Waits on:` note, and model chip **full-width below** it, so detail text and model names use the whole card instead of a thin column.
- **`ConcurrentGroup.tsx`** — trim the nested concurrent-child indentation on mobile (dashed padding, branch-connector width, child gaps) behind `sm:` breakpoints to reclaim horizontal space; desktop is unchanged.
- **`ProjectWorkspace.tsx`** — reduce the PRD card's mobile padding (`p-6` → `p-4`; `sm:`/`md:` paddings unchanged) for more horizontal room on phones.
- **`CLAUDE.md`** — sync the progress-timeline description to record the new full-width detail layout.

Presentation-only: no schema, state, pipeline, or data-flow change. The shared `StepBody` restructure applies to both sequential rows and concurrent children, and to desktop and mobile.

## Verification

- `npm run build` (tsc -b && vite build) ✅ and `npm run lint` ✅ pass.
- `src/components/progress/__tests__` — 17 tests pass.
- Rendered the **real** `ProgressTimeline` through the app's Vite + Tailwind build at 390px (narrower than the reporting device, so a stricter test) with the concurrent children expanded: `Gemini 3 Pro (preview)` / `Gemini 3.5 Flash` show in full, and descriptions span the full card width with no empty right gutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrTduF6Sj3SwxPPFC767tX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrTduF6Sj3SwxPPFC767tX)_