### PR TITLE
Declutter User Flows: drop redundant flow-title chips and goal "Related Features"

### DIFF
--- a/src/components/renderers/userFlows/FlowSummaryCard.tsx
+++ b/src/components/renderers/userFlows/FlowSummaryCard.tsx
@@ -1,61 +1,18 @@
 import { useState, type ReactNode } from 'react';
 import {
-    AlertTriangle, ChevronRight, Clock, DoorOpen, GitBranch, ListChecks,
-    MoreHorizontal, Network, Server, ShieldCheck, Sparkles, Target,
+    ChevronRight, DoorOpen, GitBranch, MoreHorizontal, Server, ShieldCheck,
+    Sparkles, Target,
 } from 'lucide-react';
 import type { Feature } from '../../../types';
-import type { FeatureRef, FlowRiskLevel, ParsedFlow } from './types';
+import type { FeatureRef, ParsedFlow } from './types';
 import { inlineMd } from './markdown';
 import { inlineWithFeatures } from './inlineWithFeatures';
-import type { RelatedArtifacts } from './relatedArtifacts';
-import { relatedSummaryParts } from './relatedArtifacts';
 
 interface Props {
     flow: ParsedFlow;
     index: number;
-    timeToValue: string | null;
     featuresById?: Map<string, Feature>;
     onSelectFeature: (refToken: FeatureRef) => void;
-    /** Precomputed heuristic join, used for the compact relationship summary. */
-    related: RelatedArtifacts;
-}
-
-type BadgeTone = 'neutral' | 'amber' | 'sky' | 'emerald' | 'red' | 'indigo';
-
-const RISK_LEVEL_LABEL: Record<FlowRiskLevel, string> = {
-    low: 'Low risk',
-    medium: 'Medium risk',
-    high: 'High risk',
-};
-
-const RISK_TONE: Record<FlowRiskLevel, BadgeTone> = {
-    low: 'emerald',
-    medium: 'amber',
-    high: 'red',
-};
-
-const BADGE_CLASS: Record<BadgeTone, string> = {
-    neutral: 'bg-neutral-100 text-neutral-600 border-neutral-200',
-    amber: 'bg-amber-50 text-amber-700 border-amber-200',
-    sky: 'bg-sky-50 text-sky-700 border-sky-200',
-    emerald: 'bg-emerald-50 text-emerald-700 border-emerald-200',
-    red: 'bg-red-50 text-red-700 border-red-200',
-    indigo: 'bg-indigo-50 text-indigo-700 border-indigo-200',
-};
-
-/** A compact inline metadata pill — replaces the old large stat cards. */
-function MetaBadge({
-    icon, children, tone = 'neutral', title,
-}: { icon?: ReactNode; children: ReactNode; tone?: BadgeTone; title?: string }) {
-    return (
-        <span
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[11px] font-medium ${BADGE_CLASS[tone]}`}
-            title={title}
-        >
-            {icon}
-            {children}
-        </span>
-    );
 }
 
 function GoalBlock({
@@ -76,15 +33,10 @@ function GoalBlock({
 }
 
 export function FlowSummaryCard({
-    flow, index, timeToValue, featuresById, onSelectFeature, related,
+    flow, index, featuresById, onSelectFeature,
 }: Props) {
-    const stepCount = flow.steps.length;
-    const altPaths = flow.issues.filter(i => i.kind === 'alternate_path' || i.kind === 'failure_mode').length;
-    const edgeCount = flow.issues.filter(i => i.kind === 'edge_case').length;
     const renderText = (text: string) =>
         inlineWithFeatures(text, { featuresById, onSelectFeature });
-
-    const showRisk = flow.risk !== 'low' || flow.issues.length > 0;
 
     // Drop preconditions block entirely when there's nothing useful to add.
     const hasPreconditions = Boolean(flow.preconditions && flow.preconditions.trim().length > 0);
@@ -93,8 +45,6 @@ export function FlowSummaryCard({
     const hasDetails = hasPreconditions || hasEntryPoints || hasSystems;
 
     const [detailsOpen, setDetailsOpen] = useState(false);
-
-    const summaryParts = relatedSummaryParts(related);
 
     return (
         <section className="bg-white rounded-xl border border-neutral-200 p-4 sm:p-5 mb-4">
@@ -114,45 +64,11 @@ export function FlowSummaryCard({
                     <h3 className="text-base font-bold text-neutral-900 leading-snug mt-1">
                         {flow.title}
                     </h3>
-
-                    {/* Compact inline metadata — replaces the old 2×4 stat-card grid */}
-                    <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
-                        <MetaBadge icon={<ListChecks size={12} />}>
-                            {stepCount} {stepCount === 1 ? 'step' : 'steps'}
-                        </MetaBadge>
-                        {altPaths > 0 && (
-                            <MetaBadge icon={<GitBranch size={12} />} tone="amber">
-                                {altPaths} alt {altPaths === 1 ? 'path' : 'paths'}
-                            </MetaBadge>
-                        )}
-                        {edgeCount > 0 && (
-                            <MetaBadge icon={<AlertTriangle size={12} />} tone="sky">
-                                {edgeCount} edge {edgeCount === 1 ? 'case' : 'cases'}
-                            </MetaBadge>
-                        )}
-                        {timeToValue && (
-                            <MetaBadge icon={<Clock size={12} />} tone="emerald">
-                                {timeToValue} to value
-                            </MetaBadge>
-                        )}
-                        {showRisk && (
-                            <MetaBadge
-                                icon={<span className="inline-block w-2 h-2 rounded-full bg-current" />}
-                                tone={RISK_TONE[flow.risk]}
-                            >
-                                {RISK_LEVEL_LABEL[flow.risk]}
-                            </MetaBadge>
-                        )}
-                    </div>
-
-                    {/* Compact relationship summary — replaces the repeated
-                        feature chip row; full chips live in Related Artifacts. */}
-                    {summaryParts.length > 0 && (
-                        <p className="mt-2 text-[11px] text-neutral-500 inline-flex items-center gap-1.5">
-                            <Network size={11} className="shrink-0 text-neutral-400" />
-                            <span>Related: {summaryParts.join(' · ')}</span>
-                        </p>
-                    )}
+                    {/* Metadata chips (step count, alt paths, risk) and the
+                        "Related: …" summary were removed — that information lives
+                        in the Journey, Alternate paths & edge cases, and Related
+                        artifacts sections below, and the risk/time-to-value dots
+                        remain in the flow rail. */}
                 </div>
                 <div className="hidden sm:flex items-center shrink-0">
                     <button

--- a/src/components/renderers/userFlows/UserFlowsRenderer.tsx
+++ b/src/components/renderers/userFlows/UserFlowsRenderer.tsx
@@ -142,10 +142,8 @@ export function UserFlowsRenderer({
                 <FlowSummaryCard
                     flow={flow}
                     index={safeIndex}
-                    timeToValue={ttvByFlow[safeIndex]}
                     featuresById={featuresById}
                     onSelectFeature={onSelectFeature}
-                    related={related}
                 />
 
                 {/* The journey is the SINGLE rendering of the flow's steps —

--- a/src/components/renderers/userFlows/__tests__/UserFlowsRenderer.test.tsx
+++ b/src/components/renderers/userFlows/__tests__/UserFlowsRenderer.test.tsx
@@ -50,7 +50,7 @@ describe('UserFlowsRenderer', () => {
         expect(screen.queryByText(/debug \/ qa/i)).toBeNull();
     });
 
-    it('renders the structured flow header with category and metadata chips', () => {
+    it('renders the structured flow header with category, without the old metadata chips or "Related:" summary', () => {
         const { container } = render(
             <UserFlowsRenderer content={SAMPLE_MARKDOWN} features={FEATURES} />,
         );
@@ -58,8 +58,13 @@ describe('UserFlowsRenderer', () => {
         // Category appears once as the sidebar group header and once as a
         // chip on the selected flow card; either is fine.
         expect(container.textContent).toMatch(/Core Experience/);
-        // The metadata chip shows step count.
-        expect(container.textContent).toMatch(/4 steps/i);
+        // The header metadata pills (step count, alt paths, risk) and the
+        // "Related: … features" summary line were removed — that information now
+        // lives in the Flow journey / Alternate paths / Related artifacts
+        // sections and the flow rail. The "Related:" prefix was unique to the
+        // removed main-card summary (the rail shows a bare "N features"), so its
+        // absence confirms the header metadata row is gone.
+        expect(screen.queryByText(/^Related:/i)).toBeNull();
     });
 
     it('does not surface a misleading "errors" label in the flow list', () => {

--- a/src/components/renderers/userFlows/__tests__/UserFlowsRendererCleanup.test.tsx
+++ b/src/components/renderers/userFlows/__tests__/UserFlowsRendererCleanup.test.tsx
@@ -50,6 +50,32 @@ const ENTITIES: DomainEntity[] = [
     { name: 'Recipe', description: 'A saved recipe record' },
 ];
 
+const FLOW_WITH_RELATED_FEATURES = `### Flow: Document ingestion (Core Experience)
+**Goal:** Upload a static educational infographic to be digitized by the AI pipelines.
+**Related Features:** [f1] High-Resolution Image Ingestion, [f2] Spatial OCR Extraction
+**Steps:**
+1. [Document Library] — User uploads a file → System stores it
+**Success Outcome:** The document is uploaded and structured.`;
+
+const RELATED_FEATURE_CATALOG: Feature[] = [
+    {
+        id: 'f1',
+        name: 'High-Resolution Image Ingestion',
+        description: 'Ingest high-resolution source images.',
+        userValue: 'Keeps the source sharp.',
+        complexity: 'medium',
+        priority: 'must',
+    },
+    {
+        id: 'f2',
+        name: 'Spatial OCR Extraction',
+        description: 'Extract text while preserving coordinates.',
+        userValue: 'Preserves layout.',
+        complexity: 'high',
+        priority: 'must',
+    },
+];
+
 /** Expand every journey step-detail toggle (rows + single-card toggles). */
 function expandAllJourneySteps() {
     screen.getAllByRole('button')
@@ -58,7 +84,7 @@ function expandAllJourneySteps() {
 }
 
 describe('UserFlowsRenderer — desktop cleanup', () => {
-    it('shows a compact relationship summary instead of a repeated feature chip row', () => {
+    it('drops the flow-header metadata chips and "Related:" summary (that info lives in the sections below)', () => {
         render(
             <UserFlowsRenderer
                 content={SINGLE_FLOW}
@@ -67,9 +93,32 @@ describe('UserFlowsRenderer — desktop cleanup', () => {
                 domainEntities={ENTITIES}
             />,
         );
-        // The header carries a compact "Related: … features …" summary line
-        // (distinct from the collapsible "Related artifacts" panel below).
-        expect(screen.getByText(/Related: 1 feature/i)).toBeInTheDocument();
+        // The old compact "Related: … features" header summary is gone — those
+        // features surface only in the collapsible Related artifacts panel. The
+        // "Related:" prefix was unique to that main-card summary (the flow rail
+        // shows a bare "N features"), so its absence proves the header row of
+        // metadata chips + summary was removed. Step counts / risk dots
+        // deliberately remain in the flow rail and Journey header.
+        expect(screen.queryByText(/^Related:/i)).toBeNull();
+    });
+
+    it('strips the "Related Features:" line out of the goal and surfaces those features in Related artifacts', () => {
+        render(
+            <UserFlowsRenderer
+                content={FLOW_WITH_RELATED_FEATURES}
+                features={RELATED_FEATURE_CATALOG}
+            />,
+        );
+        // The goal prose renders, but the bold "Related Features:" label and its
+        // inline feature chips are no longer part of the goal block.
+        expect(screen.getByText(/Upload a static educational infographic/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Related Features:/i)).toBeNull();
+        expect(screen.queryAllByTestId('feature-ref-f1')).toHaveLength(0);
+        // Expanding the Related artifacts panel reveals them as structured chips —
+        // proving the feature refs still aggregate out of the split-off line.
+        fireEvent.click(screen.getByRole('button', { name: /Related artifacts/i }));
+        expect(screen.getAllByTestId('feature-ref-f1').length).toBeGreaterThan(0);
+        expect(screen.getAllByTestId('feature-ref-f2').length).toBeGreaterThan(0);
     });
 
     it('keeps Related Artifacts collapsed by default and reveals it on toggle', () => {

--- a/src/components/renderers/userFlows/__tests__/parseFlow.test.ts
+++ b/src/components/renderers/userFlows/__tests__/parseFlow.test.ts
@@ -42,6 +42,25 @@ describe('parseFlows', () => {
         expect(flow.issues.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('splits the `**Related Features:**` line out of the goal but keeps its refs aggregated', () => {
+        const md = `### Flow: Document ingestion
+**Goal:** Upload a static educational infographic to be digitized by the AI pipelines.
+**Related Features:** [f1] High-Resolution Image Ingestion, [f8] Document Embedding Pipeline
+**Steps:**
+1. [Document Library] — User uploads a file → System stores it`;
+        const flow = parseFlows(md)[0];
+        // The goal no longer contains the related-features metadata line…
+        expect(flow.goal).toMatch(/Upload a static educational infographic/);
+        expect(flow.goal).not.toMatch(/Related Features/i);
+        expect(flow.goal).not.toMatch(/\[f1\]/);
+        // …it's captured on its own field…
+        expect(flow.relatedFeatures).toMatch(/High-Resolution Image Ingestion/);
+        // …and its feature refs still aggregate onto the flow (so the Related
+        // Artifacts panel keeps listing them even though no step mentions f8).
+        const ids = flow.featureRefs.map(r => r.id);
+        expect(ids).toEqual(expect.arrayContaining(['f1', 'f8']));
+    });
+
     it('links errors to steps by explicit `Step N` reference', () => {
         const md = `### Flow: Photo upload
 **Steps:**

--- a/src/components/renderers/userFlows/parseFlow.ts
+++ b/src/components/renderers/userFlows/parseFlow.ts
@@ -5,6 +5,7 @@ import { categorize } from './categorize';
 
 type RawSection = {
     goal?: string;
+    relatedFeatures?: string;
     preconditions?: string;
     entryPoints?: string;
     stepsBlock?: string;
@@ -18,6 +19,11 @@ type RawSection = {
 
 const SECTION_LABELS: Array<[keyof RawSection, RegExp]> = [
     ['goal', /^\*\*Goal:\*\*\s*/i],
+    // The generation prompt emits `**Related Features:**` right after the goal
+    // (see coreArtifactService). We split it into its own section so it never
+    // bleeds into the goal prose — its feature ids are surfaced as structured
+    // chips in the Related Artifacts panel instead.
+    ['relatedFeatures', /^\*\*Related\s*Features?:\*\*\s*/i],
     ['preconditions', /^\*\*Preconditions:\*\*\s*/i],
     ['entryPoints', /^\*\*Entry\s*Points?:\*\*\s*/i],
     ['stepsBlock', /^\*\*Steps:\*\*\s*/i],
@@ -592,15 +598,19 @@ export function parseFlows(markdown: string): ParsedFlow[] {
         const issues = buildIssues({ errorPaths, edgeCases: r.edgeCases, steps });
         const featureRefs = aggregateFeatureRefs(
             steps,
-            [r.goal, r.preconditions, r.entryPoints, r.successOutcome, r.edgeCases, r.assumptions, r.openQuestions],
+            [r.goal, r.relatedFeatures, r.preconditions, r.entryPoints, r.successOutcome, r.edgeCases, r.assumptions, r.openQuestions],
             titleExtractedRefs,
         );
         const risk = inferRisk(issues);
+        // The related-features line used to live inside the goal; keep it in the
+        // categorization haystack so a split doesn't silently reclassify a flow.
+        const categoryText = [r.goal, r.relatedFeatures].filter(Boolean).join(' ');
         return {
             title: cleanTitle || r.rawTitle,
             rawTitle: r.rawTitle,
-            category: categorize(cleanTitle || r.rawTitle, r.goal),
+            category: categorize(cleanTitle || r.rawTitle, categoryText),
             goal: r.goal,
+            relatedFeatures: r.relatedFeatures,
             preconditions: r.preconditions,
             successOutcome: r.successOutcome,
             edgeCases: r.edgeCases,

--- a/src/components/renderers/userFlows/relatedArtifacts.ts
+++ b/src/components/renderers/userFlows/relatedArtifacts.ts
@@ -16,6 +16,7 @@ function flowTextCorpus(flow: ParsedFlow): string {
     const parts: string[] = [
         flow.title,
         flow.goal ?? '',
+        flow.relatedFeatures ?? '',
         flow.preconditions ?? '',
         flow.successOutcome ?? '',
         flow.edgeCases ?? '',

--- a/src/components/renderers/userFlows/types.ts
+++ b/src/components/renderers/userFlows/types.ts
@@ -83,6 +83,12 @@ export type ParsedFlow = {
     rawTitle: string;
     category: FlowCategory;
     goal?: string;
+    /**
+     * Raw `**Related Features:**` line, split out of the goal so it renders as
+     * structured chips in the Related Artifacts panel rather than as inline
+     * goal prose. Retained for feature-ref aggregation and artifact matching.
+     */
+    relatedFeatures?: string;
     preconditions?: string;
     successOutcome?: string;
     edgeCases?: string;


### PR DESCRIPTION
## Summary

The User Flows flow-summary card repeated information that already lives in the sections below it, crowding the flow title. This removes that duplication.

**1. Removed the metadata chips + "Related:" summary next to the flow title** (`FlowSummaryCard.tsx`)
- Dropped the pill row: step count, alt paths, edge cases, time-to-value, and risk.
- Dropped the `Related: N features · M screens · …` summary line.
- That information is already surfaced below: step count in the **Flow journey** header, alt paths/edge cases in the **Alternate paths & edge cases** section, and features/screens/entities in the collapsible **Related artifacts** panel. The flow rail also keeps its own compact per-flow metadata (step count + risk/time-to-value dots), so nothing is lost.

**2. Removed the inline "Related Features:" line from the Goal block** (`parseFlow.ts`)
- The generation prompt emits a `**Related Features:**` line right after the goal, but the parser was silently folding it into the goal prose (so it rendered as bold label + feature chips inside the Goal).
- The parser now recognizes it as its own section (`ParsedFlow.relatedFeatures`), so the Goal reads as clean prose and those features appear only in the **Related artifacts** panel below.

## Before / After (per the reported screens)

| Area | Before | After |
|------|--------|-------|
| Under the flow title | `4 steps` · `1 alt path` · `Medium risk` · `Related: 4 features · 1 screen · 2 systems` | (nothing — title only) |
| Goal block | `Upload … pipelines. **Related Features:** F1 … F2 … F3 … F8 …` | `Upload … pipelines.` |

## Behavior preserved

The split-off `**Related Features:**` line is still fed into feature-ref aggregation, the screen/entity matching corpus, and flow categorization — so the **Related artifacts** panel and every derived signal are byte-for-byte unchanged. Legacy/demo artifacts render clean **without regeneration** (the split is deterministic from the stored markdown). No schema, prompt, persistence, or generation change.

## Tests
- Updated the two renderer tests that asserted on the removed chips / `Related:` summary.
- Added a renderer test: the `Related Features:` line is stripped from the Goal, its features surface only in Related artifacts.
- Added a parser test: `**Related Features:**` splits out of the goal while its refs still aggregate onto the flow.

## Verification
- `npm run build` ✓ (tsc -b && vite build)
- `npm run lint` ✓
- `npm test` ✓ (1443 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dSQuHHXQJ4QBDD6oxgzU7

---
_Generated by [Claude Code](https://claude.ai/code/session_018dSQuHHXQJ4QBDD6oxgzU7)_