### PR TITLE
Fix queued artifact card showing fabricated progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2644,6 +2644,22 @@ three drive modes, in priority order:
    so the indicator doesn't yank to the wrong stage.
 3. **Timer-driven** (fallback) — labels rotate on `minDuration` timers.
 
+**The `waiting` prop overrides all three drive modes and is REQUIRED for a
+`queued` (not-yet-started) slot.** A queued artifact slot has an empty
+`progressLog`, so without `waiting` it falls into the timer-driven fallback and
+**fabricates progress** — rotating stage labels and marching the bar on a timer
+while no work is happening (the "Queued — will start as a slot frees up"
+subtitle beside a moving progress bar and a late stage label like "Documenting
+decision points…"). When `waiting` is true the component renders an honest
+not-started state: the rotation timer is disabled, `barWidthPct` is 0, every
+stage dot is inert (`activeDotIndex === -1`, a preview of the pipeline with none
+active/complete), the title dot doesn't pulse, and no work-stage label is shown
+(only the `subtitle`). Both queued renders in `ArtifactWorkspace` (the Screens
+row and the generic artifact/mockup slot) pass `waiting={status === 'queued'}`;
+any new queued-slot progress render must do the same. Do NOT drive
+`GenerationProgress` with stages for a slot that hasn't started without
+`waiting`. Regression: `src/components/__tests__/GenerationProgressWaiting.test.tsx`.
+
 When supplying `history`, the stage label strings in
 `generationStages.ts` must be a substring-prefix match for the strings
 emitted via `onProgress` for the indicator to track. Don't include

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -879,6 +879,7 @@ export function ArtifactWorkspace({
                             variant="systematic"
                             title={screensStatus === 'queued' ? 'Queued: Screens' : 'Generating Screen Inventory'}
                             subtitle={screensStatus === 'queued' ? 'Queued — will start as a generation slot frees up' : undefined}
+                            waiting={screensStatus === 'queued'}
                             history={job?.slots.screen_inventory?.progressLog ?? []}
                         />
                     </div>
@@ -1082,6 +1083,7 @@ export function ArtifactWorkspace({
                         variant={activeSelection === 'mockup' ? 'creative' : 'systematic'}
                         title={title}
                         subtitle={status === 'queued' ? 'Queued — will start as a generation slot frees up' : undefined}
+                        waiting={status === 'queued'}
                         history={job?.slots[activeSelection]?.progressLog ?? []}
                     />
                 </div>

--- a/src/components/GenerationProgress.tsx
+++ b/src/components/GenerationProgress.tsx
@@ -53,6 +53,16 @@ interface GenerationProgressProps {
      * Falls back to the section id itself when omitted.
      */
     sectionTitles?: Record<string, string>;
+    /**
+     * The operation is queued but has NOT started (no work is happening yet).
+     * When true, the component renders an honest waiting state: the
+     * timer-driven stage rotation is disabled, the progress bar stays at 0,
+     * the stage dots render inert (a preview of the pipeline, none active),
+     * and no fabricated "current stage" label is shown. Without this, an
+     * un-started slot would fake progress — cycling stage labels and filling
+     * the bar on a timer while the underlying work sits in the queue.
+     */
+    waiting?: boolean;
 }
 
 const VISIBLE_HISTORY_CAP = 8;
@@ -115,6 +125,7 @@ export function GenerationProgress({
     history,
     sectionStatus,
     sectionTitles,
+    waiting = false,
 }: GenerationProgressProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isFading, setIsFading] = useState(false);
@@ -137,6 +148,11 @@ export function GenerationProgress({
     }, [hasActiveSection]);
 
     useEffect(() => {
+        // A queued/not-started operation must never fake progress — there is
+        // no work happening, so rotating stage labels and filling the bar on a
+        // timer would be fiction (the "Queued — will start…" subtitle beside a
+        // marching progress bar is exactly the contradiction this guards).
+        if (waiting) return;
         // Skip the rotation timer entirely when the parent supplies real
         // progress data — either an explicit `progress` value or a `history`
         // event stream. Letting the timer run alongside real progress
@@ -164,7 +180,7 @@ export function GenerationProgress({
             clearTimeout(id);
             if (timerRef.current) clearTimeout(timerRef.current);
         };
-    }, [currentIndex, stages, isStateDriven, hasHistory]);
+    }, [currentIndex, stages, isStateDriven, hasHistory, waiting]);
 
     if (stages.length === 0 && !hasHistory) return null;
 
@@ -205,14 +221,16 @@ export function GenerationProgress({
             lastMatchedStage = stageIndexFromMessage(dedupedHistory[i]);
         }
     }
-    const activeDotIndex = isStateDriven
-        ? Math.min(
-              stages.length - 1,
-              Math.floor((clampedProgress / 100) * stages.length),
-          )
-        : hasHistory
-            ? (lastMatchedStage !== null ? lastMatchedStage : 0)
-            : currentIndex;
+    const activeDotIndex = waiting
+        ? -1 // queued: no stage is active — render every dot inert
+        : isStateDriven
+            ? Math.min(
+                  stages.length - 1,
+                  Math.floor((clampedProgress / 100) * stages.length),
+              )
+            : hasHistory
+                ? (lastMatchedStage !== null ? lastMatchedStage : 0)
+                : currentIndex;
 
     const currentLabel = isStateDriven
         ? (statusLabel ?? stages[activeDotIndex]?.label ?? stages[stages.length - 1]?.label)
@@ -220,16 +238,20 @@ export function GenerationProgress({
             ? (historyLatest ?? stages[activeDotIndex]?.label ?? stages[stages.length - 1]?.label)
             : (stages[currentIndex]?.label ?? stages[stages.length - 1]?.label);
 
-    const barWidthPct = isStateDriven
-        ? clampedProgress
-        : hasHistory
-            ? Math.min(((activeDotIndex + 1) / Math.max(stages.length, 1)) * 100, 95)
-            : Math.min(((currentIndex + 1) / stages.length) * 100, 95);
+    const barWidthPct = waiting
+        ? 0 // queued: nothing has run, so the bar reflects zero real progress
+        : isStateDriven
+            ? clampedProgress
+            : hasHistory
+                ? Math.min(((activeDotIndex + 1) / Math.max(stages.length, 1)) * 100, 95)
+                : Math.min(((currentIndex + 1) / stages.length) * 100, 95);
 
     if (inline) {
-        const inlineLabel = hasHistory && dedupedHistory.length > 0
-            ? `${currentLabel} — ${dedupedHistory[dedupedHistory.length - 1]}`
-            : currentLabel;
+        const inlineLabel = waiting
+            ? 'Waiting to start…'
+            : hasHistory && dedupedHistory.length > 0
+                ? `${currentLabel} — ${dedupedHistory[dedupedHistory.length - 1]}`
+                : currentLabel;
         return (
             <div className="flex items-center gap-3">
                 <span className="relative flex h-2 w-2">
@@ -259,7 +281,11 @@ export function GenerationProgress({
                 {title && (
                     <div className="flex items-center gap-2.5 mb-2">
                         <span className="relative flex h-2 w-2">
-                            <span className={`animate-ping absolute inline-flex h-full w-full rounded-full ${style.dotColor} opacity-75`} />
+                            {/* No pulse while queued — a ping animation reads as
+                                active work, which a not-yet-started slot isn't. */}
+                            {!waiting && (
+                                <span className={`animate-ping absolute inline-flex h-full w-full rounded-full ${style.dotColor} opacity-75`} />
+                            )}
                             <span className={`relative inline-flex rounded-full h-2 w-2 ${style.dotColor}`} />
                         </span>
                         <span className={`text-sm font-semibold ${style.accent}`}>{title}</span>
@@ -298,6 +324,11 @@ export function GenerationProgress({
                                 })}
                             </ul>
                         </>
+                    ) : waiting ? (
+                        // Queued: the subtitle already says "will start as a slot
+                        // frees up". Show no work-stage label — the inert stage
+                        // dots below preview the pipeline that hasn't run yet.
+                        null
                     ) : (
                         <p
                             className={`text-sm text-neutral-600 transition-opacity duration-300 ${isFading ? 'opacity-0' : 'opacity-100'}`}

--- a/src/components/__tests__/GenerationProgressWaiting.test.tsx
+++ b/src/components/__tests__/GenerationProgressWaiting.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { GenerationProgress } from '../GenerationProgress';
+import { getArtifactStages } from '../generationStages';
+
+// Regression test for the "Queued — will start as a slot frees up" card that
+// simultaneously showed a marching progress bar and a late stage label
+// ("Documenting decision points…"). The card fell into GenerationProgress's
+// timer-driven fallback (no real `history` while a slot is merely queued), so
+// it fabricated stage rotation + bar fill for work that had NOT started. The
+// `waiting` prop makes a queued slot render an honest not-started state.
+
+const USER_FLOWS_STAGES = getArtifactStages('user_flows');
+const FIRST_STAGE = USER_FLOWS_STAGES[0].label; // "Mapping user journeys..."
+const LAST_STAGE = USER_FLOWS_STAGES[USER_FLOWS_STAGES.length - 1].label; // "Documenting decision points..."
+const QUEUED_SUBTITLE = 'Queued — will start as a generation slot frees up';
+
+afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+});
+
+describe('GenerationProgress — a queued/waiting slot never fakes progress', () => {
+    // Control: proves the same props WITHOUT `waiting` fabricate progress, so
+    // the `waiting` assertions below aren't passing vacuously. The fabrication
+    // is present at mount (before any real work), which is exactly the lie the
+    // fix removes — a queued slot has done nothing yet.
+    it('WITHOUT `waiting`, progress is already fabricated at mount (the old behavior)', () => {
+        vi.useFakeTimers();
+        const { queryByText, container } = render(
+            <GenerationProgress
+                stages={USER_FLOWS_STAGES}
+                title="Queued: User Flows"
+                subtitle={QUEUED_SUBTITLE}
+            />,
+        );
+
+        // At mount, before any timer fires and before any work happens: a work
+        // stage label is shown, a stage dot is active (`w-5`), and the bar
+        // already reads > 0% — fabricated progress.
+        expect(queryByText(FIRST_STAGE)).toBeInTheDocument();
+        expect(container.querySelectorAll('.w-5').length).toBe(1);
+        const barAtMount = container.querySelector<HTMLDivElement>('.h-full');
+        expect(barAtMount).not.toBeNull();
+        expect(barAtMount!.style.width).not.toBe('0%');
+    });
+
+    it('WITH `waiting`, no stage label ever shows, no dot is active, and the bar stays at 0%', async () => {
+        vi.useFakeTimers();
+        const { queryByText, container } = render(
+            <GenerationProgress
+                stages={USER_FLOWS_STAGES}
+                title="Queued: User Flows"
+                subtitle={QUEUED_SUBTITLE}
+                waiting
+            />,
+        );
+
+        // No fabricated work-stage label at mount…
+        expect(queryByText(FIRST_STAGE)).not.toBeInTheDocument();
+        expect(queryByText(LAST_STAGE)).not.toBeInTheDocument();
+
+        // …and none appears once time passes: the rotation timer is disabled.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(20000);
+        });
+        expect(queryByText(FIRST_STAGE)).not.toBeInTheDocument();
+        expect(queryByText(LAST_STAGE)).not.toBeInTheDocument();
+
+        // The honest queued message is still shown.
+        expect(queryByText(QUEUED_SUBTITLE)).toBeInTheDocument();
+
+        // Every stage dot is inert — none is marked active (`w-5`) or complete (`w-3`).
+        expect(container.querySelectorAll('.w-5').length).toBe(0);
+        expect(container.querySelectorAll('.w-3').length).toBe(0);
+
+        // The progress bar reflects zero real progress.
+        const bar = container.querySelector<HTMLDivElement>('.h-full');
+        expect(bar).not.toBeNull();
+        expect(bar!.style.width).toBe('0%');
+    });
+});


### PR DESCRIPTION
## Problem

When navigating to an artifact (e.g. **User Flows**) while it is still **queued**, the progress card showed a contradiction: the honest subtitle **"Queued — will start as a generation slot frees up"** sat directly above a **marching progress bar** and a late work-stage label like **"Documenting decision points…"**, as if the artifact were actively being produced.

The "Queued" message was correct. **The progress was fake.**

## Root cause

A queued artifact slot is initialized with an **empty `progressLog`** (`generationJobsSlice.initJob`). `ArtifactWorkspace` renders `<GenerationProgress>` for both `queued` and `generating` states, passing the full `stages` array and `history={progressLog}` (empty when queued).

With no `progress` value and empty `history`, `GenerationProgress` fell into its **timer-driven fallback**: a `setTimeout` loop that rotates stage labels ("Mapping user journeys…" → "Defining flow sequences…" → "Documenting decision points…") and advances the progress bar to 95% — **purely on timers, with no underlying work happening**. A queued slot that hadn't started thus animated as if it were mid-generation, parking on the last stage.

## Fix

Add a `waiting` prop to `GenerationProgress` that overrides all three drive modes and renders an **honest not-started state** for a queued slot:

- the rotation timer is disabled (no fabricated stage advancement),
- `barWidthPct` is pinned to **0%**,
- every stage dot renders **inert** (`activeDotIndex === -1` — a preview of the pipeline, none active/complete),
- the title dot **doesn't pulse** (a ping reads as active work),
- **no** work-stage label is shown — only the honest `subtitle`.

Both queued renders in `ArtifactWorkspace` (the **Screens** row and the generic **artifact/mockup** slot) now pass `waiting={status === 'queued'}`. The `generating` state is unchanged — a genuinely-active slot still shows its real `onProgress` history (and the timer placeholder only during the brief window before the first real message).

## Testing

- New regression test `src/components/__tests__/GenerationProgressWaiting.test.tsx`: proves a `waiting` card renders no stage label, no active dot, and a 0% bar even after time passes; a control case asserts the same props **without** `waiting` do fabricate progress (so the test can't pass vacuously).
- `npm run build` ✓ · `npm run lint` ✓ · full suite **1443 tests** ✓

## Docs

Updated the **Other-flow progress UI** section of `CLAUDE.md` to document the `waiting` mode and the rule that any queued-slot progress render must use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUQLUJQNsNWCoXpDFiQ3fT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUQLUJQNsNWCoXpDFiQ3fT)_