### PR TITLE
Mobile PRD cleanup: Review & Confirm, Decision Log, feature-id consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,31 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     The legacy multi-pass scoring + revision passes were removed — old projects
     in localStorage retain their saved `qualityScores`, but no new generation
     writes them.
+    - **PRD Review & Confirm + Decision Log (2026-07 mobile cleanup pass).**
+      Assumptions no longer render as a passive trailing "Assumptions" section
+      (or as the Implementation Summary's "Open Decisions" list — both are
+      gone, as are the summary's "Defer" bucket, the Success Metrics
+      Instrumentation column, and the "Derived from features and assumptions"
+      subtitle). Instead the PRD carries two mirrored sections near the top:
+      **Review & Confirm** (unresolved assumptions, sorted by confidence
+      highest-first, each with Confirm / "Not right"+correction actions) and
+      **Decision Log** (confirmed user choices only — decided assumptions +
+      confirmed features — never unresolved items). State lives ON the
+      `StructuredPRD` itself via all-optional fields (`Assumption.decision` /
+      `decisionNote` / `decidedAt`; `Feature.confirmed` / `confirmedAt` —
+      legacy PRDs simply read as "all unresolved"); every confirm/reject/undo
+      is a normal PRD edit through `editSpineStructuredPRD` (appends a
+      version, descriptive editSummary, undoable via version history). All
+      derivations (`sortAssumptionsByConfidence`, `splitAssumptions`,
+      `deriveDecisionLog`, `resolveScopeFeature` — the MVP-scope-string →
+      feature matcher — and `isDisplayableFeatureId`) are pure/read-side in
+      `src/lib/derive/prdDecisions.ts`; do NOT persist a separate
+      decision-log structure. Feature ids render everywhere through the
+      shared `FeatureIdBadge` (`src/components/prd/FeatureIdBadge.tsx`),
+      which mirrors the User Flows `FeatureReferenceChip` fuchsia look and
+      hides uuid-shaped ids; feature confirmation uses the same green-check
+      language as the Screens `ScreenConfirmPanel`. Within Core Features the
+      order is **Detailed Features before Feature Systems** (both renderers).
     - **User project name → `productName`.** The name the user types when
       creating a project is threaded into generation as an optional
       `projectName` (call site `runPrdGeneration`/`ProjectWorkspace.handleRegenerate`

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,15 +1,18 @@
 import { useState } from 'react';
-import { Pencil, Check, X } from 'lucide-react';
+import { Pencil, Check, X, Circle } from 'lucide-react';
 import type { Feature } from '../types';
 import { MvpTag } from './prd/PremiumSections';
+import { FeatureIdBadge } from './prd/FeatureIdBadge';
 
 interface FeatureCardProps {
     feature: Feature;
     onUpdate: (updated: Feature) => void;
+    /** Toggle the reviewed/confirmed state. Absent → no confirm affordance. */
+    onToggleConfirm?: (feature: Feature) => void;
     readOnly: boolean;
 }
 
-export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
+export function FeatureCard({ feature, onUpdate, onToggleConfirm, readOnly }: FeatureCardProps) {
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(feature.name);
     const [editDescription, setEditDescription] = useState(feature.description);
@@ -67,23 +70,44 @@ export function FeatureCard({ feature, onUpdate, readOnly }: FeatureCardProps) {
         );
     }
 
+    const confirmed = !!feature.confirmed;
+
     return (
-        <div className="group p-4 bg-white border border-neutral-200 rounded-lg hover:border-neutral-300 transition">
+        <div className={`group p-4 bg-white border rounded-lg transition ${confirmed ? 'border-emerald-200' : 'border-neutral-200 hover:border-neutral-300'}`}>
             <div className="flex items-start justify-between mb-2 gap-2">
                 <div className="flex items-center gap-2 flex-wrap min-w-0">
-                    <h4 className="font-semibold text-neutral-800">{feature.name}</h4>
+                    <FeatureIdBadge id={feature.id} />
+                    <h4 className="font-bold text-neutral-900">{feature.name}</h4>
                     <MvpTag tier={feature.tier} />
                 </div>
-                {!readOnly && (
-                    <button
-                        onClick={() => setIsEditing(true)}
-                        className="p-1 text-neutral-300 hover:text-neutral-500 opacity-0 group-hover:opacity-100 transition shrink-0"
-                        title="Edit feature"
-                        aria-label="Edit feature"
-                    >
-                        <Pencil size={14} />
-                    </button>
-                )}
+                <div className="flex items-center gap-1 shrink-0">
+                    {!readOnly && (
+                        <button
+                            onClick={() => setIsEditing(true)}
+                            className="p-1 text-neutral-300 hover:text-neutral-500 opacity-0 group-hover:opacity-100 transition"
+                            title="Edit feature"
+                            aria-label="Edit feature"
+                        >
+                            <Pencil size={14} />
+                        </button>
+                    )}
+                    {/* Compact inline confirm — same green-check language as
+                        Confirm Screen. Confirmed features feed the Decision Log. */}
+                    {onToggleConfirm && (readOnly ? confirmed : true) && (
+                        <button
+                            onClick={() => !readOnly && onToggleConfirm(feature)}
+                            disabled={readOnly}
+                            className={confirmed
+                                ? 'inline-flex items-center justify-center h-6 w-6 rounded-full bg-emerald-100 text-emerald-700 transition'
+                                : 'inline-flex items-center justify-center h-6 w-6 rounded-full text-neutral-300 hover:text-emerald-600 hover:bg-emerald-50 transition'}
+                            title={confirmed ? 'Confirmed — tap to reopen' : 'Confirm feature'}
+                            aria-label={confirmed ? `Reopen feature ${feature.name}` : `Confirm feature ${feature.name}`}
+                            aria-pressed={confirmed}
+                        >
+                            {confirmed ? <Check size={14} /> : <Circle size={14} />}
+                        </button>
+                    )}
+                </div>
             </div>
             <p className="text-sm text-neutral-600 mb-2">{feature.description}</p>
             <p className="text-xs text-neutral-500 mb-2">

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -19,6 +19,9 @@ import {
     serializeActions,
 } from '../lib/groundingFields';
 import { ImplementationSummarySection } from './prd/ImplementationSummarySection';
+import { ReviewConfirmSection } from './prd/ReviewConfirmSection';
+import { DecisionLogSection } from './prd/DecisionLogSection';
+import { splitAssumptions, deriveDecisionLog } from '../lib/derive/prdDecisions';
 import {
     ExecutiveSummarySection,
     ProductThesisSection,
@@ -34,7 +37,6 @@ import {
     RisksDetailedSection,
     MvpScopeSection,
     MetricsSection,
-    AssumptionsSection,
     HandoffAppendixSection,
 } from './prd/PremiumSections';
 
@@ -278,6 +280,78 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
         savePRD(updated, `Edited feature: ${updatedFeature.name || 'Untitled'}`);
     };
 
+    // ── Review & Confirm / Decision Log ────────────────────────────────
+    // Confirmations are PRD edits like any other: they append a new spine
+    // version (never overwrite) with a descriptive edit summary, so every
+    // decision is undoable through version history too.
+    const truncate = (s: string, max = 60) =>
+        s.length > max ? `${s.slice(0, max - 1).trim()}…` : s;
+
+    const patchAssumption = (
+        assumptionId: string,
+        patch: Partial<NonNullable<StructuredPRD['assumptions']>[number]>,
+        editSummary: string,
+    ) => {
+        const updated = {
+            ...structuredPRD,
+            assumptions: (structuredPRD.assumptions ?? []).map(a =>
+                a.id === assumptionId ? { ...a, ...patch } : a,
+            ),
+        };
+        savePRD(updated, editSummary);
+    };
+
+    const handleConfirmAssumption = (assumptionId: string) => {
+        const a = structuredPRD.assumptions?.find(x => x.id === assumptionId);
+        if (!a) return;
+        patchAssumption(
+            assumptionId,
+            { decision: 'confirmed', decisionNote: undefined, decidedAt: Date.now() },
+            `Confirmed assumption: ${truncate(a.statement)}`,
+        );
+    };
+
+    const handleRejectAssumption = (assumptionId: string, note: string) => {
+        const a = structuredPRD.assumptions?.find(x => x.id === assumptionId);
+        if (!a) return;
+        patchAssumption(
+            assumptionId,
+            { decision: 'rejected', decisionNote: note || undefined, decidedAt: Date.now() },
+            `Marked assumption incorrect: ${truncate(a.statement)}`,
+        );
+    };
+
+    const handleUndoAssumption = (assumptionId: string) => {
+        const a = structuredPRD.assumptions?.find(x => x.id === assumptionId);
+        if (!a) return;
+        patchAssumption(
+            assumptionId,
+            { decision: undefined, decisionNote: undefined, decidedAt: undefined },
+            `Reopened assumption: ${truncate(a.statement)}`,
+        );
+    };
+
+    const handleToggleFeatureConfirm = (feature: Feature) => {
+        const confirmed = !feature.confirmed;
+        const updated = {
+            ...structuredPRD,
+            features: structuredPRD.features.map(f =>
+                f.id === feature.id
+                    ? { ...f, confirmed: confirmed || undefined, confirmedAt: confirmed ? Date.now() : undefined }
+                    : f,
+            ),
+        };
+        savePRD(
+            updated,
+            confirmed
+                ? `Confirmed feature: ${feature.name || 'Untitled'}`
+                : `Reopened feature: ${feature.name || 'Untitled'}`,
+        );
+    };
+
+    const { unresolved: unresolvedAssumptions } = splitAssumptions(structuredPRD.assumptions);
+    const decisionLog = deriveDecisionLog(structuredPRD);
+
     const handleAddFeature = () => {
         const newFeature: Feature = {
             id: uuidv4(),
@@ -497,13 +571,24 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                         No primary actions captured. These become the primary CTAs across generated mockups.
                     </div>
                 ) : (
-                    <ul className="p-4 bg-neutral-50 border border-neutral-200 rounded-lg space-y-1">
-                        {items.map((action, i) => (
-                            <li key={`${action.verb}-${action.target}-${i}`} className="text-sm text-neutral-700">
-                                <span className="font-semibold text-neutral-900">{action.verb}</span> {action.target}
-                            </li>
-                        ))}
-                    </ul>
+                    // Compact chip row — these ground mockup CTAs, so they stay in
+                    // the PRD, but as a scannable reference rather than a heavy list.
+                    <div className="p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
+                        <p className="text-[11px] text-neutral-500 mb-2">
+                            The primary calls-to-action generated mockups are grounded on.
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                            {items.map((action, i) => (
+                                <span
+                                    key={`${action.verb}-${action.target}-${i}`}
+                                    className="inline-flex items-baseline gap-1 rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-xs text-neutral-700"
+                                >
+                                    <span className="font-semibold text-neutral-900">{action.verb}</span>
+                                    {action.target}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
                 )}
             </div>
         );
@@ -557,6 +642,26 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     the entire document. Hidden if the PRD has no actionable signal. */}
                 <ImplementationSummarySection prd={structuredPRD} />
 
+                {/* Review & Confirm — the actionable home for assumptions / open
+                    decisions (highest confidence first). Confirmed/corrected items
+                    move to the Decision Log below; both hide when empty. */}
+                <ReviewConfirmSection
+                    assumptions={unresolvedAssumptions}
+                    onConfirm={handleConfirmAssumption}
+                    onReject={handleRejectAssumption}
+                    readOnly={readOnly}
+                />
+
+                <DecisionLogSection
+                    entries={decisionLog}
+                    onUndoAssumption={handleUndoAssumption}
+                    onUndoFeature={(featureId) => {
+                        const f = structuredPRD.features.find(x => x.id === featureId);
+                        if (f) handleToggleFeatureConfirm(f);
+                    }}
+                    readOnly={readOnly}
+                />
+
                 {/* Section order is a logical reading flow (mirrors
                     prdMarkdownRenderer): Product Overview → Target Users → MVP
                     Scope → Features → UX → Metrics → Risks → Technical
@@ -583,15 +688,10 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
 
                 {/* MVP Scope — what ships first, before the full feature detail */}
                 {structuredPRD.mvpScope && (structuredPRD.mvpScope.mvp.length || structuredPRD.mvpScope.v1.length || structuredPRD.mvpScope.later.length) ? (
-                    <MvpScopeSection scope={structuredPRD.mvpScope} />
+                    <MvpScopeSection scope={structuredPRD.mvpScope} features={structuredPRD.features} />
                 ) : null}
 
-                {/* Core Features */}
-                {structuredPRD.featureSystems && structuredPRD.featureSystems.length > 0 && (
-                    <FeatureSystemsSection systems={structuredPRD.featureSystems} />
-                )}
-
-                {/* Features */}
+                {/* Core Features — concrete features first, system grouping after */}
                 <div className="mb-8" id="prd-features">
                     <div className="flex items-center justify-between mb-4 border-b border-neutral-200 pb-2">
                         <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight">Detailed Features</h3>
@@ -611,6 +711,7 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                                 <FeatureCard
                                     feature={feature}
                                     onUpdate={handleFeatureUpdate}
+                                    onToggleConfirm={handleToggleFeatureConfirm}
                                     readOnly={readOnly}
                                 />
                                 {!readOnly && (
@@ -631,6 +732,10 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                         ))}
                     </div>
                 </div>
+
+                {structuredPRD.featureSystems && structuredPRD.featureSystems.length > 0 && (
+                    <FeatureSystemsSection systems={structuredPRD.featureSystems} />
+                )}
 
                 {/* User Experience: UX Architecture → Core User Loops */}
                 {structuredPRD.uxPages && structuredPRD.uxPages.length > 0 && (
@@ -670,13 +775,10 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     <StateMachinesSection machines={structuredPRD.stateMachines} />
                 )}
 
-                {/* Appendix / Reference Material */}
+                {/* Appendix / Reference Material. Assumptions no longer render
+                    here — they live in Review & Confirm / Decision Log above. */}
                 {renderDomainEntities()}
                 {renderPrimaryActions()}
-
-                {structuredPRD.assumptions && structuredPRD.assumptions.length > 0 && (
-                    <AssumptionsSection assumptions={structuredPRD.assumptions} />
-                )}
 
                 <HandoffAppendixSection />
             </div>

--- a/src/components/__tests__/StructuredPRDReview.test.tsx
+++ b/src/components/__tests__/StructuredPRDReview.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { useProjectStore } from '../../store/projectStore';
+import { StructuredPRDView } from '../StructuredPRDView';
+import { ReviewConfirmSection } from '../prd/ReviewConfirmSection';
+import { DecisionLogSection } from '../prd/DecisionLogSection';
+import { deriveDecisionLog, splitAssumptions } from '../../lib/derive/prdDecisions';
+import type { SpineVersion, StructuredPRD } from '../../types';
+
+// mark.js walks real DOM ranges — irrelevant to these tests and flaky in
+// jsdom, so stub it out.
+vi.mock('mark.js', () => ({
+    default: class {
+        mark() {}
+        unmark() {}
+    },
+}));
+
+const PROJECT_ID = 'p1';
+const SPINE_ID = 'spine1';
+
+const prd: StructuredPRD = {
+    vision: 'v',
+    targetUsers: ['Solo builders'],
+    coreProblem: 'p',
+    architecture: 'a',
+    risks: [],
+    features: [
+        { id: 'f1', name: 'Quick Capture', description: 'd', userValue: 'v', complexity: 'low', tier: 'mvp' },
+        { id: 'f2', name: 'Weekly Review', description: 'd', userValue: 'v', complexity: 'low', tier: 'v1' },
+    ],
+    featureSystems: [
+        { id: 's1', name: 'Capture System', purpose: 'sp', featureIds: ['f1'] },
+    ],
+    successMetrics: [{ name: 'Activation', target: '40%', instrumentation: 'legacy event name' }],
+    assumptions: [
+        { id: 'a1', statement: 'Users are mobile-first', confidence: 'low' },
+        { id: 'a2', statement: 'Weekly cadence works', confidence: 'high' },
+    ],
+};
+
+function seedStore() {
+    const spine: Partial<SpineVersion> = {
+        id: SPINE_ID,
+        projectId: PROJECT_ID,
+        promptText: 'idea',
+        responseText: 'md',
+        structuredPRD: prd,
+        isLatest: true,
+        isFinal: false,
+        createdAt: 1,
+    };
+    useProjectStore.setState({
+        projects: {},
+        spineVersions: { [PROJECT_ID]: [spine as SpineVersion] },
+        historyEvents: {},
+        branches: {},
+        artifacts: {},
+        artifactVersions: {},
+        feedbackItems: {},
+    });
+}
+
+beforeEach(() => {
+    seedStore();
+    vi.stubGlobal(
+        'matchMedia',
+        vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    );
+});
+
+const latestSpine = () => {
+    const versions = useProjectStore.getState().spineVersions[PROJECT_ID];
+    return versions[versions.length - 1];
+};
+
+function renderView(readOnly = false) {
+    return render(
+        <StructuredPRDView
+            projectId={PROJECT_ID}
+            spineId={SPINE_ID}
+            structuredPRD={prd}
+            readOnly={readOnly}
+        />,
+    );
+}
+
+describe('StructuredPRDView — section cleanup & ordering', () => {
+    it('renders Detailed Features before Feature Systems', () => {
+        const { container } = renderView();
+        const html = container.innerHTML;
+        const features = html.indexOf('Detailed Features');
+        const systems = html.indexOf('Feature Systems');
+        expect(features).toBeGreaterThan(-1);
+        expect(systems).toBeGreaterThan(-1);
+        expect(features).toBeLessThan(systems);
+    });
+
+    it('does not render a Defer bucket or the derived-from clutter line', () => {
+        renderView();
+        expect(screen.getByText('Implementation Summary')).toBeInTheDocument();
+        expect(screen.queryByText('Defer')).toBeNull();
+        expect(screen.queryByText(/derived from features and assumptions/i)).toBeNull();
+    });
+
+    it('omits Instrumentation from Success Metrics', () => {
+        renderView();
+        expect(screen.getByText('Success Metrics')).toBeInTheDocument();
+        expect(screen.queryByText(/instrumentation/i)).toBeNull();
+        expect(screen.queryByText('legacy event name')).toBeNull();
+    });
+
+    it('replaces the passive Assumptions section with Review & Confirm', () => {
+        renderView();
+        expect(screen.queryByText('Assumptions')).toBeNull();
+        expect(screen.getByText('Review & Confirm')).toBeInTheDocument();
+    });
+
+    it('presents MVP scope items resolved to features with id badges', () => {
+        render(
+            <StructuredPRDView
+                projectId={PROJECT_ID}
+                spineId={SPINE_ID}
+                structuredPRD={{ ...prd, mvpScope: { mvp: ['F1: Quick Capture'], v1: ['Weekly Review polish'], later: ['Integrations'] } }}
+                readOnly
+            />,
+        );
+        const mvpSection = document.getElementById('prd-mvp-scope')!;
+        expect(within(mvpSection).getAllByText('f1').length).toBeGreaterThan(0);
+        expect(within(mvpSection).getByText('Quick Capture')).toBeInTheDocument();
+        // "Later" stays a quiet secondary list — never a "Defer" section.
+        expect(within(mvpSection).getByText('Later')).toBeInTheDocument();
+        expect(within(mvpSection).queryByText(/defer/i)).toBeNull();
+    });
+});
+
+describe('StructuredPRDView — assumption review flow', () => {
+    it('orders unresolved assumptions by confidence (highest first)', () => {
+        renderView();
+        const section = document.getElementById('prd-review-confirm')!;
+        const items = within(section).getAllByRole('listitem');
+        expect(items[0].textContent).toContain('Weekly cadence works');
+        expect(items[1].textContent).toContain('Users are mobile-first');
+    });
+
+    it('confirming an assumption appends a new spine version with the decision', () => {
+        renderView();
+        fireEvent.click(screen.getByRole('button', { name: 'Confirm assumption: Weekly cadence works' }));
+        const spine = latestSpine();
+        expect(spine.id).not.toBe(SPINE_ID);
+        const decided = spine.structuredPRD?.assumptions?.find(a => a.id === 'a2');
+        expect(decided?.decision).toBe('confirmed');
+        expect(decided?.decidedAt).toBeTypeOf('number');
+        expect(spine.provenance?.editSummary).toContain('Confirmed assumption');
+    });
+
+    it('rejecting an assumption records the correction note', () => {
+        renderView();
+        fireEvent.click(screen.getByRole('button', { name: 'Mark assumption incorrect: Users are mobile-first' }));
+        fireEvent.change(screen.getByPlaceholderText(/What's actually true/), {
+            target: { value: 'Desktop-first actually' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Mark incorrect' }));
+        const decided = latestSpine().structuredPRD?.assumptions?.find(a => a.id === 'a1');
+        expect(decided?.decision).toBe('rejected');
+        expect(decided?.decisionNote).toBe('Desktop-first actually');
+    });
+
+    it('confirming a feature appends a version with confirmed set', () => {
+        renderView();
+        fireEvent.click(screen.getByRole('button', { name: 'Confirm feature Quick Capture' }));
+        const spine = latestSpine();
+        const f = spine.structuredPRD?.features.find(x => x.id === 'f1');
+        expect(f?.confirmed).toBe(true);
+        expect(spine.provenance?.editSummary).toBe('Confirmed feature: Quick Capture');
+    });
+
+    it('hides confirm/reject actions in read-only mode', () => {
+        renderView(true);
+        expect(screen.queryByRole('button', { name: /Confirm assumption/ })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Confirm feature/ })).toBeNull();
+    });
+});
+
+describe('ReviewConfirmSection / DecisionLogSection units', () => {
+    it('ReviewConfirmSection renders nothing when all assumptions are decided', () => {
+        const { container } = render(
+            <ReviewConfirmSection assumptions={[]} onConfirm={() => {}} onReject={() => {}} readOnly={false} />,
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('DecisionLogSection renders confirmed and rejected entries distinctly', () => {
+        const entries = deriveDecisionLog({
+            ...prd,
+            assumptions: [
+                { id: 'a1', statement: 'Solo users only', confidence: 'med', decision: 'rejected', decisionNote: 'Teams too', decidedAt: 1 },
+                { id: 'a2', statement: 'Weekly cadence works', confidence: 'high', decision: 'confirmed', decidedAt: 2 },
+            ],
+            features: [{ ...prd.features[0], confirmed: true, confirmedAt: 3 }],
+        });
+        const onUndoAssumption = vi.fn();
+        render(
+            <DecisionLogSection
+                entries={entries}
+                onUndoAssumption={onUndoAssumption}
+                onUndoFeature={() => {}}
+                readOnly={false}
+            />,
+        );
+        expect(screen.getByText('Decision Log')).toBeInTheDocument();
+        expect(screen.getByText('Marked incorrect')).toBeInTheDocument();
+        expect(screen.getByText('Confirmed')).toBeInTheDocument();
+        expect(screen.getByText('Feature confirmed')).toBeInTheDocument();
+        expect(screen.getByText(/Teams too/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Undo decision: Solo users only' }));
+        expect(onUndoAssumption).toHaveBeenCalledWith('a1');
+    });
+
+    it('splitAssumptions keeps unresolved and decided visually separable inputs', () => {
+        const { unresolved, decided } = splitAssumptions([
+            { id: 'a1', statement: 's1', confidence: 'low' },
+            { id: 'a2', statement: 's2', confidence: 'high', decision: 'confirmed' },
+        ]);
+        expect(unresolved.map(a => a.id)).toEqual(['a1']);
+        expect(decided.map(a => a.id)).toEqual(['a2']);
+    });
+});

--- a/src/components/prd/DecisionLogSection.tsx
+++ b/src/components/prd/DecisionLogSection.tsx
@@ -1,0 +1,101 @@
+import { Check, X, Undo2 } from 'lucide-react';
+import type { DecisionLogEntry } from '../../lib/derive/prdDecisions';
+import { FeatureIdBadge } from './FeatureIdBadge';
+import { isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
+
+// Decision Log — the record of confirmed user choices (accepted/corrected
+// assumptions and confirmed features). Deliberately separate from the
+// unresolved "Review & Confirm" items above it: everything here has been
+// decided by the user. Derived read-side (deriveDecisionLog); never persisted
+// as its own structure.
+
+function VerdictIcon({ verdict }: { verdict: DecisionLogEntry['verdict'] }) {
+    if (verdict === 'confirmed') {
+        return (
+            <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-emerald-100 shrink-0">
+                <Check size={13} className="text-emerald-700" aria-hidden />
+            </span>
+        );
+    }
+    return (
+        <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-neutral-100 shrink-0">
+            <X size={13} className="text-neutral-500" aria-hidden />
+        </span>
+    );
+}
+
+function ReferenceBadge({ entry }: { entry: DecisionLogEntry }) {
+    if (entry.kind === 'feature') return <FeatureIdBadge id={entry.label} />;
+    if (!isDisplayableFeatureId(entry.label)) return null;
+    return (
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded-md bg-neutral-100 border border-neutral-200 text-neutral-600 text-[11px] font-mono font-semibold uppercase leading-none shrink-0">
+            {entry.label}
+        </span>
+    );
+}
+
+interface Props {
+    entries: DecisionLogEntry[];
+    /** Reopen an assumption decision (back to Review & Confirm). */
+    onUndoAssumption: (assumptionId: string) => void;
+    /** Clear a feature confirmation. */
+    onUndoFeature: (featureId: string) => void;
+    readOnly: boolean;
+}
+
+export function DecisionLogSection({ entries, onUndoAssumption, onUndoFeature, readOnly }: Props) {
+    if (entries.length === 0) return null;
+    return (
+        <div id="prd-decision-log" className="mb-8 scroll-mt-24">
+            <div className="flex items-center gap-2 mb-3 border-b border-neutral-200 pb-2">
+                <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight whitespace-nowrap">
+                    Decision Log
+                </h3>
+                <span className="text-[11px] text-neutral-400">{entries.length}</span>
+            </div>
+            <ul className="space-y-2">
+                {entries.map(entry => (
+                    <li
+                        key={`${entry.kind}-${entry.id}`}
+                        className="flex items-start gap-2.5 rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-2.5"
+                    >
+                        <VerdictIcon verdict={entry.verdict} />
+                        <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <ReferenceBadge entry={entry} />
+                                <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-400">
+                                    {entry.kind === 'feature'
+                                        ? 'Feature confirmed'
+                                        : entry.verdict === 'confirmed' ? 'Confirmed' : 'Marked incorrect'}
+                                </span>
+                            </div>
+                            <p className={`text-sm mt-0.5 ${entry.verdict === 'rejected' ? 'text-neutral-500 line-through decoration-neutral-300' : 'text-neutral-800'}`}>
+                                {entry.statement}
+                            </p>
+                            {entry.note && (
+                                <p className="text-xs text-neutral-700 mt-1">
+                                    <span className="font-semibold text-neutral-500">Correction:</span> {entry.note}
+                                </p>
+                            )}
+                        </div>
+                        {!readOnly && (
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    entry.kind === 'feature'
+                                        ? onUndoFeature(entry.id)
+                                        : onUndoAssumption(entry.id)
+                                }
+                                className="p-1 text-neutral-300 hover:text-neutral-500 transition shrink-0"
+                                title="Undo decision"
+                                aria-label={`Undo decision: ${entry.statement}`}
+                            >
+                                <Undo2 size={14} />
+                            </button>
+                        )}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/prd/FeatureIdBadge.tsx
+++ b/src/components/prd/FeatureIdBadge.tsx
@@ -1,0 +1,18 @@
+import { isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
+
+/**
+ * Non-interactive feature-id badge (F1, F2, …). Mirrors the visual language
+ * of the clickable FeatureReferenceChip used in User Flows so feature
+ * references read the same everywhere in the app. Renders nothing for
+ * uuid-shaped ids (hand-added features).
+ */
+export function FeatureIdBadge({ id, className }: { id?: string; className?: string }) {
+    if (!isDisplayableFeatureId(id)) return null;
+    return (
+        <span
+            className={`inline-flex items-center px-1.5 py-0.5 rounded-md bg-fuchsia-50 border border-fuchsia-200 text-fuchsia-700 text-[11px] font-mono font-semibold uppercase leading-none shrink-0 ${className ?? ''}`}
+        >
+            {id}
+        </span>
+    );
+}

--- a/src/components/prd/ImplementationSummarySection.tsx
+++ b/src/components/prd/ImplementationSummarySection.tsx
@@ -1,25 +1,23 @@
-import { ArrowRight, ListChecks, Pause, ShieldQuestion } from 'lucide-react';
+import { ArrowRight, ListChecks } from 'lucide-react';
 import type { StructuredPRD } from '../../types';
 import {
     deriveImplementationSummary,
     isImplementationSummaryEmpty,
     type SummaryFeature,
 } from '../../lib/derive/implementationSummary';
+import { FeatureIdBadge } from './FeatureIdBadge';
 
-// Synthesized "what to build first / next / defer / risks / decisions" view.
-// Pure derivation — no LLM call. Renders at the top of the PRD so a reader
-// can answer "what would I do Monday morning?" without scrolling 30 pages.
+// Synthesized "what to build first / next" view. Pure derivation — no LLM
+// call. Renders at the top of the PRD so a reader can answer "what would I do
+// Monday morning?" without scrolling 30 pages. Deferred work and open
+// decisions deliberately do NOT live here: deferred scope stays in MVP Scope
+// ("Later") and open decisions moved to the actionable Review & Confirm
+// section.
 
-function FeatureCard({ feature, accent }: { feature: SummaryFeature; accent: 'green' | 'blue' | 'neutral' }) {
+function FeatureCard({ feature, accent }: { feature: SummaryFeature; accent: 'green' | 'blue' }) {
     const accentClasses = {
         green: 'bg-green-50/60 border-green-200',
         blue: 'bg-blue-50/60 border-blue-200',
-        neutral: 'bg-neutral-50 border-neutral-200',
-    }[accent];
-    const idClasses = {
-        green: 'text-green-700',
-        blue: 'text-blue-700',
-        neutral: 'text-neutral-500',
     }[accent];
     return (
         <a
@@ -27,7 +25,7 @@ function FeatureCard({ feature, accent }: { feature: SummaryFeature; accent: 'gr
             className={`block rounded-md border ${accentClasses} px-3 py-2 hover:shadow-sm transition`}
         >
             <div className="flex items-baseline gap-2">
-                <span className={`text-[11px] font-mono font-bold ${idClasses}`}>{feature.id}</span>
+                <FeatureIdBadge id={feature.id} />
                 <span className="text-sm font-semibold text-neutral-900 truncate">{feature.name}</span>
             </div>
             {feature.reason && (
@@ -46,14 +44,13 @@ function FeatureBucket({
 }: {
     title: string;
     icon: typeof ListChecks;
-    accent: 'green' | 'blue' | 'neutral';
+    accent: 'green' | 'blue';
     features: SummaryFeature[];
     emptyHint: string;
 }) {
     const headerClasses = {
         green: 'text-green-700',
         blue: 'text-blue-700',
-        neutral: 'text-neutral-500',
     }[accent];
     return (
         <div>
@@ -83,17 +80,14 @@ export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
 
     return (
         <div id="prd-implementation-summary" className="mb-8 scroll-mt-24">
-            <div className="flex items-center justify-between mb-3 border-b border-neutral-200 pb-2">
-                <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight">
+            <div className="mb-3 border-b border-neutral-200 pb-2">
+                <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight whitespace-nowrap">
                     Implementation Summary
                 </h3>
-                <span className="text-[11px] text-neutral-400">
-                    Derived from features and assumptions
-                </span>
             </div>
 
             <div className="bg-gradient-to-br from-indigo-50/40 to-white border border-indigo-100 rounded-xl p-4">
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <FeatureBucket
                         title="Build First"
                         icon={ListChecks}
@@ -108,41 +102,7 @@ export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
                         features={summary.buildNext}
                         emptyHint="No V1 features tagged."
                     />
-                    <FeatureBucket
-                        title="Defer"
-                        icon={Pause}
-                        accent="neutral"
-                        features={summary.defer}
-                        emptyHint="No deferred features."
-                    />
                 </div>
-
-                {summary.openDecisions.length > 0 && (
-                    <div className="pt-4 border-t border-indigo-100">
-                        <div className="flex items-center gap-2 mb-2">
-                            <ShieldQuestion size={14} className="text-amber-700" />
-                            <h4 className="text-[11px] font-bold uppercase tracking-wider text-amber-700">
-                                Open Decisions
-                            </h4>
-                            <span className="text-[11px] text-neutral-400">{summary.openDecisions.length}</span>
-                        </div>
-                        <ul className="space-y-1.5">
-                            {summary.openDecisions.map(d => (
-                                <li
-                                    key={d.id}
-                                    className="rounded-md border border-amber-100 bg-amber-50/40 px-3 py-2"
-                                >
-                                    <div className="flex items-start gap-2">
-                                        <span className="shrink-0 mt-0.5 text-[10px] font-mono font-bold text-amber-700">
-                                            {d.id}
-                                        </span>
-                                        <p className="text-sm text-neutral-900">{d.statement}</p>
-                                    </div>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
             </div>
         </div>
     );

--- a/src/components/prd/PremiumSections.tsx
+++ b/src/components/prd/PremiumSections.tsx
@@ -1,11 +1,13 @@
 import type {
     Jtbd, Principle, UserLoop, UXPage, FeatureSystem, PrdDataModel,
     StateMachine, RolePermission, ArchFlow, RiskDetailed, MvpScope,
-    SuccessMetric, Assumption, ProductThesis,
+    SuccessMetric, ProductThesis, Feature,
 } from '../../types';
 import { coerceToBulletList, looksDegenerate } from '../../lib/textCleanup';
 import { sanitizeRolePermissions } from '../../lib/prdRolesSanitizer';
 import { stripLeadingListNumber } from '../../lib/utils/stripLeadingListNumber';
+import { resolveScopeFeature, isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
+import { FeatureIdBadge } from './FeatureIdBadge';
 
 // Shared section wrapper. Mirrors the heading style used in StructuredPRDView
 // for visual consistency.
@@ -231,9 +233,14 @@ export function FeatureSystemsSection({ systems }: { systems: FeatureSystem[] })
                         <p className="text-sm font-bold text-neutral-900">{s.name}</p>
                         <p className="text-xs text-neutral-600 mt-1 leading-relaxed">{s.purpose}</p>
                         {s.featureIds?.length ? (
-                            <p className="text-[11px] text-neutral-500 mt-2">
-                                <span className="font-semibold uppercase tracking-wider">Features:</span> {s.featureIds.join(', ')}
-                            </p>
+                            <div className="flex items-center gap-1.5 flex-wrap mt-2">
+                                <span className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">Features:</span>
+                                {s.featureIds.map(id =>
+                                    isDisplayableFeatureId(id)
+                                        ? <FeatureIdBadge key={id} id={id} />
+                                        : <span key={id} className="text-[11px] font-mono text-neutral-500">{id}</span>,
+                                )}
+                            </div>
                         ) : null}
                         {s.endToEndBehavior && (
                             <p className="text-xs text-neutral-700 mt-2"><span className="font-semibold">End-to-end:</span> {s.endToEndBehavior}</p>
@@ -495,7 +502,26 @@ export function RisksDetailedSection({ risks }: { risks: RiskDetailed[] }) {
     );
 }
 
-export function MvpScopeSection({ scope }: { scope: MvpScope }) {
+// One MVP/V1 scope entry, presented explicitly as a feature when it can be
+// resolved to one (id badge + bold name, supporting text secondary). Falls
+// back to the raw string so legacy scope items always render.
+function ScopeFeatureItem({ item, features }: { item: string; features: Feature[] }) {
+    const { feature, secondary } = resolveScopeFeature(item, features);
+    if (!feature) {
+        return <li className="text-sm text-neutral-800">{item}</li>;
+    }
+    return (
+        <li className="text-sm">
+            <div className="flex items-baseline gap-2 flex-wrap">
+                <FeatureIdBadge id={feature.id} />
+                <span className="font-bold text-neutral-900">{feature.name}</span>
+            </div>
+            {secondary && <p className="text-xs text-neutral-600 mt-0.5">{secondary}</p>}
+        </li>
+    );
+}
+
+export function MvpScopeSection({ scope, features = [] }: { scope: MvpScope; features?: Feature[] }) {
     return (
         <Section title="MVP Scope" id="prd-mvp-scope">
             {scope.rationale && (
@@ -504,30 +530,35 @@ export function MvpScopeSection({ scope }: { scope: MvpScope }) {
                     {scope.rationale}
                 </div>
             )}
-            <div className="grid sm:grid-cols-3 gap-3">
+            <div className="grid sm:grid-cols-2 gap-3">
                 <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
                     <p className="text-xs font-bold uppercase tracking-wider text-green-800 mb-2">MVP — ship first</p>
-                    <ul className="list-disc pl-4 space-y-0.5 text-sm text-neutral-800">
-                        {scope.mvp.map((i, k) => <li key={k}>{i}</li>)}
+                    <ul className="space-y-2">
+                        {scope.mvp.map((i, k) => <ScopeFeatureItem key={k} item={i} features={features} />)}
                     </ul>
                 </div>
                 <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
                     <p className="text-xs font-bold uppercase tracking-wider text-blue-800 mb-2">V1 — soon after launch</p>
-                    <ul className="list-disc pl-4 space-y-0.5 text-sm text-neutral-800">
-                        {scope.v1.map((i, k) => <li key={k}>{i}</li>)}
-                    </ul>
-                </div>
-                <div className="p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
-                    <p className="text-xs font-bold uppercase tracking-wider text-neutral-700 mb-2">Later — defer</p>
-                    <ul className="list-disc pl-4 space-y-0.5 text-sm text-neutral-700">
-                        {scope.later.map((i, k) => <li key={k}>{i}</li>)}
+                    <ul className="space-y-2">
+                        {scope.v1.map((i, k) => <ScopeFeatureItem key={k} item={i} features={features} />)}
                     </ul>
                 </div>
             </div>
+            {scope.later?.length ? (
+                <div className="mt-3 p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
+                    <p className="text-xs font-bold uppercase tracking-wider text-neutral-500 mb-1.5">Later</p>
+                    <ul className="list-disc pl-4 space-y-0.5 text-xs text-neutral-600">
+                        {scope.later.map((i, k) => <li key={k}>{i}</li>)}
+                    </ul>
+                </div>
+            ) : null}
         </Section>
     );
 }
 
+// Instrumentation was dropped from this table: new generations no longer
+// produce it (analytics detail belongs to downstream artifacts) so the column
+// rendered blank and eroded trust. Legacy values simply aren't shown.
 export function MetricsSection({ metrics }: { metrics: SuccessMetric[] }) {
     return (
         <Section title="Success Metrics" id="prd-metrics">
@@ -537,7 +568,6 @@ export function MetricsSection({ metrics }: { metrics: SuccessMetric[] }) {
                         <tr>
                             <th className="px-3 py-2 text-left">Metric</th>
                             <th className="px-3 py-2 text-left">Target</th>
-                            <th className="px-3 py-2 text-left">Instrumentation</th>
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-neutral-100">
@@ -545,34 +575,11 @@ export function MetricsSection({ metrics }: { metrics: SuccessMetric[] }) {
                             <tr key={i}>
                                 <td className="px-3 py-2 font-semibold text-neutral-800">{m.name}</td>
                                 <td className="px-3 py-2 text-neutral-700">{m.target || '—'}</td>
-                                <td className="px-3 py-2 text-neutral-700">{m.instrumentation || '—'}</td>
                             </tr>
                         ))}
                     </tbody>
                 </table>
             </div>
-        </Section>
-    );
-}
-
-const confidenceTone = (c: 'low' | 'med' | 'high') =>
-    c === 'high' ? 'bg-emerald-100 text-emerald-800' :
-    c === 'med' ? 'bg-amber-100 text-amber-800' :
-    'bg-neutral-100 text-neutral-700';
-
-export function AssumptionsSection({ assumptions }: { assumptions: Assumption[] }) {
-    return (
-        <Section title="Assumptions" id="prd-assumptions">
-            <ul className="space-y-2">
-                {assumptions.map(a => (
-                    <li key={a.id} className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900">
-                        <span className={`inline-block text-[10px] font-bold uppercase tracking-wider mr-2 px-1.5 py-0.5 rounded ${confidenceTone(a.confidence)}`}>
-                            {a.confidence} confidence
-                        </span>
-                        {a.statement}
-                    </li>
-                ))}
-            </ul>
         </Section>
     );
 }

--- a/src/components/prd/ReviewConfirmSection.tsx
+++ b/src/components/prd/ReviewConfirmSection.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { Check, X } from 'lucide-react';
+import type { Assumption } from '../../types';
+
+// "Review & Confirm" — the actionable replacement for the old passive
+// Assumptions / Open Decisions sections. Every unresolved assumption gets an
+// obvious next action: confirm it as true (green check, same visual language
+// as Confirm Screen) or mark it incorrect with an optional correction.
+// Decided items disappear from here and surface in the Decision Log below.
+// Calm by design — these are ordinary product decisions, not warnings.
+
+const confidenceTone: Record<string, string> = {
+    high: 'bg-emerald-100 text-emerald-800',
+    med: 'bg-amber-100 text-amber-800',
+    low: 'bg-neutral-100 text-neutral-700',
+};
+
+function ConfidenceChip({ confidence }: { confidence?: string }) {
+    if (!confidence) return null;
+    const tone = confidenceTone[confidence] ?? confidenceTone.low;
+    return (
+        <span className={`inline-block shrink-0 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${tone}`}>
+            {confidence} confidence
+        </span>
+    );
+}
+
+interface Props {
+    /** Unresolved assumptions, already sorted by confidence (highest first). */
+    assumptions: Assumption[];
+    /** Confirm the assumption as true. */
+    onConfirm: (assumptionId: string) => void;
+    /** Mark the assumption incorrect, with an optional correction/clarification. */
+    onReject: (assumptionId: string, note: string) => void;
+    readOnly: boolean;
+}
+
+export function ReviewConfirmSection({ assumptions, onConfirm, onReject, readOnly }: Props) {
+    const [rejectingId, setRejectingId] = useState<string | null>(null);
+    const [note, setNote] = useState('');
+
+    if (assumptions.length === 0) return null;
+
+    const startReject = (id: string) => {
+        setRejectingId(id);
+        setNote('');
+    };
+
+    const submitReject = (id: string) => {
+        onReject(id, note.trim());
+        setRejectingId(null);
+        setNote('');
+    };
+
+    return (
+        <div id="prd-review-confirm" className="mb-8 scroll-mt-24">
+            <div className="flex items-center gap-2 mb-3 border-b border-neutral-200 pb-2">
+                <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight whitespace-nowrap">
+                    Review &amp; Confirm
+                </h3>
+                <span className="text-[11px] text-neutral-400">{assumptions.length}</span>
+            </div>
+            <p className="text-sm text-neutral-600 mb-3">
+                Synapse made these assumptions while drafting the PRD. Confirm the ones that are
+                right — or correct the ones that aren&rsquo;t — and they move to the Decision Log.
+            </p>
+            <ul className="space-y-2">
+                {assumptions.map(a => (
+                    <li key={a.id} className="rounded-lg border border-neutral-200 bg-white px-4 py-3">
+                        <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 flex-1">
+                                <ConfidenceChip confidence={a.confidence} />
+                                <p className="text-sm text-neutral-900 mt-1.5">{a.statement}</p>
+                            </div>
+                            {!readOnly && rejectingId !== a.id && (
+                                <div className="flex items-center gap-1.5 shrink-0">
+                                    <button
+                                        type="button"
+                                        onClick={() => onConfirm(a.id)}
+                                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-md bg-emerald-600 hover:bg-emerald-700 text-white transition"
+                                        aria-label={`Confirm assumption: ${a.statement}`}
+                                    >
+                                        <Check size={13} /> Confirm
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => startReject(a.id)}
+                                        className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md bg-neutral-100 hover:bg-neutral-200 text-neutral-700 transition"
+                                        aria-label={`Mark assumption incorrect: ${a.statement}`}
+                                    >
+                                        <X size={12} /> Not right
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                        {rejectingId === a.id && (
+                            <div className="mt-3 space-y-2">
+                                <textarea
+                                    value={note}
+                                    onChange={e => setNote(e.target.value)}
+                                    className="w-full bg-neutral-50 border border-neutral-200 rounded-lg px-3 py-2 text-sm text-neutral-700 focus:outline-none focus:border-indigo-400 min-h-[64px]"
+                                    placeholder="What's actually true? (optional)"
+                                    autoFocus
+                                />
+                                <div className="flex justify-end gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={() => setRejectingId(null)}
+                                        className="px-2.5 py-1.5 text-xs font-medium rounded-md text-neutral-500 hover:text-neutral-700 transition"
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => submitReject(a.id)}
+                                        className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-semibold rounded-md bg-neutral-800 hover:bg-neutral-900 text-white transition"
+                                    >
+                                        Mark incorrect
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/lib/__tests__/implementationSummary.test.ts
+++ b/src/lib/__tests__/implementationSummary.test.ts
@@ -36,7 +36,6 @@ describe('deriveImplementationSummary — feature bucketing', () => {
         const s = deriveImplementationSummary(prd);
         expect(s.buildFirst.map(f => f.id)).toEqual(['f1']);
         expect(s.buildNext.map(f => f.id)).toEqual(['f2']);
-        expect(s.defer.map(f => f.id)).toEqual(['f3']);
     });
 
     it('falls back to priority when tier is missing', () => {
@@ -50,7 +49,6 @@ describe('deriveImplementationSummary — feature bucketing', () => {
         const s = deriveImplementationSummary(prd);
         expect(s.buildFirst.map(f => f.id)).toEqual(['f1']);
         expect(s.buildNext.map(f => f.id)).toEqual(['f2']);
-        expect(s.defer.map(f => f.id)).toEqual(['f3']);
     });
 
     it('legacy untagged PRDs split features by declaration order', () => {
@@ -62,7 +60,15 @@ describe('deriveImplementationSummary — feature bucketing', () => {
         const s = deriveImplementationSummary(prd);
         expect(s.buildFirst).toHaveLength(4);
         expect(s.buildNext).toHaveLength(4);
-        expect(s.defer).toHaveLength(2);
+    });
+
+    it('exposes no defer bucket (removed from the summary)', () => {
+        const prd = basePRD({
+            features: [baseFeature({ id: 'f1', name: 'F1', tier: 'later' })],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect('defer' in s).toBe(false);
+        expect('openDecisions' in s).toBe(false);
     });
 
     it('orders buckets by feature id so f1, f2, f3… stay in natural order', () => {
@@ -116,20 +122,6 @@ describe('deriveImplementationSummary — risks', () => {
         const prd = basePRD({ risks: ['Timezone bugs', 'Latency spikes'] });
         const s = deriveImplementationSummary(prd);
         expect(s.highestRisks.map(r => r.risk)).toEqual(['Timezone bugs', 'Latency spikes']);
-    });
-});
-
-describe('deriveImplementationSummary — open decisions', () => {
-    it('prefers low-confidence assumptions', () => {
-        const prd = basePRD({
-            assumptions: [
-                { id: 'a1', statement: 'high', confidence: 'high' },
-                { id: 'a2', statement: 'low', confidence: 'low' },
-                { id: 'a3', statement: 'med', confidence: 'med' },
-            ],
-        });
-        const s = deriveImplementationSummary(prd);
-        expect(s.openDecisions.map(d => d.id)).toEqual(['a2']);
     });
 });
 

--- a/src/lib/__tests__/prdDecisions.test.ts
+++ b/src/lib/__tests__/prdDecisions.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+    sortAssumptionsByConfidence,
+    splitAssumptions,
+    deriveDecisionLog,
+    resolveScopeFeature,
+    isDisplayableFeatureId,
+} from '../derive/prdDecisions';
+import type { Assumption, Feature, StructuredPRD } from '../../types';
+
+const assumption = (overrides: Partial<Assumption>): Assumption => ({
+    id: 'a1',
+    statement: 'Users have smartphones',
+    confidence: 'med',
+    ...overrides,
+});
+
+const feature = (overrides: Partial<Feature>): Feature => ({
+    id: 'f1',
+    name: 'Quick Capture',
+    description: 'd',
+    userValue: 'v',
+    complexity: 'low',
+    ...overrides,
+});
+
+const basePRD = (overrides: Partial<StructuredPRD>): StructuredPRD => ({
+    vision: 'v',
+    targetUsers: [],
+    coreProblem: 'p',
+    features: [],
+    architecture: 'a',
+    risks: [],
+    ...overrides,
+});
+
+describe('sortAssumptionsByConfidence', () => {
+    it('orders high → med → low', () => {
+        const sorted = sortAssumptionsByConfidence([
+            assumption({ id: 'a1', confidence: 'low' }),
+            assumption({ id: 'a2', confidence: 'high' }),
+            assumption({ id: 'a3', confidence: 'med' }),
+        ]);
+        expect(sorted.map(a => a.id)).toEqual(['a2', 'a3', 'a1']);
+    });
+
+    it('is deterministic and stable within a confidence level', () => {
+        const input = [
+            assumption({ id: 'a1', confidence: 'high' }),
+            assumption({ id: 'a2', confidence: 'high' }),
+            assumption({ id: 'a3', confidence: 'high' }),
+        ];
+        expect(sortAssumptionsByConfidence(input).map(a => a.id)).toEqual(['a1', 'a2', 'a3']);
+        // Re-running yields the identical order.
+        expect(sortAssumptionsByConfidence(input).map(a => a.id)).toEqual(['a1', 'a2', 'a3']);
+    });
+
+    it('handles missing/unknown confidence gracefully (sorts last)', () => {
+        const legacy = { id: 'a1', statement: 's' } as Assumption; // no confidence
+        const sorted = sortAssumptionsByConfidence([
+            legacy,
+            assumption({ id: 'a2', confidence: 'low' }),
+            assumption({ id: 'a3', confidence: 'high' }),
+        ]);
+        expect(sorted.map(a => a.id)).toEqual(['a3', 'a2', 'a1']);
+    });
+
+    it('does not mutate the input array', () => {
+        const input = [
+            assumption({ id: 'a1', confidence: 'low' }),
+            assumption({ id: 'a2', confidence: 'high' }),
+        ];
+        sortAssumptionsByConfidence(input);
+        expect(input.map(a => a.id)).toEqual(['a1', 'a2']);
+    });
+});
+
+describe('splitAssumptions', () => {
+    it('separates unresolved from decided and sorts unresolved by confidence', () => {
+        const { unresolved, decided } = splitAssumptions([
+            assumption({ id: 'a1', confidence: 'low' }),
+            assumption({ id: 'a2', confidence: 'high', decision: 'confirmed' }),
+            assumption({ id: 'a3', confidence: 'high' }),
+            assumption({ id: 'a4', confidence: 'med', decision: 'rejected' }),
+        ]);
+        expect(unresolved.map(a => a.id)).toEqual(['a3', 'a1']);
+        expect(decided.map(a => a.id)).toEqual(['a2', 'a4']);
+    });
+
+    it('treats undefined input (legacy PRDs) as empty', () => {
+        const { unresolved, decided } = splitAssumptions(undefined);
+        expect(unresolved).toEqual([]);
+        expect(decided).toEqual([]);
+    });
+});
+
+describe('deriveDecisionLog', () => {
+    it('includes decided assumptions and confirmed features, never unresolved items', () => {
+        const prd = basePRD({
+            assumptions: [
+                assumption({ id: 'a1', decision: 'confirmed', decidedAt: 100 }),
+                assumption({ id: 'a2' }), // unresolved
+                assumption({ id: 'a3', decision: 'rejected', decisionNote: 'Actually offline-first', decidedAt: 50 }),
+            ],
+            features: [
+                feature({ id: 'f1', confirmed: true, confirmedAt: 75 }),
+                feature({ id: 'f2' }), // unconfirmed
+            ],
+        });
+        const log = deriveDecisionLog(prd);
+        expect(log.map(e => e.id)).toEqual(['a3', 'f1', 'a1']); // chronological
+        expect(log.find(e => e.id === 'a3')?.verdict).toBe('rejected');
+        expect(log.find(e => e.id === 'a3')?.note).toBe('Actually offline-first');
+        expect(log.find(e => e.id === 'f1')?.kind).toBe('feature');
+        expect(log.some(e => e.id === 'a2' || e.id === 'f2')).toBe(false);
+    });
+
+    it('is empty for legacy PRDs with no decisions', () => {
+        const prd = basePRD({
+            assumptions: [assumption({ id: 'a1' })],
+            features: [feature({ id: 'f1' })],
+        });
+        expect(deriveDecisionLog(prd)).toEqual([]);
+    });
+
+    it('sorts undated entries last, in document order', () => {
+        const prd = basePRD({
+            assumptions: [
+                assumption({ id: 'a1', decision: 'confirmed' }), // undated
+                assumption({ id: 'a2', decision: 'confirmed', decidedAt: 10 }),
+            ],
+        });
+        expect(deriveDecisionLog(prd).map(e => e.id)).toEqual(['a2', 'a1']);
+    });
+});
+
+describe('resolveScopeFeature', () => {
+    const features = [
+        feature({ id: 'f1', name: 'Quick Capture' }),
+        feature({ id: 'f2', name: 'Weekly Review' }),
+        feature({ id: 'f12', name: 'Weekly Review Digest' }),
+    ];
+
+    it('matches an explicit id token and strips it from the secondary text', () => {
+        const m = resolveScopeFeature('F1: Quick Capture — one-tap logging', features);
+        expect(m.feature?.id).toBe('f1');
+        expect(m.secondary).toBe('one-tap logging');
+    });
+
+    it('matches by feature name when no id token is present', () => {
+        const m = resolveScopeFeature('Weekly Review for retros', features);
+        expect(m.feature?.id).toBe('f2');
+        expect(m.secondary).toBe('for retros');
+    });
+
+    it('prefers the longest name match', () => {
+        const m = resolveScopeFeature('Weekly Review Digest emails', features);
+        expect(m.feature?.id).toBe('f12');
+    });
+
+    it('returns no match for plain prose items (renders raw string)', () => {
+        expect(resolveScopeFeature('Basic auth and onboarding', features).feature).toBeUndefined();
+    });
+
+    it('returns no match when the PRD has no features', () => {
+        expect(resolveScopeFeature('F1: anything', []).feature).toBeUndefined();
+    });
+
+    it('omits secondary when the item is only the feature reference', () => {
+        const m = resolveScopeFeature('F2: Weekly Review', features);
+        expect(m.feature?.id).toBe('f2');
+        expect(m.secondary).toBeUndefined();
+    });
+});
+
+describe('isDisplayableFeatureId', () => {
+    it('accepts short human tokens and rejects uuids', () => {
+        expect(isDisplayableFeatureId('f1')).toBe(true);
+        expect(isDisplayableFeatureId('F12')).toBe(true);
+        expect(isDisplayableFeatureId('a-3')).toBe(true);
+        expect(isDisplayableFeatureId('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+        expect(isDisplayableFeatureId(undefined)).toBe(false);
+        expect(isDisplayableFeatureId('')).toBe(false);
+    });
+});

--- a/src/lib/__tests__/prdDecisions.test.ts
+++ b/src/lib/__tests__/prdDecisions.test.ts
@@ -158,6 +158,18 @@ describe('resolveScopeFeature', () => {
         expect(m.feature?.id).toBe('f12');
     });
 
+    it('never matches a short feature name inside an unrelated word', () => {
+        const withAi = [...features, feature({ id: 'f9', name: 'AI' })];
+        // "Daily digest" contains "ai" as a substring of "Daily" — a token
+        // match must NOT resolve it to the "AI" feature.
+        const m = resolveScopeFeature('Daily digest emails', withAi);
+        expect(m.feature).toBeUndefined();
+        // …while a real whole-token reference still resolves.
+        const hit = resolveScopeFeature('AI smart replies', withAi);
+        expect(hit.feature?.id).toBe('f9');
+        expect(hit.secondary).toBe('smart replies');
+    });
+
     it('returns no match for plain prose items (renders raw string)', () => {
         expect(resolveScopeFeature('Basic auth and onboarding', features).feature).toBeUndefined();
     });

--- a/src/lib/__tests__/prdMarkdownRenderer.test.ts
+++ b/src/lib/__tests__/prdMarkdownRenderer.test.ts
@@ -21,6 +21,81 @@ describe('renderPremiumMarkdown handoff appendix', () => {
     });
 });
 
+describe('renderPremiumMarkdown mobile-cleanup pass', () => {
+    const richPrd: StructuredPRD = {
+        ...minimalPrd,
+        features: [
+            { id: 'f1', name: 'Quick Capture', description: 'd', userValue: 'v', complexity: 'low', tier: 'mvp' },
+            { id: 'f2', name: 'Weekly Review', description: 'd', userValue: 'v', complexity: 'low', tier: 'later', confirmed: true, confirmedAt: 2 },
+        ],
+        featureSystems: [
+            { id: 's1', name: 'Capture System', purpose: 'p', featureIds: ['f1'] },
+        ],
+        successMetrics: [
+            { name: 'Activation', target: '40%', instrumentation: 'legacy event' },
+        ],
+        assumptions: [
+            { id: 'a1', statement: 'Users are mobile-first', confidence: 'low' },
+            { id: 'a2', statement: 'Weekly cadence works', confidence: 'high' },
+            { id: 'a3', statement: 'Solo users only', confidence: 'med', decision: 'rejected', decisionNote: 'Teams too', decidedAt: 1 },
+        ],
+    };
+
+    it('renders Detailed Features before Feature Systems', () => {
+        const md = renderPremiumMarkdown(richPrd);
+        expect(md.indexOf('## Detailed Features')).toBeGreaterThan(-1);
+        expect(md.indexOf('## Feature Systems')).toBeGreaterThan(-1);
+        expect(md.indexOf('## Detailed Features')).toBeLessThan(md.indexOf('## Feature Systems'));
+    });
+
+    it('renders no Defer section in the Implementation Summary', () => {
+        const md = renderPremiumMarkdown(richPrd);
+        expect(md).toContain('## Implementation Summary');
+        expect(md).not.toContain('### Defer');
+        expect(md).not.toContain('### Open Decisions');
+    });
+
+    it('omits Instrumentation from Success Metrics', () => {
+        const md = renderPremiumMarkdown(richPrd);
+        expect(md).toContain('## Success Metrics');
+        expect(md).toContain('| Metric | Target |');
+        expect(md).not.toContain('Instrumentation');
+        expect(md).not.toContain('legacy event');
+    });
+
+    it('renders unresolved assumptions as Review & Confirm, sorted by confidence', () => {
+        const md = renderPremiumMarkdown(richPrd);
+        expect(md).toContain('## Review & Confirm');
+        expect(md).not.toContain('## Assumptions');
+        const high = md.indexOf('Weekly cadence works');
+        const low = md.indexOf('Users are mobile-first');
+        expect(high).toBeGreaterThan(-1);
+        expect(low).toBeGreaterThan(high);
+    });
+
+    it('renders decided assumptions and confirmed features in the Decision Log', () => {
+        const md = renderPremiumMarkdown(richPrd);
+        expect(md).toContain('## Decision Log');
+        expect(md).toContain('**Marked incorrect** (a3): Solo users only — Correction: Teams too');
+        expect(md).toContain('**Feature confirmed** (f2): Weekly Review');
+        // Unresolved items never appear in the log.
+        const logStart = md.indexOf('## Decision Log');
+        const logEnd = md.indexOf('##', logStart + 1);
+        expect(md.slice(logStart, logEnd)).not.toContain('mobile-first');
+    });
+
+    it('legacy PRDs with plain assumptions still render safely (all unresolved)', () => {
+        const legacy: StructuredPRD = {
+            ...minimalPrd,
+            assumptions: [{ id: 'a1', statement: 'Old assumption', confidence: 'med' }],
+        };
+        const md = renderPremiumMarkdown(legacy);
+        expect(md).toContain('## Review & Confirm');
+        expect(md).toContain('Old assumption');
+        expect(md).not.toContain('## Decision Log');
+    });
+});
+
 describe('renderPremiumMarkdown legacy-field back-compat', () => {
     it('still renders retired-section content stored on legacy PRDs', () => {
         const legacyPrd: StructuredPRD = {

--- a/src/lib/derive/implementationSummary.ts
+++ b/src/lib/derive/implementationSummary.ts
@@ -17,23 +17,19 @@ export type SummaryRisk = {
     impact: string;
 };
 
-export type SummaryDecision = {
-    id: string;
-    statement: string;
-};
-
+// Note: the old "Defer" bucket and "Open Decisions" list were removed from
+// this summary — deferred work lives in MVP Scope ("Later") and the feature
+// tier tags, and open decisions moved to the actionable "Review & Confirm"
+// section (src/lib/derive/prdDecisions.ts).
 export type ImplementationSummary = {
     buildFirst: SummaryFeature[];
     buildNext: SummaryFeature[];
-    defer: SummaryFeature[];
     highestRisks: SummaryRisk[];
-    openDecisions: SummaryDecision[];
 };
 
 const HIGH_IMPACT_KEYWORDS = /(outage|loss|critical|blocker|catastroph|exposed|leak|breach)/i;
 const MAX_FEATURES_PER_BUCKET = 5;
 const MAX_RISKS = 4;
-const MAX_DECISIONS = 4;
 
 function isMvp(feature: Feature): boolean {
     if (feature.tier === 'mvp') return true;
@@ -44,12 +40,6 @@ function isMvp(feature: Feature): boolean {
 function isV1(feature: Feature): boolean {
     if (feature.tier === 'v1') return true;
     if (!feature.tier && feature.priority === 'should') return true;
-    return false;
-}
-
-function isLater(feature: Feature): boolean {
-    if (feature.tier === 'later') return true;
-    if (!feature.tier && feature.priority === 'could') return true;
     return false;
 }
 
@@ -80,21 +70,18 @@ function buildReason(f: Feature): string {
 function pickFeatures(features: Feature[]): {
     buildFirst: Feature[];
     buildNext: Feature[];
-    defer: Feature[];
 } {
     const tagged = features.some(f => f.tier || f.priority);
     if (!tagged) {
         // Legacy PRDs without any prioritization. Use declaration order
-        // as a rough proxy: first 4 → first, next 4 → next, rest → defer.
+        // as a rough proxy: first 4 → first, next 4 → next.
         return {
             buildFirst: features.slice(0, 4),
             buildNext: features.slice(4, 8),
-            defer: features.slice(8),
         };
     }
     const buildFirst = features.filter(isMvp);
     const buildNext = features.filter(f => !isMvp(f) && isV1(f));
-    const defer = features.filter(f => !isMvp(f) && !isV1(f) && isLater(f));
 
     // Within each bucket sort by the numeric portion of the feature id so the
     // user sees f1, f2, f3… in their natural order rather than a complexity
@@ -105,7 +92,6 @@ function pickFeatures(features: Feature[]): {
     return {
         buildFirst: sortById(buildFirst),
         buildNext: sortById(buildNext),
-        defer: sortById(defer),
     };
 }
 
@@ -136,25 +122,13 @@ function pickHighestRisks(prd: StructuredPRD): SummaryRisk[] {
     return fallback.map(r => ({ risk: r, likelihood: 'unknown', impact: '' }));
 }
 
-function pickOpenDecisions(prd: StructuredPRD): SummaryDecision[] {
-    const assumptions = prd.assumptions || [];
-    const lowConfidence = assumptions.filter(a => a.confidence === 'low');
-    const source = lowConfidence.length > 0 ? lowConfidence : assumptions.slice(0, MAX_DECISIONS);
-    return source.slice(0, MAX_DECISIONS).map(a => ({
-        id: a.id,
-        statement: a.statement,
-    }));
-}
-
 export function deriveImplementationSummary(prd: StructuredPRD): ImplementationSummary {
     const features = prd.features || [];
-    const { buildFirst, buildNext, defer } = pickFeatures(features);
+    const { buildFirst, buildNext } = pickFeatures(features);
     return {
         buildFirst: buildFirst.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, true)),
         buildNext: buildNext.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, false)),
-        defer: defer.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, false)),
         highestRisks: pickHighestRisks(prd),
-        openDecisions: pickOpenDecisions(prd),
     };
 }
 
@@ -162,8 +136,6 @@ export function isImplementationSummaryEmpty(s: ImplementationSummary): boolean 
     return (
         s.buildFirst.length === 0 &&
         s.buildNext.length === 0 &&
-        s.defer.length === 0 &&
-        s.highestRisks.length === 0 &&
-        s.openDecisions.length === 0
+        s.highestRisks.length === 0
     );
 }

--- a/src/lib/derive/prdDecisions.ts
+++ b/src/lib/derive/prdDecisions.ts
@@ -1,0 +1,167 @@
+// Pure derivations behind the PRD "Review & Confirm" section and the
+// Decision Log. No LLM call, no store access — everything is computed at
+// read time from the StructuredPRD so legacy PRDs (whose assumptions carry
+// no decision fields) render safely as "all unresolved".
+
+import type { Assumption, Feature, StructuredPRD } from '../../types';
+
+const CONFIDENCE_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };
+
+/** Missing/unknown confidence sorts last, after low. */
+const confidenceRank = (a: Assumption): number =>
+    CONFIDENCE_RANK[a.confidence] ?? 3;
+
+/**
+ * Order assumptions by confidence, highest first. Deterministic and stable:
+ * items sharing a confidence keep their original relative order, and
+ * missing/unknown confidence values sort last.
+ */
+export function sortAssumptionsByConfidence(assumptions: Assumption[]): Assumption[] {
+    return assumptions
+        .map((a, i) => ({ a, i }))
+        .sort((x, y) => confidenceRank(x.a) - confidenceRank(y.a) || x.i - y.i)
+        .map(x => x.a);
+}
+
+export type AssumptionSplit = {
+    /** Undecided items, sorted by confidence (highest first). */
+    unresolved: Assumption[];
+    /** Confirmed/rejected items, in original document order. */
+    decided: Assumption[];
+};
+
+/** Split assumptions into unresolved (needs user input) vs decided. */
+export function splitAssumptions(assumptions: Assumption[] | undefined): AssumptionSplit {
+    const list = assumptions ?? [];
+    return {
+        unresolved: sortAssumptionsByConfidence(list.filter(a => !a.decision)),
+        decided: list.filter(a => !!a.decision),
+    };
+}
+
+export type DecisionLogEntry = {
+    /** Stable id of the source item (assumption id / feature id). */
+    id: string;
+    kind: 'assumption' | 'feature';
+    verdict: 'confirmed' | 'rejected';
+    /** Short reference label shown as a badge (assumption id or feature id). */
+    label: string;
+    statement: string;
+    note?: string;
+    decidedAt?: number;
+};
+
+/**
+ * Derive the Decision Log — confirmed user choices only, never unresolved
+ * assumptions. Sources: assumptions the user confirmed/rejected and features
+ * the user confirmed. Ordered chronologically by decision time (undated
+ * entries last, in document order) so the log reads as a running record.
+ */
+export function deriveDecisionLog(prd: StructuredPRD): DecisionLogEntry[] {
+    const entries: DecisionLogEntry[] = [];
+
+    (prd.assumptions ?? []).forEach(a => {
+        if (!a.decision) return;
+        entries.push({
+            id: a.id,
+            kind: 'assumption',
+            verdict: a.decision,
+            label: a.id,
+            statement: a.statement,
+            note: a.decisionNote || undefined,
+            decidedAt: a.decidedAt,
+        });
+    });
+
+    (prd.features ?? []).forEach(f => {
+        if (!f.confirmed) return;
+        entries.push({
+            id: f.id,
+            kind: 'feature',
+            verdict: 'confirmed',
+            label: f.id,
+            statement: f.name,
+            decidedAt: f.confirmedAt,
+        });
+    });
+
+    return entries
+        .map((e, i) => ({ e, i }))
+        .sort((x, y) => {
+            const xa = x.e.decidedAt ?? Number.MAX_SAFE_INTEGER;
+            const ya = y.e.decidedAt ?? Number.MAX_SAFE_INTEGER;
+            return xa - ya || x.i - y.i;
+        })
+        .map(x => x.e);
+}
+
+/**
+ * True when a feature id is a short human-readable token (F1, f12) worth
+ * rendering as an id badge. Hand-added features get uuids — showing those as
+ * badges would be noise, so callers hide the badge instead.
+ */
+export function isDisplayableFeatureId(id: string | undefined): boolean {
+    return !!id && /^[a-zA-Z]{1,3}-?\d{1,3}$/.test(id.trim());
+}
+
+export type ScopeFeatureMatch = {
+    /** The PRD feature the scope item refers to, when one can be resolved. */
+    feature?: Feature;
+    /** Supporting text left over once the id/name reference is stripped. */
+    secondary?: string;
+};
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Resolve an MVP-scope string ("F1: Quick capture — one-tap logging") to its
+ * PRD feature so the MVP/V1 lists can present items as features (id badge +
+ * bold name) instead of plain prose. Conservative, read-side only:
+ * 1. an explicit id token (`f1`, `F-1`, `[f1]`) wins;
+ * 2. else the longest feature name contained in the item;
+ * 3. no match → undefined (the caller renders the raw string unchanged).
+ * The leftover text (minus the matched id/name and separators) is returned
+ * as `secondary` supporting copy.
+ */
+export function resolveScopeFeature(item: string, features: Feature[]): ScopeFeatureMatch {
+    const text = item.trim();
+    if (!text || features.length === 0) return {};
+
+    const byId = new Map<string, Feature>();
+    features.forEach(f => byId.set(f.id.toLowerCase().replace(/-/g, ''), f));
+
+    let feature: Feature | undefined;
+    let consumed: RegExp | undefined;
+
+    const idToken = text.match(/\[?\b([a-zA-Z]-?\d+)\b\]?/);
+    if (idToken) {
+        feature = byId.get(idToken[1].toLowerCase().replace(/-/g, ''));
+        if (feature) consumed = new RegExp(`\\[?${escapeRegExp(idToken[1])}\\]?`, 'i');
+    }
+
+    if (!feature) {
+        const lower = text.toLowerCase();
+        const named = features
+            .filter(f => f.name && lower.includes(f.name.toLowerCase()))
+            .sort((a, b) => b.name.length - a.name.length)[0];
+        if (named) {
+            feature = named;
+            consumed = new RegExp(escapeRegExp(named.name), 'i');
+        }
+    }
+
+    if (!feature) return {};
+
+    let secondary = consumed ? text.replace(consumed, '') : text;
+    // Strip the feature name too when the item was matched by id but also
+    // repeats the name ("F1: Quick capture — …").
+    if (feature.name) {
+        secondary = secondary.replace(new RegExp(escapeRegExp(feature.name), 'i'), '');
+    }
+    secondary = secondary
+        .replace(/^[\s:–—-]+/, '')
+        .replace(/[\s:–—-]+$/, '')
+        .trim();
+
+    return { feature, secondary: secondary || undefined };
+}

--- a/src/lib/derive/prdDecisions.ts
+++ b/src/lib/derive/prdDecisions.ts
@@ -113,6 +113,13 @@ export type ScopeFeatureMatch = {
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+// Whole-token match for a feature name inside a scope item. A bare substring
+// test would resolve unrelated words (feature "AI" matching inside "Daily")
+// and then strip mid-word text from the secondary copy — scope entries are
+// often free prose, so the name must sit on its own token boundaries.
+const nameMatchRegExp = (name: string) =>
+    new RegExp(`(?<![A-Za-z0-9])${escapeRegExp(name)}(?![A-Za-z0-9])`, 'i');
+
 /**
  * Resolve an MVP-scope string ("F1: Quick capture — one-tap logging") to its
  * PRD feature so the MVP/V1 lists can present items as features (id badge +
@@ -140,13 +147,12 @@ export function resolveScopeFeature(item: string, features: Feature[]): ScopeFea
     }
 
     if (!feature) {
-        const lower = text.toLowerCase();
         const named = features
-            .filter(f => f.name && lower.includes(f.name.toLowerCase()))
+            .filter(f => f.name && nameMatchRegExp(f.name).test(text))
             .sort((a, b) => b.name.length - a.name.length)[0];
         if (named) {
             feature = named;
-            consumed = new RegExp(escapeRegExp(named.name), 'i');
+            consumed = nameMatchRegExp(named.name);
         }
     }
 
@@ -156,7 +162,7 @@ export function resolveScopeFeature(item: string, features: Feature[]): ScopeFea
     // Strip the feature name too when the item was matched by id but also
     // repeats the name ("F1: Quick capture — …").
     if (feature.name) {
-        secondary = secondary.replace(new RegExp(escapeRegExp(feature.name), 'i'), '');
+        secondary = secondary.replace(nameMatchRegExp(feature.name), '');
     }
     secondary = secondary
         .replace(/^[\s:–—-]+/, '')

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -29,6 +29,7 @@ import {
     deriveImplementationSummary,
     isImplementationSummaryEmpty,
 } from '../derive/implementationSummary';
+import { splitAssumptions, deriveDecisionLog } from '../derive/prdDecisions';
 import { sanitizeRolePermissions } from '../prdRolesSanitizer';
 import { stripLeadingListNumber } from '../utils/stripLeadingListNumber';
 
@@ -237,12 +238,15 @@ const renderRisksDetailed = (risks: RiskDetailed[]): string[] => {
     return lines;
 };
 
+// Instrumentation was dropped from this table: new generations no longer
+// produce it (analytics detail belongs to downstream artifacts) so the column
+// rendered blank. Mirrors MetricsSection in PremiumSections.tsx.
 const renderMetrics = (metrics: SuccessMetric[]): string[] => {
     const lines: string[] = [];
-    lines.push('| Metric | Target | Instrumentation |');
-    lines.push('|---|---|---|');
+    lines.push('| Metric | Target |');
+    lines.push('|---|---|');
     metrics.forEach(m => {
-        lines.push(`| ${escapeCell(m.name)} | ${escapeCell(m.target || '—')} | ${escapeCell(m.instrumentation || '—')} |`);
+        lines.push(`| ${escapeCell(m.name)} | ${escapeCell(m.target || '—')} |`);
     });
     return lines;
 };
@@ -288,11 +292,6 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
             summary.buildNext.forEach(f => lines.push(`- **${f.id}** ${f.name}`));
             lines.push('');
         }
-        if (summary.defer.length > 0) {
-            lines.push('### Defer');
-            summary.defer.forEach(f => lines.push(`- **${f.id}** ${f.name}`));
-            lines.push('');
-        }
         if (summary.highestRisks.length > 0) {
             lines.push('### Highest Risks');
             summary.highestRisks.forEach(r => {
@@ -302,11 +301,32 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
             });
             lines.push('');
         }
-        if (summary.openDecisions.length > 0) {
-            lines.push('### Open Decisions');
-            summary.openDecisions.forEach(d => lines.push(`- **${d.id}** ${d.statement}`));
-            lines.push('');
-        }
+    }
+
+    // ── Review & Confirm / Decision Log — mirrors ReviewConfirmSection and
+    // DecisionLogSection in the structured view. Unresolved assumptions
+    // surface as items awaiting user confirmation (highest confidence first);
+    // decided ones read as a running log of confirmed user choices.
+    const { unresolved: unresolvedAssumptions } = splitAssumptions(prd.assumptions);
+    const decisionLog = deriveDecisionLog(prd);
+    if (unresolvedAssumptions.length > 0) {
+        lines.push('## Review & Confirm');
+        lines.push('Assumptions made while drafting this PRD that still need user confirmation or correction:');
+        unresolvedAssumptions.forEach(a => {
+            lines.push(`- **${a.confidence} confidence** — ${a.statement}`);
+        });
+        lines.push('');
+    }
+    if (decisionLog.length > 0) {
+        lines.push('## Decision Log');
+        decisionLog.forEach(e => {
+            const verdict = e.kind === 'feature'
+                ? 'Feature confirmed'
+                : e.verdict === 'confirmed' ? 'Confirmed' : 'Marked incorrect';
+            const note = e.note ? ` — Correction: ${e.note}` : '';
+            lines.push(`- **${verdict}** (${e.label}): ${e.statement}${note}`);
+        });
+        lines.push('');
     }
 
     // ── Section order is a logical reading flow (see StructuredPRDView, which
@@ -381,13 +401,18 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         }
         if (prd.mvpScope.later?.length) {
             lines.push('');
-            lines.push('**Later — defer:**');
+            lines.push('**Later:**');
             prd.mvpScope.later.forEach(i => lines.push(`- \`[Later]\` ${i}`));
         }
         lines.push('');
     }
 
     // ── Core Features ───────────────────────────────────────────────────
+    // Detailed Features first — the concrete features — then the Feature
+    // Systems grouping (mirrors StructuredPRDView's order).
+    lines.push('## Detailed Features');
+    prd.features.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
+
     // Feature Systems
     if (prd.featureSystems?.length) {
         lines.push('## Feature Systems');
@@ -405,10 +430,6 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
             lines.push('');
         });
     }
-
-    // Detailed Features
-    lines.push('## Detailed Features');
-    prd.features.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
 
     // ── User Experience ─────────────────────────────────────────────────
     // UX Architecture
@@ -504,14 +525,8 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('');
     }
 
-    // Assumptions & Open Questions — last so they're easy to find
-    if (prd.assumptions?.length) {
-        lines.push('## Assumptions');
-        prd.assumptions.forEach(a => {
-            lines.push(`> [!ASSUMPTION] **${a.confidence} confidence** — ${a.statement}`);
-            lines.push('');
-        });
-    }
+    // (Assumptions no longer render as a trailing section — they surface in
+    // the Review & Confirm / Decision Log blocks near the top.)
 
     // Static handoff appendix — always rendered (legacy PRDs included).
     // Wording must stay bullet-for-bullet identical to HandoffAppendixSection

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,10 @@ export type Feature = {
     uiAcceptanceCriteria?: string[];  // UI behavior expectations
     analyticsEvents?: string[];       // events that should fire
     tier?: 'mvp' | 'v1' | 'later';    // release tier
+    // --- User review (optional; legacy PRDs lack these). A confirmed
+    // feature appears in the derived Decision Log. ---
+    confirmed?: boolean;
+    confirmedAt?: number;             // epoch ms
 };
 
 export type StructuredPRD = {
@@ -245,10 +249,18 @@ export type SuccessMetric = {
     instrumentation?: string;
 };
 
+// User verdict on an assumption / open decision. Recorded via the PRD's
+// "Review & Confirm" section; decided items feed the derived Decision Log.
+export type AssumptionDecision = 'confirmed' | 'rejected';
+
 export type Assumption = {
     id: string;
     statement: string;
     confidence: 'low' | 'med' | 'high';
+    // --- User review (all optional; legacy PRDs lack them) ---
+    decision?: AssumptionDecision;
+    decisionNote?: string;            // user clarification / correction
+    decidedAt?: number;               // epoch ms
 };
 
 export type ImplementationPlanPhase = {


### PR DESCRIPTION
## Summary

Focused UI/UX cleanup of the PRD on mobile: less clutter, clearer user actions, and feature references that match the visual language used elsewhere in Synapse. No pipeline, schema-required, or persistence-format changes — all new PRD fields are optional and every derivation is read-side, so legacy PRDs keep rendering unchanged.

### Section cleanup
- **Implementation Summary**: title renders on one line; the "Derived from features and assumptions" subtitle is gone; the **Defer** bucket and **Open Decisions** list are removed (now a clean two-column Build First / Build Next card).
- **Success Metrics**: the **Instrumentation** column is removed (new generations never produce it, so it rendered blank).
- **Primary Actions**: kept (it grounds mockup CTAs) but collapsed into a compact chip row with a one-line explanation instead of a heavy list section.
- **MVP Scope**: MVP/V1 items are presented explicitly as features — feature-id badge + **bold name** + secondary supporting text (`resolveScopeFeature`, conservative id/name matching with a raw-string fallback). "Later — defer" becomes a quiet secondary "Later" list.
- **Detailed Features now renders before Feature Systems** in both mirrored renderers (in-app structured view and `renderPremiumMarkdown`).

### Review & Confirm + Decision Log
- The passive **Assumptions** section and the Implementation Summary's "Open Decisions" are replaced by an actionable **Review & Confirm** section near the top: unresolved assumptions sorted by confidence (highest first, deterministic, missing confidence handled), each with a green-check **Confirm** action and a **"Not right"** action that takes an optional correction. Calm styling — not a warning state.
- Decided items move to a new **Decision Log** section: confirmed user choices only (accepted/corrected assumptions + confirmed features), chronological, visually separate from unresolved items, with per-entry undo.
- State persists as optional fields on the `StructuredPRD` itself (`Assumption.decision/decisionNote/decidedAt`, `Feature.confirmed/confirmedAt`); every confirm/reject/undo is a normal PRD edit through `editSpineStructuredPRD` — appends a version with a descriptive edit summary, so decisions ride version history, snapshots, and cloud sync for free.

### Feature confirmation & id consistency
- `FeatureCard` gets a compact inline confirm toggle (green check when confirmed — same language as the Screens `ScreenConfirmPanel`); confirmed features feed the Decision Log.
- New shared `FeatureIdBadge` mirrors the User Flows `FeatureReferenceChip` (fuchsia, mono, uppercase) and hides uuid-shaped ids. Used in feature cards, the Implementation Summary, Feature Systems, and MVP Scope.

## Tests
- New `src/lib/__tests__/prdDecisions.test.ts` (sorting, split, decision log, scope→feature matching, legacy handling).
- New `src/components/__tests__/StructuredPRDReview.test.tsx` (section ordering, Defer/Instrumentation removal, confidence ordering, confirm/reject/feature-confirm flows appending spine versions, read-only mode).
- Extended `prdMarkdownRenderer.test.ts` (mirrored ordering/removals, Review & Confirm, Decision Log, legacy-assumption compat); updated `implementationSummary.test.ts`.
- Full gate: `npm test` (162 files / 1480 tests), `npm run lint`, and `npm run build` (`tsc -b`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QckpoKEAFUKhFMYXjbHvU

---
_Generated by [Claude Code](https://claude.ai/code/session_015QckpoKEAFUKhFMYXjbHvU)_