### PR TITLE
Polish Data Model artifact card + fix relationship-label overlap (mobile)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -859,8 +859,17 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     The **`data_model` renderer** (`DataModelRenderer.tsx` +
     `src/components/renderers/dataModel/`) presents the artifact as an
     interactive entity-relationship design surface rather than a schema dump:
-    a compact **overview header** (`DataModelOverview` — provenance/freshness +
-    entity/relationship/constraint/index/PII counts), an **ER-style diagram**
+    a compact **overview header** (`DataModelOverview` — a single header row of
+    database-icon + "Data Model" title with an optional freshness pill, over a
+    2-col-on-mobile grid of **six metric tiles**: entities, relationships,
+    constraints, indexes, entities-with-PII, and **API endpoints** — the API
+    count comes straight from `summary.apiEndpointCount`, never hardcoded).
+    **Provenance is deliberately NOT shown inside this card** — "Generated from
+    PRD Version N" lives once at the artifact/page level
+    (`ArtifactWorkspace.renderVersionControls`), so the card takes only
+    `staleness` (the "Current" pill), not `prdVersionLabel`. Don't re-add a
+    subtitle count line or a "From PRD …" pill to the card. Next comes an
+    **ER-style diagram**
     (`EntityGraph`) that mirrors the artifact dependency graph / user-flow
     diagrams (rounded node cards, deterministic layered SVG layout, directional
     cardinality-labelled edges, click-a-node-to-open-its-card), and
@@ -878,15 +887,24 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
     unresolved/self references separately, and derives conservative entity
     **categories** (`core`/`user_config`/`generated`/`system`/`external`, from
     userFacing/mutability/integration-shaped signals only) used for the optional
-    "Group by category" swimlanes and node accents. The renderer keeps the legacy
-    ReactMarkdown fallback for unparseable content and preserves the
-    "How This Data Model Works", "How This Appears in the Product", and
+    "Group by category" swimlanes and node accents. **Relationship-edge labels
+    never overlap entity cards:** `EntityGraph` places each verb+cardinality pill
+    with the pure, unit-tested **`placeEdgeLabels`** collision solver (also in
+    `dataModelGraph.ts`) — each label starts on its edge midpoint (between-row
+    labels already sit in the clear row gap and don't move), and any label that
+    would intersect a card (chiefly same-row/horizontal edges, whose midpoint
+    lands on the cards' shared vertical centre) is nudged to the nearest clear,
+    canvas-clamped position and tethered to its edge with a thin dashed line; the
+    graph reserves a top/bottom label lane (`ROW_GAP`) only when a same-row edge
+    exists. Don't reintroduce raw midpoint positioning for the pills. The renderer
+    keeps the legacy ReactMarkdown fallback for unparseable content and preserves
+    the "How This Data Model Works", "How This Appears in the Product", and
     "API Endpoints" sections. Multi-entity models start collapsed (single-entity
-    expanded) for scannability; provenance/freshness reach the overview via the
-    optional `prdVersionLabel`/`staleness` props threaded through
-    `ArtifactContentRenderer` for `data_model` only. Do **not** change
-    `dataModelMarkdown.ts`'s parser output shape without re-checking
-    `dataModelGraph.ts`, which consumes its `ParsedEntity.callouts`.
+    expanded) for scannability; freshness reaches the overview via the optional
+    `staleness` prop threaded through `ArtifactContentRenderer` for `data_model`
+    (the `prdVersionLabel` prop is passed only to `implementation_plan` now). Do
+    **not** change `dataModelMarkdown.ts`'s parser output shape without
+    re-checking `dataModelGraph.ts`, which consumes its `ParsedEntity.callouts`.
     The `component_inventory` renderer is a mobile-first, searchable
     component library (sticky search + category/complexity/used-in
     filters, expandable cards with live previews) decomposed under

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -1382,7 +1382,10 @@ export function ArtifactWorkspace({
                         generatedAt={subtype === 'prompt_pack' ? preferred.createdAt : undefined}
                         versionNumber={subtype === 'prompt_pack' ? preferred.versionNumber : undefined}
                         prdVersionLabel={
-                            subtype === 'data_model' || subtype === 'implementation_plan'
+                            // Data Model shows provenance once at the page level
+                            // (the version-controls strip above), so only the plan
+                            // consumes this in-content label.
+                            subtype === 'implementation_plan'
                                 ? resolveSpineLabel(preferred.sourceRefs.find(r => r.sourceType === 'spine')?.sourceArtifactVersionId)
                                 : undefined
                         }

--- a/src/components/renderers/DataModelRenderer.tsx
+++ b/src/components/renderers/DataModelRenderer.tsx
@@ -28,9 +28,11 @@ import { CategoryBadge } from './dataModel/badges';
 
 interface Props {
     content: string;
-    /** Optional provenance label ("Version 2") for the overview header. */
-    prdVersionLabel?: string;
-    /** Optional freshness state for the overview header. */
+    /**
+     * Optional freshness state for the overview header (the "Current" pill).
+     * PRD provenance is intentionally not passed here — it's shown once at the
+     * artifact/page level, not repeated inside the summary card.
+     */
     staleness?: StalenessState;
 }
 
@@ -75,7 +77,7 @@ function MethodPill({ method }: { method: string }) {
     );
 }
 
-export function DataModelRenderer({ content, prdVersionLabel, staleness }: Props) {
+export function DataModelRenderer({ content, staleness }: Props) {
     const { parsed, sourceMarkdown } = useMemo(() => {
         const json = tryParseAsJson(content);
         if (json) {
@@ -102,7 +104,6 @@ export function DataModelRenderer({ content, prdVersionLabel, staleness }: Props
         <DataModelBody
             key={signature}
             parsed={parsed}
-            prdVersionLabel={prdVersionLabel}
             staleness={staleness}
         />
     );
@@ -110,11 +111,10 @@ export function DataModelRenderer({ content, prdVersionLabel, staleness }: Props
 
 interface BodyProps {
     parsed: ParsedDataModel;
-    prdVersionLabel?: string;
     staleness?: StalenessState;
 }
 
-function DataModelBody({ parsed, prdVersionLabel, staleness }: BodyProps) {
+function DataModelBody({ parsed, staleness }: BodyProps) {
     const isMobile = useIsMobile();
     const { graph, summary } = useMemo(() => analyzeDataModel(parsed), [parsed]);
 
@@ -189,7 +189,7 @@ function DataModelBody({ parsed, prdVersionLabel, staleness }: BodyProps) {
 
     return (
         <div className="space-y-6">
-            <DataModelOverview summary={summary} prdVersionLabel={prdVersionLabel} staleness={staleness} />
+            <DataModelOverview summary={summary} staleness={staleness} />
 
             {parsed.overview && (
                 <section className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-5">

--- a/src/components/renderers/__tests__/DataModelRenderer.test.tsx
+++ b/src/components/renderers/__tests__/DataModelRenderer.test.tsx
@@ -36,30 +36,60 @@ const twoEntityModel: DataModelContent = {
     apiEndpoints: [],
 };
 
-function renderModel(content: DataModelContent, props: Partial<{ prdVersionLabel: string; staleness: 'current' | 'possibly_outdated' | 'outdated' }> = {}) {
+function renderModel(content: DataModelContent, props: Partial<{ staleness: 'current' | 'possibly_outdated' | 'outdated' }> = {}) {
     return render(<DataModelRenderer content={JSON.stringify(content)} {...props} />);
 }
 
+const modelWithApi: DataModelContent = {
+    entities: twoEntityModel.entities,
+    apiEndpoints: [
+        { method: 'GET', path: '/users', description: 'List users', entity: 'User' },
+        { method: 'POST', path: '/users', description: 'Create user', entity: 'User' },
+        { method: 'GET', path: '/orders', description: 'List orders', entity: 'Order' },
+        { method: 'POST', path: '/orders', description: 'Create order', entity: 'Order' },
+        { method: 'DELETE', path: '/orders/:id', description: 'Delete order', entity: 'Order' },
+    ],
+};
+
 describe('DataModelRenderer — overview header', () => {
-    it('renders a Data Model overview with entity/relationship counts', () => {
+    it('renders the database icon and title on a single header row', () => {
         const { getByLabelText } = renderModel(twoEntityModel);
         const overview = getByLabelText('Data model overview');
-        expect(overview).toHaveTextContent('Data Model');
-        expect(overview).toHaveTextContent('Entities');
-        // Singular label when there is exactly one deduped relationship.
-        expect(overview).toHaveTextContent('Relationship');
-        // 2 entities stat tile value.
-        expect(within(overview).getByText('2')).toBeInTheDocument();
+        // Title renders as an <h2> heading next to the icon.
+        expect(within(overview).getByRole('heading', { name: 'Data Model' })).toBeInTheDocument();
     });
 
-    it('shows optional PRD provenance and staleness when provided', () => {
-        const { getByLabelText } = renderModel(twoEntityModel, {
-            prdVersionLabel: 'Version 3',
-            staleness: 'possibly_outdated',
-        });
+    it('does not repeat PRD provenance or a count subtitle inside the card', () => {
+        // Provenance ("From PRD Version N") lives at the page level, not the card.
+        const { getByLabelText } = renderModel(modelWithApi, { staleness: 'current' });
         const overview = getByLabelText('Data model overview');
-        expect(overview).toHaveTextContent('From PRD Version 3');
-        expect(overview).toHaveTextContent('May be outdated');
+        expect(overview).not.toHaveTextContent('From PRD');
+        // The old "6 entities · 5 API endpoints" subtitle is gone — the entity
+        // count now only appears as a metric tile value, not a subtitle string.
+        expect(within(overview).queryByText(/\d+ entities/)).toBeNull();
+        expect(within(overview).queryByText(/API endpoints/)).toBeNull(); // lowercase subtitle form
+    });
+
+    it('keeps the freshness ("Current") pill when staleness is provided', () => {
+        const { getByLabelText } = renderModel(twoEntityModel, { staleness: 'current' });
+        const overview = getByLabelText('Data model overview');
+        expect(overview).toHaveTextContent('Current');
+    });
+
+    it('renders six metric cards, including a real API-endpoint count', () => {
+        const { getByLabelText } = renderModel(modelWithApi);
+        const overview = getByLabelText('Data model overview');
+        const metrics = within(overview).getByRole('list', { name: 'Data model metrics' });
+        expect(within(metrics).getAllByRole('listitem')).toHaveLength(6);
+        // API Endpoints is a first-class tile driven by the artifact's real count.
+        expect(within(metrics).getByText('API Endpoints')).toBeInTheDocument();
+        expect(within(metrics).getByText('5')).toBeInTheDocument();
+        // The other five metric labels are all present too.
+        expect(within(metrics).getByText('Entities')).toBeInTheDocument();
+        expect(within(metrics).getByText('Relationship')).toBeInTheDocument();
+        expect(within(metrics).getByText('Constraints')).toBeInTheDocument();
+        expect(within(metrics).getByText('Indexes')).toBeInTheDocument();
+        expect(within(metrics).getByText('Entities with PII')).toBeInTheDocument();
     });
 });
 

--- a/src/components/renderers/dataModel/DataModelOverview.tsx
+++ b/src/components/renderers/dataModel/DataModelOverview.tsx
@@ -1,12 +1,11 @@
 import {
-    Database, GitBranch, ShieldCheck, ShieldAlert, SlidersHorizontal, KeyRound, Table2,
+    Database, GitBranch, ShieldCheck, ShieldAlert, SlidersHorizontal, KeyRound, Network,
 } from 'lucide-react';
 import type { StalenessState } from '../../../types';
 import type { DataModelSummary } from '../../../lib/dataModelGraph';
 
 interface Props {
     summary: DataModelSummary;
-    prdVersionLabel?: string;
     staleness?: StalenessState;
 }
 
@@ -27,7 +26,10 @@ function StatTile({
     const toneCls =
         tone === 'indigo' ? 'text-indigo-600' : tone === 'rose' ? 'text-rose-600' : 'text-neutral-700';
     return (
-        <div className="flex items-center gap-2.5 rounded-lg border border-neutral-200 bg-neutral-50/60 px-3 py-2">
+        <div
+            role="listitem"
+            className="flex items-center gap-2.5 rounded-lg border border-neutral-200 bg-neutral-50/60 px-3 py-2"
+        >
             <Icon size={16} className={`shrink-0 ${toneCls}`} aria-hidden="true" />
             <div className="min-w-0">
                 <div className="text-base font-bold leading-none text-neutral-900 tabular-nums">{value}</div>
@@ -39,52 +41,44 @@ function StatTile({
 
 /**
  * Compact overview header for the Data Model artifact — a confidence check that
- * summarizes provenance, freshness, and the shape of the model (entities,
- * relationships, constraints, indexes, PII) before the user explores details.
+ * summarizes freshness and the shape of the model (entities, relationships,
+ * constraints, indexes, PII, API endpoints) before the user explores details.
+ *
+ * PRD provenance ("Generated from PRD Version N") is deliberately NOT repeated
+ * here — it lives once at the artifact/page level (ArtifactWorkspace's version
+ * controls strip) so the same fact isn't shown twice in close proximity.
  */
-export function DataModelOverview({ summary, prdVersionLabel, staleness }: Props) {
+export function DataModelOverview({ summary, staleness }: Props) {
     const stale = staleness ? STALENESS_CONFIG[staleness] : undefined;
-    const piiLabel =
-        summary.piiEntityCount === 0
-            ? 'No PII entities'
-            : `${summary.piiEntityCount} ${summary.piiEntityCount === 1 ? 'entity' : 'entities'} with PII`;
+    const piiLabel = summary.piiEntityCount === 1 ? 'Entity with PII' : 'Entities with PII';
 
     return (
         <section
             aria-label="Data model overview"
             className="rounded-xl border border-neutral-200 bg-white shadow-sm p-4 md:p-5"
         >
-            <div className="flex items-start justify-between gap-3 flex-wrap">
-                <div className="flex items-start gap-3 min-w-0">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-2.5 min-w-0">
                     <div className="p-2 rounded-lg bg-indigo-50 text-indigo-600 shrink-0">
                         <Database size={18} />
                     </div>
-                    <div className="min-w-0">
-                        <h2 className="text-base font-bold text-neutral-900">Data Model</h2>
-                        <p className="text-xs text-neutral-500 mt-0.5">
-                            {summary.entityCount} {summary.entityCount === 1 ? 'entity' : 'entities'}
-                            {summary.apiEndpointCount > 0 && ` · ${summary.apiEndpointCount} API ${summary.apiEndpointCount === 1 ? 'endpoint' : 'endpoints'}`}
-                        </p>
-                    </div>
+                    <h2 className="text-base font-bold text-neutral-900 truncate">Data Model</h2>
                 </div>
-                <div className="flex items-center gap-2 flex-wrap">
-                    {prdVersionLabel && (
-                        <span className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-full bg-neutral-100 text-neutral-600 font-medium">
-                            <Table2 size={11} /> From PRD {prdVersionLabel}
-                        </span>
-                    )}
-                    {stale && (
-                        <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-full font-medium ${stale.className}`}>
-                            {staleness === 'current'
-                                ? <ShieldCheck size={11} />
-                                : <ShieldAlert size={11} />}
-                            {stale.label}
-                        </span>
-                    )}
-                </div>
+                {stale && (
+                    <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-full font-medium ${stale.className}`}>
+                        {staleness === 'current'
+                            ? <ShieldCheck size={11} />
+                            : <ShieldAlert size={11} />}
+                        {stale.label}
+                    </span>
+                )}
             </div>
 
-            <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+            <div
+                role="list"
+                aria-label="Data model metrics"
+                className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2"
+            >
                 <StatTile icon={Database} value={summary.entityCount} label="Entities" tone="indigo" />
                 <StatTile icon={GitBranch} value={summary.relationshipCount} label={summary.relationshipCount === 1 ? 'Relationship' : 'Relationships'} />
                 <StatTile icon={SlidersHorizontal} value={summary.constraintCount} label={summary.constraintCount === 1 ? 'Constraint' : 'Constraints'} />
@@ -95,6 +89,7 @@ export function DataModelOverview({ summary, prdVersionLabel, staleness }: Props
                     label={piiLabel}
                     tone={summary.piiEntityCount > 0 ? 'rose' : 'neutral'}
                 />
+                <StatTile icon={Network} value={summary.apiEndpointCount} label={summary.apiEndpointCount === 1 ? 'API Endpoint' : 'API Endpoints'} />
             </div>
         </section>
     );

--- a/src/components/renderers/dataModel/EntityGraph.tsx
+++ b/src/components/renderers/dataModel/EntityGraph.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react';
 import { Database, GitBranch, MousePointerClick } from 'lucide-react';
 import {
-    computeDataModelLayout, type DataModelGraph, type DataModelNode,
+    computeDataModelLayout, placeEdgeLabels,
+    type DataModelGraph, type DataModelNode, type DataModelEdge,
+    type EdgeLabelInput, type Rect,
 } from '../../../lib/dataModelGraph';
 import { CATEGORY_STYLES, EDGE_STROKE } from './dataModelStyles';
 import { CategoryBadge } from './badges';
@@ -23,6 +25,18 @@ const GAP_X = 40;
 const ROW_GAP = 92;
 
 type Selection = { type: 'node'; id: string } | { type: 'edge'; id: string } | null;
+
+/**
+ * Estimate a relationship pill's rendered footprint (verb line + optional
+ * cardinality line) so the collision solver can keep it off the entity cards.
+ * Slightly generous on width and clamped to the pill's `max-w-[10rem]`.
+ */
+function estimateLabelSize(edge: DataModelEdge): { w: number; h: number } {
+    const chars = Math.max(edge.verb.length, edge.cardinality?.length ?? 0);
+    const w = Math.min(160, Math.max(48, chars * 6.5 + 20));
+    const h = edge.cardinality ? 34 : 22;
+    return { w, h };
+}
 
 function NodeCardInner({ node }: { node: DataModelNode }) {
     return (
@@ -93,25 +107,87 @@ export function EntityGraph(props: Props) {
     const geometry = useMemo(() => {
         const maxCols = Math.max(1, ...layout.rows.map(r => r.length));
         const canvasW = maxCols * CARD_W + (maxCols - 1) * GAP_X;
-        const canvasH = layout.rows.length * CARD_H + Math.max(0, layout.rows.length - 1) * ROW_GAP;
+        const baseH = layout.rows.length * CARD_H + Math.max(0, layout.rows.length - 1) * ROW_GAP;
+
+        // Same-row (horizontal) edges are the overlap-prone case: their label
+        // would land on the cards' vertical centre. When any exist we reserve a
+        // clear label lane above and below the card stack so lifted labels always
+        // have room — including single-row graphs, which have no inter-row gap to
+        // borrow. Non-hierarchical graphs pay nothing (lane = 0).
+        const rowOf = new Map<string, number>();
+        layout.rows.forEach((row, r) => row.forEach(id => rowOf.set(id, r)));
+        const hasSameRowEdge = graph.edges.some(e => rowOf.get(e.fromId) === rowOf.get(e.toId));
+        const lane = hasSameRowEdge ? ROW_GAP : 0;
+
+        const canvasH = baseH + lane * 2;
         const positions = new Map<string, { x: number; y: number }>();
         layout.rows.forEach((row, r) => {
             const rowWidth = row.length * CARD_W + (row.length - 1) * GAP_X;
             row.forEach((id, i) => {
                 positions.set(id, {
                     x: (canvasW - rowWidth) / 2 + i * (CARD_W + GAP_X),
-                    y: r * (CARD_H + ROW_GAP),
+                    y: lane + r * (CARD_H + ROW_GAP),
                 });
             });
         });
         return { canvasW, canvasH, positions };
-    }, [layout]);
+    }, [layout, graph.edges]);
+
+    const { canvasW, canvasH, positions } = geometry;
+
+    // Edge path geometry + natural (edge-midpoint) label anchor, independent of
+    // selection so the collision solver below can be memoized.
+    const edgeGeometry = useMemo(() => {
+        return graph.edges.map(edge => {
+            const from = positions.get(edge.fromId);
+            const to = positions.get(edge.toId);
+            if (!from || !to) return null;
+            let x1: number, y1: number, x2: number, y2: number, d: string, mx: number, my: number;
+            if (to.y > from.y) {
+                x1 = from.x + CARD_W / 2; y1 = from.y + CARD_H;
+                x2 = to.x + CARD_W / 2; y2 = to.y;
+                const midY = (y1 + y2) / 2;
+                d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
+                mx = (x1 + x2) / 2; my = midY;
+            } else if (to.y < from.y) {
+                x1 = from.x + CARD_W / 2; y1 = from.y;
+                x2 = to.x + CARD_W / 2; y2 = to.y + CARD_H;
+                const midY = (y1 + y2) / 2;
+                d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
+                mx = (x1 + x2) / 2; my = midY;
+            } else {
+                const leftToRight = to.x >= from.x;
+                x1 = from.x + (leftToRight ? CARD_W : 0); y1 = from.y + CARD_H / 2;
+                x2 = to.x + (leftToRight ? 0 : CARD_W); y2 = to.y + CARD_H / 2;
+                const midX = (x1 + x2) / 2;
+                d = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
+                mx = midX; my = (y1 + y2) / 2;
+            }
+            return { edge, d, mx, my };
+        }).filter((e): e is NonNullable<typeof e> => e !== null);
+    }, [graph.edges, positions]);
+
+    // Collision-aware label placement — pills never overlap the entity cards.
+    const labelPlacements = useMemo(() => {
+        const cardRects: Rect[] = graph.nodes
+            .map(n => {
+                const p = positions.get(n.id);
+                return p ? { x: p.x, y: p.y, w: CARD_W, h: CARD_H } : null;
+            })
+            .filter((r): r is Rect => r !== null);
+        const inputs: EdgeLabelInput[] = edgeGeometry.map(({ edge, mx, my }) => {
+            const { w, h } = estimateLabelSize(edge);
+            return { id: edge.id, cx: mx, cy: my, w, h };
+        });
+        return new Map(
+            placeEdgeLabels(inputs, cardRects, { width: canvasW, height: canvasH })
+                .map(p => [p.id, p]),
+        );
+    }, [edgeGeometry, graph.nodes, positions, canvasW, canvasH]);
 
     if (graph.edges.length === 0) {
         return <EntityGrid {...props} />;
     }
-
-    const { canvasW, canvasH, positions } = geometry;
 
     // Which edges / nodes are highlighted by the current selection.
     const activeEdgeIds = new Set<string>();
@@ -134,36 +210,7 @@ export function EntityGraph(props: Props) {
         }
     }
 
-    // Edge path + midpoint label position, choosing connection points by the
-    // relative vertical position of the two nodes (down / up / same row).
-    const edgeRenders = graph.edges.map(edge => {
-        const from = positions.get(edge.fromId);
-        const to = positions.get(edge.toId);
-        if (!from || !to) return null;
-        const active = activeEdgeIds.has(edge.id);
-        let x1: number, y1: number, x2: number, y2: number, d: string, mx: number, my: number;
-        if (to.y > from.y) {
-            x1 = from.x + CARD_W / 2; y1 = from.y + CARD_H;
-            x2 = to.x + CARD_W / 2; y2 = to.y;
-            const midY = (y1 + y2) / 2;
-            d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
-            mx = (x1 + x2) / 2; my = midY;
-        } else if (to.y < from.y) {
-            x1 = from.x + CARD_W / 2; y1 = from.y;
-            x2 = to.x + CARD_W / 2; y2 = to.y + CARD_H;
-            const midY = (y1 + y2) / 2;
-            d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
-            mx = (x1 + x2) / 2; my = midY;
-        } else {
-            const leftToRight = to.x >= from.x;
-            x1 = from.x + (leftToRight ? CARD_W : 0); y1 = from.y + CARD_H / 2;
-            x2 = to.x + (leftToRight ? 0 : CARD_W); y2 = to.y + CARD_H / 2;
-            const midX = (x1 + x2) / 2;
-            d = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
-            mx = midX; my = (y1 + y2) / 2;
-        }
-        return { edge, active, d, mx, my };
-    }).filter((e): e is NonNullable<typeof e> => e !== null);
+    const edgeRenders = edgeGeometry.map(g => ({ ...g, active: activeEdgeIds.has(g.edge.id) }));
 
     return (
         <div className="space-y-2">
@@ -209,30 +256,56 @@ export function EntityGraph(props: Props) {
                                 markerStart={edge.arrow === 'both' ? `url(#dm-arrow-${active ? 'active' : 'base'}-start)` : undefined}
                             />
                         ))}
+                        {/* Tether a label to its edge when the collision solver
+                            had to lift it off the connector's midpoint. */}
+                        {edgeRenders.map(({ edge, active, mx, my }) => {
+                            const p = labelPlacements.get(edge.id);
+                            if (!p || !p.moved) return null;
+                            return (
+                                <line
+                                    key={`tether-${edge.id}`}
+                                    x1={mx}
+                                    y1={my}
+                                    x2={p.x}
+                                    y2={p.y}
+                                    stroke={active ? EDGE_STROKE.active : EDGE_STROKE.base}
+                                    strokeWidth={1}
+                                    strokeDasharray="2 3"
+                                />
+                            );
+                        })}
                     </svg>
 
-                    {/* Edge labels (verb + cardinality) as positioned pills. */}
-                    {edgeRenders.map(({ edge, active, mx, my }) => (
-                        <button
-                            key={`label-${edge.id}`}
-                            type="button"
-                            onClick={() => setSelection(sel =>
-                                sel?.type === 'edge' && sel.id === edge.id ? null : { type: 'edge', id: edge.id },
-                            )}
-                            style={{ left: mx, top: my, transform: 'translate(-50%, -50%)' }}
-                            className={`absolute z-10 max-w-[10rem] rounded-full border px-2 py-0.5 text-[10px] font-medium leading-tight shadow-sm transition ${
-                                active
-                                    ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
-                                    : 'border-neutral-200 bg-white text-neutral-600 hover:border-indigo-200'
-                            }`}
-                            title={edge.description || `${edge.verb}${edge.cardinality ? ` (${edge.cardinality})` : ''}`}
-                        >
-                            <span className="block truncate">{edge.verb}</span>
-                            {edge.cardinality && (
-                                <span className="block text-[9px] font-mono text-neutral-400 leading-none">{edge.cardinality}</span>
-                            )}
-                        </button>
-                    ))}
+                    {/* Edge labels (verb + cardinality) as positioned pills, placed
+                        by the collision solver so they never cover an entity card. */}
+                    {edgeRenders.map(({ edge, active, mx, my }) => {
+                        const placement = labelPlacements.get(edge.id);
+                        return (
+                            <button
+                                key={`label-${edge.id}`}
+                                type="button"
+                                onClick={() => setSelection(sel =>
+                                    sel?.type === 'edge' && sel.id === edge.id ? null : { type: 'edge', id: edge.id },
+                                )}
+                                style={{
+                                    left: placement?.x ?? mx,
+                                    top: placement?.y ?? my,
+                                    transform: 'translate(-50%, -50%)',
+                                }}
+                                className={`absolute z-10 max-w-[10rem] rounded-full border px-2 py-0.5 text-[10px] font-medium leading-tight shadow-sm transition ${
+                                    active
+                                        ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
+                                        : 'border-neutral-200 bg-white text-neutral-600 hover:border-indigo-200'
+                                }`}
+                                title={edge.description || `${edge.verb}${edge.cardinality ? ` (${edge.cardinality})` : ''}`}
+                            >
+                                <span className="block truncate">{edge.verb}</span>
+                                {edge.cardinality && (
+                                    <span className="block text-[9px] font-mono text-neutral-400 leading-none">{edge.cardinality}</span>
+                                )}
+                            </button>
+                        );
+                    })}
 
                     {/* Entity nodes. */}
                     {graph.nodes.map(node => {

--- a/src/components/renderers/index.tsx
+++ b/src/components/renderers/index.tsx
@@ -63,7 +63,8 @@ interface DispatchProps {
     generatedAt?: number;
     /** Only consumed by `prompt_pack`; current artifact version number. */
     versionNumber?: number;
-    /** Consumed by `data_model` and `implementation_plan`: source PRD version label. */
+    /** Consumed by `implementation_plan`: source PRD version label. (Data Model
+     * shows provenance at the page level, so it doesn't take this.) */
     prdVersionLabel?: string;
     /** Consumed by `data_model` and `implementation_plan`: freshness state. */
     staleness?: StalenessState;
@@ -123,7 +124,9 @@ export function ArtifactContentRenderer({
         return <ScreenInventoryRenderer content={content} imageContext={screenImageContext} />;
     }
     if (subtype === 'data_model') {
-        return <DataModelRenderer content={content} prdVersionLabel={prdVersionLabel} staleness={staleness} />;
+        // PRD provenance (`prdVersionLabel`) is shown once at the page level, not
+        // repeated inside the Data Model summary card — so it isn't passed here.
+        return <DataModelRenderer content={content} staleness={staleness} />;
     }
     if (subtype === 'component_inventory' && isJsonString(content)) {
         return <ComponentInventoryRenderer content={content} />;

--- a/src/lib/__tests__/dataModelGraph.test.ts
+++ b/src/lib/__tests__/dataModelGraph.test.ts
@@ -13,7 +13,9 @@ import {
     isStructuredFieldType,
     normalizeMutability,
     parseRelationshipCallout,
+    placeEdgeLabels,
     slugifyEntity,
+    type Rect,
 } from '../dataModelGraph';
 
 // A realistic model exercised end-to-end through the converter + parser so the
@@ -298,5 +300,80 @@ describe('helpers', () => {
     it('normalizes mutability for display', () => {
         expect(normalizeMutability('mostly_immutable')).toBe('mostly immutable');
         expect(normalizeMutability(undefined)).toBeUndefined();
+    });
+});
+
+describe('placeEdgeLabels — collision-aware relationship-label placement', () => {
+    // A label placement's box, given its resolved centre + size.
+    const boxOf = (p: { x: number; y: number }, w: number, h: number): Rect => ({
+        x: p.x - w / 2, y: p.y - h / 2, w, h,
+    });
+    const overlaps = (a: Rect, b: Rect): boolean =>
+        a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+
+    it('leaves a non-colliding label on its natural edge-midpoint anchor', () => {
+        const [p] = placeEdgeLabels(
+            [{ id: 'e', cx: 300, cy: 300, w: 60, h: 30 }],
+            [{ x: 0, y: 0, w: 100, h: 60 }],
+            { width: 600, height: 600 },
+        );
+        expect(p.moved).toBe(false);
+        expect(p.x).toBe(300);
+        expect(p.y).toBe(300);
+    });
+
+    it('moves a label off any entity card it would overlap', () => {
+        const card: Rect = { x: 0, y: 0, w: 200, h: 140 };
+        const [p] = placeEdgeLabels(
+            [{ id: 'e', cx: 100, cy: 70, w: 60, h: 30 }], // anchor inside the card
+            [card],
+            { width: 600, height: 600 },
+        );
+        expect(p.moved).toBe(true);
+        expect(overlaps(boxOf(p, 60, 30), card)).toBe(false);
+    });
+
+    it('clears the same-row (horizontal-edge) label off both connected cards', () => {
+        // Two cards side-by-side with a 40px gap and a reserved label lane above
+        // and below (mirrors EntityGraph geometry). The natural anchor sits on the
+        // cards' shared vertical centre — the configuration that used to overlap.
+        const w = 70, h = 34;
+        const a: Rect = { x: 0, y: 92, w: 224, h: 140 };
+        const b: Rect = { x: 264, y: 92, w: 224, h: 140 };
+        const [p] = placeEdgeLabels(
+            [{ id: 'e', cx: 244, cy: 162, w, h }],
+            [a, b],
+            { width: 488, height: 324 },
+        );
+        expect(p.moved).toBe(true);
+        expect(overlaps(boxOf(p, w, h), a)).toBe(false);
+        expect(overlaps(boxOf(p, w, h), b)).toBe(false);
+    });
+
+    it('does not stack two labels sharing the same anchor', () => {
+        const w = 60, h = 30;
+        const [pa, pb] = placeEdgeLabels(
+            [
+                { id: 'a', cx: 100, cy: 100, w, h },
+                { id: 'b', cx: 100, cy: 100, w, h },
+            ],
+            [],
+            { width: 600, height: 600 },
+        );
+        expect(overlaps(boxOf(pa, w, h), boxOf(pb, w, h))).toBe(false);
+    });
+
+    it('keeps every label fully inside the canvas', () => {
+        const w = 60, h = 30;
+        const [p] = placeEdgeLabels(
+            [{ id: 'e', cx: 4, cy: 4, w, h }], // anchor pinned to the top-left corner
+            [],
+            { width: 600, height: 600 },
+        );
+        const box = boxOf(p, w, h);
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.y).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.w).toBeLessThanOrEqual(600);
+        expect(box.y + box.h).toBeLessThanOrEqual(600);
     });
 });

--- a/src/lib/dataModelGraph.ts
+++ b/src/lib/dataModelGraph.ts
@@ -491,6 +491,134 @@ export function computeDataModelLayout(graph: DataModelGraph): DataModelLayout {
 }
 
 // ---------------------------------------------------------------------------
+// Edge-label placement (collision-aware — pure, so it's unit-testable)
+// ---------------------------------------------------------------------------
+
+/** Axis-aligned rectangle in canvas space (top-left origin). */
+export interface Rect { x: number; y: number; w: number; h: number }
+
+/** A relationship-label's natural anchor (its edge midpoint) + estimated size. */
+export interface EdgeLabelInput {
+    id: string;
+    /** Natural center x (edge midpoint). */
+    cx: number;
+    /** Natural center y (edge midpoint). */
+    cy: number;
+    w: number;
+    h: number;
+}
+
+export interface EdgeLabelPlacement {
+    id: string;
+    /** Resolved center x. */
+    x: number;
+    /** Resolved center y. */
+    y: number;
+    /** True when nudged off its natural anchor to avoid a collision. */
+    moved: boolean;
+}
+
+export interface PlaceEdgeLabelsOptions {
+    /** Minimum clear gap kept between a label and any card. */
+    margin?: number;
+    /** Search step (px) and how many rings out to look before giving up. */
+    step?: number;
+    maxRings?: number;
+}
+
+function rectsOverlap(a: Rect, b: Rect, margin: number): boolean {
+    return (
+        a.x - margin < b.x + b.w &&
+        a.x + a.w + margin > b.x &&
+        a.y - margin < b.y + b.h &&
+        a.y + a.h + margin > b.y
+    );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+    if (hi < lo) return lo;
+    return v < lo ? lo : v > hi ? hi : v;
+}
+
+/**
+ * Collision-aware placement for relationship-edge labels so the pills never
+ * overlap entity cards (the "graph looks broken" bug on narrow screens).
+ *
+ * Each label starts on its edge midpoint. Between-row edges already sit in the
+ * clear vertical gap between layout rows, so their labels don't move. Same-row
+ * (horizontal) edges — the overlap-prone case, where the label lands on the
+ * cards' vertical centre inside a gap far narrower than the label — get lifted
+ * into an adjacent clear lane. The search is deterministic (fixed direction
+ * ring, vertical moves preferred so labels drop into row gaps), every candidate
+ * is clamped inside the canvas, and already-placed labels are treated as soft
+ * obstacles so two labels don't stack either. Pure: no DOM, no measurement.
+ */
+export function placeEdgeLabels(
+    labels: EdgeLabelInput[],
+    cards: Rect[],
+    canvas: { width: number; height: number },
+    options: PlaceEdgeLabelsOptions = {},
+): EdgeLabelPlacement[] {
+    const margin = options.margin ?? 6;
+    const step = options.step ?? 14;
+    const maxRings = options.maxRings ?? 12;
+
+    const boxAt = (cx: number, cy: number, w: number, h: number): Rect => ({
+        x: cx - w / 2, y: cy - h / 2, w, h,
+    });
+    // Keep the whole label box on-canvas by clamping its centre.
+    const clampCenter = (cx: number, cy: number, w: number, h: number) => ({
+        x: clamp(cx, w / 2, canvas.width - w / 2),
+        y: clamp(cy, h / 2, canvas.height - h / 2),
+    });
+
+    const placed: Rect[] = [];
+    const isClear = (box: Rect): boolean =>
+        !cards.some(c => rectsOverlap(box, c, margin)) &&
+        // Labels crowd each other less than they crowd cards — lighter margin.
+        !placed.some(p => rectsOverlap(box, p, margin / 2));
+
+    // Vertical moves first (drop into row gaps), then horizontal, then diagonals.
+    const directions: Array<[number, number]> = [
+        [0, -1], [0, 1], [-1, 0], [1, 0], [-1, -1], [1, -1], [-1, 1], [1, 1],
+    ];
+
+    const result: EdgeLabelPlacement[] = [];
+    for (const label of labels) {
+        const natural = clampCenter(label.cx, label.cy, label.w, label.h);
+        let chosen = natural;
+
+        if (!isClear(boxAt(natural.x, natural.y, label.w, label.h))) {
+            let found: { x: number; y: number } | null = null;
+            for (let ring = 1; ring <= maxRings && !found; ring++) {
+                for (const [dx, dy] of directions) {
+                    const c = clampCenter(
+                        label.cx + dx * step * ring,
+                        label.cy + dy * step * ring,
+                        label.w, label.h,
+                    );
+                    if (isClear(boxAt(c.x, c.y, label.w, label.h))) {
+                        found = c;
+                        break;
+                    }
+                }
+            }
+            // Best effort: if nothing is fully clear, keep the clamped anchor.
+            if (found) chosen = found;
+        }
+
+        placed.push(boxAt(chosen.x, chosen.y, label.w, label.h));
+        result.push({
+            id: label.id,
+            x: chosen.x,
+            y: chosen.y,
+            moved: chosen.x !== label.cx || chosen.y !== label.cy,
+        });
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

Cleans up the **Data Model artifact page** so it feels intentional, readable, and trustworthy on mobile. Targets the four issues from the review screenshots: overlapping relationship pills in the graph, a bloated summary-card header, a missing API-endpoints metric, and provenance shown twice.

## Changes

**1. Relationship labels never overlap entity cards** (`src/lib/dataModelGraph.ts`, `EntityGraph.tsx`)
- New **pure, unit-tested** collision solver `placeEdgeLabels(labels, cards, canvas)`. Each verb+cardinality pill starts on its edge midpoint; between-row labels already sit in the clear row gap and stay put, while same-row (horizontal) labels — whose midpoint lands on the cards' shared vertical centre, the overlap-prone case — are nudged to the nearest clear, canvas-clamped position and **tethered to the edge with a thin dashed line**. Labels also avoid stacking on each other.
- `EntityGraph` reserves a top/bottom label lane (`ROW_GAP`) only when a same-row edge exists, and splits selection-independent edge geometry out so placement can be memoized. Prefers improving layout over hiding labels — nothing is dropped.

**2. Compact summary-card header** (`DataModelOverview.tsx`)
- Database icon and **Data Model** title now share one header row; the **Current** freshness pill sits cleanly to the right (wraps below on very narrow widths).
- Removed the `N entities · M API endpoints` subtitle and the in-card `From PRD Version N` pill.

**3. API Endpoints is a first-class metric tile**
- Six metric tiles total — Entities, Relationships, Constraints, Indexes, Entities with PII, **API Endpoints** — laid out 2-col on mobile, 6-col at `lg`. The API value is read from `summary.apiEndpointCount` (`parsed.apiEndpoints.length`), never hardcoded. The PII tile keeps its rose/warning treatment.

**4. No duplicated provenance**
- "Generated from PRD Version N" stays once at the page level (`ArtifactWorkspace.renderVersionControls`); `data_model` no longer receives `prdVersionLabel` (only `staleness`). `implementation_plan` still consumes it.

## How the API count is derived
`analyzeDataModel` → `summarizeDataModel` already computes `apiEndpointCount = parsed.apiEndpoints.length` from the parsed artifact; the new tile renders that value directly.

## How overlap was prevented
Collision-aware placement (the task's top-suggested approach) rather than brittle per-screenshot CSS: the solver clamps every pill to a card-free, on-canvas position and tethers relocated labels so they stay clearly associated with their edge.

## Tests & checks
- `placeEdgeLabels` unit tests (no-collision no-op, moves off a card, clears both cards on the same-row case, no label stacking, canvas containment).
- Updated `DataModelRenderer` tests: single header row, no in-card provenance/subtitle, **six** metric tiles including a real API-endpoint count, freshness pill retained.
- `npm run build` (tsc -b + vite) ✅ · `npm run lint` ✅ · full `vitest` suite **1488 passed** ✅
- Visual QA via Playwright at **375 / 390 / 430 px** and desktop: no horizontal body overflow, clean 2-col metric grid, and no pill-over-card overlaps in the graph.

## Notes
- Presentation-only over the existing parser/graph/summary layers — no schema, prompt, pipeline, sync, or persistence change. Legacy artifacts render unchanged.
- `CLAUDE.md` data_model section updated per the docs rule. README needs no change (this is polish to an existing artifact, not a new user-visible capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu5oVSkSTtsTtrwtJzncac

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu5oVSkSTtsTtrwtJzncac)_