### PR TITLE
Declutter Data Model entity cards on mobile

### DIFF
--- a/src/components/renderers/DataModelRenderer.tsx
+++ b/src/components/renderers/DataModelRenderer.tsx
@@ -14,7 +14,6 @@ import {
     entityAnchorId,
     resolveEntityId,
     slugifyEntity,
-    ENTITY_CATEGORY_LABEL,
     ENTITY_CATEGORY_ORDER,
     type DataModelNode,
 } from '../../lib/dataModelGraph';
@@ -275,9 +274,6 @@ function DataModelBody({ parsed, prdVersionLabel, staleness }: BodyProps) {
                                     {showHeader && (
                                         <div className="flex items-center gap-2 pt-2 pb-1.5">
                                             <CategoryBadge category={node.category} />
-                                            <span className="text-[11px] text-neutral-400">
-                                                {ENTITY_CATEGORY_LABEL[node.category]}
-                                            </span>
                                             <span className="flex-1 h-px bg-neutral-100" />
                                         </div>
                                     )}
@@ -288,6 +284,8 @@ function DataModelBody({ parsed, prdVersionLabel, staleness }: BodyProps) {
                                         onToggle={() => toggleEntity(node.id)}
                                         resolveTargetId={resolveTargetId}
                                         onNavigateToEntity={focusEntity}
+                                        showCategory={!grouped}
+                                        isMobile={isMobile}
                                     />
                                 </div>
                             );

--- a/src/components/renderers/__tests__/DataModelRenderer.test.tsx
+++ b/src/components/renderers/__tests__/DataModelRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import { render, fireEvent, within } from '@testing-library/react';
 import { DataModelRenderer } from '../DataModelRenderer';
 import type { DataModelContent } from '../../../types';
@@ -7,6 +7,20 @@ import type { DataModelContent } from '../../../types';
 beforeAll(() => {
     Element.prototype.scrollIntoView = vi.fn();
 });
+
+/** Stub `window.matchMedia` so `useIsMobile()` reports the given viewport. */
+function stubViewport(isMobile: boolean) {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+        matches: isMobile,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+}
 
 const twoEntityModel: DataModelContent = {
     entities: [
@@ -155,5 +169,137 @@ describe('DataModelRenderer — inspector rows + categories', () => {
         };
         const { getByRole } = renderModel(model);
         expect(getByRole('button', { name: /Group by category/i })).toBeInTheDocument();
+    });
+});
+
+// A mixed-category model that groups by default (>= 4 entities, >= 2 categories).
+const groupedModel: DataModelContent = {
+    entities: [
+        {
+            name: 'KnowledgeNode',
+            description: 'A structured, hierarchical concept.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [
+                { name: 'id', type: 'UUID', required: true, description: 'pk' },
+                { name: 'title', type: 'String', required: true, description: 'Concept title' },
+            ],
+            relationships: [{ type: 'has_many', target: 'Flashcard' }],
+            indexes: ['idx_title on (title)'],
+        },
+        {
+            name: 'Flashcard',
+            description: 'An active recall study card.',
+            userFacing: true,
+            mutability: 'mutable',
+            fields: [{ name: 'id', type: 'UUID', required: true, description: 'pk' }],
+            relationships: [{ type: 'belongs_to', target: 'KnowledgeNode' }],
+        },
+        {
+            // mostly_immutable + user-facing → Generated Outputs; carries PII.
+            name: 'InfographicSource',
+            description: 'Represents the uploaded visual asset.',
+            userFacing: true,
+            mutability: 'mostly_immutable',
+            fields: [{ name: 'id', type: 'UUID', required: true, description: 'pk' }],
+            relationships: [],
+            privacyRules: ['uploaded_image must be access-controlled'],
+            indexes: ['idx_source on (id)'],
+        },
+        {
+            name: 'AuditLog',
+            description: 'System event log.',
+            userFacing: false,
+            fields: [{ name: 'id', type: 'UUID', required: true, description: 'pk' }],
+            relationships: [],
+        },
+    ],
+    apiEndpoints: [],
+};
+
+/** The Entities list section (excludes the ER diagram, which also shows category badges). */
+function entitiesSection(getByRole: ReturnType<typeof renderModel>['getByRole']): HTMLElement {
+    const section = getByRole('button', { name: /Group by category/i }).closest('section');
+    if (!section) throw new Error('entities section not found');
+    return section as HTMLElement;
+}
+
+describe('DataModelRenderer — grouped category headers (no redundant label)', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('shows each category name once — in the group header, not repeated as plain text', () => {
+        const result = renderModel(groupedModel);
+        const section = entitiesSection(result.getByRole);
+        // Grouped by default: the header pill is the only "Core Product Data" in
+        // the list — the old duplicate plain-text label is gone and cards omit it.
+        expect(within(section).getAllByText('Core Product Data')).toHaveLength(1);
+    });
+
+    it('does not repeat the category chip inside entity cards in grouped mode', () => {
+        const { container } = renderModel(groupedModel);
+        const card = container.querySelector('#data-model-entity-knowledgenode') as HTMLElement;
+        expect(card).toBeTruthy();
+        expect(within(card).queryByText('Core Product Data')).toBeNull();
+    });
+
+    it('restores the per-card category chip when grouping is turned off', () => {
+        const result = renderModel(groupedModel);
+        fireEvent.click(result.getByRole('button', { name: /Group by category/i }));
+
+        const section = entitiesSection(result.getByRole);
+        // Ungrouped: no group header, so each of the two Core entities shows its
+        // own chip to preserve context.
+        expect(within(section).getAllByText('Core Product Data')).toHaveLength(2);
+
+        const card = result.container.querySelector('#data-model-entity-knowledgenode') as HTMLElement;
+        expect(within(card).getByText('Core Product Data')).toBeInTheDocument();
+    });
+});
+
+describe('DataModelRenderer — mobile entity-card chip density', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('caps chips on a collapsed mobile card and keeps Contains PII visible', () => {
+        stubViewport(true);
+        const { container } = renderModel(groupedModel);
+        const card = container.querySelector('#data-model-entity-infographicsource') as HTMLElement;
+        expect(card).toBeTruthy();
+
+        // PII stays prominent; lower-priority chips collapse into "+N more".
+        expect(within(card).getByText('Contains PII')).toBeInTheDocument();
+        expect(within(card).getByText('+2 more')).toBeInTheDocument();
+        expect(within(card).queryByText('mostly immutable')).toBeNull();
+        // The "Indexed" attribute chip is hidden (the lowercase "indexes" count
+        // label is a different string and unaffected).
+        expect(within(card).queryByText('Indexed')).toBeNull();
+    });
+
+    it('drops the low-value "No PII" chip on a collapsed mobile card', () => {
+        stubViewport(true);
+        const { container } = renderModel(groupedModel);
+        // KnowledgeNode: User-facing + mutable + Indexed = 3 chips, No PII dropped.
+        const card = container.querySelector('#data-model-entity-knowledgenode') as HTMLElement;
+        expect(within(card).queryByText('No PII')).toBeNull();
+        expect(within(card).queryByText('+1 more')).toBeNull();
+        expect(within(card).getByText('User-facing')).toBeInTheDocument();
+        expect(within(card).getByText('Indexed')).toBeInTheDocument();
+    });
+
+    it('shows every chip on desktop (no "+N more" truncation)', () => {
+        stubViewport(false);
+        const { container } = renderModel(groupedModel);
+        const card = container.querySelector('#data-model-entity-infographicsource') as HTMLElement;
+        expect(within(card).getByText('Contains PII')).toBeInTheDocument();
+        expect(within(card).getByText('mostly immutable')).toBeInTheDocument();
+        expect(within(card).getByText('Indexed')).toBeInTheDocument();
+        expect(within(card).queryByText(/\+\d+ more/)).toBeNull();
+    });
+
+    it('aligns the entity title so long names truncate without pushing the chevron', () => {
+        const { container } = renderModel(groupedModel);
+        const title = within(container.querySelector('#data-model-entity-knowledgenode') as HTMLElement)
+            .getByText('KnowledgeNode');
+        expect(title.className).toContain('truncate');
+        expect(title.className).toContain('min-w-0');
     });
 });

--- a/src/components/renderers/dataModel/EntityCard.tsx
+++ b/src/components/renderers/dataModel/EntityCard.tsx
@@ -17,6 +17,13 @@ interface Props {
     /** Resolve a relationship target name to a known node id (for linking). */
     resolveTargetId: (targetName: string) => string | undefined;
     onNavigateToEntity: (nodeId: string) => void;
+    /**
+     * Show the per-card category chip. False in grouped mode, where the category
+     * is already shown once in the surrounding group header (avoids repetition).
+     */
+    showCategory: boolean;
+    /** Mobile viewport — drives collapsed-card chip density. */
+    isMobile: boolean;
 }
 
 function CountChip({ icon: Icon, count, label, tone = 'neutral' }: {
@@ -99,7 +106,9 @@ function FieldTable({ group, indexed }: { group: ParsedFieldGroup; indexed: Set<
  * inspector-style rows for relationships / constraints / privacy / indexes,
  * plus the example record.
  */
-export function EntityCard({ entity, node, expanded, onToggle, resolveTargetId, onNavigateToEntity }: Props) {
+export function EntityCard({
+    entity, node, expanded, onToggle, resolveTargetId, onNavigateToEntity, showCategory, isMobile,
+}: Props) {
     const indexed = useMemo(() => indexedFieldNames(entity), [entity]);
 
     const relationships = entity.callouts.filter(c => c.kind === 'RELATIONSHIP');
@@ -114,37 +123,38 @@ export function EntityCard({ entity, node, expanded, onToggle, resolveTargetId, 
                 type="button"
                 onClick={onToggle}
                 aria-expanded={expanded}
-                className="w-full text-left px-4 py-3 flex items-start gap-3 hover:bg-neutral-50/60 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset"
+                className="w-full text-left px-4 py-3 hover:bg-neutral-50/60 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset"
             >
-                <div className="mt-0.5 p-1.5 rounded-lg bg-neutral-100 text-neutral-500 shrink-0">
-                    <Database size={15} />
+                {/* Title row — icon, name, and chevron sit on one center-aligned line. */}
+                <div className="flex items-center gap-3">
+                    <div className="p-1.5 rounded-lg bg-neutral-100 text-neutral-500 shrink-0">
+                        <Database size={15} />
+                    </div>
+                    <h4 className="min-w-0 flex-1 text-sm font-semibold text-neutral-900 truncate">{entity.name}</h4>
+                    <ChevronDown
+                        size={18}
+                        className={`shrink-0 text-neutral-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+                        aria-hidden="true"
+                    />
                 </div>
-                <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                        <h4 className="text-sm font-semibold text-neutral-900">{entity.name}</h4>
-                        <CategoryBadge category={node.category} size="xs" />
-                    </div>
-                    {entity.description && (
-                        <p className={`text-xs text-neutral-500 mt-0.5 ${expanded ? '' : 'line-clamp-1'}`}>
-                            {entity.description}
-                        </p>
-                    )}
-                    <div className="mt-2 flex items-center gap-1.5 flex-wrap">
-                        <EntityAttributeBadges node={node} />
-                    </div>
-                    <div className="mt-2 flex items-center gap-1.5 flex-wrap">
-                        <CountChip icon={ListTree} count={node.fieldCount} label="fields" />
-                        <CountChip icon={GitBranch} count={node.relationshipCount} label="relationships" />
-                        <CountChip icon={SlidersHorizontal} count={node.constraintCount} label="constraints" />
-                        <CountChip icon={ShieldAlert} count={node.privacyCount} label="privacy" tone="rose" />
-                        <CountChip icon={KeyRound} count={node.indexCount} label="indexes" />
-                    </div>
+
+                {/* Detail — description, attribute chips, and counts, full-width below. */}
+                {entity.description && (
+                    <p className={`mt-2 text-xs text-neutral-500 ${expanded ? '' : 'line-clamp-1'}`}>
+                        {entity.description}
+                    </p>
+                )}
+                <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+                    {showCategory && <CategoryBadge category={node.category} size="xs" />}
+                    <EntityAttributeBadges node={node} collapsed={isMobile && !expanded} />
                 </div>
-                <ChevronDown
-                    size={18}
-                    className={`shrink-0 mt-1 text-neutral-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
-                    aria-hidden="true"
-                />
+                <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+                    <CountChip icon={ListTree} count={node.fieldCount} label="fields" />
+                    <CountChip icon={GitBranch} count={node.relationshipCount} label="relationships" />
+                    <CountChip icon={SlidersHorizontal} count={node.constraintCount} label="constraints" />
+                    <CountChip icon={ShieldAlert} count={node.privacyCount} label="privacy" tone="rose" />
+                    <CountChip icon={KeyRound} count={node.indexCount} label="indexes" />
+                </div>
             </button>
 
             {expanded && (

--- a/src/components/renderers/dataModel/badges.tsx
+++ b/src/components/renderers/dataModel/badges.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Boxes, Cable, Cog, Fingerprint, KeyRound, ShieldCheck, Sparkles, User,
 } from 'lucide-react';
@@ -27,39 +27,76 @@ export function CategoryBadge({ category, size = 'sm' }: { category: EntityCateg
     );
 }
 
+/** Max attribute chips shown on a collapsed mobile card before "+N more". */
+const MAX_COLLAPSED_CHIPS = 3;
+
 /**
- * Compact attribute badges for an entity: visibility, mutability, PII, indexed.
- * These sit alongside the category chip and stay readable at any width.
+ * Compact attribute badges for an entity, in priority order:
+ * Contains PII → visibility → mutability → indexed → (No PII, lowest).
+ *
+ * Returns a fragment of pills so the caller's flex row controls spacing (and can
+ * prepend a category chip in ungrouped mode). When `collapsed` (a mobile card
+ * that isn't expanded), the lowest-value "No PII" chip is dropped entirely and
+ * the list is capped with a "+N more" affordance — expanding the card reveals
+ * the full set. Desktop / expanded cards always show every chip.
  */
-export function EntityAttributeBadges({ node }: { node: DataModelNode }) {
-    return (
-        <span className="inline-flex flex-wrap items-center gap-1">
-            {node.userFacing !== undefined && (
-                <Pill className={node.userFacing
-                    ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
-                    : 'bg-slate-100 text-slate-600 ring-1 ring-slate-200'}>
-                    {node.userFacing ? 'User-facing' : 'System'}
-                </Pill>
-            )}
-            {node.mutability && (
-                <Pill className={mutabilityClass(node.mutability)}>{node.mutability}</Pill>
-            )}
-            {node.hasPII ? (
-                <Pill className="bg-rose-50 text-rose-700 ring-1 ring-rose-200">
-                    <Fingerprint size={10} className="shrink-0" /> Contains PII
-                </Pill>
-            ) : (
-                <Pill className="bg-neutral-50 text-neutral-500 ring-1 ring-neutral-200">
-                    <ShieldCheck size={10} className="shrink-0" /> No PII
-                </Pill>
-            )}
-            {node.indexed && (
-                <Pill className="bg-slate-50 text-slate-600 ring-1 ring-slate-200">
-                    <KeyRound size={10} className="shrink-0" /> Indexed
-                </Pill>
-            )}
-        </span>
-    );
+export function EntityAttributeBadges({ node, collapsed = false }: { node: DataModelNode; collapsed?: boolean }) {
+    const chips: ReactElement[] = [];
+
+    // Priority 1 — PII. "Contains PII" is trust/safety-relevant and always leads.
+    if (node.hasPII) {
+        chips.push(
+            <Pill key="pii" className="bg-rose-50 text-rose-700 ring-1 ring-rose-200">
+                <Fingerprint size={10} className="shrink-0" /> Contains PII
+            </Pill>,
+        );
+    }
+    // Priority 2 — visibility.
+    if (node.userFacing !== undefined) {
+        chips.push(
+            <Pill key="visibility" className={node.userFacing
+                ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                : 'bg-slate-100 text-slate-600 ring-1 ring-slate-200'}>
+                {node.userFacing ? 'User-facing' : 'System'}
+            </Pill>,
+        );
+    }
+    // Priority 3 — mutability.
+    if (node.mutability) {
+        chips.push(<Pill key="mutability" className={mutabilityClass(node.mutability)}>{node.mutability}</Pill>);
+    }
+    // Priority 4 — indexed.
+    if (node.indexed) {
+        chips.push(
+            <Pill key="indexed" className="bg-slate-50 text-slate-600 ring-1 ring-slate-200">
+                <KeyRound size={10} className="shrink-0" /> Indexed
+            </Pill>,
+        );
+    }
+    // Lowest priority — "No PII". Reassuring but not urgent, so it is shown only on
+    // expanded/desktop cards and dropped (not counted) on collapsed mobile cards.
+    if (!node.hasPII && !collapsed) {
+        chips.push(
+            <Pill key="no-pii" className="bg-neutral-50 text-neutral-500 ring-1 ring-neutral-200">
+                <ShieldCheck size={10} className="shrink-0" /> No PII
+            </Pill>,
+        );
+    }
+
+    if (collapsed && chips.length > MAX_COLLAPSED_CHIPS) {
+        const visible = chips.slice(0, MAX_COLLAPSED_CHIPS - 1);
+        const hiddenCount = chips.length - visible.length;
+        return (
+            <>
+                {visible}
+                <span className="inline-flex items-center text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-neutral-100 text-neutral-500 ring-1 ring-neutral-200">
+                    +{hiddenCount} more
+                </span>
+            </>
+        );
+    }
+
+    return <>{chips}</>;
 }
 
 function mutabilityClass(mutability: string): string {


### PR DESCRIPTION
## Summary

Continuation of the Data Model mobile cleanup. Reduces chip/label redundancy and fixes header alignment in the **Entities** section of the Data Model artifact so the list is easier to scan on small screens. Presentation-only — no schema, data-model, or generation changes.

## Changes

**1. Category group headers no longer repeat the category name.** The group header previously rendered the category pill *and* the same name again as plain text next to it. The redundant text is gone — the header is now just the pill + the divider line.

**2. Grouped mode no longer repeats the category chip inside every entity card.** When cards are already grouped under a category header, each card echoing the same chip was noise. A new `EntityCard` `showCategory` prop hides it in grouped mode; **ungrouped mode still shows the chip** so context is preserved when the group header is gone.

**3. Entity card header is one clean, center-aligned row.** The database icon, entity title, and chevron now share a single `flex items-center` row instead of the icon aligning to the top of a stacked column (which made the title sit visibly lower). Long names truncate (`min-w-0 flex-1 truncate`) without pushing the chevron offscreen.

**4. Collapsed mobile cards reduce chip density.** Attribute chips are emitted in priority order — **Contains PII → visibility → mutability → indexed** — the low-value **"No PII"** chip is dropped on collapsed mobile cards, and the list is capped with a **"+N more"** affordance (2 chips + more). `Contains PII` always stays visible (trust/safety). The full set (including the previously hidden chips and `No PII`) returns when the card is expanded, and **desktop is unchanged** (always shows every chip).

## Files changed

- `src/components/renderers/DataModelRenderer.tsx` — remove the duplicate category-label span in the group header; thread `showCategory`/`isMobile` into `EntityCard`.
- `src/components/renderers/dataModel/EntityCard.tsx` — restructure the header into a single center-aligned icon/title/chevron row; move description/attributes/counts below.
- `src/components/renderers/dataModel/badges.tsx` — priority-ordered `EntityAttributeBadges` with collapsed-mobile density rule (`+N more`, drop `No PII`).
- `src/components/renderers/__tests__/DataModelRenderer.test.tsx` — tests for header dedup, grouped-vs-ungrouped chip behavior, mobile density (`+N more`, `Contains PII` kept, `No PII` dropped), desktop showing all chips, and title truncation.

## How full metadata stays available

Nothing is removed from the underlying data model. Chips hidden on a collapsed mobile card reappear when the card is expanded, alongside the full field tables, relationships, constraints, privacy, and index inspector rows.

## Testing

- `npm test` — full suite green (162 files / 1488 tests), including the new cases.
- `npm run build` and `npm run lint` — both pass.
- Visual QA at **375 / 390 / 430px** via Chromium against the real renderer: no horizontal overflow at any width; verified collapsed and expanded states for entities with and without PII, and short and long names.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWav55KjdasxCqhf7x6ZVv)_