### PR TITLE
Consolidate PRD scope into Implementation Summary; deferred features move to the Decision Log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,10 +541,13 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       is a normal PRD edit through `editSpineStructuredPRD` (appends a
       version, descriptive editSummary, undoable via version history). All
       derivations (`sortAssumptionsByConfidence`, `splitAssumptions`,
-      `deriveDecisionLog`, `resolveScopeFeature` — the MVP-scope-string →
-      feature matcher — and `isDisplayableFeatureId`) are pure/read-side in
-      `src/lib/derive/prdDecisions.ts`; do NOT persist a separate
-      decision-log structure. Feature ids render everywhere through the
+      `deriveDecisionLog`, and `isDisplayableFeatureId`) are pure/read-side in
+      `src/lib/derive/prdDecisions.ts`, which re-exports `resolveScopeFeature`
+      — the MVP-scope-string → feature matcher, now defined in
+      `src/lib/derive/scopeFeatureMatch.ts` (extracted so
+      `implementationSummary.ts` can use it too without an import cycle) — for
+      back-compat; do NOT persist a separate decision-log structure. Feature
+      ids render everywhere through the
       shared `FeatureIdBadge` (`src/components/prd/FeatureIdBadge.tsx`),
       which mirrors the User Flows `FeatureReferenceChip` fuchsia look and
       hides uuid-shaped ids; feature confirmation uses the same green-check
@@ -557,24 +560,37 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       `renderPremiumMarkdown`); the scope *rationale* (`mvpScope.rationale`)
       now renders as the Decision callout at the top of
       `ImplementationSummarySection`, and the summary buckets are **uncapped**
-      (every tagged MVP/V1 feature appears; legacy untagged PRDs keep the
-      declaration-order 4+4 heuristic). Bucket cards show the feature
+      (every tagged MVP/V1 feature appears). `deriveImplementationSummary`
+      (`src/lib/derive/implementationSummary.ts`) buckets by feature
+      `tier`/`priority` when present; when a PRD has **no** tier/priority tags
+      but DOES have `mvpScope.mvp`/`v1` entries, those explicit free-form scope
+      strings drive the buckets instead (resolved to features via
+      `resolveScopeFeature` where possible; an unresolved entry still renders
+      as a plain scope card with no id badge — `SummaryFeature.id` is
+      optional). Only when BOTH signals are absent does it fall back to the
+      declaration-order 4+4 heuristic. Bucket cards show the feature
       **description** as supporting text (falling back to userValue) — never
       the raw complexity rating prefix ("low · "). Do not reintroduce a
       separate MVP Scope feature list.
       **Deferred scope renders ONLY in the Decision Log** — PRD sections must
-      never present features outside the MVP/V1 phases. `deriveDecisionLog`
-      appends derived `verdict: 'deferred'` entries for features tagged
-      `tier: 'later'` and for `mvpScope.later` items (resolved via
-      `resolveScopeFeature` and deduped against deferred features; deferred
-      entries carry no undo — they are scope records, not user decisions).
-      Deferred features are excluded from Detailed Features and from Feature
-      Systems' feature-id chips (both renderers filter on `isDeferredFeature`).
-      **Detailed Features groups by tier** (`splitFeaturesByTier` in
-      `src/lib/derive/implementationSummary.ts`): MVP + untiered features
-      visible by default (hand-added features have no tier and must stay
-      visible), V1 features behind a collapsed disclosure, deferred features
-      linked out to the Decision Log. Each detail card is anchored
+      never present features outside the MVP/V1 phases. `deriveDeferredFeatureIds(prd)`
+      is the single scope-aware source of truth for "deferred": features
+      tagged `tier: 'later'`, PLUS any untagged feature an `mvpScope.later`
+      item resolves to (an explicit `mvp`/`v1` tier tag always wins over a
+      later item naming that feature — a data conflict logs the later item as
+      a raw `kind: 'scope'` entry instead of hiding the tagged feature).
+      `deriveDecisionLog` appends derived `verdict: 'deferred'` entries from
+      this set (deferred entries carry no undo — they are scope records, not
+      user decisions), and every other consumer (`splitFeaturesByTier`, Feature
+      Systems' chip filter, the summary buckets) takes the same set so a
+      feature can never read as both deferred and in scope. Do not derive
+      "deferred" locally from `tier === 'later'` alone in a new call site —
+      use `deriveDeferredFeatureIds`.
+      **Detailed Features groups by tier** (`splitFeaturesByTier(features,
+      deferredIds)` in `src/lib/derive/implementationSummary.ts`): MVP +
+      untiered features visible by default (hand-added features have no tier
+      and must stay visible), V1 features behind a collapsed disclosure,
+      deferred features linked out to the Decision Log. Each detail card is anchored
       (`featureDetailAnchorId` → `prd-feature-<id>`): Implementation Summary
       cards deep-link to it (`StructuredPRDView.handleNavigateToFeature`
       auto-expands the V1 group when the target lives inside it) and each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,8 +532,9 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       subtitle). Instead the PRD carries two mirrored sections near the top:
       **Review & Confirm** (unresolved assumptions, sorted by confidence
       highest-first, each with Confirm / "Not right"+correction actions) and
-      **Decision Log** (confirmed user choices only — decided assumptions +
-      confirmed features — never unresolved items). State lives ON the
+      **Decision Log** (decided items — decided assumptions + confirmed
+      features + derived **Deferred** entries, never unresolved items). State
+      lives ON the
       `StructuredPRD` itself via all-optional fields (`Assumption.decision` /
       `decisionNote` / `decidedAt`; `Feature.confirmed` / `confirmedAt` —
       legacy PRDs simply read as "all unresolved"); every confirm/reject/undo
@@ -549,6 +550,36 @@ path and is **independent of the owner-only snapshot feature** (`api/snapshots.j
       hides uuid-shaped ids; feature confirmation uses the same green-check
       language as the Screens `ScreenConfirmPanel`. Within Core Features the
       order is **Detailed Features before Feature Systems** (both renderers).
+    - **Scope presentation (2026-07 demo formatting pass): the Implementation
+      Summary is the SINGLE MVP/V1 scope surface.** The old `MVP Scope`
+      section duplicated the summary's Build First / Build Next buckets and
+      was removed from BOTH renderers (`StructuredPRDView` +
+      `renderPremiumMarkdown`); the scope *rationale* (`mvpScope.rationale`)
+      now renders as the Decision callout at the top of
+      `ImplementationSummarySection`, and the summary buckets are **uncapped**
+      (every tagged MVP/V1 feature appears; legacy untagged PRDs keep the
+      declaration-order 4+4 heuristic). Bucket cards show the feature
+      **description** as supporting text (falling back to userValue) — never
+      the raw complexity rating prefix ("low · "). Do not reintroduce a
+      separate MVP Scope feature list.
+      **Deferred scope renders ONLY in the Decision Log** — PRD sections must
+      never present features outside the MVP/V1 phases. `deriveDecisionLog`
+      appends derived `verdict: 'deferred'` entries for features tagged
+      `tier: 'later'` and for `mvpScope.later` items (resolved via
+      `resolveScopeFeature` and deduped against deferred features; deferred
+      entries carry no undo — they are scope records, not user decisions).
+      Deferred features are excluded from Detailed Features and from Feature
+      Systems' feature-id chips (both renderers filter on `isDeferredFeature`).
+      **Detailed Features groups by tier** (`splitFeaturesByTier` in
+      `src/lib/derive/implementationSummary.ts`): MVP + untiered features
+      visible by default (hand-added features have no tier and must stay
+      visible), V1 features behind a collapsed disclosure, deferred features
+      linked out to the Decision Log. Each detail card is anchored
+      (`featureDetailAnchorId` → `prd-feature-<id>`): Implementation Summary
+      cards deep-link to it (`StructuredPRDView.handleNavigateToFeature`
+      auto-expands the V1 group when the target lives inside it) and each
+      `FeatureCard` shows a "Summary" back affordance (`onBackToSummary`)
+      returning to `#prd-implementation-summary`.
     - **User project name → `productName`.** The name the user types when
       creating a project is threaded into generation as an optional
       `projectName` (call site `runPrdGeneration`/`ProjectWorkspace.handleRegenerate`

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pencil, Check, X, Circle } from 'lucide-react';
+import { Pencil, Check, X, Circle, ArrowUp } from 'lucide-react';
 import type { Feature } from '../types';
 import { MvpTag } from './prd/PremiumSections';
 import { FeatureIdBadge } from './prd/FeatureIdBadge';
@@ -9,10 +9,12 @@ interface FeatureCardProps {
     onUpdate: (updated: Feature) => void;
     /** Toggle the reviewed/confirmed state. Absent → no confirm affordance. */
     onToggleConfirm?: (feature: Feature) => void;
+    /** Scroll back to the Implementation Summary. Absent → no back affordance. */
+    onBackToSummary?: () => void;
     readOnly: boolean;
 }
 
-export function FeatureCard({ feature, onUpdate, onToggleConfirm, readOnly }: FeatureCardProps) {
+export function FeatureCard({ feature, onUpdate, onToggleConfirm, onBackToSummary, readOnly }: FeatureCardProps) {
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(feature.name);
     const [editDescription, setEditDescription] = useState(feature.description);
@@ -81,6 +83,17 @@ export function FeatureCard({ feature, onUpdate, onToggleConfirm, readOnly }: Fe
                     <MvpTag tier={feature.tier} />
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
+                    {onBackToSummary && (
+                        <button
+                            onClick={onBackToSummary}
+                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-neutral-400 hover:text-indigo-600 hover:bg-indigo-50 transition"
+                            title="Back to Implementation Summary"
+                            aria-label={`Back to Implementation Summary from ${feature.name}`}
+                        >
+                            <ArrowUp size={12} />
+                            Summary
+                        </button>
+                    )}
                     {!readOnly && (
                         <button
                             onClick={() => setIsEditing(true)}

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { Pencil, Check, X, Plus, Trash2, Sparkles, Loader2 } from 'lucide-react';
+import { Pencil, Check, X, Plus, Trash2, Sparkles, Loader2, ChevronDown, ChevronRight } from 'lucide-react';
 import Mark from 'mark.js';
 import { useProjectStore } from '../store/projectStore';
 import { structuredPRDToMarkdown, replyInBranch } from '../lib/llmProvider';
@@ -23,6 +23,12 @@ import { ReviewConfirmSection } from './prd/ReviewConfirmSection';
 import { DecisionLogSection } from './prd/DecisionLogSection';
 import { splitAssumptions, deriveDecisionLog } from '../lib/derive/prdDecisions';
 import {
+    deriveImplementationSummary,
+    featureDetailAnchorId,
+    isImplementationSummaryEmpty,
+    splitFeaturesByTier,
+} from '../lib/derive/implementationSummary';
+import {
     ExecutiveSummarySection,
     ProductThesisSection,
     JtbdSection,
@@ -35,7 +41,6 @@ import {
     RolesSection,
     ArchFlowsSection,
     RisksDetailedSection,
-    MvpScopeSection,
     MetricsSection,
     HandoffAppendixSection,
 } from './prd/PremiumSections';
@@ -352,6 +357,48 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
     const { unresolved: unresolvedAssumptions } = splitAssumptions(structuredPRD.assumptions);
     const decisionLog = deriveDecisionLog(structuredPRD);
 
+    // ── Detailed Features grouping & summary ↔ detail navigation ───────
+    // MVP (and unclassified) features render by default; V1 features sit
+    // behind a collapsed disclosure; deferred (tier 'later') features are
+    // NOT rendered here — they appear only as Decision Log entries above.
+    const featureGroups = useMemo(
+        () => splitFeaturesByTier(structuredPRD.features),
+        [structuredPRD.features],
+    );
+    const [showV1Features, setShowV1Features] = useState(false);
+    const pendingScrollRef = useRef<string | null>(null);
+
+    const summaryPresent = useMemo(
+        () =>
+            !isImplementationSummaryEmpty(deriveImplementationSummary(structuredPRD))
+            || !!structuredPRD.mvpScope?.rationale,
+        [structuredPRD],
+    );
+
+    const scrollToAnchor = (elementId: string) => {
+        document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    // Jump from an Implementation Summary card to the feature's detail card,
+    // expanding the collapsed V1 group first when the target lives inside it.
+    const handleNavigateToFeature = (featureId: string) => {
+        const elementId = featureDetailAnchorId(featureId);
+        if (!showV1Features && featureGroups.v1.some(f => f.id === featureId)) {
+            pendingScrollRef.current = elementId;
+            setShowV1Features(true);
+            return;
+        }
+        scrollToAnchor(elementId);
+    };
+
+    // Scroll to a just-expanded V1 feature once it is actually in the DOM.
+    useEffect(() => {
+        if (!pendingScrollRef.current) return;
+        const elementId = pendingScrollRef.current;
+        pendingScrollRef.current = null;
+        document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, [showV1Features]);
+
     const handleAddFeature = () => {
         const newFeature: Feature = {
             id: uuidv4(),
@@ -594,6 +641,34 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
         );
     };
 
+    // One feature detail card. Anchored so the Implementation Summary cards
+    // can deep-link to it, with a back affordance returning to the summary.
+    const renderFeatureCard = (feature: Feature) => (
+        <div key={feature.id} id={featureDetailAnchorId(feature.id)} className="relative group/feature scroll-mt-24">
+            <FeatureCard
+                feature={feature}
+                onUpdate={handleFeatureUpdate}
+                onToggleConfirm={handleToggleFeatureConfirm}
+                onBackToSummary={summaryPresent ? () => scrollToAnchor('prd-implementation-summary') : undefined}
+                readOnly={readOnly}
+            />
+            {!readOnly && (
+                <button
+                    onClick={() => {
+                        if (window.confirm(`Delete feature "${feature.name}"?`)) {
+                            handleDeleteFeature(feature.id);
+                        }
+                    }}
+                    className="absolute -right-2 -top-2 p-1 bg-white border border-neutral-200 rounded-full text-neutral-300 hover:text-red-500 opacity-0 group-hover/feature:opacity-100 transition shadow-sm"
+                    title="Delete feature"
+                    aria-label="Delete feature"
+                >
+                    <Trash2 size={12} />
+                </button>
+            )}
+        </div>
+    );
+
     const renderGroundingBackfill = () => {
         if (readOnly || !groundingMissing) return null;
         return (
@@ -639,8 +714,13 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
 
                 {/* Implementation summary — synthesized from existing fields so a
                     reader can answer "what should I build first?" without scrolling
-                    the entire document. Hidden if the PRD has no actionable signal. */}
-                <ImplementationSummarySection prd={structuredPRD} />
+                    the entire document. THE section presenting MVP/V1 scope (the old
+                    MVP Scope lists duplicated it); its cards jump to the feature
+                    detail cards below. Hidden if the PRD has no actionable signal. */}
+                <ImplementationSummarySection
+                    prd={structuredPRD}
+                    onNavigateToFeature={handleNavigateToFeature}
+                />
 
                 {/* Review & Confirm — the actionable home for assumptions / open
                     decisions (highest confidence first). Confirmed/corrected items
@@ -663,10 +743,12 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                 />
 
                 {/* Section order is a logical reading flow (mirrors
-                    prdMarkdownRenderer): Product Overview → Target Users → MVP
-                    Scope → Features → UX → Metrics → Risks → Technical
-                    Architecture → Data Model → State Machines → reference →
-                    Where the Detail Lives (static handoff appendix). */}
+                    prdMarkdownRenderer): Product Overview → Target Users →
+                    Features → UX → Metrics → Risks → Technical Architecture →
+                    Data Model → State Machines → reference → Where the Detail
+                    Lives (static handoff appendix). MVP/V1 scope lives in the
+                    Implementation Summary at the top; deferred scope in the
+                    Decision Log. */}
 
                 {/* Product Overview: Vision → Problem → Thesis → Principles */}
                 {renderTextSection('Vision', 'vision', structuredPRD.vision)}
@@ -686,12 +768,9 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                     ? <JtbdSection jtbd={structuredPRD.jtbd} />
                     : renderListSection('Target Users', 'targetUsers', structuredPRD.targetUsers)}
 
-                {/* MVP Scope — what ships first, before the full feature detail */}
-                {structuredPRD.mvpScope && (structuredPRD.mvpScope.mvp.length || structuredPRD.mvpScope.v1.length || structuredPRD.mvpScope.later.length) ? (
-                    <MvpScopeSection scope={structuredPRD.mvpScope} features={structuredPRD.features} />
-                ) : null}
-
-                {/* Core Features — concrete features first, system grouping after */}
+                {/* Core Features — concrete features first, system grouping after.
+                    MVP (and unclassified) features show by default; V1 features are
+                    collapsed; deferred features render only in the Decision Log. */}
                 <div className="mb-8" id="prd-features">
                     <div className="flex items-center justify-between mb-4 border-b border-neutral-200 pb-2">
                         <h3 className="text-lg font-extrabold text-neutral-900 tracking-tight">Detailed Features</h3>
@@ -706,35 +785,45 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                         )}
                     </div>
                     <div className="space-y-3">
-                        {structuredPRD.features.map(feature => (
-                            <div key={feature.id} className="relative group/feature">
-                                <FeatureCard
-                                    feature={feature}
-                                    onUpdate={handleFeatureUpdate}
-                                    onToggleConfirm={handleToggleFeatureConfirm}
-                                    readOnly={readOnly}
-                                />
-                                {!readOnly && (
-                                    <button
-                                        onClick={() => {
-                                            if (window.confirm(`Delete feature "${feature.name}"?`)) {
-                                                handleDeleteFeature(feature.id);
-                                            }
-                                        }}
-                                        className="absolute -right-2 -top-2 p-1 bg-white border border-neutral-200 rounded-full text-neutral-300 hover:text-red-500 opacity-0 group-hover/feature:opacity-100 transition shadow-sm"
-                                        title="Delete feature"
-                                        aria-label="Delete feature"
-                                    >
-                                        <Trash2 size={12} />
-                                    </button>
-                                )}
-                            </div>
-                        ))}
+                        {featureGroups.mvp.map(feature => renderFeatureCard(feature))}
                     </div>
+                    {featureGroups.v1.length > 0 && (
+                        <div className="mt-4">
+                            <button
+                                type="button"
+                                onClick={() => setShowV1Features(v => !v)}
+                                aria-expanded={showV1Features}
+                                className="flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-blue-700 hover:text-blue-900 transition"
+                            >
+                                {showV1Features ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                                V1 — soon after launch
+                                <span className="font-normal normal-case tracking-normal text-neutral-400">
+                                    {featureGroups.v1.length} feature{featureGroups.v1.length === 1 ? '' : 's'} · {showV1Features ? 'hide' : 'show'}
+                                </span>
+                            </button>
+                            {showV1Features && (
+                                <div className="space-y-3 mt-3">
+                                    {featureGroups.v1.map(feature => renderFeatureCard(feature))}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                    {featureGroups.deferred.length > 0 && (
+                        <p className="mt-4 text-xs text-neutral-500">
+                            {featureGroups.deferred.length} deferred feature{featureGroups.deferred.length === 1 ? ' is' : 's are'} recorded in the{' '}
+                            <a
+                                href="#prd-decision-log"
+                                onClick={(e) => { e.preventDefault(); scrollToAnchor('prd-decision-log'); }}
+                                className="text-indigo-600 hover:text-indigo-800 underline"
+                            >
+                                Decision Log
+                            </a>.
+                        </p>
+                    )}
                 </div>
 
                 {structuredPRD.featureSystems && structuredPRD.featureSystems.length > 0 && (
-                    <FeatureSystemsSection systems={structuredPRD.featureSystems} />
+                    <FeatureSystemsSection systems={structuredPRD.featureSystems} features={structuredPRD.features} />
                 )}
 
                 {/* User Experience: UX Architecture → Core User Loops */}

--- a/src/components/StructuredPRDView.tsx
+++ b/src/components/StructuredPRDView.tsx
@@ -23,6 +23,7 @@ import { ReviewConfirmSection } from './prd/ReviewConfirmSection';
 import { DecisionLogSection } from './prd/DecisionLogSection';
 import { splitAssumptions, deriveDecisionLog } from '../lib/derive/prdDecisions';
 import {
+    deriveDeferredFeatureIds,
     deriveImplementationSummary,
     featureDetailAnchorId,
     isImplementationSummaryEmpty,
@@ -361,9 +362,13 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
     // MVP (and unclassified) features render by default; V1 features sit
     // behind a collapsed disclosure; deferred (tier 'later') features are
     // NOT rendered here — they appear only as Decision Log entries above.
+    const deferredFeatureIds = useMemo(
+        () => deriveDeferredFeatureIds(structuredPRD),
+        [structuredPRD],
+    );
     const featureGroups = useMemo(
-        () => splitFeaturesByTier(structuredPRD.features),
-        [structuredPRD.features],
+        () => splitFeaturesByTier(structuredPRD.features, deferredFeatureIds),
+        [structuredPRD.features, deferredFeatureIds],
     );
     const [showV1Features, setShowV1Features] = useState(false);
     const pendingScrollRef = useRef<string | null>(null);
@@ -823,7 +828,7 @@ export function StructuredPRDView({ projectId, spineId, structuredPRD, readOnly 
                 </div>
 
                 {structuredPRD.featureSystems && structuredPRD.featureSystems.length > 0 && (
-                    <FeatureSystemsSection systems={structuredPRD.featureSystems} features={structuredPRD.features} />
+                    <FeatureSystemsSection systems={structuredPRD.featureSystems} deferredFeatureIds={deferredFeatureIds} />
                 )}
 
                 {/* User Experience: UX Architecture → Core User Loops */}

--- a/src/components/__tests__/StructuredPRDReview.test.tsx
+++ b/src/components/__tests__/StructuredPRDReview.test.tsx
@@ -124,21 +124,73 @@ describe('StructuredPRDView — section cleanup & ordering', () => {
         expect(screen.getByText('Review & Confirm')).toBeInTheDocument();
     });
 
-    it('presents MVP scope items resolved to features with id badges', () => {
+    it('renders no MVP Scope section — the Implementation Summary is the single scope surface', () => {
         render(
             <StructuredPRDView
                 projectId={PROJECT_ID}
                 spineId={SPINE_ID}
-                structuredPRD={{ ...prd, mvpScope: { mvp: ['F1: Quick Capture'], v1: ['Weekly Review polish'], later: ['Integrations'] } }}
+                structuredPRD={{
+                    ...prd,
+                    mvpScope: {
+                        mvp: ['F1: Quick Capture'],
+                        v1: ['Weekly Review polish'],
+                        later: ['Integrations'],
+                        rationale: 'Capture loop first.',
+                    },
+                }}
                 readOnly
             />,
         );
-        const mvpSection = document.getElementById('prd-mvp-scope')!;
-        expect(within(mvpSection).getAllByText('f1').length).toBeGreaterThan(0);
-        expect(within(mvpSection).getByText('Quick Capture')).toBeInTheDocument();
-        // "Later" stays a quiet secondary list — never a "Defer" section.
-        expect(within(mvpSection).getByText('Later')).toBeInTheDocument();
-        expect(within(mvpSection).queryByText(/defer/i)).toBeNull();
+        expect(document.getElementById('prd-mvp-scope')).toBeNull();
+        expect(screen.queryByText('MVP Scope')).toBeNull();
+        // The scope rationale surfaces in the Implementation Summary…
+        const summary = document.getElementById('prd-implementation-summary')!;
+        expect(within(summary).getByText(/Capture loop first/)).toBeInTheDocument();
+        // …and "Later" items surface as Deferred entries in the Decision Log.
+        const log = document.getElementById('prd-decision-log')!;
+        expect(within(log).getByText('Integrations')).toBeInTheDocument();
+        expect(within(log).getByText('Deferred')).toBeInTheDocument();
+    });
+
+    it('collapses V1 features by default and expands them on toggle', () => {
+        renderView();
+        // f1 (mvp) visible; f2 (v1) hidden behind the disclosure.
+        expect(screen.getByRole('heading', { level: 4, name: 'Quick Capture' })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { level: 4, name: 'Weekly Review' })).toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: /V1 — soon after launch/ }));
+        expect(screen.getByRole('heading', { level: 4, name: 'Weekly Review' })).toBeInTheDocument();
+    });
+
+    it('excludes deferred features from Detailed Features and points at the Decision Log', () => {
+        render(
+            <StructuredPRDView
+                projectId={PROJECT_ID}
+                spineId={SPINE_ID}
+                structuredPRD={{
+                    ...prd,
+                    features: [
+                        ...prd.features,
+                        { id: 'f10', name: 'Anki Export', description: 'CSV export', userValue: 'v', complexity: 'low', tier: 'later' },
+                    ],
+                }}
+                readOnly
+            />,
+        );
+        expect(screen.queryByRole('heading', { level: 4, name: 'Anki Export' })).toBeNull();
+        expect(screen.getByText(/deferred feature is recorded in the/)).toBeInTheDocument();
+        const log = document.getElementById('prd-decision-log')!;
+        expect(within(log).getByText('Anki Export')).toBeInTheDocument();
+    });
+
+    it('summary cards deep-link to feature detail anchors with a back affordance', () => {
+        renderView();
+        const summary = document.getElementById('prd-implementation-summary')!;
+        const link = within(summary).getByTitle('Jump to Quick Capture details');
+        expect(link.getAttribute('href')).toBe('#prd-feature-f1');
+        expect(document.getElementById('prd-feature-f1')).not.toBeNull();
+        expect(
+            screen.getByRole('button', { name: 'Back to Implementation Summary from Quick Capture' }),
+        ).toBeInTheDocument();
     });
 });
 

--- a/src/components/prd/DecisionLogSection.tsx
+++ b/src/components/prd/DecisionLogSection.tsx
@@ -1,19 +1,27 @@
-import { Check, X, Undo2 } from 'lucide-react';
+import { Check, X, Undo2, Clock } from 'lucide-react';
 import type { DecisionLogEntry } from '../../lib/derive/prdDecisions';
 import { FeatureIdBadge } from './FeatureIdBadge';
 import { isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
 
-// Decision Log — the record of confirmed user choices (accepted/corrected
-// assumptions and confirmed features). Deliberately separate from the
+// Decision Log — the record of decided scope (accepted/corrected assumptions,
+// confirmed features, and deferred work). Deliberately separate from the
 // unresolved "Review & Confirm" items above it: everything here has been
-// decided by the user. Derived read-side (deriveDecisionLog); never persisted
-// as its own structure.
+// decided. Deferred features/scope items appear ONLY here — no other PRD
+// section presents features outside the MVP/V1 phases. Derived read-side
+// (deriveDecisionLog); never persisted as its own structure.
 
 function VerdictIcon({ verdict }: { verdict: DecisionLogEntry['verdict'] }) {
     if (verdict === 'confirmed') {
         return (
             <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-emerald-100 shrink-0">
                 <Check size={13} className="text-emerald-700" aria-hidden />
+            </span>
+        );
+    }
+    if (verdict === 'deferred') {
+        return (
+            <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-neutral-100 shrink-0">
+                <Clock size={13} className="text-neutral-500" aria-hidden />
             </span>
         );
     }
@@ -25,6 +33,7 @@ function VerdictIcon({ verdict }: { verdict: DecisionLogEntry['verdict'] }) {
 }
 
 function ReferenceBadge({ entry }: { entry: DecisionLogEntry }) {
+    if (!entry.label) return null;
     if (entry.kind === 'feature') return <FeatureIdBadge id={entry.label} />;
     if (!isDisplayableFeatureId(entry.label)) return null;
     return (
@@ -33,6 +42,12 @@ function ReferenceBadge({ entry }: { entry: DecisionLogEntry }) {
         </span>
     );
 }
+
+const verdictLabel = (entry: DecisionLogEntry): string => {
+    if (entry.verdict === 'deferred') return 'Deferred';
+    if (entry.kind === 'feature') return 'Feature confirmed';
+    return entry.verdict === 'confirmed' ? 'Confirmed' : 'Marked incorrect';
+};
 
 interface Props {
     entries: DecisionLogEntry[];
@@ -56,7 +71,7 @@ export function DecisionLogSection({ entries, onUndoAssumption, onUndoFeature, r
             <ul className="space-y-2">
                 {entries.map(entry => (
                     <li
-                        key={`${entry.kind}-${entry.id}`}
+                        key={`${entry.kind}-${entry.verdict}-${entry.id}`}
                         className="flex items-start gap-2.5 rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-2.5"
                     >
                         <VerdictIcon verdict={entry.verdict} />
@@ -64,9 +79,7 @@ export function DecisionLogSection({ entries, onUndoAssumption, onUndoFeature, r
                             <div className="flex items-center gap-2 flex-wrap">
                                 <ReferenceBadge entry={entry} />
                                 <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-400">
-                                    {entry.kind === 'feature'
-                                        ? 'Feature confirmed'
-                                        : entry.verdict === 'confirmed' ? 'Confirmed' : 'Marked incorrect'}
+                                    {verdictLabel(entry)}
                                 </span>
                             </div>
                             <p className={`text-sm mt-0.5 ${entry.verdict === 'rejected' ? 'text-neutral-500 line-through decoration-neutral-300' : 'text-neutral-800'}`}>
@@ -74,11 +87,16 @@ export function DecisionLogSection({ entries, onUndoAssumption, onUndoFeature, r
                             </p>
                             {entry.note && (
                                 <p className="text-xs text-neutral-700 mt-1">
-                                    <span className="font-semibold text-neutral-500">Correction:</span> {entry.note}
+                                    {entry.verdict === 'rejected' && (
+                                        <span className="font-semibold text-neutral-500">Correction: </span>
+                                    )}
+                                    {entry.note}
                                 </p>
                             )}
                         </div>
-                        {!readOnly && (
+                        {/* Deferred entries are scope records, not undoable user
+                            decisions — no undo affordance. */}
+                        {!readOnly && entry.verdict !== 'deferred' && (
                             <button
                                 type="button"
                                 onClick={() =>

--- a/src/components/prd/ImplementationSummarySection.tsx
+++ b/src/components/prd/ImplementationSummarySection.tsx
@@ -29,20 +29,31 @@ function FeatureCard({
         green: 'bg-green-50/60 border-green-200',
         blue: 'bg-blue-50/60 border-blue-200',
     }[accent];
-    return (
-        <a
-            href={`#${featureDetailAnchorId(feature.id)}`}
-            onClick={onNavigate ? (e) => { e.preventDefault(); onNavigate(feature.id); } : undefined}
-            className={`block rounded-md border ${accentClasses} px-3 py-2 hover:shadow-sm transition`}
-            title={`Jump to ${feature.name} details`}
-        >
+    const body = (
+        <>
             <div className="flex items-baseline gap-2">
-                <FeatureIdBadge id={feature.id} />
+                {feature.id && <FeatureIdBadge id={feature.id} />}
                 <span className="text-sm font-semibold text-neutral-900 truncate">{feature.name}</span>
             </div>
             {feature.reason && (
                 <p className="text-[11px] text-neutral-600 mt-0.5 line-clamp-2">{feature.reason}</p>
             )}
+        </>
+    );
+    // A free-form scope entry with no backing feature has no detail card to
+    // link to — render it as a plain card.
+    if (!feature.id) {
+        return <div className={`rounded-md border ${accentClasses} px-3 py-2`}>{body}</div>;
+    }
+    const featureId = feature.id;
+    return (
+        <a
+            href={`#${featureDetailAnchorId(featureId)}`}
+            onClick={onNavigate ? (e) => { e.preventDefault(); onNavigate(featureId); } : undefined}
+            className={`block rounded-md border ${accentClasses} px-3 py-2 hover:shadow-sm transition`}
+            title={`Jump to ${feature.name} details`}
+        >
+            {body}
         </a>
     );
 }
@@ -80,7 +91,7 @@ function FeatureBucket({
             ) : (
                 <div className="space-y-1.5">
                     {features.map(f => (
-                        <FeatureCard key={f.id} feature={f} accent={accent} onNavigate={onNavigate} />
+                        <FeatureCard key={f.id ?? f.name} feature={f} accent={accent} onNavigate={onNavigate} />
                     ))}
                 </div>
             )}

--- a/src/components/prd/ImplementationSummarySection.tsx
+++ b/src/components/prd/ImplementationSummarySection.tsx
@@ -2,6 +2,7 @@ import { ArrowRight, ListChecks } from 'lucide-react';
 import type { StructuredPRD } from '../../types';
 import {
     deriveImplementationSummary,
+    featureDetailAnchorId,
     isImplementationSummaryEmpty,
     type SummaryFeature,
 } from '../../lib/derive/implementationSummary';
@@ -9,20 +10,31 @@ import { FeatureIdBadge } from './FeatureIdBadge';
 
 // Synthesized "what to build first / next" view. Pure derivation — no LLM
 // call. Renders at the top of the PRD so a reader can answer "what would I do
-// Monday morning?" without scrolling 30 pages. Deferred work and open
-// decisions deliberately do NOT live here: deferred scope stays in MVP Scope
-// ("Later") and open decisions moved to the actionable Review & Confirm
-// section.
+// Monday morning?" without scrolling 30 pages. This is THE section presenting
+// MVP/V1 scope (the old MVP Scope feature lists duplicated it and were folded
+// in — the scope rationale renders here as the Decision callout). Deferred
+// work and open decisions deliberately do NOT live here: deferred scope lives
+// in the Decision Log and open decisions in Review & Confirm.
 
-function FeatureCard({ feature, accent }: { feature: SummaryFeature; accent: 'green' | 'blue' }) {
+function FeatureCard({
+    feature,
+    accent,
+    onNavigate,
+}: {
+    feature: SummaryFeature;
+    accent: 'green' | 'blue';
+    onNavigate?: (featureId: string) => void;
+}) {
     const accentClasses = {
         green: 'bg-green-50/60 border-green-200',
         blue: 'bg-blue-50/60 border-blue-200',
     }[accent];
     return (
         <a
-            href={`#prd-features`}
+            href={`#${featureDetailAnchorId(feature.id)}`}
+            onClick={onNavigate ? (e) => { e.preventDefault(); onNavigate(feature.id); } : undefined}
             className={`block rounded-md border ${accentClasses} px-3 py-2 hover:shadow-sm transition`}
+            title={`Jump to ${feature.name} details`}
         >
             <div className="flex items-baseline gap-2">
                 <FeatureIdBadge id={feature.id} />
@@ -41,12 +53,14 @@ function FeatureBucket({
     accent,
     features,
     emptyHint,
+    onNavigate,
 }: {
     title: string;
     icon: typeof ListChecks;
     accent: 'green' | 'blue';
     features: SummaryFeature[];
     emptyHint: string;
+    onNavigate?: (featureId: string) => void;
 }) {
     const headerClasses = {
         green: 'text-green-700',
@@ -66,7 +80,7 @@ function FeatureBucket({
             ) : (
                 <div className="space-y-1.5">
                     {features.map(f => (
-                        <FeatureCard key={f.id} feature={f} accent={accent} />
+                        <FeatureCard key={f.id} feature={f} accent={accent} onNavigate={onNavigate} />
                     ))}
                 </div>
             )}
@@ -74,9 +88,17 @@ function FeatureBucket({
     );
 }
 
-export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
+export function ImplementationSummarySection({
+    prd,
+    onNavigateToFeature,
+}: {
+    prd: StructuredPRD;
+    /** Jump to a feature's detail card (expands the collapsed V1 group when needed). */
+    onNavigateToFeature?: (featureId: string) => void;
+}) {
     const summary = deriveImplementationSummary(prd);
-    if (isImplementationSummaryEmpty(summary)) return null;
+    const rationale = prd.mvpScope?.rationale;
+    if (isImplementationSummaryEmpty(summary) && !rationale) return null;
 
     return (
         <div id="prd-implementation-summary" className="mb-8 scroll-mt-24">
@@ -86,24 +108,35 @@ export function ImplementationSummarySection({ prd }: { prd: StructuredPRD }) {
                 </h3>
             </div>
 
-            <div className="bg-gradient-to-br from-indigo-50/40 to-white border border-indigo-100 rounded-xl p-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <FeatureBucket
-                        title="Build First"
-                        icon={ListChecks}
-                        accent="green"
-                        features={summary.buildFirst}
-                        emptyHint="No MVP features tagged."
-                    />
-                    <FeatureBucket
-                        title="Build Next"
-                        icon={ArrowRight}
-                        accent="blue"
-                        features={summary.buildNext}
-                        emptyHint="No V1 features tagged."
-                    />
+            {rationale && (
+                <div className="mb-3 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-indigo-900">
+                    <span className="text-[10px] uppercase font-bold tracking-wider mr-2 px-1.5 py-0.5 rounded bg-indigo-200 text-indigo-900">Decision</span>
+                    {rationale}
                 </div>
-            </div>
+            )}
+
+            {!isImplementationSummaryEmpty(summary) && (
+                <div className="bg-gradient-to-br from-indigo-50/40 to-white border border-indigo-100 rounded-xl p-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <FeatureBucket
+                            title="Build First"
+                            icon={ListChecks}
+                            accent="green"
+                            features={summary.buildFirst}
+                            emptyHint="No MVP features tagged."
+                            onNavigate={onNavigateToFeature}
+                        />
+                        <FeatureBucket
+                            title="Build Next"
+                            icon={ArrowRight}
+                            accent="blue"
+                            features={summary.buildNext}
+                            emptyHint="No V1 features tagged."
+                            onNavigate={onNavigateToFeature}
+                        />
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/prd/PremiumSections.tsx
+++ b/src/components/prd/PremiumSections.tsx
@@ -1,12 +1,13 @@
 import type {
     Jtbd, Principle, UserLoop, UXPage, FeatureSystem, PrdDataModel,
-    StateMachine, RolePermission, ArchFlow, RiskDetailed, MvpScope,
+    StateMachine, RolePermission, ArchFlow, RiskDetailed,
     SuccessMetric, ProductThesis, Feature,
 } from '../../types';
 import { coerceToBulletList, looksDegenerate } from '../../lib/textCleanup';
 import { sanitizeRolePermissions } from '../../lib/prdRolesSanitizer';
 import { stripLeadingListNumber } from '../../lib/utils/stripLeadingListNumber';
-import { resolveScopeFeature, isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
+import { isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
+import { isDeferredFeature } from '../../lib/derive/implementationSummary';
 import { FeatureIdBadge } from './FeatureIdBadge';
 
 // Shared section wrapper. Mirrors the heading style used in StructuredPRDView
@@ -224,18 +225,23 @@ export function UxArchitectureSection({ pages }: { pages: UXPage[] }) {
     );
 }
 
-export function FeatureSystemsSection({ systems }: { systems: FeatureSystem[] }) {
+export function FeatureSystemsSection({ systems, features = [] }: { systems: FeatureSystem[]; features?: Feature[] }) {
+    // PRD sections must not refer to features outside the MVP/V1 phases —
+    // deferred features surface only in the Decision Log.
+    const deferredIds = new Set(features.filter(isDeferredFeature).map(f => f.id.toLowerCase()));
     return (
         <Section title="Feature Systems" id="prd-feature-systems">
             <div className="grid sm:grid-cols-2 gap-3">
-                {systems.map((s) => (
+                {systems.map((s) => {
+                    const visibleIds = (s.featureIds ?? []).filter(id => !deferredIds.has(id.toLowerCase()));
+                    return (
                     <div key={s.id} className="p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
                         <p className="text-sm font-bold text-neutral-900">{s.name}</p>
                         <p className="text-xs text-neutral-600 mt-1 leading-relaxed">{s.purpose}</p>
-                        {s.featureIds?.length ? (
+                        {visibleIds.length ? (
                             <div className="flex items-center gap-1.5 flex-wrap mt-2">
                                 <span className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">Features:</span>
-                                {s.featureIds.map(id =>
+                                {visibleIds.map(id =>
                                     isDisplayableFeatureId(id)
                                         ? <FeatureIdBadge key={id} id={id} />
                                         : <span key={id} className="text-[11px] font-mono text-neutral-500">{id}</span>,
@@ -249,7 +255,8 @@ export function FeatureSystemsSection({ systems }: { systems: FeatureSystem[] })
                             <p className="text-xs text-neutral-700 mt-1"><span className="font-semibold">MVP vs later:</span> {s.mvpVsLater}</p>
                         )}
                     </div>
-                ))}
+                    );
+                })}
             </div>
         </Section>
     );
@@ -502,59 +509,10 @@ export function RisksDetailedSection({ risks }: { risks: RiskDetailed[] }) {
     );
 }
 
-// One MVP/V1 scope entry, presented explicitly as a feature when it can be
-// resolved to one (id badge + bold name, supporting text secondary). Falls
-// back to the raw string so legacy scope items always render.
-function ScopeFeatureItem({ item, features }: { item: string; features: Feature[] }) {
-    const { feature, secondary } = resolveScopeFeature(item, features);
-    if (!feature) {
-        return <li className="text-sm text-neutral-800">{item}</li>;
-    }
-    return (
-        <li className="text-sm">
-            <div className="flex items-baseline gap-2 flex-wrap">
-                <FeatureIdBadge id={feature.id} />
-                <span className="font-bold text-neutral-900">{feature.name}</span>
-            </div>
-            {secondary && <p className="text-xs text-neutral-600 mt-0.5">{secondary}</p>}
-        </li>
-    );
-}
-
-export function MvpScopeSection({ scope, features = [] }: { scope: MvpScope; features?: Feature[] }) {
-    return (
-        <Section title="MVP Scope" id="prd-mvp-scope">
-            {scope.rationale && (
-                <div className="mb-3 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-indigo-900">
-                    <span className="text-[10px] uppercase font-bold tracking-wider mr-2 px-1.5 py-0.5 rounded bg-indigo-200 text-indigo-900">Decision</span>
-                    {scope.rationale}
-                </div>
-            )}
-            <div className="grid sm:grid-cols-2 gap-3">
-                <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
-                    <p className="text-xs font-bold uppercase tracking-wider text-green-800 mb-2">MVP — ship first</p>
-                    <ul className="space-y-2">
-                        {scope.mvp.map((i, k) => <ScopeFeatureItem key={k} item={i} features={features} />)}
-                    </ul>
-                </div>
-                <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                    <p className="text-xs font-bold uppercase tracking-wider text-blue-800 mb-2">V1 — soon after launch</p>
-                    <ul className="space-y-2">
-                        {scope.v1.map((i, k) => <ScopeFeatureItem key={k} item={i} features={features} />)}
-                    </ul>
-                </div>
-            </div>
-            {scope.later?.length ? (
-                <div className="mt-3 p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
-                    <p className="text-xs font-bold uppercase tracking-wider text-neutral-500 mb-1.5">Later</p>
-                    <ul className="list-disc pl-4 space-y-0.5 text-xs text-neutral-600">
-                        {scope.later.map((i, k) => <li key={k}>{i}</li>)}
-                    </ul>
-                </div>
-            ) : null}
-        </Section>
-    );
-}
+// (The old MvpScopeSection was removed: it duplicated the Implementation
+// Summary's Build First / Build Next buckets. The scope rationale now renders
+// as the Decision callout in ImplementationSummarySection and "Later" items
+// surface as Deferred entries in the Decision Log.)
 
 // Instrumentation was dropped from this table: new generations no longer
 // produce it (analytics detail belongs to downstream artifacts) so the column

--- a/src/components/prd/PremiumSections.tsx
+++ b/src/components/prd/PremiumSections.tsx
@@ -1,13 +1,12 @@
 import type {
     Jtbd, Principle, UserLoop, UXPage, FeatureSystem, PrdDataModel,
     StateMachine, RolePermission, ArchFlow, RiskDetailed,
-    SuccessMetric, ProductThesis, Feature,
+    SuccessMetric, ProductThesis,
 } from '../../types';
 import { coerceToBulletList, looksDegenerate } from '../../lib/textCleanup';
 import { sanitizeRolePermissions } from '../../lib/prdRolesSanitizer';
 import { stripLeadingListNumber } from '../../lib/utils/stripLeadingListNumber';
 import { isDisplayableFeatureId } from '../../lib/derive/prdDecisions';
-import { isDeferredFeature } from '../../lib/derive/implementationSummary';
 import { FeatureIdBadge } from './FeatureIdBadge';
 
 // Shared section wrapper. Mirrors the heading style used in StructuredPRDView
@@ -225,10 +224,17 @@ export function UxArchitectureSection({ pages }: { pages: UXPage[] }) {
     );
 }
 
-export function FeatureSystemsSection({ systems, features = [] }: { systems: FeatureSystem[]; features?: Feature[] }) {
-    // PRD sections must not refer to features outside the MVP/V1 phases —
-    // deferred features surface only in the Decision Log.
-    const deferredIds = new Set(features.filter(isDeferredFeature).map(f => f.id.toLowerCase()));
+export function FeatureSystemsSection({
+    systems,
+    deferredFeatureIds,
+}: {
+    systems: FeatureSystem[];
+    /** Scope-aware deferred set (deriveDeferredFeatureIds) — PRD sections must
+     * not refer to features outside the MVP/V1 phases; deferred features
+     * surface only in the Decision Log. */
+    deferredFeatureIds?: ReadonlySet<string>;
+}) {
+    const deferredIds = new Set([...(deferredFeatureIds ?? [])].map(id => id.toLowerCase()));
     return (
         <Section title="Feature Systems" id="prd-feature-systems">
             <div className="grid sm:grid-cols-2 gap-3">

--- a/src/lib/__tests__/implementationSummary.test.ts
+++ b/src/lib/__tests__/implementationSummary.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+    deriveDeferredFeatureIds,
     deriveImplementationSummary,
     isImplementationSummaryEmpty,
     splitFeaturesByTier,
@@ -129,6 +130,85 @@ describe('splitFeaturesByTier', () => {
         expect(groups.mvp.map(f => f.id)).toEqual(['f1', 'f4']);
         expect(groups.v1.map(f => f.id)).toEqual(['f2', 'f5']);
         expect(groups.deferred.map(f => f.id)).toEqual(['f3']);
+    });
+
+    it('defers extra ids from the scope-aware deferred set', () => {
+        const features = [
+            baseFeature({ id: 'f1', tier: 'mvp' }),
+            baseFeature({ id: 'f9', name: 'Anki Export' }), // untiered, deferred via scope
+        ];
+        const groups = splitFeaturesByTier(features, new Set(['f9']));
+        expect(groups.mvp.map(f => f.id)).toEqual(['f1']);
+        expect(groups.deferred.map(f => f.id)).toEqual(['f9']);
+    });
+});
+
+describe('deriveDeferredFeatureIds', () => {
+    it('includes tier-later features and untagged features named by mvpScope.later', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'f3', tier: 'later' }),
+                baseFeature({ id: 'f9', name: 'Anki Export' }), // no tier
+            ],
+            mvpScope: { mvp: [], v1: [], later: ['Anki Export (f9): CSV utility'] },
+        });
+        expect([...deriveDeferredFeatureIds(prd)].sort()).toEqual(['f3', 'f9']);
+    });
+
+    it('never defers a feature whose explicit mvp/v1 tier tag conflicts with a later item', () => {
+        const prd = basePRD({
+            features: [baseFeature({ id: 'f1', name: 'Quick Capture', tier: 'mvp' })],
+            mvpScope: { mvp: [], v1: [], later: ['Advanced Quick Capture filters'] },
+        });
+        expect(deriveDeferredFeatureIds(prd).size).toBe(0);
+    });
+});
+
+describe('deriveImplementationSummary — explicit mvpScope entries', () => {
+    it('drives the buckets from mvpScope when features carry no tier/priority tags', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'f1', name: 'Quick Capture', description: 'One-tap logging' }),
+                baseFeature({ id: 'f2', name: 'Weekly Review', description: 'Retro view' }),
+                baseFeature({ id: 'f3', name: 'Something Else' }),
+            ],
+            mvpScope: {
+                mvp: ['F1: Quick Capture'],
+                v1: ['Weekly Review polish'],
+                later: [],
+            },
+        });
+        const s = deriveImplementationSummary(prd);
+        // No declaration-order guess — the explicit scope decisions win.
+        expect(s.buildFirst.map(f => f.id)).toEqual(['f1']);
+        expect(s.buildNext.map(f => f.id)).toEqual(['f2']);
+    });
+
+    it('preserves free-form scope entries that resolve to no feature', () => {
+        const prd = basePRD({
+            features: [baseFeature({ id: 'f1', name: 'Quick Capture', tier: 'mvp' })],
+            mvpScope: {
+                mvp: ['Basic auth and onboarding'],
+                v1: ['Billing integration'],
+                later: [],
+            },
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst.map(f => f.name)).toEqual(['Quick Capture', 'Basic auth and onboarding']);
+        expect(s.buildFirst[1].id).toBeUndefined();
+        expect(s.buildNext.map(f => f.name)).toEqual(['Billing integration']);
+    });
+
+    it('excludes scope-deferred features from the buckets', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'f1', name: 'Quick Capture', priority: 'must' }),
+                baseFeature({ id: 'f9', name: 'Anki Export', priority: 'must' }), // untiered but deferred by scope
+            ],
+            mvpScope: { mvp: [], v1: [], later: ['Anki Export (f9)'] },
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst.map(f => f.id)).toEqual(['f1']);
     });
 });
 

--- a/src/lib/__tests__/implementationSummary.test.ts
+++ b/src/lib/__tests__/implementationSummary.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
     deriveImplementationSummary,
     isImplementationSummaryEmpty,
+    splitFeaturesByTier,
 } from '../derive/implementationSummary';
 import type { StructuredPRD, Feature } from '../../types';
 
@@ -83,14 +84,51 @@ describe('deriveImplementationSummary — feature bucketing', () => {
         expect(s.buildFirst.map(f => f.id)).toEqual(['f1', 'f2', 'f3']);
     });
 
-    it('caps each bucket at 5', () => {
+    it('lists every tagged feature (no cap — this is THE scope section)', () => {
         const prd = basePRD({
             features: Array.from({ length: 10 }, (_, i) =>
                 baseFeature({ id: `f${i}`, name: `F${i}`, tier: 'mvp' }),
             ),
         });
         const s = deriveImplementationSummary(prd);
-        expect(s.buildFirst).toHaveLength(5);
+        expect(s.buildFirst).toHaveLength(10);
+    });
+
+    it('uses the feature description as the reason, without the complexity prefix', () => {
+        const prd = basePRD({
+            features: [
+                baseFeature({ id: 'f1', name: 'F1', tier: 'mvp', description: 'Upload pipeline for images', complexity: 'low' }),
+                baseFeature({ id: 'f2', name: 'F2', tier: 'v1', description: 'Flashcard generation', complexity: 'high' }),
+            ],
+        });
+        const s = deriveImplementationSummary(prd);
+        expect(s.buildFirst[0].reason).toBe('Upload pipeline for images');
+        expect(s.buildFirst[0].reason).not.toMatch(/^low/);
+        // Build Next carries the description too — both buckets read the same.
+        expect(s.buildNext[0].reason).toBe('Flashcard generation');
+    });
+
+    it('falls back to user value when a feature has no description', () => {
+        const prd = basePRD({
+            features: [baseFeature({ id: 'f1', name: 'F1', tier: 'mvp', description: '', userValue: 'Saves time' })],
+        });
+        expect(deriveImplementationSummary(prd).buildFirst[0].reason).toBe('Saves time');
+    });
+});
+
+describe('splitFeaturesByTier', () => {
+    it('groups mvp/v1/deferred and keeps untiered features visible with mvp', () => {
+        const features = [
+            baseFeature({ id: 'f1', tier: 'mvp' }),
+            baseFeature({ id: 'f2', tier: 'v1' }),
+            baseFeature({ id: 'f3', tier: 'later' }),
+            baseFeature({ id: 'f4' }), // hand-added, no tier — must stay visible
+            baseFeature({ id: 'f5', priority: 'should' }), // legacy priority → v1
+        ];
+        const groups = splitFeaturesByTier(features);
+        expect(groups.mvp.map(f => f.id)).toEqual(['f1', 'f4']);
+        expect(groups.v1.map(f => f.id)).toEqual(['f2', 'f5']);
+        expect(groups.deferred.map(f => f.id)).toEqual(['f3']);
     });
 });
 

--- a/src/lib/__tests__/prdDecisions.test.ts
+++ b/src/lib/__tests__/prdDecisions.test.ts
@@ -132,6 +132,53 @@ describe('deriveDecisionLog', () => {
         });
         expect(deriveDecisionLog(prd).map(e => e.id)).toEqual(['a2', 'a1']);
     });
+
+    it('records deferred (tier later) features as Deferred entries', () => {
+        const prd = basePRD({
+            features: [
+                feature({ id: 'f1', tier: 'mvp' }),
+                feature({ id: 'f10', name: 'Anki CSV Export', description: 'Export flashcards to CSV', tier: 'later' }),
+            ],
+        });
+        const log = deriveDecisionLog(prd);
+        expect(log).toHaveLength(1);
+        expect(log[0]).toMatchObject({
+            id: 'f10',
+            kind: 'feature',
+            verdict: 'deferred',
+            statement: 'Anki CSV Export',
+            note: 'Export flashcards to CSV',
+        });
+    });
+
+    it('records mvpScope.later items as Deferred, resolving and deduping against deferred features', () => {
+        const prd = basePRD({
+            features: [
+                feature({ id: 'f10', name: 'Anki CSV Export', tier: 'later' }),
+            ],
+            mvpScope: {
+                mvp: [],
+                v1: [],
+                later: [
+                    'Anki CSV Export (f10): Utility to export flashcards', // dupes the f10 feature
+                    'Team workspaces someday', // plain prose
+                ],
+            },
+        });
+        const log = deriveDecisionLog(prd);
+        const deferred = log.filter(e => e.verdict === 'deferred');
+        expect(deferred).toHaveLength(2); // f10 logged once, prose item kept
+        expect(deferred[0].id).toBe('f10');
+        expect(deferred[1]).toMatchObject({ kind: 'scope', statement: 'Team workspaces someday', label: '' });
+    });
+
+    it('places deferred entries after dated user decisions', () => {
+        const prd = basePRD({
+            assumptions: [assumption({ id: 'a1', decision: 'confirmed', decidedAt: 10 })],
+            features: [feature({ id: 'f3', tier: 'later' })],
+        });
+        expect(deriveDecisionLog(prd).map(e => e.id)).toEqual(['a1', 'f3']);
+    });
 });
 
 describe('resolveScopeFeature', () => {
@@ -182,6 +229,13 @@ describe('resolveScopeFeature', () => {
         const m = resolveScopeFeature('F2: Weekly Review', features);
         expect(m.feature?.id).toBe('f2');
         expect(m.secondary).toBeUndefined();
+    });
+
+    it('strips the empty parens left behind by a bracketed id ("Name (F1): …")', () => {
+        const m = resolveScopeFeature('Quick Capture (F1): one-tap logging', features);
+        expect(m.feature?.id).toBe('f1');
+        // Must not render as "(): one-tap logging".
+        expect(m.secondary).toBe('one-tap logging');
     });
 });
 

--- a/src/lib/__tests__/prdDecisions.test.ts
+++ b/src/lib/__tests__/prdDecisions.test.ts
@@ -172,6 +172,30 @@ describe('deriveDecisionLog', () => {
         expect(deferred[1]).toMatchObject({ kind: 'scope', statement: 'Team workspaces someday', label: '' });
     });
 
+    it('defers an UNTAGGED feature named by mvpScope.later (feature entry, not raw scope)', () => {
+        const prd = basePRD({
+            features: [feature({ id: 'f9', name: 'Anki Export' })], // no tier
+            mvpScope: { mvp: [], v1: [], later: ['Anki Export (f9): CSV utility'] },
+        });
+        const log = deriveDecisionLog(prd);
+        expect(log).toHaveLength(1);
+        expect(log[0]).toMatchObject({ id: 'f9', kind: 'feature', verdict: 'deferred' });
+    });
+
+    it('logs a later item naming an explicitly mvp-tagged feature as a raw scope record (tier wins)', () => {
+        const prd = basePRD({
+            features: [feature({ id: 'f1', name: 'Quick Capture', tier: 'mvp' })],
+            mvpScope: { mvp: [], v1: [], later: ['Advanced Quick Capture filters'] },
+        });
+        const log = deriveDecisionLog(prd);
+        expect(log).toHaveLength(1);
+        expect(log[0]).toMatchObject({
+            kind: 'scope',
+            verdict: 'deferred',
+            statement: 'Advanced Quick Capture filters',
+        });
+    });
+
     it('places deferred entries after dated user decisions', () => {
         const prd = basePRD({
             assumptions: [assumption({ id: 'a1', decision: 'confirmed', decidedAt: 10 })],

--- a/src/lib/__tests__/prdMarkdownRenderer.test.ts
+++ b/src/lib/__tests__/prdMarkdownRenderer.test.ts
@@ -85,6 +85,29 @@ describe('renderPremiumMarkdown mobile-cleanup pass', () => {
         expect(md).toContain('- **Deferred** (f2): Weekly Review');
     });
 
+    it('excludes an untagged feature deferred via mvpScope.later from Detailed Features', () => {
+        const md = renderPremiumMarkdown({
+            ...richPrd,
+            features: [
+                ...richPrd.features,
+                { id: 'f9', name: 'Anki Export', description: 'CSV utility', userValue: 'v', complexity: 'low' }, // no tier
+            ],
+            mvpScope: { mvp: [], v1: [], later: ['Anki Export (f9)'] },
+        });
+        expect(md).not.toContain('### Anki Export');
+        expect(md).toContain('- **Deferred** (f9): Anki Export — CSV utility');
+    });
+
+    it('preserves explicit mvpScope entries with no matching tagged feature in the summary', () => {
+        const md = renderPremiumMarkdown({
+            ...richPrd,
+            mvpScope: { mvp: ['Basic auth and onboarding'], v1: [], later: [] },
+        });
+        const summaryStart = md.indexOf('## Implementation Summary');
+        const summaryEnd = md.indexOf('\n## ', summaryStart + 1);
+        expect(md.slice(summaryStart, summaryEnd)).toContain('Basic auth and onboarding');
+    });
+
     it('never references deferred features from Feature Systems', () => {
         const md = renderPremiumMarkdown({
             ...richPrd,

--- a/src/lib/__tests__/prdMarkdownRenderer.test.ts
+++ b/src/lib/__tests__/prdMarkdownRenderer.test.ts
@@ -55,6 +55,47 @@ describe('renderPremiumMarkdown mobile-cleanup pass', () => {
         expect(md).not.toContain('### Open Decisions');
     });
 
+    it('renders no MVP Scope section — the Implementation Summary is the scope surface', () => {
+        const md = renderPremiumMarkdown({
+            ...richPrd,
+            mvpScope: {
+                mvp: ['Quick Capture (f1): one-tap logging'],
+                v1: [],
+                later: ['Integrations someday'],
+                rationale: 'Focus on the capture loop first.',
+            },
+        });
+        expect(md).not.toContain('## MVP Scope');
+        // The scope rationale surfaces as the decision callout in the summary.
+        const summaryStart = md.indexOf('## Implementation Summary');
+        const summaryEnd = md.indexOf('\n## ', summaryStart + 1);
+        expect(md.slice(summaryStart, summaryEnd)).toContain('> [!DECISION] Focus on the capture loop first.');
+        // "Later" scope items surface as Deferred entries in the Decision Log.
+        expect(md).toContain('- **Deferred**: Integrations someday');
+    });
+
+    it('excludes deferred features from Detailed Features and logs them as Deferred', () => {
+        const md = renderPremiumMarkdown(richPrd);
+        const featuresStart = md.indexOf('## Detailed Features');
+        const featuresEnd = md.indexOf('\n## ', featuresStart + 1);
+        const featuresBlock = md.slice(featuresStart, featuresEnd);
+        expect(featuresBlock).toContain('### Quick Capture');
+        // f2 is tier 'later' — deferred features never render as detail sections.
+        expect(featuresBlock).not.toContain('### Weekly Review');
+        expect(md).toContain('- **Deferred** (f2): Weekly Review');
+    });
+
+    it('never references deferred features from Feature Systems', () => {
+        const md = renderPremiumMarkdown({
+            ...richPrd,
+            featureSystems: [
+                { id: 's1', name: 'Capture System', purpose: 'p', featureIds: ['f1', 'f2'] },
+            ],
+        });
+        expect(md).toContain('**Features:** f1');
+        expect(md).not.toContain('**Features:** f1, f2');
+    });
+
     it('omits Instrumentation from Success Metrics', () => {
         const md = renderPremiumMarkdown(richPrd);
         expect(md).toContain('## Success Metrics');

--- a/src/lib/derive/implementationSummary.ts
+++ b/src/lib/derive/implementationSummary.ts
@@ -4,9 +4,12 @@
 // have to read 30 KB of prose to learn what to build first.
 
 import type { Feature, RiskDetailed, StructuredPRD } from '../../types';
+import { resolveScopeFeature } from './scopeFeatureMatch';
 
 export type SummaryFeature = {
-    id: string;
+    /** Present when the entry is backed by a PRD feature; absent for a
+     * free-form mvpScope string that resolves to no feature. */
+    id?: string;
     name: string;
     reason?: string;
 };
@@ -48,9 +51,32 @@ export function isV1Feature(feature: Feature): boolean {
 }
 
 /** Deferred = explicitly tagged 'later'. Untagged features are never treated
- * as deferred (hand-added features carry no tier and must stay visible). */
+ * as deferred by tier alone (hand-added features carry no tier and must stay
+ * visible) — see deriveDeferredFeatureIds for the scope-aware full set. */
 export function isDeferredFeature(feature: Feature): boolean {
     return feature.tier === 'later';
+}
+
+/**
+ * The complete deferred set: features tagged 'later' PLUS features an
+ * `mvpScope.later` item resolves to. An explicit mvp/v1 tier tag is
+ * authoritative — a later item naming a tier-tagged feature is a data
+ * conflict and never hides that feature (it stays in its tagged phase; the
+ * later item is logged as a raw scope record instead). This one set drives
+ * every surface — Detailed Features, Feature Systems chips, the summary
+ * buckets, and the Decision Log's Deferred entries — so a feature can never
+ * read as both deferred and in scope.
+ */
+export function deriveDeferredFeatureIds(prd: StructuredPRD): Set<string> {
+    const features = prd.features || [];
+    const ids = new Set(features.filter(isDeferredFeature).map(f => f.id));
+    (prd.mvpScope?.later ?? []).forEach(item => {
+        const match = resolveScopeFeature(item, features);
+        if (match.feature && match.feature.tier !== 'mvp' && match.feature.tier !== 'v1') {
+            ids.add(match.feature.id);
+        }
+    });
+    return ids;
 }
 
 export type FeatureTierSplit = {
@@ -58,7 +84,7 @@ export type FeatureTierSplit = {
      * anything not explicitly pushed out of the initial build stays visible. */
     mvp: Feature[];
     v1: Feature[];
-    /** Explicitly deferred (tier 'later') — surfaced only in the Decision Log. */
+    /** Deferred — surfaced only as Decision Log entries. */
     deferred: Feature[];
 };
 
@@ -66,14 +92,19 @@ export type FeatureTierSplit = {
  * Split features into the display groups used by the Detailed Features
  * section: visible MVP (plus unclassified), collapsed V1, and deferred
  * (rendered only as Decision Log entries — PRD sections must not present
- * features outside the MVP/V1 phases).
+ * features outside the MVP/V1 phases). Pass `deriveDeferredFeatureIds(prd)`
+ * as `deferredIds` so scope-deferred (untagged) features are excluded too;
+ * without it only tier-tagged deferral applies.
  */
-export function splitFeaturesByTier(features: Feature[]): FeatureTierSplit {
+export function splitFeaturesByTier(
+    features: Feature[],
+    deferredIds?: ReadonlySet<string>,
+): FeatureTierSplit {
     const mvp: Feature[] = [];
     const v1: Feature[] = [];
     const deferred: Feature[] = [];
     features.forEach(f => {
-        if (isDeferredFeature(f)) deferred.push(f);
+        if (isDeferredFeature(f) || deferredIds?.has(f.id)) deferred.push(f);
         else if (isV1Feature(f)) v1.push(f);
         else mvp.push(f);
     });
@@ -100,21 +131,30 @@ function buildReason(f: Feature): string | undefined {
         : text;
 }
 
-function pickFeatures(features: Feature[]): {
-    buildFirst: Feature[];
-    buildNext: Feature[];
+function pickBuckets(prd: StructuredPRD): {
+    buildFirst: SummaryFeature[];
+    buildNext: SummaryFeature[];
 } {
-    const tagged = features.some(f => f.tier || f.priority);
-    if (!tagged) {
-        // Legacy PRDs without any prioritization. Use declaration order
-        // as a rough proxy: first 4 → first, next 4 → next.
-        return {
-            buildFirst: features.slice(0, 4),
-            buildNext: features.slice(4, 8),
-        };
+    const features = prd.features || [];
+    const deferredIds = deriveDeferredFeatureIds(prd);
+    const active = features.filter(f => !deferredIds.has(f.id));
+    const tagged = active.some(f => f.tier || f.priority);
+    const scope = prd.mvpScope;
+    const hasScopeLists = !!scope && (scope.mvp.length > 0 || scope.v1.length > 0);
+
+    let first: Feature[] = [];
+    let next: Feature[] = [];
+    if (tagged) {
+        first = active.filter(isMvpFeature);
+        next = active.filter(f => !isMvpFeature(f) && isV1Feature(f));
+    } else if (!hasScopeLists) {
+        // Legacy PRDs with no prioritization signal at all. Use declaration
+        // order as a rough proxy: first 4 → first, next 4 → next.
+        first = active.slice(0, 4);
+        next = active.slice(4, 8);
     }
-    const buildFirst = features.filter(isMvpFeature);
-    const buildNext = features.filter(f => !isMvpFeature(f) && isV1Feature(f));
+    // (untagged + scope lists → the explicit scope entries below drive the
+    // buckets instead of a declaration-order guess)
 
     // Within each bucket sort by the numeric portion of the feature id so the
     // user sees f1, f2, f3… in their natural order rather than a complexity
@@ -122,10 +162,31 @@ function pickFeatures(features: Feature[]): {
     const sortById = (arr: Feature[]) =>
         [...arr].sort((a, b) => featureIdSortKey(a.id) - featureIdSortKey(b.id));
 
-    return {
-        buildFirst: sortById(buildFirst),
-        buildNext: sortById(buildNext),
-    };
+    const buildFirst: SummaryFeature[] = sortById(first).map(summaryFeatureFor);
+    const buildNext: SummaryFeature[] = sortById(next).map(summaryFeatureFor);
+
+    // Explicit mvpScope entries the feature buckets don't already carry —
+    // scope lists are free-form strings, so a legacy PRD's ship-first/next
+    // decisions must not vanish just because no feature is tier-tagged.
+    if (scope) {
+        const seen = new Set([...first, ...next].map(f => f.id));
+        const augment = (items: string[], bucket: SummaryFeature[]) => {
+            items.forEach(item => {
+                const match = resolveScopeFeature(item, features);
+                if (match.feature) {
+                    if (seen.has(match.feature.id) || deferredIds.has(match.feature.id)) return;
+                    seen.add(match.feature.id);
+                    bucket.push(summaryFeatureFor(match.feature));
+                } else {
+                    bucket.push({ name: item });
+                }
+            });
+        };
+        augment(scope.mvp ?? [], buildFirst);
+        augment(scope.v1 ?? [], buildNext);
+    }
+
+    return { buildFirst, buildNext };
 }
 
 function pickHighestRisks(prd: StructuredPRD): SummaryRisk[] {
@@ -157,13 +218,12 @@ function pickHighestRisks(prd: StructuredPRD): SummaryRisk[] {
 
 // The summary is THE section presenting MVP/V1 scope (the old MVP Scope
 // feature lists were folded into it), so the buckets are deliberately
-// uncapped — every tagged MVP/V1 feature must appear.
+// uncapped — every tagged MVP/V1 feature and explicit scope entry appears.
 export function deriveImplementationSummary(prd: StructuredPRD): ImplementationSummary {
-    const features = prd.features || [];
-    const { buildFirst, buildNext } = pickFeatures(features);
+    const { buildFirst, buildNext } = pickBuckets(prd);
     return {
-        buildFirst: buildFirst.map(summaryFeatureFor),
-        buildNext: buildNext.map(summaryFeatureFor),
+        buildFirst,
+        buildNext,
         highestRisks: pickHighestRisks(prd),
     };
 }

--- a/src/lib/derive/implementationSummary.ts
+++ b/src/lib/derive/implementationSummary.ts
@@ -18,8 +18,8 @@ export type SummaryRisk = {
 };
 
 // Note: the old "Defer" bucket and "Open Decisions" list were removed from
-// this summary — deferred work lives in MVP Scope ("Later") and the feature
-// tier tags, and open decisions moved to the actionable "Review & Confirm"
+// this summary — deferred work lives in the Decision Log (as "Deferred"
+// entries), and open decisions moved to the actionable "Review & Confirm"
 // section (src/lib/derive/prdDecisions.ts).
 export type ImplementationSummary = {
     buildFirst: SummaryFeature[];
@@ -27,20 +27,57 @@ export type ImplementationSummary = {
     highestRisks: SummaryRisk[];
 };
 
-const HIGH_IMPACT_KEYWORDS = /(outage|loss|critical|blocker|catastroph|exposed|leak|breach)/i;
-const MAX_FEATURES_PER_BUCKET = 5;
-const MAX_RISKS = 4;
+/** DOM id of a feature's detail card in the PRD view — the Implementation
+ * Summary cards deep-link to it and the detail cards link back. */
+export const featureDetailAnchorId = (featureId: string) => `prd-feature-${featureId}`;
 
-function isMvp(feature: Feature): boolean {
+const HIGH_IMPACT_KEYWORDS = /(outage|loss|critical|blocker|catastroph|exposed|leak|breach)/i;
+const MAX_RISKS = 4;
+const MAX_REASON_LENGTH = 110;
+
+export function isMvpFeature(feature: Feature): boolean {
     if (feature.tier === 'mvp') return true;
     if (!feature.tier && feature.priority === 'must') return true;
     return false;
 }
 
-function isV1(feature: Feature): boolean {
+export function isV1Feature(feature: Feature): boolean {
     if (feature.tier === 'v1') return true;
     if (!feature.tier && feature.priority === 'should') return true;
     return false;
+}
+
+/** Deferred = explicitly tagged 'later'. Untagged features are never treated
+ * as deferred (hand-added features carry no tier and must stay visible). */
+export function isDeferredFeature(feature: Feature): boolean {
+    return feature.tier === 'later';
+}
+
+export type FeatureTierSplit = {
+    /** MVP features PLUS untiered features that match no other bucket —
+     * anything not explicitly pushed out of the initial build stays visible. */
+    mvp: Feature[];
+    v1: Feature[];
+    /** Explicitly deferred (tier 'later') — surfaced only in the Decision Log. */
+    deferred: Feature[];
+};
+
+/**
+ * Split features into the display groups used by the Detailed Features
+ * section: visible MVP (plus unclassified), collapsed V1, and deferred
+ * (rendered only as Decision Log entries — PRD sections must not present
+ * features outside the MVP/V1 phases).
+ */
+export function splitFeaturesByTier(features: Feature[]): FeatureTierSplit {
+    const mvp: Feature[] = [];
+    const v1: Feature[] = [];
+    const deferred: Feature[] = [];
+    features.forEach(f => {
+        if (isDeferredFeature(f)) deferred.push(f);
+        else if (isV1Feature(f)) v1.push(f);
+        else mvp.push(f);
+    });
+    return { mvp, v1, deferred };
 }
 
 function featureIdSortKey(id: string): number {
@@ -48,23 +85,19 @@ function featureIdSortKey(id: string): number {
     return match ? parseInt(match[0], 10) : Number.MAX_SAFE_INTEGER;
 }
 
-function summaryFeatureFor(f: Feature, withReason: boolean): SummaryFeature {
-    const reason = withReason
-        ? buildReason(f)
-        : undefined;
-    return { id: f.id, name: f.name, reason };
+function summaryFeatureFor(f: Feature): SummaryFeature {
+    return { id: f.id, name: f.name, reason: buildReason(f) };
 }
 
-function buildReason(f: Feature): string {
-    const parts: string[] = [];
-    if (f.complexity) parts.push(f.complexity);
-    if (f.userValue) {
-        const trimmed = f.userValue.length > 80
-            ? `${f.userValue.slice(0, 78).trim()}…`
-            : f.userValue;
-        parts.push(trimmed);
-    }
-    return parts.join(' · ');
+// A short "what this feature is" line — the feature description (falling back
+// to user value). Deliberately NOT prefixed with the complexity rating: an
+// unexplained "low · " / "high · " read as noise in the summary cards.
+function buildReason(f: Feature): string | undefined {
+    const text = (f.description || f.userValue || '').trim();
+    if (!text) return undefined;
+    return text.length > MAX_REASON_LENGTH
+        ? `${text.slice(0, MAX_REASON_LENGTH - 2).trim()}…`
+        : text;
 }
 
 function pickFeatures(features: Feature[]): {
@@ -80,8 +113,8 @@ function pickFeatures(features: Feature[]): {
             buildNext: features.slice(4, 8),
         };
     }
-    const buildFirst = features.filter(isMvp);
-    const buildNext = features.filter(f => !isMvp(f) && isV1(f));
+    const buildFirst = features.filter(isMvpFeature);
+    const buildNext = features.filter(f => !isMvpFeature(f) && isV1Feature(f));
 
     // Within each bucket sort by the numeric portion of the feature id so the
     // user sees f1, f2, f3… in their natural order rather than a complexity
@@ -122,12 +155,15 @@ function pickHighestRisks(prd: StructuredPRD): SummaryRisk[] {
     return fallback.map(r => ({ risk: r, likelihood: 'unknown', impact: '' }));
 }
 
+// The summary is THE section presenting MVP/V1 scope (the old MVP Scope
+// feature lists were folded into it), so the buckets are deliberately
+// uncapped — every tagged MVP/V1 feature must appear.
 export function deriveImplementationSummary(prd: StructuredPRD): ImplementationSummary {
     const features = prd.features || [];
     const { buildFirst, buildNext } = pickFeatures(features);
     return {
-        buildFirst: buildFirst.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, true)),
-        buildNext: buildNext.slice(0, MAX_FEATURES_PER_BUCKET).map(f => summaryFeatureFor(f, false)),
+        buildFirst: buildFirst.map(summaryFeatureFor),
+        buildNext: buildNext.map(summaryFeatureFor),
         highestRisks: pickHighestRisks(prd),
     };
 }

--- a/src/lib/derive/prdDecisions.ts
+++ b/src/lib/derive/prdDecisions.ts
@@ -3,8 +3,14 @@
 // read time from the StructuredPRD so legacy PRDs (whose assumptions carry
 // no decision fields) render safely as "all unresolved".
 
-import type { Assumption, Feature, StructuredPRD } from '../../types';
-import { isDeferredFeature } from './implementationSummary';
+import type { Assumption, StructuredPRD } from '../../types';
+import { deriveDeferredFeatureIds } from './implementationSummary';
+import { resolveScopeFeature } from './scopeFeatureMatch';
+
+// Back-compat re-export — resolveScopeFeature moved to scopeFeatureMatch.ts
+// (implementationSummary needs it too, and importing it from here would cycle).
+export { resolveScopeFeature } from './scopeFeatureMatch';
+export type { ScopeFeatureMatch } from './scopeFeatureMatch';
 
 const CONFIDENCE_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };
 
@@ -91,10 +97,12 @@ export function deriveDecisionLog(prd: StructuredPRD): DecisionLogEntry[] {
     });
 
     // Deferred scope — the record of what was consciously pushed out of the
-    // MVP/V1 phases. Features tagged 'later' first…
-    const deferredIds = new Set<string>();
-    features.filter(isDeferredFeature).forEach(f => {
-        deferredIds.add(f.id);
+    // MVP/V1 phases. The deferred set (deriveDeferredFeatureIds) is the same
+    // one the renderers use to EXCLUDE these features from every other PRD
+    // section, so a feature can never read as both deferred and in scope.
+    const deferredIds = deriveDeferredFeatureIds(prd);
+    features.forEach(f => {
+        if (!deferredIds.has(f.id)) return;
         entries.push({
             id: f.id,
             kind: 'feature',
@@ -105,30 +113,19 @@ export function deriveDecisionLog(prd: StructuredPRD): DecisionLogEntry[] {
         });
     });
 
-    // …then mvpScope "Later" items, resolved to features where possible and
-    // deduped against features already logged as deferred above.
+    // mvpScope "Later" items that did NOT resolve into the deferred set —
+    // plain prose, or a data conflict where the item names a feature whose
+    // explicit mvp/v1 tier tag wins. Logged as raw scope records.
     (prd.mvpScope?.later ?? []).forEach((item, i) => {
         const match = resolveScopeFeature(item, features);
-        if (match.feature) {
-            if (deferredIds.has(match.feature.id)) return;
-            deferredIds.add(match.feature.id);
-            entries.push({
-                id: match.feature.id,
-                kind: 'feature',
-                verdict: 'deferred',
-                label: match.feature.id,
-                statement: match.feature.name,
-                note: match.secondary,
-            });
-        } else {
-            entries.push({
-                id: `scope-later-${i}`,
-                kind: 'scope',
-                verdict: 'deferred',
-                label: '',
-                statement: item,
-            });
-        }
+        if (match.feature && deferredIds.has(match.feature.id)) return; // logged above
+        entries.push({
+            id: `scope-later-${i}`,
+            kind: 'scope',
+            verdict: 'deferred',
+            label: '',
+            statement: item,
+        });
     });
 
     return entries
@@ -150,74 +147,4 @@ export function isDisplayableFeatureId(id: string | undefined): boolean {
     return !!id && /^[a-zA-Z]{1,3}-?\d{1,3}$/.test(id.trim());
 }
 
-export type ScopeFeatureMatch = {
-    /** The PRD feature the scope item refers to, when one can be resolved. */
-    feature?: Feature;
-    /** Supporting text left over once the id/name reference is stripped. */
-    secondary?: string;
-};
-
-const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-// Whole-token match for a feature name inside a scope item. A bare substring
-// test would resolve unrelated words (feature "AI" matching inside "Daily")
-// and then strip mid-word text from the secondary copy — scope entries are
-// often free prose, so the name must sit on its own token boundaries.
-const nameMatchRegExp = (name: string) =>
-    new RegExp(`(?<![A-Za-z0-9])${escapeRegExp(name)}(?![A-Za-z0-9])`, 'i');
-
-/**
- * Resolve an MVP-scope string ("F1: Quick capture — one-tap logging") to its
- * PRD feature so the MVP/V1 lists can present items as features (id badge +
- * bold name) instead of plain prose. Conservative, read-side only:
- * 1. an explicit id token (`f1`, `F-1`, `[f1]`) wins;
- * 2. else the longest feature name contained in the item;
- * 3. no match → undefined (the caller renders the raw string unchanged).
- * The leftover text (minus the matched id/name and separators) is returned
- * as `secondary` supporting copy.
- */
-export function resolveScopeFeature(item: string, features: Feature[]): ScopeFeatureMatch {
-    const text = item.trim();
-    if (!text || features.length === 0) return {};
-
-    const byId = new Map<string, Feature>();
-    features.forEach(f => byId.set(f.id.toLowerCase().replace(/-/g, ''), f));
-
-    let feature: Feature | undefined;
-    let consumed: RegExp | undefined;
-
-    const idToken = text.match(/\[?\b([a-zA-Z]-?\d+)\b\]?/);
-    if (idToken) {
-        feature = byId.get(idToken[1].toLowerCase().replace(/-/g, ''));
-        if (feature) consumed = new RegExp(`\\[?${escapeRegExp(idToken[1])}\\]?`, 'i');
-    }
-
-    if (!feature) {
-        const named = features
-            .filter(f => f.name && nameMatchRegExp(f.name).test(text))
-            .sort((a, b) => b.name.length - a.name.length)[0];
-        if (named) {
-            feature = named;
-            consumed = nameMatchRegExp(named.name);
-        }
-    }
-
-    if (!feature) return {};
-
-    let secondary = consumed ? text.replace(consumed, '') : text;
-    // Strip the feature name too when the item was matched by id but also
-    // repeats the name ("F1: Quick capture — …").
-    if (feature.name) {
-        secondary = secondary.replace(nameMatchRegExp(feature.name), '');
-    }
-    secondary = secondary
-        // An id matched inside brackets ("Name (F1): …") leaves an empty
-        // "()" / "[]" behind once the token is stripped — remove it, or the
-        // supporting copy renders as "(): Upload pipeline…".
-        .replace(/\(\s*\)|\[\s*\]/g, '')
-        .replace(/^[\s:–—-]+/, '')
-        .replace(/[\s:–—-]+$/, '')
-        .trim();
-
-    return { feature, secondary: secondary || undefined };
-}
+// (resolveScopeFeature lives in scopeFeatureMatch.ts — re-exported above.)

--- a/src/lib/derive/prdDecisions.ts
+++ b/src/lib/derive/prdDecisions.ts
@@ -4,6 +4,7 @@
 // no decision fields) render safely as "all unresolved".
 
 import type { Assumption, Feature, StructuredPRD } from '../../types';
+import { isDeferredFeature } from './implementationSummary';
 
 const CONFIDENCE_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };
 
@@ -40,10 +41,10 @@ export function splitAssumptions(assumptions: Assumption[] | undefined): Assumpt
 }
 
 export type DecisionLogEntry = {
-    /** Stable id of the source item (assumption id / feature id). */
+    /** Stable id of the source item (assumption id / feature id / scope item). */
     id: string;
-    kind: 'assumption' | 'feature';
-    verdict: 'confirmed' | 'rejected';
+    kind: 'assumption' | 'feature' | 'scope';
+    verdict: 'confirmed' | 'rejected' | 'deferred';
     /** Short reference label shown as a badge (assumption id or feature id). */
     label: string;
     statement: string;
@@ -52,10 +53,13 @@ export type DecisionLogEntry = {
 };
 
 /**
- * Derive the Decision Log — confirmed user choices only, never unresolved
- * assumptions. Sources: assumptions the user confirmed/rejected and features
- * the user confirmed. Ordered chronologically by decision time (undated
- * entries last, in document order) so the log reads as a running record.
+ * Derive the Decision Log — decided items only, never unresolved assumptions.
+ * Sources: assumptions the user confirmed/rejected, features the user
+ * confirmed, and DEFERRED scope (features tagged 'later' plus `mvpScope.later`
+ * items). The Decision Log is the ONLY place deferred work is presented — no
+ * other PRD section may refer to features outside the MVP/V1 phases. User
+ * decisions are ordered chronologically (undated last, in document order);
+ * deferred entries carry no timestamp so they read as a trailing record.
  */
 export function deriveDecisionLog(prd: StructuredPRD): DecisionLogEntry[] {
     const entries: DecisionLogEntry[] = [];
@@ -73,7 +77,8 @@ export function deriveDecisionLog(prd: StructuredPRD): DecisionLogEntry[] {
         });
     });
 
-    (prd.features ?? []).forEach(f => {
+    const features = prd.features ?? [];
+    features.forEach(f => {
         if (!f.confirmed) return;
         entries.push({
             id: f.id,
@@ -83,6 +88,47 @@ export function deriveDecisionLog(prd: StructuredPRD): DecisionLogEntry[] {
             statement: f.name,
             decidedAt: f.confirmedAt,
         });
+    });
+
+    // Deferred scope — the record of what was consciously pushed out of the
+    // MVP/V1 phases. Features tagged 'later' first…
+    const deferredIds = new Set<string>();
+    features.filter(isDeferredFeature).forEach(f => {
+        deferredIds.add(f.id);
+        entries.push({
+            id: f.id,
+            kind: 'feature',
+            verdict: 'deferred',
+            label: f.id,
+            statement: f.name,
+            note: f.description || undefined,
+        });
+    });
+
+    // …then mvpScope "Later" items, resolved to features where possible and
+    // deduped against features already logged as deferred above.
+    (prd.mvpScope?.later ?? []).forEach((item, i) => {
+        const match = resolveScopeFeature(item, features);
+        if (match.feature) {
+            if (deferredIds.has(match.feature.id)) return;
+            deferredIds.add(match.feature.id);
+            entries.push({
+                id: match.feature.id,
+                kind: 'feature',
+                verdict: 'deferred',
+                label: match.feature.id,
+                statement: match.feature.name,
+                note: match.secondary,
+            });
+        } else {
+            entries.push({
+                id: `scope-later-${i}`,
+                kind: 'scope',
+                verdict: 'deferred',
+                label: '',
+                statement: item,
+            });
+        }
     });
 
     return entries
@@ -165,6 +211,10 @@ export function resolveScopeFeature(item: string, features: Feature[]): ScopeFea
         secondary = secondary.replace(nameMatchRegExp(feature.name), '');
     }
     secondary = secondary
+        // An id matched inside brackets ("Name (F1): …") leaves an empty
+        // "()" / "[]" behind once the token is stripped — remove it, or the
+        // supporting copy renders as "(): Upload pipeline…".
+        .replace(/\(\s*\)|\[\s*\]/g, '')
         .replace(/^[\s:–—-]+/, '')
         .replace(/[\s:–—-]+$/, '')
         .trim();

--- a/src/lib/derive/scopeFeatureMatch.ts
+++ b/src/lib/derive/scopeFeatureMatch.ts
@@ -1,0 +1,77 @@
+// Pure matcher resolving a free-form MVP-scope string to the PRD feature it
+// refers to. Extracted from prdDecisions.ts so both the decision-log and the
+// implementation-summary derivations can use it without an import cycle.
+
+import type { Feature } from '../../types';
+
+export type ScopeFeatureMatch = {
+    /** The PRD feature the scope item refers to, when one can be resolved. */
+    feature?: Feature;
+    /** Supporting text left over once the id/name reference is stripped. */
+    secondary?: string;
+};
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Whole-token match for a feature name inside a scope item. A bare substring
+// test would resolve unrelated words (feature "AI" matching inside "Daily")
+// and then strip mid-word text from the secondary copy — scope entries are
+// often free prose, so the name must sit on its own token boundaries.
+const nameMatchRegExp = (name: string) =>
+    new RegExp(`(?<![A-Za-z0-9])${escapeRegExp(name)}(?![A-Za-z0-9])`, 'i');
+
+/**
+ * Resolve an MVP-scope string ("F1: Quick capture — one-tap logging") to its
+ * PRD feature so the MVP/V1 lists can present items as features (id badge +
+ * bold name) instead of plain prose. Conservative, read-side only:
+ * 1. an explicit id token (`f1`, `F-1`, `[f1]`) wins;
+ * 2. else the longest feature name contained in the item;
+ * 3. no match → undefined (the caller renders the raw string unchanged).
+ * The leftover text (minus the matched id/name and separators) is returned
+ * as `secondary` supporting copy.
+ */
+export function resolveScopeFeature(item: string, features: Feature[]): ScopeFeatureMatch {
+    const text = item.trim();
+    if (!text || features.length === 0) return {};
+
+    const byId = new Map<string, Feature>();
+    features.forEach(f => byId.set(f.id.toLowerCase().replace(/-/g, ''), f));
+
+    let feature: Feature | undefined;
+    let consumed: RegExp | undefined;
+
+    const idToken = text.match(/\[?\b([a-zA-Z]-?\d+)\b\]?/);
+    if (idToken) {
+        feature = byId.get(idToken[1].toLowerCase().replace(/-/g, ''));
+        if (feature) consumed = new RegExp(`\\[?${escapeRegExp(idToken[1])}\\]?`, 'i');
+    }
+
+    if (!feature) {
+        const named = features
+            .filter(f => f.name && nameMatchRegExp(f.name).test(text))
+            .sort((a, b) => b.name.length - a.name.length)[0];
+        if (named) {
+            feature = named;
+            consumed = nameMatchRegExp(named.name);
+        }
+    }
+
+    if (!feature) return {};
+
+    let secondary = consumed ? text.replace(consumed, '') : text;
+    // Strip the feature name too when the item was matched by id but also
+    // repeats the name ("F1: Quick capture — …").
+    if (feature.name) {
+        secondary = secondary.replace(nameMatchRegExp(feature.name), '');
+    }
+    secondary = secondary
+        // An id matched inside brackets ("Name (F1): …") leaves an empty
+        // "()" / "[]" behind once the token is stripped — remove it, or the
+        // supporting copy renders as "(): Upload pipeline…".
+        .replace(/\(\s*\)|\[\s*\]/g, '')
+        .replace(/^[\s:–—-]+/, '')
+        .replace(/[\s:–—-]+$/, '')
+        .trim();
+
+    return { feature, secondary: secondary || undefined };
+}

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../types';
 import { coerceToBulletList } from '../textCleanup';
 import {
+    deriveDeferredFeatureIds,
     deriveImplementationSummary,
     isImplementationSummaryEmpty,
     splitFeaturesByTier,
@@ -289,16 +290,18 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         if (summary.buildFirst.length > 0) {
             lines.push('### Build First');
             summary.buildFirst.forEach((f, i) => {
+                const id = f.id ? `**${f.id}** ` : '';
                 const reason = f.reason ? ` — ${f.reason}` : '';
-                lines.push(`${i + 1}. **${f.id}** ${f.name}${reason}`);
+                lines.push(`${i + 1}. ${id}${f.name}${reason}`);
             });
             lines.push('');
         }
         if (summary.buildNext.length > 0) {
             lines.push('### Build Next');
             summary.buildNext.forEach(f => {
+                const id = f.id ? `**${f.id}** ` : '';
                 const reason = f.reason ? ` — ${f.reason}` : '';
-                lines.push(`- **${f.id}** ${f.name}${reason}`);
+                lines.push(`- ${id}${f.name}${reason}`);
             });
             lines.push('');
         }
@@ -406,7 +409,7 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
     // unclassified) features render first, V1 features after (collapsed in
     // the app); deferred features are excluded — they appear only as
     // Deferred entries in the Decision Log above.
-    const featureGroups = splitFeaturesByTier(prd.features);
+    const featureGroups = splitFeaturesByTier(prd.features, deriveDeferredFeatureIds(prd));
     lines.push('## Detailed Features');
     featureGroups.mvp.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
     featureGroups.v1.forEach(f => renderFeature(f).forEach(l => lines.push(l)));

--- a/src/lib/services/prdMarkdownRenderer.ts
+++ b/src/lib/services/prdMarkdownRenderer.ts
@@ -28,6 +28,7 @@ import { coerceToBulletList } from '../textCleanup';
 import {
     deriveImplementationSummary,
     isImplementationSummaryEmpty,
+    splitFeaturesByTier,
 } from '../derive/implementationSummary';
 import { splitAssumptions, deriveDecisionLog } from '../derive/prdDecisions';
 import { sanitizeRolePermissions } from '../prdRolesSanitizer';
@@ -274,11 +275,17 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
 
     // Implementation Summary — synthesized from features/risks/assumptions so
     // exports (PDF, markdown download) carry the same "what to build first"
-    // entry point the in-app PRD now shows.
+    // entry point the in-app PRD now shows. THE section presenting MVP/V1
+    // scope (the old `## MVP Scope` block duplicated it and was removed);
+    // the scope rationale renders here as the decision callout.
     const summary = deriveImplementationSummary(prd);
-    if (!isImplementationSummaryEmpty(summary)) {
+    if (!isImplementationSummaryEmpty(summary) || prd.mvpScope?.rationale) {
         lines.push('## Implementation Summary');
         lines.push('');
+        if (prd.mvpScope?.rationale) {
+            lines.push(`> [!DECISION] ${prd.mvpScope.rationale}`);
+            lines.push('');
+        }
         if (summary.buildFirst.length > 0) {
             lines.push('### Build First');
             summary.buildFirst.forEach((f, i) => {
@@ -289,7 +296,10 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         }
         if (summary.buildNext.length > 0) {
             lines.push('### Build Next');
-            summary.buildNext.forEach(f => lines.push(`- **${f.id}** ${f.name}`));
+            summary.buildNext.forEach(f => {
+                const reason = f.reason ? ` — ${f.reason}` : '';
+                lines.push(`- **${f.id}** ${f.name}${reason}`);
+            });
             lines.push('');
         }
         if (summary.highestRisks.length > 0) {
@@ -320,20 +330,25 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
     if (decisionLog.length > 0) {
         lines.push('## Decision Log');
         decisionLog.forEach(e => {
-            const verdict = e.kind === 'feature'
-                ? 'Feature confirmed'
-                : e.verdict === 'confirmed' ? 'Confirmed' : 'Marked incorrect';
-            const note = e.note ? ` — Correction: ${e.note}` : '';
-            lines.push(`- **${verdict}** (${e.label}): ${e.statement}${note}`);
+            const verdict = e.verdict === 'deferred'
+                ? 'Deferred'
+                : e.kind === 'feature'
+                    ? 'Feature confirmed'
+                    : e.verdict === 'confirmed' ? 'Confirmed' : 'Marked incorrect';
+            const notePrefix = e.verdict === 'rejected' ? ' — Correction: ' : ' — ';
+            const note = e.note ? `${notePrefix}${e.note}` : '';
+            const label = e.label ? ` (${e.label})` : '';
+            lines.push(`- **${verdict}**${label}: ${e.statement}${note}`);
         });
         lines.push('');
     }
 
     // ── Section order is a logical reading flow (see StructuredPRDView, which
-    // mirrors it): Product Overview → Target Users → MVP Scope → Features →
-    // UX → Metrics → Risks → Technical Architecture → Data Model → State
-    // Machines → NFRs → reference appendix → Where the Detail Lives (static
-    // handoff appendix). This ordering is presentation-only; downstream
+    // mirrors it): Product Overview → Target Users → Features → UX → Metrics
+    // → Risks → Technical Architecture → Data Model → State Machines → NFRs →
+    // reference appendix → Where the Detail Lives (static handoff appendix).
+    // MVP/V1 scope lives in the Implementation Summary above; deferred scope
+    // in the Decision Log. This ordering is presentation-only; downstream
     // artifacts consume the StructuredPRD object by field, not this markdown,
     // so blocks may be reordered freely without affecting generation.
 
@@ -385,42 +400,27 @@ export const renderPremiumMarkdown = (prd: StructuredPRD): string => {
         lines.push('');
     }
 
-    // ── MVP Scope (what ships first — placed before the full feature detail) ─
-    if (prd.mvpScope) {
-        lines.push('## MVP Scope');
-        if (prd.mvpScope.rationale) {
-            lines.push(`> [!DECISION] ${prd.mvpScope.rationale}`);
-            lines.push('');
-        }
-        lines.push('**MVP — ship first:**');
-        prd.mvpScope.mvp.forEach(i => lines.push(`- \`[MVP]\` ${i}`));
-        if (prd.mvpScope.v1?.length) {
-            lines.push('');
-            lines.push('**V1 — soon after launch:**');
-            prd.mvpScope.v1.forEach(i => lines.push(`- \`[V1]\` ${i}`));
-        }
-        if (prd.mvpScope.later?.length) {
-            lines.push('');
-            lines.push('**Later:**');
-            prd.mvpScope.later.forEach(i => lines.push(`- \`[Later]\` ${i}`));
-        }
-        lines.push('');
-    }
-
     // ── Core Features ───────────────────────────────────────────────────
     // Detailed Features first — the concrete features — then the Feature
-    // Systems grouping (mirrors StructuredPRDView's order).
+    // Systems grouping (mirrors StructuredPRDView's order). MVP (and
+    // unclassified) features render first, V1 features after (collapsed in
+    // the app); deferred features are excluded — they appear only as
+    // Deferred entries in the Decision Log above.
+    const featureGroups = splitFeaturesByTier(prd.features);
     lines.push('## Detailed Features');
-    prd.features.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
+    featureGroups.mvp.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
+    featureGroups.v1.forEach(f => renderFeature(f).forEach(l => lines.push(l)));
 
-    // Feature Systems
+    // Feature Systems — never reference deferred features (Decision Log only).
+    const deferredIds = new Set(featureGroups.deferred.map(f => f.id.toLowerCase()));
     if (prd.featureSystems?.length) {
         lines.push('## Feature Systems');
         prd.featureSystems.forEach(s => {
             lines.push(`### ${s.name}`);
             lines.push(`**Purpose:** ${s.purpose}`);
             if (s.endToEndBehavior) lines.push(`**End-to-end behavior:** ${s.endToEndBehavior}`);
-            if (s.featureIds?.length) lines.push(`**Features:** ${s.featureIds.join(', ')}`);
+            const visibleIds = (s.featureIds ?? []).filter(id => !deferredIds.has(id.toLowerCase()));
+            if (visibleIds.length) lines.push(`**Features:** ${visibleIds.join(', ')}`);
             if (s.dependencies?.length) lines.push(`**Dependencies:** ${s.dependencies.join(', ')}`);
             if (s.edgeCases?.length) {
                 lines.push('**Edge cases:**');


### PR DESCRIPTION
Fixes the PRD formatting issues reported from a desktop review of the demo project (AI Learn Graphics V2). All changes are read-side, applied to **both mirrored renderers** (`StructuredPRDView` in-app + `renderPremiumMarkdown` export), so legacy PRDs — including the pinned demo snapshot — display correctly **without regeneration**.

## Changes

1. **Single MVP/V1 scope surface.** The `MVP Scope` section duplicated the Implementation Summary's Build First / Build Next buckets and is removed. The Implementation Summary (top of the PRD, features linked to their details) is now the one scope section: it carries the scope *rationale* as the Decision callout, and the buckets are uncapped so every tagged MVP/V1 feature appears.
2. **No unexplained "low / medium / high" prefix.** Summary cards now show the feature's short description (falling back to user value) instead of `complexity · userValue`.
3. **Summary ⇄ detail navigation.** Each Build First / Build Next card deep-links to its feature's detail card (`#prd-feature-<id>`), auto-expanding the collapsed V1 group when needed; every detail card gets a "↑ Summary" button returning to the Implementation Summary.
4. **Deferred features never leak into PRD sections.** Features tagged `later` (and `mvpScope.later` items) render **only** as derived "Deferred" entries in the Decision Log; they are excluded from Detailed Features and filtered out of Feature Systems' feature-id chips.
5. **Detailed Features defaults to MVP.** MVP + untiered (hand-added) features are visible; V1 features sit behind a collapsed "V1 — soon after launch" disclosure; deferred features link out to the Decision Log.

Also fixes the `(): Upload pipeline…` glitch visible in the screenshots: `resolveScopeFeature` stripped an id token matched inside parens ("Name (F1): …") but left the empty `()` behind.

## Notes

- Prose sections written by the model (e.g. a paragraph mentioning a deferred feature by name) can't be deterministically rewritten read-side — the enforcement covers every structured surface (scope lists, feature cards, feature-system chips). A regenerated PRD is unaffected either way.
- The pure derive layer gained `splitFeaturesByTier` / `isDeferredFeature` / `featureDetailAnchorId`; `deriveDecisionLog` emits `verdict: 'deferred'` entries (no undo — scope records, not user decisions).
- CLAUDE.md updated in the same change per the documentation rule.

## Testing

- `npm run build` (tsc -b + vite) ✅ and `npm run lint` ✅
- `npm test`: 162 files / 1508 tests pass, including new coverage for tier splitting, deferred Decision Log entries, paren stripping, markdown mirroring, the V1 collapse toggle, and the summary ⇄ detail anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q4gADCd9zZmGpV9LzfSQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_013q4gADCd9zZmGpV9LzfSQ5)_