### PR TITLE
fix(demo): enforce read-only public project capabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,21 @@ add it to `collectProjectBundle`/`collectScreenImages`/`collectVariantImages`, t
 restore writers, and `namespaceSnapshotForRestore`, or it silently won't travel
 in snapshots.
 
+- **The public demo has one read-only capability boundary.**
+  `src/lib/projectCapabilities.ts` is authoritative for durable project actions;
+  `getProjectCapabilities` fails conservatively for a missing project and denies
+  project/spine edits, finality, artifact/version/metadata changes, reviews,
+  generation, design-system changes, persisted workflow/task state, and external
+  task exports for `DEMO_PROJECT_ID`. Persisted Zustand slice actions, artifact
+  generation controllers, and IndexedDB image writers assert the relevant
+  capability before doing work. React surfaces consume
+  `useProjectCapabilities` to hide mutation-only controls; the demo's pipeline
+  stage is component state so PRD / Assets / History navigation remains
+  explorable without persisting `currentStage`. Do not add raw demo-id mutation
+  checks or a second demo store/workspace—extend the capability categories when
+  a new durable mutation domain is introduced. Local copy/download exports that
+  do not mutate project state remain available.
+
 - **Demo hydration is route-owned.** The public demo route
   (`/p/<DEMO_PROJECT_ID>` in `App.tsx`'s `ProjectRoute`) wraps
   `ProjectWorkspace` in `DemoRouteGate` (`src/components/DemoRouteGate.tsx`),
@@ -2599,7 +2614,7 @@ Regenerate / Mark up to date / Decide later — defaulted from
 `expandSelectionWithTroubledUpstreams` (a selected dependent must never rebuild
 from a stale unselected visible input; marked-current upstreams count as
 healed) through the existing `regenerateSlots` path. Cancel aborts the finalize
-(spine stays non-final). First finalize / demo / job-active keep the direct
+(spine stays non-final). First finalize and job-active re-finalizes keep the direct
 `startAll` path. Do not reintroduce a blind full regeneration on re-finalize.
 
 ### PRD highlight → branch selection pipeline

--- a/docs/audits/SYNAPSE_CODEBASE_AUDIT_2026-07-10.md
+++ b/docs/audits/SYNAPSE_CODEBASE_AUDIT_2026-07-10.md
@@ -14,8 +14,9 @@ appended to each affected finding.
 
 | Finding | Status | Resolved by | Summary |
 | --- | --- | --- | --- |
+| SYN-001 | 🟡 Partially resolved (2026-07-10) | PR [#269](https://github.com/TGALLOWAY1/Synapse/pull/269), commits `9730d65`, `63887ce`, `fdd3aed`, branch `fix/demo-read-only-capabilities` | The public demo now has one centralized read-only capability policy enforced in UI and durable mutation boundaries. Persistent PRD, artifact, review, generation, design, image, task, workflow, and export-state changes are denied while exploration remains available. **Reset Demo and baseline restoration remain open** as the intentionally deferred portion of SYN-001. See the Resolution block under SYN-001. |
 | SYN-002 | ✅ Resolved (2026-07-10) | PR [#267](https://github.com/TGALLOWAY1/Synapse/pull/267), commit `59a92d5`, branch `claude/demo-route-hydration-jyalya` | Demo hydration moved to the route boundary: `DemoRouteGate` wraps `ProjectWorkspace` on `/p/<DEMO_PROJECT_ID>` and runs `loadDemoProject()` before mount; entry buttons navigate only. See the Resolution block under SYN-002. |
-| All other findings | Open | — | — |
+| SYN-003–SYN-018 | Open | — | — |
 
 ## 1. Executive summary
 
@@ -163,6 +164,8 @@ No P0 finding was supported by the evidence gathered.
 
 ## [SYN-001] The public demo is mutable and a destructive state change survives refresh
 
+**Status: 🟡 Partially resolved — 2026-07-10, PR [#269](https://github.com/TGALLOWAY1/Synapse/pull/269) (`fix/demo-read-only-capabilities`; commits `9730d65`, `63887ce`, `fdd3aed`). Persistent mutation prevention is complete; Reset Demo remains open. See the Resolution block below.**
+
 **Labels**
 
 - Importance: P1 — High
@@ -203,6 +206,94 @@ Inventory mutation entry points beyond `ProjectWorkspace`, including metadata ov
 **Suggested validation**
 
 Add an E2E test that opens the demo anonymously, attempts representative mutations, reloads, and asserts the original final/version/artifact state. Test reset with a deliberately corrupted local demo cache.
+
+**Resolution — read-only capability boundary (2026-07-10 — PR [#269](https://github.com/TGALLOWAY1/Synapse/pull/269), branch `fix/demo-read-only-capabilities`)**
+
+Implemented the mutation-prevention portion of this finding without creating a
+demo-only workspace or second store:
+
+- **One authoritative capability model.** `src/lib/projectCapabilities.ts`
+  defines `ProjectCapabilities`, `getProjectCapabilities`, and the reusable
+  `assertProjectCapability` domain guard. `DEMO_PROJECT_ID` may explore but is
+  denied every durable capability: project/PRD edits, finality, artifact edits,
+  review state, generation, Design System management, workflow persistence,
+  and external export state. Missing/unknown projects fail conservatively.
+  `src/hooks/useProjectCapabilities.ts` is the React adapter; components do not
+  accumulate new raw demo-id mutation checks.
+- **Project and PRD boundaries.** Project deletion/stage persistence, Design
+  System setup, spine text/structured edits, regeneration, finality, version
+  restoration, product metadata, preflight state, safety/generation results,
+  and branch create/reply/merge/delete actions assert capabilities before
+  writing. Demo Project/Assets/History navigation uses component-local state,
+  preserving exploration without persisting `currentStage`.
+- **Artifact and review boundaries.** Artifact create/update/delete, version
+  creation/preference/restoration, mark-current confirmation, metadata overlays,
+  feedback status, screen edits, prompt edits, review/checklist/confirmation
+  state, warning dismissals, relinks, plan progress, and mockup coverage overlays
+  are rejected before changing durable state.
+- **Generation and image boundaries.** `artifactJobController.startAll`,
+  `regenerateSlots`, `retrySlot`, and `resumeIfNeeded` reject the demo before a
+  job or paid request starts. The legacy mockup image store, variant image store,
+  coverage-sidecar writer, Screen Inventory upload writer, and preferred-upload
+  writer also assert capabilities before network or IndexedDB writes.
+- **Tasks, workflow, and external-export state.** Task extraction/save, status,
+  removal, recorded GitHub/Linear/Markdown export references, and persisted
+  orchestration metrics are guarded. The Convert-to-Tasks entry point is absent
+  for the demo, so its external provider workflow cannot be started from the
+  public project. Local copy/download exports that do not mutate project state
+  remain available.
+- **Intentional UI treatment.** Mutation-only controls are hidden: Final,
+  regenerate/retry, PRD and artifact edit/refine, restore, mark-current, review
+  and confirmation, Design System direction, uploads/replacements, task
+  management, branch refinement, and dependency-graph update actions. Where a
+  visible disabled generation affordance still explains the product, it carries
+  the accessible reason “This example project is read-only.” Version history,
+  comparisons, tabs, filters, sorting, expansion, dependency inspection, screen
+  details, and mockup viewing remain usable.
+- **One read-only explanation.** `DemoReadOnlyNotice` adds a single accessible
+  workspace-level `role="status"` message explaining that visitors can explore
+  the complete example without changing the saved project; artifact surfaces do
+  not repeat warning clutter.
+- **Architecture documentation.** `CLAUDE.md` now records the policy as the
+  required boundary for future durable mutation domains.
+
+*Acceptance status:* mutation-prevention criteria are met: the demo cannot
+change PRD finality/content, artifact content or versions, screen/prompt edits,
+reviews/confirmations, workflow metadata, Design System state, generated assets,
+uploads, tasks, or external-export claims through protected actions. Ordinary
+projects retain the same representative editing operations. Navigation and
+inspection remain available. The original acceptance criterion requiring a
+deterministic Reset Demo / baseline reload is **not met in this batch** and is
+the reason SYN-001 remains partially rather than fully resolved.
+
+*Tests:* `src/lib/__tests__/projectCapabilities.test.ts` covers demo, ordinary,
+missing-project, and exploration policy; `src/store/__tests__/demoReadOnlyMutations.test.ts`
+covers finality, PRD edits, screen/review metadata, generation/regeneration,
+Design System, workflow state, and ordinary-project parity;
+`src/components/__tests__/DemoReadOnlySurfaces.test.tsx` covers the notice,
+hidden generation/update/restore controls, dependency inspection, and version
+comparison. Existing affected component/store fixtures were updated to use
+real project identities under the new conservative unknown-project rule.
+
+*Validation:* `npm run lint` passed; `npm test` passed **1,545 tests across 167
+files**; `npm run build` passed with only the pre-existing generated-CSS,
+mixed static/dynamic import, and large-chunk warnings. Browser verification used
+the local application with the deployed public snapshot at 1,440 px and 390 px:
+PRD, Assets, Screens filters, screen detail, Mockups, Design System history,
+Data Model, and Implementation Plan remained explorable; mutation controls were
+absent; the 390 px journey had no horizontal overflow. The browser declined the
+final ordinary-project/console-inspection leg, so ordinary-project parity is
+supported by the passing store/component tests rather than claimed as a browser
+result.
+
+*Commits:* `9730d65` (`refactor(demo): add centralized project capabilities`),
+`63887ce` (`fix(demo): prevent persistent mutations in public projects`), and
+`fdd3aed` (`test(demo): cover read-only capability enforcement`).
+
+*Deliberately deferred:* Reset Demo, clearing only the local demo namespace,
+automatic baseline restoration after earlier cache corruption, image-manifest
+validation, and the full committed Playwright demo contract. Those remain the
+follow-up needed to close the remaining portion of SYN-001.
 
 ## [SYN-002] A cold direct demo URL does not hydrate the demo project
 

--- a/src/components/ArtifactWorkspace.tsx
+++ b/src/components/ArtifactWorkspace.tsx
@@ -56,6 +56,7 @@ import type {
     ArtifactSlotKey, CoreArtifactSubtype, MockupScreen, ProjectPlatform, StructuredPRD,
     GenerationStatus, ProjectTask,
 } from '../types';
+import { useProjectCapabilities } from '../hooks/useProjectCapabilities';
 
 // Stable empty reference for the tasks selector. Returning `[]` literal each
 // call would make Zustand's useSyncExternalStore see a fresh snapshot on every
@@ -250,6 +251,7 @@ export function ArtifactWorkspace({
     projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
     autoOpenIntent, onAutoOpenConsumed,
 }: ArtifactWorkspaceProps) {
+    const capabilities = useProjectCapabilities(projectId);
     const isMobile = useIsMobile();
     const {
         getArtifacts, getPreferredVersion, getArtifactStaleness, getJob, getProject,
@@ -516,6 +518,7 @@ export function ArtifactWorkspace({
     // Repair: pin/relink a mockup screen to a canonical screen (persisted on
     // the mockup version — survives renames and name drift thereafter).
     const handleRelinkMockupScreen = (mockupScreenId: string, screenId: string) => {
+        if (!capabilities.canEditArtifacts) return;
         if (!mockupArtifact || !mockupPreferred) return;
         const links = { ...readScreenLinks(mockupPreferred.metadata), [mockupScreenId]: screenId };
         updateArtifactVersionMetadata(projectId, mockupArtifact.id, mockupPreferred.id, { screenLinks: links });
@@ -523,6 +526,7 @@ export function ArtifactWorkspace({
 
     // Repair: hide a warning (current behavior is kept — nothing else changes).
     const handleDismissScreenIssue = (issueKey: string) => {
+        if (!capabilities.canReviewArtifacts) return;
         if (!invArtifact || !invPreferred) return;
         const dismissed = new Set(readDismissedScreenIssues(invPreferred.metadata));
         dismissed.add(issueKey);
@@ -533,6 +537,7 @@ export function ArtifactWorkspace({
 
     // Persist (or clear, with null) one screen's metadata edit overlay.
     const handleSaveScreenEdit = (screenId: string, edit: ScreenMetadataEdit | null) => {
+        if (!capabilities.canEditArtifacts) return;
         if (!invArtifact || !invPreferred) return;
         const current = readScreenEdits(invPreferred.metadata);
         const next: Record<string, ScreenMetadataEdit> = { ...current };
@@ -551,6 +556,7 @@ export function ArtifactWorkspace({
     // per-screen action (or the confirmed batch below), so adding coverage is
     // free. Returns the appended MockupScreen specs.
     const addScreensToMockups = (screenIds: string[]): MockupScreen[] => {
+        if (!capabilities.canEditArtifacts) return [];
         if (!mockupArtifact || !mockupPreferred) return [];
         const existing = readExtraMockupScreens(mockupPreferred.metadata);
         const appended: MockupScreen[] = [];
@@ -580,6 +586,7 @@ export function ArtifactWorkspace({
     // panel; failures leave that screen on its generate/upload placeholder.
     const [missingMockupsConfirm, setMissingMockupsConfirm] = useState<{ count: number } | null>(null);
     const handleGenerateMissingMockups = () => {
+        if (!capabilities.canGenerateArtifacts) return;
         const missing = screenIndex.items.filter(i => !i.mockupScreen).map(i => i.id);
         if (missing.length === 0 || !mockupArtifact || !mockupPreferred || !mockupPayload) {
             setMissingMockupsConfirm(null);
@@ -651,10 +658,11 @@ export function ArtifactWorkspace({
     // store), so without this the user lands on a workspace where missing
     // artifacts silently sit at "Idle" with no resume affordance.
     useEffect(() => {
+        if (!capabilities.canGenerateArtifacts) return;
         artifactJobController.resumeIfNeeded({
             projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
         });
-    }, [projectId, spineVersionId, prdContent, structuredPRD, projectPlatform]);
+    }, [projectId, spineVersionId, prdContent, structuredPRD, projectPlatform, capabilities.canGenerateArtifacts]);
 
     // Scroll the content pane back to the top on every page switch (including
     // opening/closing a screen detail page).
@@ -725,6 +733,7 @@ export function ArtifactWorkspace({
     });
 
     const handleRetrySlot = (slot: ArtifactSlotKey) => {
+        if (!capabilities.canGenerateArtifacts) return;
         artifactJobController.retrySlot(slot, {
             projectId, spineVersionId, prdContent, structuredPRD, projectPlatform,
         });
@@ -765,6 +774,7 @@ export function ArtifactWorkspace({
     // confirm — the preset only takes effect when the design system is
     // regenerated, so we lead the user straight into that step.
     const handleChooseDirection = (presetId: string) => {
+        if (!capabilities.canManageDesignSystem) return;
         setProjectDesignSystemPreset(projectId, presetId);
         setShowDirectionPicker(false);
         const ds = getArtifacts(projectId, 'core_artifact').find(a => a.subtype === 'design_system');
@@ -818,7 +828,7 @@ export function ArtifactWorkspace({
                         Since {prdLabel ?? 'generation'}: {changeSummary.headline}
                     </span>
                 )}
-                {staleness !== 'current' && latestSpineId && (
+                {capabilities.canReviewArtifacts && staleness !== 'current' && latestSpineId && (
                     <button
                         type="button"
                         onClick={() => markArtifactCurrentForSpine(projectId, artifactId, latestSpineId)}
@@ -900,13 +910,13 @@ export function ArtifactWorkspace({
                                 {screensError?.message && (
                                     <p className="text-sm text-neutral-600 mt-1 break-words">{screensError.message}</p>
                                 )}
-                                <button
+                                {capabilities.canGenerateArtifacts && <button
                                     type="button"
                                     onClick={() => handleRetrySlot('screen_inventory')}
                                     className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
                                 >
                                     <RefreshCcw size={14} /> Retry
-                                </button>
+                                </button>}
                             </div>
                         </div>
                     </div>
@@ -955,11 +965,11 @@ export function ArtifactWorkspace({
                         mockupContext={mockupDetailContext}
                         mobileRelevant={mobileRelevant}
                         mockupStatus={slotStatusFor('mockup')}
-                        onRetryMockup={() => handleRetrySlot('mockup')}
+                        onRetryMockup={capabilities.canGenerateArtifacts ? () => handleRetrySlot('mockup') : undefined}
                         features={structuredPRD.features}
-                        onSaveScreenEdit={invArtifact && invPreferred ? handleSaveScreenEdit : undefined}
+                        onSaveScreenEdit={capabilities.canEditArtifacts && invArtifact && invPreferred ? handleSaveScreenEdit : undefined}
                         onAddToMockups={
-                            mockupDetailContext && !detailItem.mockupScreen
+                            capabilities.canEditArtifacts && mockupDetailContext && !detailItem.mockupScreen
                                 ? () => handleAddScreenToMockups(detailItem.id)
                                 : undefined
                         }
@@ -971,7 +981,7 @@ export function ArtifactWorkspace({
                                 : undefined
                         }
                         onLinkMockup={
-                            mockupArtifact && mockupPreferred && !detailItem.mockupScreen
+                            capabilities.canEditArtifacts && mockupArtifact && mockupPreferred && !detailItem.mockupScreen
                                 ? (mockupScreenId) => handleRelinkMockupScreen(mockupScreenId, detailItem.id)
                                 : undefined
                         }
@@ -1011,12 +1021,12 @@ export function ArtifactWorkspace({
                     : undefined,
                 lastMockupGeneratedAt: mockupPreferred?.createdAt,
                 mockupDesignDrift: screensDesignDrift,
-                onMarkUpToDate: invArtifact && latestSpineId
+                onMarkUpToDate: capabilities.canReviewArtifacts && invArtifact && latestSpineId
                     ? () => markArtifactCurrentForSpine(projectId, invArtifact.id, latestSpineId)
                     : undefined,
                 onOpenVersionHistory: invArtifact ? () => setVersionHistoryArtifactId(invArtifact.id) : undefined,
                 onOpenMockupHistory: mockupArtifact ? () => setVersionHistoryArtifactId(mockupArtifact.id) : undefined,
-                onRegenerateMockup: mockupPreferred
+                onRegenerateMockup: capabilities.canGenerateArtifacts && mockupPreferred
                     ? () => setMockupRegenConfirm({ nextVersion: mockupPreferred.versionNumber + 1 })
                     : undefined,
             };
@@ -1029,8 +1039,8 @@ export function ArtifactWorkspace({
                             <ReferenceWarningsPanel
                                 issues={visibleScreenIssues}
                                 screenOptions={screenIndex.items.map(i => ({ id: i.id, name: i.screen.name }))}
-                                onRelink={mockupArtifact && mockupPreferred ? handleRelinkMockupScreen : undefined}
-                                onDismiss={invArtifact && invPreferred ? handleDismissScreenIssue : undefined}
+                                onRelink={capabilities.canEditArtifacts && mockupArtifact && mockupPreferred ? handleRelinkMockupScreen : undefined}
+                                onDismiss={capabilities.canReviewArtifacts && invArtifact && invPreferred ? handleDismissScreenIssue : undefined}
                             />
                         </div>
                     )}
@@ -1053,7 +1063,7 @@ export function ArtifactWorkspace({
                         generatedVariantsByScreen={(id) => generatedVariantsByScreen.get(id)}
                         onSelectScreen={handleOpenScreen}
                         onGenerateMissingMockups={
-                            mockupDetailContext
+                            capabilities.canGenerateArtifacts && mockupDetailContext
                                 ? () => setMissingMockupsConfirm({
                                     count: screenIndex.items.filter(i => !i.mockupScreen).length,
                                 })
@@ -1102,13 +1112,13 @@ export function ArtifactWorkspace({
                             {error?.message && (
                                 <p className="text-sm text-neutral-600 mt-1 break-words">{error.message}</p>
                             )}
-                            <button
+                            {capabilities.canGenerateArtifacts && <button
                                 type="button"
                                 onClick={() => handleRetrySlot(activeSelection)}
                                 className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition"
                             >
                                 <RefreshCcw size={14} /> Retry
-                            </button>
+                            </button>}
                         </div>
                     </div>
                 </div>
@@ -1158,13 +1168,13 @@ export function ArtifactWorkspace({
                 <div className="space-y-4">
                     <div className="flex items-center justify-between gap-2 flex-wrap">
                         {renderVersionControls(mockup.id, preferred)}
-                        <button
+                        {capabilities.canGenerateArtifacts && <button
                             type="button"
                             onClick={() => setMockupRegenConfirm({ nextVersion: preferred.versionNumber + 1 })}
                             className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-neutral-100 hover:bg-neutral-200 text-neutral-700 rounded-md transition"
                         >
                             <RefreshCcw size={12} /> Regenerate Mockup
-                        </button>
+                        </button>}
                     </div>
                     {designSystemDrift && (
                         <div className="flex items-start justify-between gap-3 flex-wrap rounded-lg border border-amber-200 bg-amber-50 p-3">
@@ -1179,13 +1189,13 @@ export function ArtifactWorkspace({
                                     </p>
                                 </div>
                             </div>
-                            <button
+                            {capabilities.canGenerateArtifacts && <button
                                 type="button"
                                 onClick={() => setMockupRegenConfirm({ nextVersion: preferred.versionNumber + 1 })}
                                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-amber-600 hover:bg-amber-700 text-white rounded-md transition shrink-0"
                             >
                                 <RefreshCcw size={12} /> Regenerate Mockup
-                            </button>
+                            </button>}
                         </div>
                     )}
                     <MockupErrorBoundary resetKey={preferred.id}>
@@ -1240,7 +1250,7 @@ export function ArtifactWorkspace({
                 return packPreferred?.content;
             })()
             : undefined;
-        const handleUpdatePromptEdits = subtype === 'prompt_pack'
+        const handleUpdatePromptEdits = subtype === 'prompt_pack' && capabilities.canEditArtifacts
             ? (next: Record<number, string>) => {
                 updateArtifactVersionMetadata(projectId, artifact.id, preferred.id, { promptEdits: next }, {
                     historyDescription: 'Developer prompt edited',
@@ -1254,12 +1264,12 @@ export function ArtifactWorkspace({
         const planSavedTasks = subtype === 'implementation_plan'
             ? projectTasks.filter(t => t.sourceArtifactId === artifact.id)
             : undefined;
-        const handleConvertToTasks = subtype === 'implementation_plan'
+        const handleConvertToTasks = subtype === 'implementation_plan' && capabilities.canPersistWorkflowState
             ? () => setTasksModalSource({ artifactId: artifact.id, content: preferred.content })
             : undefined;
         // Progress is per-version plumbing (like relink/dismiss), not a
         // content edit — no history event.
-        const handleUpdatePlanProgress = subtype === 'implementation_plan'
+        const handleUpdatePlanProgress = subtype === 'implementation_plan' && capabilities.canPersistWorkflowState
             ? (next: unknown) => {
                 updateArtifactVersionMetadata(projectId, artifact.id, preferred.id, { planProgress: next });
             }
@@ -1314,17 +1324,17 @@ export function ArtifactWorkspace({
                             <p className="text-xs text-amber-700 mt-2">
                                 The content below is preserved for review. Regenerate this artifact to try to resolve it.
                             </p>
-                            <button
+                            {capabilities.canGenerateArtifacts && <button
                                 type="button"
                                 onClick={() => handleRetrySlot(activeSelection)}
                                 className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600 hover:bg-amber-700 text-white transition"
                             >
                                 <RefreshCcw size={12} /> Regenerate
-                            </button>
+                            </button>}
                         </div>
                     </div>
                 )}
-                {subtype === 'design_system' && (
+                {subtype === 'design_system' && capabilities.canManageDesignSystem && (
                     <DesignDirectionControl
                         presetId={designSystemPreset}
                         onChangeDirection={() => setShowDirectionPicker(true)}
@@ -1334,7 +1344,7 @@ export function ArtifactWorkspace({
                     />
                 )}
                 {subtype === 'implementation_plan' && (
-                    <TaskChecklist projectId={projectId} sourceArtifactId={artifact.id} />
+                    <TaskChecklist projectId={projectId} sourceArtifactId={artifact.id} readOnly={!capabilities.canPersistWorkflowState} />
                 )}
                 <div className={
                     subtype === 'implementation_plan'
@@ -1549,7 +1559,7 @@ export function ArtifactWorkspace({
                 </div>
             </main>
 
-            {tasksModalSource && (
+            {tasksModalSource && capabilities.canPersistWorkflowState && (
                 <ConvertToTasksModal
                     projectId={projectId}
                     sourceArtifactId={tasksModalSource.artifactId}
@@ -1749,7 +1759,9 @@ export function ArtifactWorkspace({
                             before: versions.find(v => v.id === id)?.content ?? '',
                             after: preferred?.content ?? '',
                         })}
-                        onRestore={(id) => revertArtifactToVersion(projectId, artifactId, id)}
+                        onRestore={capabilities.canEditArtifacts
+                            ? (id) => revertArtifactToVersion(projectId, artifactId, id)
+                            : undefined}
                         onClose={() => setVersionHistoryArtifactId(null)}
                     />
                 );

--- a/src/components/BranchList.tsx
+++ b/src/components/BranchList.tsx
@@ -13,9 +13,10 @@ interface BranchListProps {
     spineVersionId: string;
     onConsolidate: (branch: Branch) => void;
     onCanvasOpen?: (branchId: string) => void;
+    readOnly?: boolean;
 }
 
-export function BranchList({ projectId, spineVersionId, onConsolidate, onCanvasOpen }: BranchListProps) {
+export function BranchList({ projectId, spineVersionId, onConsolidate, onCanvasOpen, readOnly = false }: BranchListProps) {
     const [animationParent] = useAutoAnimate();
     const { getBranchesForSpine, addBranchMessage, deleteBranch } = useProjectStore();
     const branches = getBranchesForSpine(projectId, spineVersionId);
@@ -79,7 +80,7 @@ export function BranchList({ projectId, spineVersionId, onConsolidate, onCanvasO
                             <div className={`text-xs px-2 py-1 rounded-full border ${branch.status === 'active' ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-neutral-100 border-neutral-200 text-neutral-500'}`}>
                                 {branch.status}
                             </div>
-                            {branch.status === 'active' && (
+                            {branch.status === 'active' && !readOnly && (
                                 <div className="flex items-center gap-1 mt-1">
                                     <button
                                         onClick={() => onCanvasOpen?.(branch.id)}
@@ -105,7 +106,7 @@ export function BranchList({ projectId, spineVersionId, onConsolidate, onCanvasO
                     </div>
 
                     {/* Consolidate Bar */}
-                    {branch.status === 'active' && (
+                    {branch.status === 'active' && !readOnly && (
                         <div className="px-3 pb-3 bg-neutral-50 flex justify-end">
                              <button
                                 onClick={() => onConsolidate(branch)}
@@ -135,7 +136,7 @@ export function BranchList({ projectId, spineVersionId, onConsolidate, onCanvasO
                     </div>
 
                     {/* Input */}
-                    {branch.status === 'active' && (
+                    {branch.status === 'active' && !readOnly && (
                         <form onSubmit={(e) => handleReply(e, branch)} className="p-2 border-t border-neutral-200 bg-white flex gap-2">
                             <input
                                 type="text"

--- a/src/components/DemoReadOnlyNotice.tsx
+++ b/src/components/DemoReadOnlyNotice.tsx
@@ -1,0 +1,13 @@
+export function DemoReadOnlyNotice() {
+    return (
+        <div
+            role="status"
+            className="shrink-0 bg-indigo-500/10 border-b border-indigo-500/30 text-indigo-200 text-sm px-4 py-2 flex items-center justify-center gap-2 z-10"
+        >
+            <span>
+                This is a read-only example project. Explore its PRD, screens, mockups, data model,
+                and implementation plan without changing the saved project.
+            </span>
+        </div>
+    );
+}

--- a/src/components/FeedbackItemsList.tsx
+++ b/src/components/FeedbackItemsList.tsx
@@ -5,6 +5,7 @@ import type { FeedbackItem, FeedbackType } from '../types';
 interface FeedbackItemsListProps {
     projectId: string;
     onApplyToPRD?: (feedback: FeedbackItem) => void;
+    readOnly?: boolean;
 }
 
 const TYPE_LABELS: Record<FeedbackType, string> = {
@@ -20,7 +21,7 @@ const TYPE_LABELS: Record<FeedbackType, string> = {
 
 
 
-export function FeedbackItemsList({ projectId, onApplyToPRD }: FeedbackItemsListProps) {
+export function FeedbackItemsList({ projectId, onApplyToPRD, readOnly = false }: FeedbackItemsListProps) {
     const { getFeedbackItems, updateFeedbackStatus } = useProjectStore();
     const allItems = getFeedbackItems(projectId);
     const openItems = allItems.filter(f => f.status === 'open' || f.status === 'accepted');
@@ -49,7 +50,7 @@ export function FeedbackItemsList({ projectId, onApplyToPRD }: FeedbackItemsList
                                 <p className="text-xs text-neutral-500 line-clamp-2">{item.description}</p>
                             )}
                         </div>
-                        <div className="flex items-center gap-1 shrink-0">
+                        {!readOnly && <div className="flex items-center gap-1 shrink-0">
                             {onApplyToPRD && (
                                 <button
                                     onClick={() => onApplyToPRD(item)}
@@ -74,7 +75,7 @@ export function FeedbackItemsList({ projectId, onApplyToPRD }: FeedbackItemsList
                             >
                                 <X size={14} />
                             </button>
-                        </div>
+                        </div>}
                     </div>
                 ))}
             </div>

--- a/src/components/ProjectWorkspace.tsx
+++ b/src/components/ProjectWorkspace.tsx
@@ -53,11 +53,13 @@ import { artifactJobController } from '../lib/services/artifactJobController';
 import { SECTION_TITLES } from '../lib/prompts/prdSectionPrompts';
 import type { SectionId } from '../lib/schemas/prdSchemas';
 import type { ArtifactSlotKey, Branch, PipelineStage, FeedbackItem } from '../types';
-import { DEMO_PROJECT_ID } from '../data/demoProject';
 import { ProjectCloudStatus, ProjectConflictBanner } from './sync/ProjectSyncStatus';
+import { useProjectCapabilities } from '../hooks/useProjectCapabilities';
+import { DemoReadOnlyNotice } from './DemoReadOnlyNotice';
 
 export function ProjectWorkspace() {
     const { projectId } = useParams<{ projectId: string }>();
+    const capabilities = useProjectCapabilities(projectId);
     const navigate = useNavigate();
     const authUser = useAuthStore((s) => s.user);
     const logout = useAuthStore((s) => s.logout);
@@ -84,6 +86,9 @@ export function ProjectWorkspace() {
     const [isExportOpen, setIsExportOpen] = useState(false);
     const [isSnapshotsOpen, setIsSnapshotsOpen] = useState(false);
     const [retryingStepId, setRetryingStepId] = useState<string | null>(null);
+    // Demo navigation is intentionally session-only. Ordinary projects retain
+    // their existing persisted currentStage behavior.
+    const [readOnlyStage, setReadOnlyStage] = useState<PipelineStage | null>(null);
     // Post-finalization transition. `showFinalizeSuccess` drives the success
     // modal shown immediately after Mark Final; `finalizeAutoOpen` is the
     // one-shot intent handed to ArtifactWorkspace so it auto-opens the panel
@@ -186,11 +191,12 @@ export function ProjectWorkspace() {
         const spine = store.getLatestSpine(projectId);
         if (!proj || proj.currentStage === 'workspace') return;
         if (spine?.isFinal && spine.structuredPRD && spine.safetyReview?.status !== 'blocked') {
-            store.setProjectStage(projectId, 'workspace');
+            if (capabilities.canPersistWorkflowState) store.setProjectStage(projectId, 'workspace');
+            else setReadOnlyStage('workspace');
         }
         // Mount-only by design (store read via getState, not deps): reacting
         // to later param changes would yank the stage from under the user.
-    }, [projectId]);
+    }, [projectId, capabilities.canPersistWorkflowState]);
 
     if (!projectId) return <div>Invalid Project</div>;
 
@@ -199,9 +205,13 @@ export function ProjectWorkspace() {
     const historyEvents = getHistoryEvents(projectId);
     const allSpines = getSpineVersions(projectId);
 
-    const pipelineStage = project?.currentStage || 'prd';
+    const pipelineStage = capabilities.canPersistWorkflowState
+        ? project?.currentStage || 'prd'
+        : readOnlyStage ?? project?.currentStage ?? 'prd';
     const setPipelineStage = (stage: PipelineStage) => {
-        if (projectId) setProjectStage(projectId, stage);
+        if (!projectId) return;
+        if (capabilities.canPersistWorkflowState) setProjectStage(projectId, stage);
+        else if (capabilities.canExplore) setReadOnlyStage(stage);
     };
 
     const activeSpine = viewedSpineId ? allSpines.find(s => s.id === viewedSpineId) || latestSpine : latestSpine;
@@ -297,6 +307,7 @@ export function ProjectWorkspace() {
             .map(a => a.title);
 
     const handleRestoreSpine = (sourceSpineId: string) => {
+        if (!capabilities.canEditProjectContent) return;
         revertSpineToVersion(projectId, sourceSpineId);
         // Return to the (new) latest version after restoring.
         setViewedSpineId(null);
@@ -331,6 +342,7 @@ export function ProjectWorkspace() {
     };
 
     const handleRegenerate = async () => {
+        if (!capabilities.canGenerateArtifacts) return;
         // Ref guard, not just `isGenerating`: two clicks in the same tick both
         // see the stale React state and would launch two concurrent pipelines
         // whose results interleave on different spines.
@@ -432,6 +444,7 @@ export function ProjectWorkspace() {
     // Re-run a single failed section, merging the new slice back into the
     // current spine's PRD while leaving every other section intact.
     const handleRetrySection = async (sectionId: string) => {
+        if (!capabilities.canGenerateArtifacts) return;
         if (!projectId || !activeSpine?.structuredPRD || isOldVersion || retryingStepId) return;
         const sourcePrompt = activeSpine.promptText;
         const id = sectionId as SectionId;
@@ -502,6 +515,7 @@ export function ProjectWorkspace() {
     };
 
     const handleApplyFeedback = (feedback: FeedbackItem) => {
+        if (!capabilities.canReviewArtifacts) return;
         if (!projectId || !latestSpine) return;
         const intent = `[Feedback: ${feedback.title}] ${feedback.description}`;
         storCreateBranch(projectId, latestSpine.id, feedback.title, intent);
@@ -544,6 +558,7 @@ export function ProjectWorkspace() {
         && pipelineStage !== 'workspace';
 
     const handleToggleFinal = () => {
+        if (!capabilities.canChangeFinality) return;
         if (!projectId || !activeSpine) return;
         // Blocked spines can never advance to the workspace / artifact stage.
         if (activeSpine.safetyReview?.status === 'blocked') return;
@@ -570,12 +585,12 @@ export function ProjectWorkspace() {
     // Continues the finalize flow after the incomplete-PRD gate. If this real
     // project will generate assets but hasn't picked a design-system direction
     // yet, ask first — the choice steers the design system (and therefore
-    // mockups + copied prompts). The demo never generates and skips through.
+    // mockups + copied prompts).
     // `ackIncomplete` records whether the user acknowledged generating from a
     // partial PRD; it's carried across the preset gate.
     const startFinalizeFlow = (ackIncomplete: boolean) => {
         if (!projectId || !activeSpine) return;
-        if (activeSpine.structuredPRD && projectId !== DEMO_PROJECT_ID && !project?.designSystemPreset) {
+        if (activeSpine.structuredPRD && capabilities.canGenerateArtifacts && !project?.designSystemPreset) {
             pendingIncompleteAck.current = ackIncomplete;
             setShowPresetChoice(true);
             return;
@@ -697,6 +712,7 @@ export function ProjectWorkspace() {
     };
 
     const handleUpdatePlanConfirm = (choices: Record<string, UpdatePlanChoice>) => {
+        if (!capabilities.canGenerateArtifacts) return;
         if (!projectId || !activeSpine?.structuredPRD || !updatePlan) return;
         // Finalize first — the durable record every path below depends on.
         markSpineFinal(projectId, activeSpine.id, true);
@@ -747,14 +763,14 @@ export function ProjectWorkspace() {
     };
 
     // Performs the actual finalize + asset kickoff. Split out so it can run
-    // either directly (preset already chosen / demo) or after the preset gate.
+    // either directly (preset already chosen) or after the preset gate.
     const finalizeAndGenerate = (ackIncomplete: boolean) => {
         if (!projectId || !activeSpine) return;
 
         // Re-finalize with existing assets: route through the Update Assets
         // plan instead of blindly regenerating everything. First finalize (no
-        // assets yet), the demo, and mid-run finalizes keep the direct path.
-        if (activeSpine.structuredPRD && projectId !== DEMO_PROJECT_ID) {
+        // assets yet) and mid-run finalizes keep the direct path.
+        if (activeSpine.structuredPRD && capabilities.canGenerateArtifacts) {
             const jobActive = !!assetJob && Object.values(assetJob.slots).some(
                 s => s && (s.status === 'generating' || s.status === 'queued'),
             );
@@ -773,7 +789,7 @@ export function ProjectWorkspace() {
         // while the success modal is visible. We deliberately do NOT switch
         // to the Assets stage yet — the modal owns the transition, and its
         // "Open Assets" action performs the navigation + panel auto-open.
-        if (activeSpine.structuredPRD && projectId !== DEMO_PROJECT_ID) {
+        if (activeSpine.structuredPRD && capabilities.canGenerateArtifacts) {
             artifactJobController.startAll({
                 projectId,
                 spineVersionId: activeSpine.id,
@@ -787,6 +803,7 @@ export function ProjectWorkspace() {
     };
 
     const handleChooseDesignSystemPreset = (presetId: string) => {
+        if (!capabilities.canManageDesignSystem) return;
         if (!projectId) return;
         // Persist the choice synchronously so the generation pipeline reads it
         // off the project when design_system runs.
@@ -803,7 +820,7 @@ export function ProjectWorkspace() {
         if (!projectId) return;
         setShowFinalizeSuccess(false);
         setFinalizeAutoOpen(true);
-        setProjectStage(projectId, 'workspace');
+        setPipelineStage('workspace');
     };
 
     const handleExport = () => {
@@ -836,7 +853,7 @@ export function ProjectWorkspace() {
                                     : `${getVersionLabel(activeSpine.id)} ${activeSpine.isFinal ? '(FINAL)' : ''}`
                             : 'Initializing...'}
                     </span>
-                    {projectId !== DEMO_PROJECT_ID && (
+                    {!capabilities.isReadOnly && (
                         <span className="hidden md:inline-flex shrink-0">
                             <ProjectCloudStatus projectId={projectId} signedIn={!!authUser} />
                         </span>
@@ -867,7 +884,7 @@ export function ProjectWorkspace() {
                         <Download size={14} />
                         <span className="hidden sm:inline">Export</span>
                     </button>
-                    {!isOldVersion && activeSpine?.safetyReview?.status !== 'blocked' && (
+                    {capabilities.canChangeFinality && !isOldVersion && activeSpine?.safetyReview?.status !== 'blocked' && (
                         <button
                             onClick={handleToggleFinal}
                             className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded transition ${activeSpine?.isFinal ? 'bg-green-600 hover:bg-green-700 text-white' : 'bg-neutral-800 hover:bg-neutral-700 text-neutral-300'}`}
@@ -899,28 +916,30 @@ export function ProjectWorkspace() {
                                 style={{ position: 'fixed', top: overflowMenuPos.top, right: overflowMenuPos.right }}
                                 className="bg-neutral-800 border border-neutral-700 rounded-lg shadow-xl py-1 z-[1000] min-w-[180px]"
                             >
-                                <button
-                                    onClick={() => { setIsSettingsOpen(true); setShowNavOverflow(false); }}
-                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition border-b border-white/5"
-                                >
-                                    <Settings size={14} className="text-indigo-400" />
-                                    Project Settings
-                                </button>
-                                <button
-                                    onClick={() => { setIsSnapshotsOpen(true); setShowNavOverflow(false); }}
-                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition border-b border-white/5"
-                                >
-                                    <Cloud size={14} className="text-indigo-400" />
-                                    Cloud Snapshots
-                                </button>
-                                <button
-                                    onClick={() => { handleRegenerate(); setShowNavOverflow(false); }}
-                                    disabled={isGenerating || hasBranches || isOldVersion}
-                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition disabled:opacity-30 disabled:hover:bg-transparent"
-                                >
-                                    <RefreshCcw size={14} className={`text-neutral-500 ${isGenerating ? 'animate-spin' : ''}`} />
-                                    {isGenerating ? 'Regenerating...' : 'Regenerate Draft'}
-                                </button>
+                                {!capabilities.isReadOnly && (<>
+                                    <button
+                                        onClick={() => { setIsSettingsOpen(true); setShowNavOverflow(false); }}
+                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition border-b border-white/5"
+                                    >
+                                        <Settings size={14} className="text-indigo-400" />
+                                        Project Settings
+                                    </button>
+                                    <button
+                                        onClick={() => { setIsSnapshotsOpen(true); setShowNavOverflow(false); }}
+                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition border-b border-white/5"
+                                    >
+                                        <Cloud size={14} className="text-indigo-400" />
+                                        Cloud Snapshots
+                                    </button>
+                                    <button
+                                        onClick={() => { handleRegenerate(); setShowNavOverflow(false); }}
+                                        disabled={isGenerating || hasBranches || isOldVersion}
+                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-300 hover:bg-white/5 transition disabled:opacity-30 disabled:hover:bg-transparent"
+                                    >
+                                        <RefreshCcw size={14} className={`text-neutral-500 ${isGenerating ? 'animate-spin' : ''}`} />
+                                        {isGenerating ? 'Regenerating...' : 'Regenerate Draft'}
+                                    </button>
+                                </>)}
                                 <button
                                     onClick={() => { setShowPrdHistory(true); setShowNavOverflow(false); }}
                                     disabled={allSpines.length === 0}
@@ -1048,7 +1067,7 @@ export function ProjectWorkspace() {
                         after: latestSpine?.structuredPRD,
                     })}
                     getStaleArtifactTitles={getStaleArtifactTitles}
-                    onRestore={handleRestoreSpine}
+                    onRestore={capabilities.canEditProjectContent ? handleRestoreSpine : undefined}
                     onClose={() => setShowPrdHistory(false)}
                 />
             )}
@@ -1058,10 +1077,12 @@ export function ProjectWorkspace() {
                     fromLabel={getVersionLabel(activeSpine.id)}
                     toLabel="Current"
                     onClose={() => setBannerCompareOpen(false)}
-                    onRestore={() => { setBannerCompareOpen(false); setBannerRestoreOpen(true); }}
+                    onRestore={capabilities.canEditProjectContent
+                        ? () => { setBannerCompareOpen(false); setBannerRestoreOpen(true); }
+                        : undefined}
                 />
             )}
-            {bannerRestoreOpen && activeSpine && (
+            {bannerRestoreOpen && activeSpine && capabilities.canEditProjectContent && (
                 <RevertConfirmModal
                     kind="prd"
                     sourceLabel={getVersionLabel(activeSpine.id)}
@@ -1090,21 +1111,16 @@ export function ProjectWorkspace() {
                 />
             </div>
 
-            {/* Demo-mode banner: shown only for the prepopulated demo project.
-                Regenerate / refine buttons stay active; the existing no-key
-                error paths surface readable messages if the user clicks one. */}
-            {projectId === DEMO_PROJECT_ID && (
-                <div className="shrink-0 bg-indigo-500/10 border-b border-indigo-500/30 text-indigo-200 text-sm px-4 py-2 flex items-center justify-center gap-2 z-10">
-                    <span>
-                        You&apos;re viewing the demo project. Regenerating or refining requires your own Gemini API key — add one in Settings to customize.
-                    </span>
-                </div>
+            {/* One workspace-level explanation; individual artifacts stay free
+                of repetitive read-only warnings. */}
+            {capabilities.isReadOnly && (
+                <DemoReadOnlyNotice />
             )}
 
             {/* Cross-device conflict banner: the cloud copy changed on another
                 device while this device has unsynced edits. Blocks silent
                 overwrite — the user picks keep-local / use-cloud / download. */}
-            {projectId !== DEMO_PROJECT_ID && authUser && (
+            {!capabilities.isReadOnly && authUser && (
                 <div className="shrink-0 px-4 py-2 z-10 empty:hidden">
                     <ProjectConflictBanner projectId={projectId} />
                 </div>
@@ -1138,12 +1154,14 @@ export function ProjectWorkspace() {
                                         Compare with current
                                     </button>
                                 )}
-                                <button
-                                    onClick={() => setBannerRestoreOpen(true)}
-                                    className="font-semibold underline hover:text-yellow-900"
-                                >
-                                    Restore this version
-                                </button>
+                                {capabilities.canEditProjectContent && (
+                                    <button
+                                        onClick={() => setBannerRestoreOpen(true)}
+                                        className="font-semibold underline hover:text-yellow-900"
+                                    >
+                                        Restore this version
+                                    </button>
+                                )}
                                 <button
                                     onClick={() => setViewedSpineId(null)}
                                     className="font-semibold underline hover:text-yellow-900"
@@ -1176,7 +1194,8 @@ export function ProjectWorkspace() {
                                 {/* Feedback items from mockups/artifacts */}
                                 <FeedbackItemsList
                                     projectId={projectId}
-                                    onApplyToPRD={handleApplyFeedback}
+                                    onApplyToPRD={capabilities.canEditProjectContent ? handleApplyFeedback : undefined}
+                                    readOnly={!capabilities.canReviewArtifacts}
                                 />
 
                                 {activeSpine ? (
@@ -1188,7 +1207,7 @@ export function ProjectWorkspace() {
                                                 <ProgressTimeline
                                                     steps={timelineSteps}
                                                     messages={prdProgress?.messages}
-                                                    onRetryStep={handleRetrySection}
+                                                    onRetryStep={capabilities.canGenerateArtifacts ? handleRetrySection : undefined}
                                                     retryingStepId={retryingStepId ?? undefined}
                                                     onViewHistory={() => setPipelineStage('history')}
                                                 />
@@ -1243,7 +1262,8 @@ export function ProjectWorkspace() {
                                             && !activeSpine.generationError
                                             && activeSpine.structuredPRD
                                             && !isPRDActivelyGenerating
-                                            && persistedFailedSections.length > 0 && (
+                                            && persistedFailedSections.length > 0
+                                            && capabilities.canGenerateArtifacts && (
                                             <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4">
                                                 <p className="font-semibold text-amber-900 text-sm mb-1">
                                                     This PRD is incomplete — {persistedFailedSections.length} section{persistedFailedSections.length > 1 ? 's' : ''} failed to generate
@@ -1271,7 +1291,7 @@ export function ProjectWorkspace() {
                                         {activeSpine.safetyReview?.status === 'blocked' ? (
                                             <SafetyReviewView
                                                 review={activeSpine.safetyReview}
-                                                canRevise={!isOldVersion && !hasBranches && !isGenerating}
+                                                canRevise={capabilities.canGenerateArtifacts && !isOldVersion && !hasBranches && !isGenerating}
                                                 onRevise={handleRegenerate}
                                             />
                                         ) : activeSpine.generationError ? (
@@ -1296,7 +1316,7 @@ export function ProjectWorkspace() {
                                                                 </div>
                                                             </details>
                                                         )}
-                                                        <div className="flex items-center gap-3">
+                                                        {capabilities.canGenerateArtifacts && <div className="flex items-center gap-3">
                                                             <button
                                                                 onClick={handleRegenerate}
                                                                 disabled={isGenerating || hasBranches}
@@ -1304,7 +1324,7 @@ export function ProjectWorkspace() {
                                                             >
                                                                 Try Again
                                                             </button>
-                                                        </div>
+                                                        </div>}
                                                     </div>
                                                 </div>
                                             </div>
@@ -1327,7 +1347,7 @@ export function ProjectWorkspace() {
                                                 projectId={projectId}
                                                 spineId={activeSpine.id}
                                                 structuredPRD={activeSpine.structuredPRD}
-                                                readOnly={isOldVersion}
+                                                readOnly={isOldVersion || !capabilities.canEditProjectContent}
                                             />
                                         ) : (
                                             <div className="prose prose-neutral max-w-none">
@@ -1335,7 +1355,7 @@ export function ProjectWorkspace() {
                                                     projectId={projectId}
                                                     spineVersionId={activeSpine.id}
                                                     text={activeSpine.responseText}
-                                                    readOnly={isOldVersion}
+                                                    readOnly={isOldVersion || !capabilities.canEditProjectContent}
                                                 />
                                             </div>
                                         )}
@@ -1345,7 +1365,7 @@ export function ProjectWorkspace() {
                                         <ProgressTimeline
                                             steps={timelineSteps}
                                             messages={prdProgress?.messages}
-                                            onRetryStep={handleRetrySection}
+                                            onRetryStep={capabilities.canGenerateArtifacts ? handleRetrySection : undefined}
                                             retryingStepId={retryingStepId ?? undefined}
                                             onViewHistory={() => setPipelineStage('history')}
                                         />
@@ -1397,6 +1417,7 @@ export function ProjectWorkspace() {
                                         spineVersionId={latestSpine.id}
                                         onConsolidate={(branch) => setConsolidatingBranch(branch)}
                                         onCanvasOpen={(branchId) => setActiveCanvasBranchId(branchId)}
+                                        readOnly={!capabilities.canEditProjectContent}
                                     />
                                 ) : (
                                     <div className="text-sm text-neutral-500 p-4 text-center border border-dashed border-neutral-300 rounded-lg bg-white shadow-sm mt-4 flex items-center justify-center gap-2">
@@ -1452,7 +1473,7 @@ export function ProjectWorkspace() {
 
             </div>
 
-            {consolidatingBranch && latestSpine && (
+            {capabilities.canEditProjectContent && consolidatingBranch && latestSpine && (
                 <ConsolidationModal
                     projectId={projectId}
                     branch={consolidatingBranch}
@@ -1461,7 +1482,7 @@ export function ProjectWorkspace() {
                 />
             )}
 
-            {activeCanvasBranchId && (
+            {capabilities.canEditProjectContent && activeCanvasBranchId && (
                 <BranchCanvas
                     projectId={projectId}
                     branchId={activeCanvasBranchId}

--- a/src/components/__tests__/DemoReadOnlySurfaces.test.tsx
+++ b/src/components/__tests__/DemoReadOnlySurfaces.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DEMO_PROJECT_ID } from '../../data/demoProject';
+import { useProjectStore } from '../../store/projectStore';
+import type { SpineVersion, StructuredPRD } from '../../types';
+import { DemoReadOnlyNotice } from '../DemoReadOnlyNotice';
+import { DependencyGraphView } from '../dependency/DependencyGraphView';
+import { VersionHistoryPanel } from '../versions';
+
+const structuredPRD = { productName: 'Demo' } as StructuredPRD;
+
+describe('read-only demo surfaces', () => {
+    it('communicates the policy once at workspace level', () => {
+        render(<DemoReadOnlyNotice />);
+
+        expect(screen.getByRole('status')).toHaveTextContent('read-only example project');
+        expect(screen.getByRole('status')).toHaveTextContent('without changing the saved project');
+    });
+
+    it('keeps dependency inspection usable while hiding generation controls', () => {
+        const spine: SpineVersion = {
+            id: 'spine-1',
+            projectId: DEMO_PROJECT_ID,
+            promptText: 'idea',
+            responseText: 'prd',
+            structuredPRD,
+            isLatest: true,
+            isFinal: true,
+            createdAt: 1,
+        };
+        useProjectStore.setState({
+            projects: { [DEMO_PROJECT_ID]: { id: DEMO_PROJECT_ID, name: 'Demo', createdAt: 1 } },
+            spineVersions: { [DEMO_PROJECT_ID]: [spine] },
+            artifacts: { [DEMO_PROJECT_ID]: [] },
+            artifactVersions: { [DEMO_PROJECT_ID]: [] },
+            jobs: {},
+        });
+
+        render(
+            <DependencyGraphView
+                projectId={DEMO_PROJECT_ID}
+                spineVersionId={spine.id}
+                prdContent={spine.responseText}
+                structuredPRD={structuredPRD}
+                onOpenNode={() => {}}
+            />,
+        );
+
+        expect(screen.queryByText(/Update 6 impacted/)).toBeNull();
+        fireEvent.click(screen.getByText('Impact View'));
+        expect(screen.getByText('Graph View')).toBeEnabled();
+        fireEvent.click(screen.getAllByText('Data Model')[0]);
+        expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled();
+        expect(screen.queryByRole('button', { name: 'Update' })).toBeNull();
+    });
+
+    it('allows version comparison but omits restore', () => {
+        render(
+            <VersionHistoryPanel
+                title="Artifact version history"
+                entries={[
+                    { id: 'v2', label: 'Version 2', isCurrent: true, createdAt: 2 },
+                    { id: 'v1', label: 'Version 1', isCurrent: false, createdAt: 1 },
+                ]}
+                restoreKind="artifact"
+                getCompareInput={() => ({ kind: 'text', before: 'old', after: 'new' })}
+                onClose={() => {}}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: /Compare/ })).toBeEnabled();
+        expect(screen.queryByRole('button', { name: /Restore/ })).toBeNull();
+    });
+});

--- a/src/components/__tests__/DependencyGraphView.test.tsx
+++ b/src/components/__tests__/DependencyGraphView.test.tsx
@@ -86,7 +86,7 @@ function seedStore(opts: { spines: SpineVersion[]; generated: boolean; artifactS
         versions.push(mockup.version);
     }
     useProjectStore.setState({
-        projects: {},
+        projects: { [PROJECT_ID]: { id: PROJECT_ID, name: 'Test', createdAt: 1 } },
         spineVersions: { [PROJECT_ID]: opts.spines },
         artifacts: { [PROJECT_ID]: artifacts },
         artifactVersions: { [PROJECT_ID]: versions },

--- a/src/components/__tests__/ScreenExperienceViews.test.tsx
+++ b/src/components/__tests__/ScreenExperienceViews.test.tsx
@@ -7,6 +7,7 @@ import { buildScreenReviewIndex, summarizeArtifactReviewReadiness } from '../../
 import { parseFlows } from '../renderers/userFlows/parseFlow';
 import { ScreenListView } from '../experience/ScreenListView';
 import { ScreenDetailView } from '../experience/ScreenDetailView';
+import { useProjectStore } from '../../store/projectStore';
 
 // Render smoke tests for the upgraded Screens experience views: the coverage
 // & readiness panel, list filters, and the structured Overview / Flow /
@@ -14,6 +15,7 @@ import { ScreenDetailView } from '../experience/ScreenDetailView';
 // states/refs/navigation), which must render fallbacks, never crash.
 
 beforeEach(() => {
+    useProjectStore.setState({ projects: { p1: { id: 'p1', name: 'Test', createdAt: 1 } } });
     vi.stubGlobal(
         'matchMedia',
         vi.fn().mockImplementation((query: string) => ({

--- a/src/components/__tests__/StructuredPRDReview.test.tsx
+++ b/src/components/__tests__/StructuredPRDReview.test.tsx
@@ -51,7 +51,7 @@ function seedStore() {
         createdAt: 1,
     };
     useProjectStore.setState({
-        projects: {},
+        projects: { [PROJECT_ID]: { id: PROJECT_ID, name: 'Test', createdAt: 1 } },
         spineVersions: { [PROJECT_ID]: [spine as SpineVersion] },
         historyEvents: {},
         branches: {},

--- a/src/components/dependency/DependencyGraphView.tsx
+++ b/src/components/dependency/DependencyGraphView.tsx
@@ -26,6 +26,7 @@ import { findFeatureReferences, makeSpineChangeResolver } from '../../lib/spineC
 import type {
     ArtifactSlotKey, GenerationStatus, ProjectPlatform, StructuredPRD,
 } from '../../types';
+import { useProjectCapabilities } from '../../hooks/useProjectCapabilities';
 
 interface DependencyGraphViewProps {
     projectId: string;
@@ -115,6 +116,7 @@ type ViewMode = 'graph' | 'impact';
 export function DependencyGraphView({
     projectId, spineVersionId, prdContent, structuredPRD, projectPlatform, onOpenNode,
 }: DependencyGraphViewProps) {
+    const capabilities = useProjectCapabilities(projectId);
     const {
         getArtifacts, getPreferredVersion, getSpineVersions, getArtifactVersions, getJob,
     } = useProjectStore();
@@ -192,6 +194,7 @@ export function DependencyGraphView({
     const startArgs = { projectId, spineVersionId, prdContent, structuredPRD, projectPlatform };
 
     const runUpdates = (order: DependencyNodeId[]) => {
+        if (!capabilities.canGenerateArtifacts) return;
         const slots = order.filter((id): id is ArtifactSlotKey => id !== 'prd');
         if (slots.length === 0) return;
         if (slots.length === 1) {
@@ -343,7 +346,7 @@ export function DependencyGraphView({
                             {summaryCounts.generating > 0 && ` · ${summaryCounts.generating} generating`}
                             {summaryCounts.error > 0 && ` · ${summaryCounts.error} failed`}
                         </span>
-                        {recommendedUpdates.length > 0 && (
+                            {capabilities.canGenerateArtifacts && recommendedUpdates.length > 0 && (
                             <button
                                 type="button"
                                 disabled={jobActive}
@@ -481,9 +484,9 @@ export function DependencyGraphView({
                     onClose={() => setSelectedId(null)}
                     onSelect={selectNode}
                     onOpenNode={onOpenNode}
-                    onUpdate={() => confirmSingleUpdate(selectedId)}
-                    onUpdateImpacted={() => confirmImpactedUpdate(selectedId)}
-                    onMarkCurrent={canMarkCurrent(selectedId) ? () => markCurrentNode(selectedId) : undefined}
+                    onUpdate={capabilities.canGenerateArtifacts ? () => confirmSingleUpdate(selectedId) : undefined}
+                    onUpdateImpacted={capabilities.canGenerateArtifacts ? () => confirmImpactedUpdate(selectedId) : undefined}
+                    onMarkCurrent={capabilities.canReviewArtifacts && canMarkCurrent(selectedId) ? () => markCurrentNode(selectedId) : undefined}
                     removedFeatureRefs={selectedRemovedFeatureRefs}
                     jobActive={jobActive}
                     titleOf={titleOf}
@@ -717,8 +720,8 @@ interface DetailPanelProps {
     onClose: () => void;
     onSelect: (id: DependencyNodeId) => void;
     onOpenNode: (id: DependencyNodeId) => void;
-    onUpdate: () => void;
-    onUpdateImpacted: () => void;
+    onUpdate?: () => void;
+    onUpdateImpacted?: () => void;
     /** Present only when the node is stale and can be confirmed current. */
     onMarkCurrent?: () => void;
     /** Removed-feature names this artifact's content still mentions. */
@@ -747,7 +750,7 @@ function DetailPanel({
     const Icon = NODE_ICONS[nodeId] ?? Package;
     const deps = getDirectDependencies(graph, nodeId);
     const { direct, indirect } = computeDownstreamImpacts(graph, nodeId);
-    const canUpdate = nodeId !== 'prd';
+    const canUpdate = nodeId !== 'prd' && Boolean(onUpdate);
     const impacted = evaluation.status === 'up_to_date' && evaluation.impactedBy.length > 0;
 
     const TABS: Array<{ key: DetailTab; label: string }> = [
@@ -935,7 +938,7 @@ function DetailPanel({
                                     </p>
                                 </div>
                             ) : null}
-                            {canUpdate && (direct.length > 0 || indirect.length > 0) && (
+                            {canUpdate && onUpdateImpacted && (direct.length > 0 || indirect.length > 0) && (
                                 <button
                                     type="button"
                                     disabled={jobActive}

--- a/src/components/experience/MockupVariantImage.tsx
+++ b/src/components/experience/MockupVariantImage.tsx
@@ -19,6 +19,7 @@ import { useMockupVariantImageStore } from '../../store/mockupVariantImageStore'
 import type { MockupVariantGenerationRequest } from '../../lib/mockupVariantRequest';
 import type { MockupVariantSourceSignature } from '../../lib/mockupVariantTrust';
 import { formatVariantLabel, type DerivedMockupVariant } from '../../lib/mockupVariants';
+import { useProjectCapabilities } from '../../hooks/useProjectCapabilities';
 
 interface Props {
     projectId: string;
@@ -42,6 +43,7 @@ export function MockupVariantImage({
     projectId, artifactId, versionId, platform, variant, request,
     sourceSignature, generatedFrom,
 }: Props) {
+    const capabilities = useProjectCapabilities(projectId);
     const scope = `${versionId}:${request.screenId}:${request.variantId}`;
     const record = useMockupVariantImageStore(s => s.getBestRecord(versionId, request.screenId, request.variantId));
     // Subscribe to the images map so a freshly-stored record re-renders us.
@@ -60,8 +62,10 @@ export function MockupVariantImage({
 
     const keyPresent = hasOpenAIKey();
     const uploadMode = getMockupImageMode() === 'user_uploaded';
-    const canGenerate = keyPresent && !uploadMode;
-    const gateReason = uploadMode ? UPLOAD_MODE_MESSAGE : DEMO_KEYLESS_MESSAGE;
+    const canGenerate = capabilities.canGenerateArtifacts && keyPresent && !uploadMode;
+    const gateReason = !capabilities.canGenerateArtifacts
+        ? 'This example project is read-only.'
+        : uploadMode ? UPLOAD_MODE_MESSAGE : DEMO_KEYLESS_MESSAGE;
 
     const handleGenerate = (quality: MockupImageQuality) => {
         if (!canGenerate) return;

--- a/src/components/mockups/MockupScreenImage.tsx
+++ b/src/components/mockups/MockupScreenImage.tsx
@@ -20,6 +20,7 @@ import { buildScreenScopeKey } from '../../lib/mockupImageStore';
 import { hasOpenAIKey } from '../../lib/openaiClient';
 import { getMockupImageMode, resolveMockupRender } from '../../lib/artifactModelSettings';
 import { MockupScreenUpload } from './MockupScreenUpload';
+import { useProjectCapabilities } from '../../hooks/useProjectCapabilities';
 
 interface Props {
     projectId: string;
@@ -51,6 +52,7 @@ const pickInitialQuality = (records: MockupImageRecord[]): MockupImageQuality | 
 };
 
 export function MockupScreenImage({ projectId, artifactId, versionId, screen, payload, settings, onGenerated }: Props) {
+    const capabilities = useProjectCapabilities(projectId);
     const scope = buildScreenScopeKey(versionId, screen.id);
     // Subscribe to the whole image map; filtered records are derived below.
     // The previous implementation subscribed only to a single keyed entry,
@@ -145,6 +147,7 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
     }
 
     const handleGenerate = (quality: MockupImageQuality) => {
+        if (!capabilities.canGenerateArtifacts) return;
         // High quality is the expensive variant — confirm before spending. Paid
         // OpenAI usage is billed to the user's own account via their key.
         if (quality === 'high' && typeof window !== 'undefined') {
@@ -219,7 +222,7 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
                         </div>
                     </div>
                 )}
-                <div className="px-4 py-2 border-t border-neutral-100 flex items-center justify-end">
+                {capabilities.canGenerateArtifacts && <div className="px-4 py-2 border-t border-neutral-100 flex items-center justify-end">
                     <button
                         type="button"
                         disabled={!keyPresent}
@@ -230,7 +233,7 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
                         <RefreshCw size={12} />
                         Regenerate
                     </button>
-                </div>
+                </div>}
             </div>
         );
     }
@@ -260,7 +263,7 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
                     <span className="text-left break-words">{error}</span>
                 </div>
             )}
-            <button
+            {capabilities.canGenerateArtifacts && <button
                 type="button"
                 disabled={!keyPresent}
                 onClick={() => handleGenerate('low')}
@@ -269,8 +272,8 @@ export function MockupScreenImage({ projectId, artifactId, versionId, screen, pa
             >
                 <Sparkles size={14} />
                 Generate AI image (low quality)
-            </button>
-            {!keyPresent && (
+            </button>}
+            {capabilities.canGenerateArtifacts && !keyPresent && (
                 <div className="mt-3 inline-flex items-center gap-1.5 text-[11px] text-neutral-500">
                     <SettingsIcon size={11} />
                     Add an OpenAI API key in Settings (gear icon) to enable.

--- a/src/components/mockups/MockupScreenUpload.tsx
+++ b/src/components/mockups/MockupScreenUpload.tsx
@@ -19,6 +19,7 @@ import { useScreenInventoryImageStore } from '../../store/screenInventoryImageSt
 import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
 import { buildScreenImagePrompt, pickImageSize } from '../../lib/services/mockupImageService';
 import { copyToClipboard } from '../../lib/utils/copyToClipboard';
+import { useProjectCapabilities } from '../../hooks/useProjectCapabilities';
 
 interface Props {
     projectId: string;
@@ -48,6 +49,7 @@ export function MockupScreenUpload({
     settings,
     forcedFallback,
 }: Props) {
+    const capabilities = useProjectCapabilities(projectId);
     const loadForArtifactVersion = useScreenInventoryImageStore((s) => s.loadForArtifactVersion);
     const upload = useScreenInventoryImageStore((s) => s.upload);
     const clearError = useScreenInventoryImageStore((s) => s.clearError);
@@ -115,11 +117,11 @@ export function MockupScreenUpload({
                         <span className="text-[11px] text-neutral-400">
                             {new Date(preferred.generatedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                         </span>
-                        <label className="ml-auto inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 cursor-pointer transition">
+                        {capabilities.canEditArtifacts && <label className="ml-auto inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md text-neutral-600 hover:bg-neutral-100 cursor-pointer transition">
                             <Upload size={12} />
                             Replace
                             <input type="file" accept="image/*" className="hidden" onChange={handleFile} />
-                        </label>
+                        </label>}
                     </div>
                 </>
             ) : (
@@ -160,7 +162,7 @@ export function MockupScreenUpload({
                         </div>
                     )}
 
-                    <div className="mt-4 flex items-center gap-3">
+                    {capabilities.canEditArtifacts && <div className="mt-4 flex items-center gap-3">
                         <label className={`inline-flex items-center gap-2 text-sm px-4 py-2 rounded-md font-medium cursor-pointer transition ${
                             isUploading
                                 ? 'bg-neutral-200 text-neutral-500 cursor-wait'
@@ -177,7 +179,7 @@ export function MockupScreenUpload({
                             />
                         </label>
                         <span className="text-[11px] text-neutral-400">Waiting for your upload</span>
-                    </div>
+                    </div>}
                 </div>
             )}
         </div>

--- a/src/components/renderers/ScreenImageGallery.tsx
+++ b/src/components/renderers/ScreenImageGallery.tsx
@@ -4,6 +4,7 @@ import type { DesignTokens, ScreenItem } from '../../types';
 import { useScreenInventoryImageStore } from '../../store/screenInventoryImageStore';
 import { buildExternalMockupPrompt } from '../../lib/services/screenInventoryImageService';
 import { slugifyScreenName } from '../../lib/screenInventoryImageStore';
+import { useProjectCapabilities } from '../../hooks/useProjectCapabilities';
 
 export interface ScreenImageGalleryContext {
     projectId: string;
@@ -35,6 +36,7 @@ interface Props {
 
 export function ScreenImageGallery({ screen, context, storageName }: Props) {
     const { projectId, artifactId, artifactVersionId, productTitle, productSummary, designTokens, platformHint } = context;
+    const capabilities = useProjectCapabilities(projectId);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [copied, setCopied] = useState(false);
     const [lightboxKey, setLightboxKey] = useState<string | null>(null);
@@ -88,26 +90,28 @@ export function ScreenImageGallery({ screen, context, storageName }: Props) {
                     {copied ? <Check size={12} className="text-green-600" /> : <Copy size={12} />}
                     {copied ? 'Copied' : 'Copy image prompt'}
                 </button>
-                <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={isUploading}
-                    className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded bg-indigo-50 text-indigo-700 hover:bg-indigo-100 disabled:opacity-60 disabled:cursor-not-allowed transition"
-                >
-                    {isUploading ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
-                    {isUploading ? 'Uploading…' : versions.length === 0 ? 'Upload image' : 'Upload new'}
-                </button>
-                <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/*"
-                    className="hidden"
-                    onChange={(e) => {
-                        handleFile(e.target.files?.[0]);
-                        // Reset so re-uploading the same filename still triggers onChange.
-                        if (fileInputRef.current) fileInputRef.current.value = '';
-                    }}
-                />
+                {capabilities.canEditArtifacts && <>
+                    <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={isUploading}
+                        className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded bg-indigo-50 text-indigo-700 hover:bg-indigo-100 disabled:opacity-60 disabled:cursor-not-allowed transition"
+                    >
+                        {isUploading ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
+                        {isUploading ? 'Uploading…' : versions.length === 0 ? 'Upload image' : 'Upload new'}
+                    </button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={(e) => {
+                            handleFile(e.target.files?.[0]);
+                            // Reset so re-uploading the same filename still triggers onChange.
+                            if (fileInputRef.current) fileInputRef.current.value = '';
+                        }}
+                    />
+                </>}
             </div>
 
             {error && (
@@ -145,9 +149,12 @@ export function ScreenImageGallery({ screen, context, storageName }: Props) {
                                     type="button"
                                     onClick={() => {
                                         if (isActive) setLightboxKey(v.key);
-                                        else void setPreferred(artifactVersionId, screen.name, v.versionNumber);
+                                        else if (capabilities.canEditArtifacts) void setPreferred(artifactVersionId, screen.name, v.versionNumber);
+                                        else setLightboxKey(v.key);
                                     }}
-                                    title={isActive ? `v${v.versionNumber} (active) — click to enlarge` : `Switch to v${v.versionNumber}`}
+                                    title={isActive
+                                        ? `v${v.versionNumber} (active) — click to enlarge`
+                                        : capabilities.canEditArtifacts ? `Switch to v${v.versionNumber}` : `View v${v.versionNumber}`}
                                     className={`relative w-10 h-10 rounded overflow-hidden border transition ${
                                         isActive
                                             ? 'border-indigo-500 ring-2 ring-indigo-200'

--- a/src/components/tasks/TaskChecklist.tsx
+++ b/src/components/tasks/TaskChecklist.tsx
@@ -14,6 +14,7 @@ const EMPTY_TASKS: ProjectTask[] = [];
 interface TaskChecklistProps {
     projectId: string;
     sourceArtifactId: string;
+    readOnly?: boolean;
 }
 
 const PRIORITY_STYLE: Record<string, string> = {
@@ -32,11 +33,12 @@ const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
     blocked: 'todo',
 };
 
-function StatusButton({ status, onClick }: { status: TaskStatus; onClick: () => void }) {
-    const label =
+function StatusButton({ status, onClick, disabled = false }: { status: TaskStatus; onClick: () => void; disabled?: boolean }) {
+    const actionLabel =
         status === 'done' ? 'Done — click to reset'
             : status === 'in_progress' ? 'In progress — click to mark done'
                 : 'To do — click to start';
+    const label = disabled ? `${status.replace('_', ' ')} (read-only)` : actionLabel;
     const Icon = status === 'done' ? CheckCircle2 : status === 'in_progress' ? Clock : Circle;
     const color =
         status === 'done' ? 'text-green-600'
@@ -46,6 +48,7 @@ function StatusButton({ status, onClick }: { status: TaskStatus; onClick: () => 
         <button
             type="button"
             onClick={onClick}
+            disabled={disabled}
             aria-label={label}
             title={label}
             className={`shrink-0 p-1 -m-1 transition ${color}`}
@@ -55,7 +58,7 @@ function StatusButton({ status, onClick }: { status: TaskStatus; onClick: () => 
     );
 }
 
-export function TaskChecklist({ projectId, sourceArtifactId }: TaskChecklistProps) {
+export function TaskChecklist({ projectId, sourceArtifactId, readOnly = false }: TaskChecklistProps) {
     const tasks = useProjectStore(s => s.tasks[projectId] ?? EMPTY_TASKS);
     const setTaskStatus = useProjectStore(s => s.setTaskStatus);
     const removeProjectTask = useProjectStore(s => s.removeProjectTask);
@@ -96,9 +99,10 @@ export function TaskChecklist({ projectId, sourceArtifactId }: TaskChecklistProp
                                 <StatusButton
                                     status={task.status}
                                     onClick={() => setTaskStatus(projectId, task.id, NEXT_STATUS[task.status])}
+                                    disabled={readOnly}
                                 />
                                 <div className="flex-1 min-w-0">
-                                    <button
+                                    {!readOnly && <button
                                         type="button"
                                         onClick={() => setExpandedId(expanded ? null : task.id)}
                                         className="w-full flex items-center gap-1.5 text-left"
@@ -107,7 +111,7 @@ export function TaskChecklist({ projectId, sourceArtifactId }: TaskChecklistProp
                                         <span className={`text-sm font-medium truncate ${task.status === 'done' ? 'text-neutral-400 line-through' : 'text-neutral-800'}`}>
                                             {task.title}
                                         </span>
-                                    </button>
+                                    </button>}
                                     {expanded && (
                                         <div className="mt-2 ml-[19px] space-y-2">
                                             <p className="text-xs text-neutral-600 leading-relaxed">{task.summary}</p>

--- a/src/components/versions/VersionHistoryPanel.tsx
+++ b/src/components/versions/VersionHistoryPanel.tsx
@@ -26,7 +26,7 @@ interface VersionHistoryPanelProps {
     getCompareInput: (id: string) => CompareInput;
     // PRD only: downstream artifacts that would go stale on restore.
     getStaleArtifactTitles?: () => string[];
-    onRestore: (id: string) => void;
+    onRestore?: (id: string) => void;
     onClose: () => void;
 }
 
@@ -68,6 +68,7 @@ export function VersionHistoryPanel({
     const confirmEntry = entries.find(e => e.id === confirmId) ?? null;
 
     const doRestore = (id: string) => {
+        if (!onRestore) return;
         onRestore(id);
         setConfirmId(null);
         setCompareId(null);
@@ -139,13 +140,15 @@ export function VersionHistoryPanel({
                                             >
                                                 <GitCompare size={12} /> Compare
                                             </button>
-                                            <button
-                                                type="button"
-                                                onClick={() => setConfirmId(entry.id)}
-                                                className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition min-h-[36px]"
-                                            >
-                                                <RotateCcw size={12} /> Restore
-                                            </button>
+                                            {onRestore && (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setConfirmId(entry.id)}
+                                                    className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition min-h-[36px]"
+                                                >
+                                                    <RotateCcw size={12} /> Restore
+                                                </button>
+                                            )}
                                         </div>
                                     )}
                                 </div>
@@ -161,7 +164,7 @@ export function VersionHistoryPanel({
                     fromLabel={compareEntry.label}
                     toLabel="Current"
                     onClose={() => setCompareId(null)}
-                    onRestore={() => setConfirmId(compareEntry.id)}
+                    onRestore={onRestore ? () => setConfirmId(compareEntry.id) : undefined}
                 />
             )}
 

--- a/src/hooks/useProjectCapabilities.ts
+++ b/src/hooks/useProjectCapabilities.ts
@@ -1,0 +1,7 @@
+import { getProjectCapabilities } from '../lib/projectCapabilities';
+import { useProjectStore } from '../store/projectStore';
+
+export function useProjectCapabilities(projectId: string | undefined) {
+    const project = useProjectStore((state) => projectId ? state.projects[projectId] : undefined);
+    return getProjectCapabilities(project);
+}

--- a/src/lib/__tests__/projectCapabilities.test.ts
+++ b/src/lib/__tests__/projectCapabilities.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { DEMO_PROJECT_ID } from '../../data/demoProject';
+import {
+    ProjectCapabilityError,
+    assertProjectCapability,
+    getProjectCapabilities,
+} from '../projectCapabilities';
+
+describe('project capabilities', () => {
+    it('denies every durable capability for the public demo while allowing exploration', () => {
+        const capabilities = getProjectCapabilities({ id: DEMO_PROJECT_ID });
+
+        expect(capabilities).toEqual({
+            isReadOnly: true,
+            canExplore: true,
+            canEditProjectContent: false,
+            canChangeFinality: false,
+            canEditArtifacts: false,
+            canReviewArtifacts: false,
+            canGenerateArtifacts: false,
+            canManageDesignSystem: false,
+            canPersistWorkflowState: false,
+            canExportExternally: false,
+        });
+    });
+
+    it('keeps ordinary projects editable', () => {
+        const capabilities = getProjectCapabilities({ id: 'ordinary-project' });
+
+        expect(capabilities.isReadOnly).toBe(false);
+        expect(capabilities.canExplore).toBe(true);
+        expect(Object.entries(capabilities)
+            .filter(([key]) => key.startsWith('can'))
+            .every(([, value]) => value)).toBe(true);
+    });
+
+    it('fails conservatively for an unknown or missing project', () => {
+        expect(getProjectCapabilities(undefined).canExplore).toBe(false);
+        expect(getProjectCapabilities(null).canEditArtifacts).toBe(false);
+        expect(() => assertProjectCapability(undefined, 'canEditProjectContent'))
+            .toThrow(ProjectCapabilityError);
+    });
+
+    it('rejects a protected demo mutation with a stable user-facing error', () => {
+        expect(() => assertProjectCapability({ id: DEMO_PROJECT_ID }, 'canGenerateArtifacts'))
+            .toThrow('This example project is read-only.');
+    });
+});

--- a/src/lib/projectCapabilities.ts
+++ b/src/lib/projectCapabilities.ts
@@ -1,0 +1,83 @@
+import { DEMO_PROJECT_ID } from '../data/demoProject';
+
+export interface ProjectCapabilities {
+    isReadOnly: boolean;
+    canExplore: boolean;
+    canEditProjectContent: boolean;
+    canChangeFinality: boolean;
+    canEditArtifacts: boolean;
+    canReviewArtifacts: boolean;
+    canGenerateArtifacts: boolean;
+    canManageDesignSystem: boolean;
+    canPersistWorkflowState: boolean;
+    canExportExternally: boolean;
+}
+
+export type DurableProjectCapability = Exclude<keyof ProjectCapabilities, 'isReadOnly' | 'canExplore'>;
+
+type ProjectIdentity = { id: string } | null | undefined;
+
+const EDITABLE_CAPABILITIES: ProjectCapabilities = Object.freeze({
+    isReadOnly: false,
+    canExplore: true,
+    canEditProjectContent: true,
+    canChangeFinality: true,
+    canEditArtifacts: true,
+    canReviewArtifacts: true,
+    canGenerateArtifacts: true,
+    canManageDesignSystem: true,
+    canPersistWorkflowState: true,
+    canExportExternally: true,
+});
+
+const READ_ONLY_CAPABILITIES: ProjectCapabilities = Object.freeze({
+    isReadOnly: true,
+    canExplore: true,
+    canEditProjectContent: false,
+    canChangeFinality: false,
+    canEditArtifacts: false,
+    canReviewArtifacts: false,
+    canGenerateArtifacts: false,
+    canManageDesignSystem: false,
+    canPersistWorkflowState: false,
+    canExportExternally: false,
+});
+
+const UNAVAILABLE_CAPABILITIES: ProjectCapabilities = Object.freeze({
+    ...READ_ONLY_CAPABILITIES,
+    canExplore: false,
+});
+
+/**
+ * The authoritative durable-action policy for a project. A missing project is
+ * deliberately unavailable rather than optimistically editable; callers must
+ * pass an identity that actually exists in the active project namespace.
+ */
+export function getProjectCapabilities(project: ProjectIdentity): ProjectCapabilities {
+    if (!project?.id) return UNAVAILABLE_CAPABILITIES;
+    return project.id === DEMO_PROJECT_ID ? READ_ONLY_CAPABILITIES : EDITABLE_CAPABILITIES;
+}
+
+export class ProjectCapabilityError extends Error {
+    readonly capability: DurableProjectCapability;
+    readonly projectId?: string;
+
+    constructor(project: ProjectIdentity, capability: DurableProjectCapability) {
+        super(project?.id === DEMO_PROJECT_ID
+            ? 'This example project is read-only.'
+            : 'This project is unavailable or does not allow that action.');
+        this.name = 'ProjectCapabilityError';
+        this.capability = capability;
+        this.projectId = project?.id;
+    }
+}
+
+/** Domain-boundary guard for all durable project mutations. */
+export function assertProjectCapability(
+    project: ProjectIdentity,
+    capability: DurableProjectCapability,
+): void {
+    if (!getProjectCapabilities(project)[capability]) {
+        throw new ProjectCapabilityError(project, capability);
+    }
+}

--- a/src/lib/services/artifactJobController.ts
+++ b/src/lib/services/artifactJobController.ts
@@ -43,6 +43,14 @@ import { hasOpenAIKey } from '../openaiClient';
 import { selectPreferredDesignSystem } from '../designTokens';
 import { parseScreenInventory } from '../screenInventoryNormalize';
 import { parseComponentInventoryMarkdown } from '../componentInventoryParse';
+import { assertProjectCapability } from '../projectCapabilities';
+
+function assertArtifactGenerationAllowed(projectId: string): void {
+    assertProjectCapability(
+        useProjectStore.getState().projects[projectId],
+        'canGenerateArtifacts',
+    );
+}
 
 export interface StartArgs {
     projectId: string;
@@ -731,6 +739,7 @@ export const artifactJobController = {
      * completion only queues slots still missing.
      */
     startAll(args: StartArgs): void {
+        assertArtifactGenerationAllowed(args.projectId);
         // Downstream protection: a spine blocked by safety review — or an
         // incomplete (partial) PRD the user hasn't acknowledged — can never
         // drive artifact generation, even if startAll is reached directly.
@@ -780,6 +789,7 @@ export const artifactJobController = {
      * their update buttons off the live job state.
      */
     regenerateSlots(slots: ArtifactSlotKey[], args: StartArgs): void {
+        assertArtifactGenerationAllowed(args.projectId);
         const spine = (useProjectStore.getState().spineVersions[args.projectId] || [])
             .find(s => s.id === args.spineVersionId);
         if (!evaluateSpineGenerationGate(spine, { acknowledgeIncomplete: args.acknowledgeIncomplete }).allowed) return;
@@ -827,6 +837,7 @@ export const artifactJobController = {
      * race against it.
      */
     retrySlot(slot: ArtifactSlotKey, args: StartArgs): void {
+        assertArtifactGenerationAllowed(args.projectId);
         const failureKey = retryFailureKey(args.projectId, slot);
         if ((retryFailures.get(failureKey) ?? 0) >= MAX_RETRY_FAILURES) {
             useProjectStore.getState().setSlotStatus(args.projectId, slot, {
@@ -916,6 +927,7 @@ export const artifactJobController = {
      * final spine. Skips when generation is already active.
      */
     resumeIfNeeded(args: StartArgs): void {
+        assertArtifactGenerationAllowed(args.projectId);
         if (this.isActive(args.projectId)) return;
         // Only auto-wake for *visible* pending slots. A hidden slot that errored
         // stays pending forever (no version), and without this filter every

--- a/src/store/__tests__/demoReadOnlyMutations.test.ts
+++ b/src/store/__tests__/demoReadOnlyMutations.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DEMO_PROJECT_ID } from '../../data/demoProject';
+import { artifactJobController } from '../../lib/services/artifactJobController';
+import type { StructuredPRD } from '../../types';
+import { useProjectStore } from '../projectStore';
+
+const projectId = DEMO_PROJECT_ID;
+const spineId = 'demo-spine';
+const artifactId = 'demo-artifact';
+const versionId = 'demo-version';
+
+const structuredPRD = { productName: 'Demo' } as StructuredPRD;
+
+beforeEach(() => {
+    useProjectStore.setState({
+        projects: {
+            [projectId]: { id: projectId, name: 'Demo', createdAt: 1, designSystemPreset: 'minimal' },
+        },
+        spineVersions: {
+            [projectId]: [{
+                id: spineId,
+                projectId,
+                promptText: 'Demo idea',
+                responseText: 'Demo PRD',
+                createdAt: 1,
+                isLatest: true,
+                isFinal: true,
+                structuredPRD,
+            }],
+        },
+        artifacts: {
+            [projectId]: [{
+                id: artifactId,
+                projectId,
+                type: 'core_artifact',
+                subtype: 'screen_inventory',
+                title: 'Screens',
+                status: 'active',
+                currentVersionId: versionId,
+                createdAt: 1,
+                updatedAt: 1,
+            }],
+        },
+        artifactVersions: {
+            [projectId]: [{
+                id: versionId,
+                artifactId,
+                versionNumber: 1,
+                parentVersionId: null,
+                content: 'saved screen content',
+                metadata: { screenEdits: {}, reviewStatus: 'draft' },
+                sourceRefs: [],
+                generationPrompt: 'demo',
+                isPreferred: true,
+                createdAt: 1,
+            }],
+        },
+        historyEvents: { [projectId]: [] },
+        branches: { [projectId]: [] },
+        feedbackItems: { [projectId]: [] },
+        tasks: { [projectId]: [] },
+        workflowRuns: { [projectId]: [] },
+        jobs: {},
+        prdProgress: {},
+        prdSectionStatus: {},
+    });
+});
+
+describe('public demo mutation boundary', () => {
+    it('rejects finality and PRD content changes without changing state', () => {
+        const store = useProjectStore.getState();
+
+        expect(() => store.markSpineFinal(projectId, spineId, false)).toThrow('read-only');
+        expect(() => store.editSpineStructuredPRD(projectId, spineId, structuredPRD))
+            .toThrow('read-only');
+        expect(store.getLatestSpine(projectId)?.isFinal).toBe(true);
+        expect(store.getSpineVersions(projectId)).toHaveLength(1);
+    });
+
+    it('rejects screen edits and review metadata changes', () => {
+        const store = useProjectStore.getState();
+
+        expect(() => store.updateArtifactVersionMetadata(
+            projectId,
+            artifactId,
+            versionId,
+            { screenEdits: { home: { name: 'Changed' } } },
+        )).toThrow('read-only');
+        expect(() => store.updateArtifactVersionMetadata(
+            projectId,
+            artifactId,
+            versionId,
+            { reviewStatus: 'accepted' },
+        )).toThrow('read-only');
+        expect(store.getPreferredVersion(projectId, artifactId)?.metadata).toEqual({
+            screenEdits: {},
+            reviewStatus: 'draft',
+        });
+    });
+
+    it('rejects generation and regeneration before any job starts', () => {
+        const args = {
+            projectId,
+            spineVersionId: spineId,
+            prdContent: 'Demo PRD',
+            structuredPRD,
+        };
+
+        expect(() => artifactJobController.startAll(args)).toThrow('read-only');
+        expect(() => artifactJobController.retrySlot('screen_inventory', args)).toThrow('read-only');
+        expect(useProjectStore.getState().getJob(projectId)).toBeUndefined();
+    });
+
+    it('rejects design-system and persisted workflow changes', () => {
+        const store = useProjectStore.getState();
+
+        expect(() => store.setProjectDesignSystemPreset(projectId, 'creative_studio')).toThrow('read-only');
+        expect(() => store.saveTasks(projectId, artifactId, [])).toThrow('read-only');
+        expect(useProjectStore.getState().projects[projectId].designSystemPreset).toBe('minimal');
+    });
+
+    it('keeps the same representative operations available to ordinary projects', () => {
+        const store = useProjectStore.getState();
+        const { projectId: editableId, spineId: editableSpineId } = store.createProject('Editable', 'Idea');
+
+        expect(() => store.markSpineFinal(editableId, editableSpineId, true)).not.toThrow();
+        expect(() => store.setProjectDesignSystemPreset(editableId, 'creative_studio')).not.toThrow();
+        const { artifactId: editableArtifactId } = store.createArtifact(
+            editableId,
+            'core_artifact',
+            'Screens',
+            'screen_inventory',
+        );
+        expect(() => store.createArtifactVersion(
+            editableId,
+            editableArtifactId,
+            'content',
+            {},
+            [],
+            'prompt',
+        )).not.toThrow();
+        expect(useProjectStore.getState().getLatestSpine(editableId)?.isFinal).toBe(true);
+    });
+});

--- a/src/store/__tests__/designSetupState.test.ts
+++ b/src/store/__tests__/designSetupState.test.ts
@@ -41,10 +41,10 @@ describe('design setup project state', () => {
         expect(project.designSystemPreset).toBeUndefined();
     });
 
-    it('both actions are no-ops for unknown projects', () => {
+    it('both actions reject unknown projects conservatively', () => {
         const before = useProjectStore.getState().projects;
-        useProjectStore.getState().setProjectDesignSystemPreset('nope', 'custom');
-        useProjectStore.getState().markDesignSetupComplete('nope');
+        expect(() => useProjectStore.getState().setProjectDesignSystemPreset('nope', 'custom')).toThrow();
+        expect(() => useProjectStore.getState().markDesignSetupComplete('nope')).toThrow();
         expect(useProjectStore.getState().projects).toEqual(before);
     });
 });

--- a/src/store/__tests__/metricsSlice.test.ts
+++ b/src/store/__tests__/metricsSlice.test.ts
@@ -4,7 +4,10 @@ import type { WorkflowRun } from '../../types';
 
 const reset = () =>
     useProjectStore.setState({
-        projects: {},
+        projects: {
+            p1: { id: 'p1', name: 'Project 1', createdAt: 1 },
+            p2: { id: 'p2', name: 'Project 2', createdAt: 1 },
+        },
         spineVersions: {},
         historyEvents: {},
         branches: {},

--- a/src/store/__tests__/mockupUpload.test.ts
+++ b/src/store/__tests__/mockupUpload.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../lib/screenInventoryImageStore', () => {
 });
 
 import { useScreenInventoryImageStore } from '../screenInventoryImageStore';
+import { useProjectStore } from '../projectStore';
 
 const makeFile = (name = 'mock.png') =>
     new File([new Uint8Array([1, 2, 3, 4])], name, { type: 'image/png' });
@@ -40,6 +41,7 @@ const makeFile = (name = 'mock.png') =>
 describe('mockup manual upload — uploaded image accepted as the mockup source', () => {
     beforeEach(() => {
         useScreenInventoryImageStore.setState({ images: {}, hydrated: {}, uploading: {}, errors: {} });
+        useProjectStore.setState({ projects: { p1: { id: 'p1', name: 'Test', createdAt: 1 } } });
     });
 
     it('stores an uploaded file as the preferred image for a mockup screen', async () => {

--- a/src/store/__tests__/mockupVariantImageStore.test.ts
+++ b/src/store/__tests__/mockupVariantImageStore.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../lib/openaiClient', () => ({
 vi.mock('../../lib/designTokens', () => ({ selectPreferredDesignTokens: () => undefined }));
 
 import { useMockupVariantImageStore } from '../mockupVariantImageStore';
+import { useProjectStore } from '../projectStore';
 
 const makeRequest = (
     overrides: Partial<MockupVariantGenerationRequest> = {},
@@ -65,6 +66,7 @@ describe('mockupVariantImageStore.generate', () => {
         shouldFail = false;
         currentB64 = 'BASE64DATA';
         useMockupVariantImageStore.setState({ images: {}, inFlight: {}, errors: {} });
+        useProjectStore.setState({ projects: { p1: { id: 'p1', name: 'Test', createdAt: 1 } } });
     });
 
     it('stores a generated variant under a per-variant key with its manifest', async () => {

--- a/src/store/__tests__/tasksSlice.test.ts
+++ b/src/store/__tests__/tasksSlice.test.ts
@@ -4,7 +4,7 @@ import type { ImplementationTask } from '../../types/tasks';
 
 const reset = () =>
     useProjectStore.setState({
-        projects: {},
+        projects: { p1: { id: 'p1', name: 'Test', createdAt: 1 } },
         spineVersions: {},
         historyEvents: {},
         branches: {},

--- a/src/store/mockupImageStore.ts
+++ b/src/store/mockupImageStore.ts
@@ -19,6 +19,7 @@ import { callOpenAIImage } from '../lib/openaiClient';
 import { buildScreenImagePrompt, pickImageSize } from '../lib/services/mockupImageService';
 import { selectPreferredDesignTokens } from '../lib/designTokens';
 import { useProjectStore } from './projectStore';
+import { assertProjectCapability } from '../lib/projectCapabilities';
 import {
     buildImageKey,
     buildScreenScopeKey,
@@ -162,6 +163,7 @@ export const useMockupImageStore = create<ImageStoreState>((set, get) => ({
     },
 
     generate: async ({ projectId, artifactId, versionId, screen, payload, settings, quality, onGenerated }) => {
+        assertProjectCapability(useProjectStore.getState().projects[projectId], 'canGenerateArtifacts');
         const scope = screenScope(versionId, screen.id);
         if (get().inFlight[scope]) return; // already generating something for this screen
 

--- a/src/store/mockupVariantImageStore.ts
+++ b/src/store/mockupVariantImageStore.ts
@@ -25,6 +25,7 @@ import {
 import type { MockupPlatform } from '../types';
 import { selectPreferredDesignTokens } from '../lib/designTokens';
 import { useProjectStore } from './projectStore';
+import { assertProjectCapability } from '../lib/projectCapabilities';
 import {
     buildVariantImageKey,
     getVariantImage as idbGetVariantImage,
@@ -137,6 +138,7 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
     },
 
     putSidecar: async (record) => {
+        assertProjectCapability(useProjectStore.getState().projects[record.projectId], 'canEditArtifacts');
         await idbPutVariantImage(record);
         set((state) => ({ images: { ...state.images, [record.key]: record } }));
     },
@@ -154,6 +156,7 @@ export const useMockupVariantImageStore = create<VariantImageStoreState>((set, g
         projectId, artifactId, versionId, platform, request, quality,
         sourceSignature, generatedFrom,
     }) => {
+        assertProjectCapability(useProjectStore.getState().projects[projectId], 'canGenerateArtifacts');
         const scope = variantScope(versionId, request.screenId, request.variantId);
         if (get().inFlight[scope]) return; // one generation per variant at a time
 

--- a/src/store/screenInventoryImageStore.ts
+++ b/src/store/screenInventoryImageStore.ts
@@ -18,6 +18,8 @@ import {
     setPreferredScreenImage as idbSetPreferred,
     slugifyScreenName,
 } from '../lib/screenInventoryImageStore';
+import { assertProjectCapability } from '../lib/projectCapabilities';
+import { useProjectStore } from './projectStore';
 
 interface UploadArgs {
     projectId: string;
@@ -101,6 +103,7 @@ export const useScreenInventoryImageStore = create<ImageStoreState>((set, get) =
     },
 
     upload: async ({ projectId, artifactId, artifactVersionId, screenName, file, prompt }) => {
+        assertProjectCapability(useProjectStore.getState().projects[projectId], 'canEditArtifacts');
         const slug = slugifyScreenName(screenName);
         const bucket = bucketKey(artifactVersionId, slug);
         if (get().uploading[bucket]) return;
@@ -162,6 +165,13 @@ export const useScreenInventoryImageStore = create<ImageStoreState>((set, get) =
 
     setPreferred: async (artifactVersionId, screenName, versionNumber) => {
         const slug = slugifyScreenName(screenName);
+        const record = Object.values(get().images).find(
+            image => image.artifactVersionId === artifactVersionId && image.screenSlug === slug,
+        );
+        assertProjectCapability(
+            record ? useProjectStore.getState().projects[record.projectId] : undefined,
+            'canEditArtifacts',
+        );
         const updated = await idbSetPreferred(artifactVersionId, slug, versionNumber);
         if (updated.length === 0) return;
         set((state) => {

--- a/src/store/slices/artifactSlice.ts
+++ b/src/store/slices/artifactSlice.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { Artifact, ArtifactVersion, ArtifactType, CoreArtifactSubtype, SourceRef, HistoryEvent, VersionProvenance } from '../../types';
 import type { ProjectState } from '../types';
 import { trackActivity } from '../../lib/recruiterApi';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 
 export type ArtifactSlice = {
     artifacts: Record<string, Artifact[]>;
@@ -27,6 +28,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
     artifactVersions: {},
 
     createArtifact: (projectId: string, type: ArtifactType, title: string, subtype?: CoreArtifactSubtype) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         const artifactId = uuidv4();
         const now = Date.now();
         const newArtifact: Artifact = {
@@ -52,6 +54,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
     },
 
     updateArtifact: (projectId: string, artifactId: string, updates: Partial<Pick<Artifact, 'title' | 'status'>>) => {
+        assertProjectCapability(get().projects[projectId], 'canEditArtifacts');
         set((state) => {
             const projectArtifacts = state.artifacts[projectId] || [];
             const updatedArtifacts = projectArtifacts.map(a =>
@@ -64,6 +67,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
     },
 
     deleteArtifact: (projectId: string, artifactId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditArtifacts');
         set((state) => ({
             artifacts: {
                 ...state.artifacts,
@@ -97,6 +101,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
         parentVersionId?: string | null,
         provenance?: VersionProvenance,
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         const versionId = uuidv4();
         const now = Date.now();
         const historyEventId = uuidv4();
@@ -180,6 +185,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
     // incrementing and the timeline shows the revert as its own honest event.
     // All reads happen inside set() against the fresh `state` (concurrency rule).
     revertArtifactToVersion: (projectId: string, artifactId: string, sourceVersionId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditArtifacts');
         const allVersions = get().artifactVersions[projectId] || [];
         const source = allVersions.find(v => v.id === sourceVersionId && v.artifactId === artifactId);
         if (!source) throw new Error('No artifact version to restore');
@@ -255,6 +261,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
     // leave the graph reporting dependency_changed. All reads inside set()
     // (concurrency rule).
     markArtifactCurrentForSpine: (projectId: string, artifactId: string, spineVersionId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canReviewArtifacts');
         const preferred = (get().artifactVersions[projectId] || [])
             .find(v => v.artifactId === artifactId && v.isPreferred);
         if (!preferred) throw new Error('No preferred artifact version to mark current');
@@ -356,6 +363,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
     },
 
     setPreferredVersion: (projectId: string, artifactId: string, versionId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditArtifacts');
         set((state) => {
             const allVersions = state.artifactVersions[projectId] || [];
             const updatedVersions = allVersions.map(v => {
@@ -401,6 +409,7 @@ export const createArtifactSlice: StateCreator<ProjectState, [], [], ArtifactSli
         patch: Record<string, unknown>,
         opts?: { historyDescription?: string },
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canEditArtifacts');
         set((state) => {
             const allVersions = state.artifactVersions[projectId] || [];
             const updatedVersions = allVersions.map(v =>

--- a/src/store/slices/branchSlice.ts
+++ b/src/store/slices/branchSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
 import type { Branch, SpineVersion, HistoryEvent } from '../../types';
 import type { ProjectState } from '../types';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 
 export type BranchSlice = {
     branches: Record<string, Branch[]>;
@@ -16,6 +17,7 @@ export const createBranchSlice: StateCreator<ProjectState, [], [], BranchSlice> 
     branches: {},
 
     createBranch: (projectId: string, spineVersionId: string, anchorText: string, initialIntent: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         const branchId = uuidv4();
         const now = Date.now();
         const newBranch: Branch = {
@@ -43,6 +45,7 @@ export const createBranchSlice: StateCreator<ProjectState, [], [], BranchSlice> 
     },
 
     addBranchMessage: (projectId: string, branchId: string, role: 'user' | 'assistant', content: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const projectBranches = state.branches[projectId] || [];
             const updatedBranches = projectBranches.map(b => {
@@ -64,6 +67,7 @@ export const createBranchSlice: StateCreator<ProjectState, [], [], BranchSlice> 
     },
 
     mergeBranch: (projectId: string, branchId: string, newSpineText: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         // Validate against a snapshot, but perform the array derivations inside
         // the set() updater against the fresh `state` so a concurrent spine /
         // branch mutation cannot be clobbered by a stale snapshot.
@@ -130,6 +134,7 @@ export const createBranchSlice: StateCreator<ProjectState, [], [], BranchSlice> 
     },
 
     deleteBranch: (projectId: string, branchId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const projectBranches = state.branches[projectId] || [];
             return {

--- a/src/store/slices/feedbackSlice.ts
+++ b/src/store/slices/feedbackSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
 import type { FeedbackItem, FeedbackType, FeedbackStatus, ArtifactType, HistoryEvent } from '../../types';
 import type { ProjectState } from '../types';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 
 export type FeedbackSlice = {
     feedbackItems: Record<string, FeedbackItem[]>;
@@ -21,6 +22,7 @@ export const createFeedbackSlice: StateCreator<ProjectState, [], [], FeedbackSli
         description: string,
         targetArtifactType: ArtifactType
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canReviewArtifacts');
         const feedbackId = uuidv4();
         const now = Date.now();
         const newFeedback: FeedbackItem = {
@@ -60,6 +62,7 @@ export const createFeedbackSlice: StateCreator<ProjectState, [], [], FeedbackSli
     },
 
     updateFeedbackStatus: (projectId: string, feedbackId: string, status: FeedbackStatus) => {
+        assertProjectCapability(get().projects[projectId], 'canReviewArtifacts');
         set((state) => {
             const items = state.feedbackItems[projectId] || [];
             const updatedItems = items.map(f =>

--- a/src/store/slices/metricsSlice.ts
+++ b/src/store/slices/metricsSlice.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from 'zustand';
 import type { WorkflowRun } from '../../types';
 import type { ProjectState } from '../types';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 
 // Persisted orchestration-metrics history. Each project keeps a capped, newest-
 // first list of WorkflowRun records (PRD generations and artifact bundles) so
@@ -24,6 +25,7 @@ export const createMetricsSlice: StateCreator<ProjectState, [], [], MetricsSlice
     workflowRuns: {},
 
     recordWorkflowRun: (run) => {
+        assertProjectCapability(get().projects[run.projectId], 'canPersistWorkflowState');
         set((state) => {
             const existing = state.workflowRuns[run.projectId] ?? [];
             const next = [run, ...existing].slice(0, RUNS_PER_PROJECT_CAP);
@@ -42,6 +44,7 @@ export const createMetricsSlice: StateCreator<ProjectState, [], [], MetricsSlice
     },
 
     clearWorkflowRuns: (projectId) => {
+        assertProjectCapability(get().projects[projectId], 'canPersistWorkflowState');
         set((state) => {
             if (!state.workflowRuns[projectId]) return state;
             const next = { ...state.workflowRuns };

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -11,6 +11,7 @@ import {
 } from '../../lib/snapshotClient';
 import { projectsDebug } from '../../lib/projectsDebug';
 import { resolveProjectStorageName } from '../userScope';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 
 export type ProjectSlice = {
     projects: Record<string, Project>;
@@ -79,6 +80,7 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
     },
 
     deleteProject: (projectId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const newProjects = { ...state.projects };
             delete newProjects[projectId];
@@ -121,6 +123,7 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
     },
 
     setProjectStage: (projectId: string, stage: PipelineStage) => {
+        assertProjectCapability(get().projects[projectId], 'canPersistWorkflowState');
         set((state) => ({
             projects: {
                 ...state.projects,
@@ -131,6 +134,7 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
     },
 
     setProjectDesignSystemPreset: (projectId: string, presetId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canManageDesignSystem');
         set((state) => {
             const project = state.projects[projectId];
             if (!project) return state;
@@ -146,6 +150,7 @@ export const createProjectSlice: StateCreator<ProjectState, [], [], ProjectSlice
     },
 
     markDesignSetupComplete: (projectId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canManageDesignSystem');
         set((state) => {
             const project = state.projects[projectId];
             if (!project) return state;

--- a/src/store/slices/spineSlice.ts
+++ b/src/store/slices/spineSlice.ts
@@ -6,6 +6,7 @@ import type {
     PreflightSession,
 } from '../../types';
 import type { ProjectState, SpineGenerationMetaInput } from '../types';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 import { buildCanonicalPrdSpine } from '../../lib/canonicalPrdSpine';
 
 export type SpineSlice = {
@@ -50,6 +51,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     spineVersions: {},
 
     updateSpineText: (projectId: string, spineId: string, text: string) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map(s =>
@@ -60,6 +62,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     regenerateSpine: (projectId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         // Validate against a snapshot, but perform the array derivations inside
         // the set() updater against the fresh `state` so a concurrent spine
         // mutation cannot be clobbered by a stale snapshot.
@@ -117,6 +120,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     markSpineFinal: (projectId: string, spineId: string, isFinal: boolean) => {
+        assertProjectCapability(get().projects[projectId], 'canChangeFinality');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map(s =>
@@ -133,6 +137,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
 
     // --- Preflight clarification --------------------------------------------
     initPreflightSession: (projectId, spineId, mode, originalIdea) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map((s) =>
@@ -155,6 +160,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     setPreflightQuestions: (projectId, spineId, questions, usedFallback) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
@@ -170,6 +176,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     setPreflightAnswer: (projectId, spineId, questionId, answer, skipped) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
@@ -184,6 +191,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     setPreflightIndex: (projectId, spineId, index) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
@@ -206,6 +214,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     setPreflightSummary: (projectId, spineId, { summary, assumptions, unknowns }) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
@@ -221,6 +230,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     completePreflightSession: (projectId, spineId) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
@@ -234,6 +244,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     setPreflightError: (projectId, spineId, message) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => ({
             spineVersions: {
                 ...state.spineVersions,
@@ -246,6 +257,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     updateStructuredPRD: (projectId: string, spineId: string, structuredPRD: StructuredPRD) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map(s =>
@@ -262,6 +274,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
         responseText: string,
         meta?: SpineGenerationMetaInput,
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map(s => {
@@ -314,6 +327,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     // the fresh `state` (concurrency rule); the new id is a UUID and display
     // labels derive from array position, never the id.
     editSpineStructuredPRD: (projectId, spineId, nextStructuredPRD, opts) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         // Validate against a snapshot; do array derivations inside set().
         const source = (get().spineVersions[projectId] || []).find(s => s.id === spineId);
         if (!source) throw new Error('No spine version to edit');
@@ -376,6 +390,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     // cloning its content. The source version is never mutated or deleted, so
     // all history before the revert is preserved.
     revertSpineToVersion: (projectId, sourceSpineId) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         const versions = get().spineVersions[projectId] || [];
         const sourceIdx = versions.findIndex(s => s.id === sourceSpineId);
         if (sourceIdx < 0) throw new Error('No spine version to restore');
@@ -432,6 +447,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
         scores: QualityScores,
         generationMeta?: GenerationMeta,
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map(s => {
@@ -450,6 +466,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
         projectId: string,
         meta: { productName?: string; productCategory?: string },
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canEditProjectContent');
         set((state) => {
             const project = state.projects[projectId];
             if (!project) return state;
@@ -461,6 +478,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     markSpineGenerationStarted: (projectId: string, spineId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const updatedSpines = projectSpines.map(s =>
@@ -476,6 +494,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
         review: SpineSafetyReview,
         responseText?: string,
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const spine = projectSpines.find(s => s.id === spineId);
@@ -520,6 +539,7 @@ export const createSpineSlice: StateCreator<ProjectState, [], [], SpineSlice> = 
     },
 
     setSpineError: (projectId: string, spineId: string, error: { message: string; category: string; timestamp: number; raw?: string } | null) => {
+        assertProjectCapability(get().projects[projectId], 'canGenerateArtifacts');
         set((state) => {
             const projectSpines = state.spineVersions[projectId] || [];
             const spine = projectSpines.find(s => s.id === spineId);

--- a/src/store/slices/tasksSlice.ts
+++ b/src/store/slices/tasksSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 import type { ProjectTask, TaskStatus, TaskExternalRef } from '../../types';
 import type { ImplementationTask } from '../../types/tasks';
 import type { ProjectState } from '../types';
+import { assertProjectCapability } from '../../lib/projectCapabilities';
 
 export type TasksSlice = {
     tasks: Record<string, ProjectTask[]>;
@@ -46,6 +47,7 @@ export const createTasksSlice: StateCreator<ProjectState, [], [], TasksSlice> = 
     tasks: {},
 
     saveTasks: (projectId, sourceArtifactId, tasks, sourceSpineVersionId) => {
+        assertProjectCapability(get().projects[projectId], 'canPersistWorkflowState');
         const now = Date.now();
         set((state) => {
             const existing = state.tasks[projectId] || [];
@@ -68,6 +70,7 @@ export const createTasksSlice: StateCreator<ProjectState, [], [], TasksSlice> = 
     },
 
     setTaskStatus: (projectId: string, taskId: string, status: TaskStatus) => {
+        assertProjectCapability(get().projects[projectId], 'canPersistWorkflowState');
         set((state) => {
             const list = state.tasks[projectId] || [];
             return {
@@ -82,6 +85,7 @@ export const createTasksSlice: StateCreator<ProjectState, [], [], TasksSlice> = 
     },
 
     removeProjectTask: (projectId: string, taskId: string) => {
+        assertProjectCapability(get().projects[projectId], 'canPersistWorkflowState');
         set((state) => {
             const list = state.tasks[projectId] || [];
             return {
@@ -94,6 +98,7 @@ export const createTasksSlice: StateCreator<ProjectState, [], [], TasksSlice> = 
         projectId: string,
         refs: Array<{ taskId: string; ref: TaskExternalRef }>,
     ) => {
+        assertProjectCapability(get().projects[projectId], 'canExportExternally');
         if (refs.length === 0) return;
         const byTask = new Map<string, TaskExternalRef[]>();
         for (const { taskId, ref } of refs) {


### PR DESCRIPTION
## Summary

- add one centralized `ProjectCapabilities` policy for durable project actions
- enforce the public demo's read-only boundary in persisted Zustand slices, artifact generation controllers, and IndexedDB image writers
- hide or disable mutation-only controls while preserving navigation, filtering, tabs, screen details, dependency inspection, version history, and local copy/download exports
- keep demo pipeline navigation session-local so exploration does not persist `currentStage`
- add focused capability, mutation-boundary, and component coverage

## Root cause

The pinned public demo is restored into the ordinary project namespace and previously used the same persistent mutation handlers as editable projects. Cloud-sync exclusions protected the owner's source snapshot, but visitors could still corrupt their cached local demo.

## Behavior

The demo now denies PRD/finality edits, artifact and metadata changes, review/confirmation state, generation/regeneration/refinement, Design System changes, image uploads or replacement, task workflow persistence, and external task-export metadata. Ordinary projects retain their existing editing behavior.

Reset Demo and baseline restoration remain intentionally out of scope for this batch.

## Validation

- `npm run lint`
- `npm test` — 167 test files, 1,545 tests passed
- `npm run build`
- browser verification at 1440px and 390px across PRD, Screens, screen detail, Mockups, Design System history, Data Model, and Implementation Plan; no horizontal overflow at 390px

Build retains the repository's existing generated-CSS, mixed-import, and large-chunk warnings.