### PR TITLE
Revise audit for pre-launch development context

### DIFF
--- a/docs/audits/SYNAPSE_CODEBASE_AUDIT_2026-07-10.md
+++ b/docs/audits/SYNAPSE_CODEBASE_AUDIT_2026-07-10.md
@@ -19,6 +19,14 @@ appended to each affected finding.
 
 ## 1. Executive summary
 
+## Development-stage assumptions
+
+**Clarification applied after the point-in-time review:** Synapse is pre-launch. It has no active production users and no production user projects or historical data to preserve. Breaking internal schemas, artifact metadata, internal APIs, fixtures, and seeded data is acceptable when it produces a cleaner, more reliable intended architecture.
+
+Development `localStorage`, IndexedDB records, cached snapshots, and local projects may be invalidated or cleared. Seeded demo projects and pinned snapshots may be regenerated or republished. Existing fixtures and tests may be rewritten around the canonical model, and obsolete compatibility layers may be deleted. Create a migration only when it is materially simpler or safer than resetting development data—not because of hypothetical user impact. Prefer one canonical representation over old/new adapters or compatibility windows; use a quick repository/code-path check when an active consumer is uncertain.
+
+**Regression boundary:** breaking obsolete development data is acceptable. Breaking the intended current product experience is not. Continue strong regression protection for the public recruiter-facing demo; authentication and project isolation; current project creation, generation, and intended cloud sync; security boundaries; artifact dependency correctness; promised versioning behavior; responsive and accessible UI; build/lint/unit/integration/E2E behavior; and canonical seeded projects or demo fixtures used for product validation.
+
 Synapse is healthier than its size and domain complexity initially suggest. A clean install produces a passing TypeScript production build, a clean lint run, and **1,495 passing Vitest tests across 162 files**. The codebase has several strong foundations: project data is namespaced per user, cloud sync is local-first with explicit revision-conflict handling, interrupted generations are reconciled after reload, artifact generation is dependency-aware, partial PRD output is not silently treated as complete, and server APIs consistently enforce session ownership. The live Data Model and Implementation Plan views were visually strong on both desktop and mobile, and the deployed journey produced no browser-console errors during the audit.
 
 The highest-value risks are concentrated around product truthfulness and consistency, especially in **View Demo**:
@@ -33,7 +41,7 @@ Two systemic issues matter beyond the demo. First, artifact freshness is calcula
 
 The most concrete security issue is local and fixable: the legacy Design System Markdown renderer enables unsanitized raw HTML. Generated or restored content can therefore create arbitrary elements such as an `iframe` with `srcdoc`. Removing raw-HTML parsing is preferable to introducing a large sanitization policy because its only current purpose is a hex-color annotation that can be rendered safely in React.
 
-The main simplification opportunities are not a rewrite. They are: make demo mode a single explicit boundary; consolidate freshness behind one evaluator; separate immutable content revisions from mutable workflow overlays; route-split the workspace; and progressively extract controller/state-selection responsibilities from the two 1,400–1,800-line workspace components. Most urgent fixes are local or cross-component. The state/version issues are cross-artifact and require deliberate migration and regression coverage.
+The main simplification opportunities are not a rewrite. They are: make demo mode a single explicit boundary; consolidate freshness behind one evaluator; separate immutable content revisions from mutable workflow overlays; route-split the workspace; and progressively extract controller/state-selection responsibilities from the two 1,400–1,800-line workspace components. Most urgent fixes are local or cross-component. The state/version issues are cross-artifact and require coordinated replacement plus deliberate regression coverage, not preservation of discarded development records.
 
 No P0 issue was found. Seven P1 findings should be addressed before treating the demo as a dependable first-class acquisition surface.
 
@@ -64,7 +72,7 @@ No P0 issue was found. Seven P1 findings should be addressed before treating the
 - `design_system` and `data_model` depend directly on the PRD.
 - `implementation_plan` depends on `screen_inventory` and `data_model`.
 - Mockups depend on `screen_inventory`, hidden `component_inventory`, and `design_system`.
-- `prompt_pack` is retired from new generation but retained for legacy rendering/export and migration compatibility.
+- Prompt Packs are a current, critical part of the Implementation Plan: the consolidated plan exposes them for implementation work. The separate `prompt_pack` artifact subtype is retired from new generation because its content is folded into that canonical Implementation Plan representation. Retain the adapter and renderer path that serves the current consolidated plan; only delete obsolete standalone persistence compatibility after confirming it is not needed by current exports or canonical fixtures.
 - `src/lib/coreArtifactPipeline.ts` is the canonical dependency definition; `src/lib/artifactDependencyGraph.ts` derives the visible graph from it and collapses hidden nodes transitively.
 
 ### State concepts
@@ -167,7 +175,7 @@ No P0 finding was supported by the evidence gathered.
 
 - Importance: P1 — High
 - Bug severity: S2 — Significant
-- Effort: M
+- Effort: S–M (replacement preferred)
 - Confidence: High
 - Category: Demo
 - Scope: Cross-component
@@ -341,7 +349,7 @@ Generation specification, image presence, coverage metadata, and snapshot transp
 
 **Concrete recommendation**
 
-Make actual image presence a requirement for `generated`. Represent `spec_ready`, `image_missing`, and `generated` distinctly only where the distinction helps recovery. At demo pin time, validate a manifest of required primary images and reject an incomplete snapshot. During runtime, keep a previously complete cached demo rather than replacing it with an incomplete fetch; otherwise show one explicit degraded-demo state. Preserve retries, but do not label missing data as success.
+Make actual image presence a requirement for `generated`, with one authoritative image/status model. Delete `legacyGenerated` and overlapping legacy/screen/variant representations where they are not needed by the intended application; consolidate them if that makes the model simpler. Regenerate or repin the public demo, invalidate old demo caches, clear development IndexedDB/localStorage, and rewrite fixtures/seeded data to the canonical representation. Reject incomplete snapshots rather than indefinitely supporting partial legacy shapes; remove obsolete mockup specs with no active consumer. At demo pin time validate a required-image manifest; at runtime retain a known-complete current-format cache or show one honest degraded state.
 
 **Acceptance criteria**
 
@@ -352,7 +360,7 @@ Make actual image presence a requirement for `generated`. Represent `spec_ready`
 
 **Dependencies and risks**
 
-Image records span legacy mockup, screen, and variant stores. Migration must not erase old specs when an image is genuinely unavailable.
+Image records span legacy mockup, screen, and variant stores. First identify the current demo and generation consumers, then replace the overlapping model in one focused change. No migration is warranted for obsolete local records.
 
 **Suggested validation**
 
@@ -390,15 +398,15 @@ Remove `rehypeRaw` and the `rehype-raw` dependency. Tokenize hex values into Rea
 
 - `<script>`, `<iframe>`, `srcdoc`, event handlers, and raw `<img>` HTML cannot create DOM elements from artifact content.
 - Hex swatches still render.
-- Existing tokenized and legacy Design Systems remain readable.
+- The current canonical seeded Design System and demo remain readable.
 
 **Dependencies and risks**
 
-Visually compare legacy Design Systems that may contain intentional HTML. If any exists, migrate it to Markdown/structured data rather than expanding an allowlist without evidence.
+Prefer deletion: remove the legacy Markdown fallback entirely when it has no intended current consumer, remove `rehypeRaw`/`rehype-raw`, delete obsolete raw-HTML fixtures, and convert the canonical seed/demo to structured data. Do not retain intentional raw HTML from development snapshots. If a current canonical path still requires fallback rendering, keep only a safe non-raw renderer.
 
 **Suggested validation**
 
-Renderer tests with malicious HTML and benign hex Markdown, plus a browser CSP regression test. Search snapshots for intentional raw HTML before removal.
+Renderer tests with malicious HTML and safe hex-token visualization, plus a browser CSP regression test. Validate the canonical demo rather than preserving old raw-HTML snapshots.
 
 ## [SYN-005] Two freshness engines can give the same artifact incompatible statuses
 
@@ -406,7 +414,7 @@ Renderer tests with malicious HTML and benign hex Markdown, plus a browser CSP r
 
 - Importance: P1 — High
 - Bug severity: S2 — Significant
-- Effort: M
+- Effort: M (broad call sites; no data migration)
 - Confidence: High
 - Category: State model
 - Scope: Cross-artifact
@@ -426,7 +434,7 @@ The earlier spine-only model remained in the store after a richer graph evaluato
 
 **Concrete recommendation**
 
-Make the dependency evaluator the single canonical artifact-health computation. Expose small selectors/adapters for display vocabulary, but do not reimplement the rules. Decide explicitly how `likelyUnaffected`, manual “mark current,” missing provenance, job state, and token-identical regeneration map into each UI. Deprecate and delete `stalenessSlice` only after all call sites and persisted escape-hatch behavior migrate.
+Replace both freshness implementations with one canonical evaluator. Change internal status types and persisted metadata shapes freely, migrate all consumers together where that is safer than transitional adapters, and delete `stalenessSlice`, obsolete selectors, duplicate mappings, timestamp-only provenance handling, and manual “mark current” behavior when they do not fit the desired model. Rewrite project fixtures, provenance, and seeded artifacts; reset local development projects on schema change. Characterization tests define desired canonical behavior, not contradictory historical behavior.
 
 **Acceptance criteria**
 
@@ -436,7 +444,7 @@ Make the dependency evaluator the single canonical artifact-health computation. 
 
 **Dependencies and risks**
 
-This touches gating and regeneration decisions. Preserve conservative legacy timestamp handling and the mockup token-hash rule. Migrate in small commits with characterization tests.
+This touches gating and regeneration decisions. Retain the mockup token/design-system dependency rules and the distinction between system freshness, user review, and implementation readiness. The risk is broad call-site behavior, not migration: use focused commits and characterization tests, then make the coordinated cutover.
 
 **Suggested validation**
 
@@ -468,7 +476,7 @@ Test investment is concentrated in pure domain/store behavior and renderer fragm
 
 **Concrete recommendation**
 
-Add a minimal Playwright suite using the already-installed dependency. Protect only high-value contracts: cold direct demo link, baseline read-only/reset behavior, all generated primary mockups have images, navigation through PRD/Screens/Data Model/Plan/history, refresh, no console errors, and no 360 px overflow. Keep visual snapshots sparse and stable; prefer semantic assertions.
+Add a minimal Playwright suite using the already-installed dependency. Protect the canonical implementation: cold direct demo entry, current-format cached refresh, read-only behavior, real images behind every `Generated` status, navigation through PRD/Screens/Data Model/Plan/history, no console errors, honest incomplete current-format image hydration, and no horizontal overflow on desktop or mobile. Regenerate deterministic E2E fixtures and replace old demo snapshots/caches as schemas change; test only supported formats. Keep visual snapshots sparse and stable; prefer semantic assertions.
 
 **Acceptance criteria**
 
@@ -478,7 +486,7 @@ Add a minimal Playwright suite using the already-installed dependency. Protect o
 
 **Dependencies and risks**
 
-Fix SYN-001–003 first or mark tests as expected failures only on a short-lived branch. Avoid testing third-party LLM generation.
+Implement after the canonical demo fixture is available; do not add compatibility tests for intentionally invalidated caches/snapshots. Avoid testing third-party LLM generation.
 
 **Suggested validation**
 
@@ -637,7 +645,7 @@ Metadata became a convenient shared persistence channel for both content customi
 
 **Concrete recommendation**
 
-Define the boundary explicitly: content-changing screen/prompt edits append an immutable artifact revision (or an immutable overlay revision linked to the base); review state, checklist progress, dismissals, and similar workflow state live in a separate keyed record that can mutate. Avoid versioning every checkbox. Provide migration that treats existing metadata as the current overlay/base.
+Redesign `ArtifactVersion` around the explicit boundary: content-changing screen/prompt edits append immutable, comparable, restorable revisions, while review state, checklist progress, dismissals, and similar workflow state live in a separately mutable keyed record. Avoid versioning every checkbox. Invalidate development project data, delete the mixed metadata representation, and rebuild canonical demo/test projects under the new model instead of adding compatibility adapters or a migration for obsolete local projects.
 
 **Acceptance criteria**
 
@@ -648,11 +656,11 @@ Define the boundary explicitly: content-changing screen/prompt edits append an i
 
 **Dependencies and risks**
 
-Requires a product decision about what counts as content. Existing saved data, exports, screen joins, and sync bundles need migration/compatibility handling.
+Requires a product decision about what counts as content. Preserve current sync, project isolation, exports, and screen joins under the new schema; rewrite their canonical fixtures and contracts. Migration complexity is not a risk because there is no production data.
 
 **Suggested validation**
 
-Store tests for edit/edit/compare/revert; migration fixtures from current metadata; cross-device sync conflict tests; UI journey through screen edit history.
+Store tests for edit/edit/compare/revert; new canonical fixtures; cross-device sync conflict tests; and a UI journey through screen edit history.
 
 ## [SYN-011] The anonymous entry route downloads a 576 kB gzip application bundle
 
@@ -722,7 +730,7 @@ Product workflows accumulated in page components while pure domain helpers evolv
 
 **Concrete recommendation**
 
-Refactor incrementally around demonstrated seams: route/demo loader, finalize/update-plan controller, artifact-health selector, and per-artifact view models. Replace whole-store hooks with narrow selectors and shallow comparison. Keep pure derivation in existing `src/lib` modules. Do not create a generic framework or rewrite the store.
+Refactor incrementally around demonstrated seams: route/demo loader, finalize/update-plan controller, artifact-health selector, and per-artifact view models. Replace whole-store hooks with narrow selectors and shallow comparison. Keep pure derivation in existing `src/lib` modules. Do not create a generic framework or rewrite the store. Incremental commits are for reviewability and regression isolation—not rollout or preservation of historical records.
 
 **Acceptance criteria**
 
@@ -765,7 +773,7 @@ Documentation remained tied to the original local-only SPA while backend/auth/sy
 
 **Concrete recommendation**
 
-Replace the architecture page with the current system map and make one setup guide canonical. Document the command that serves both frontend and `/api` functions (likely `vercel dev`) and required environment categories; explicitly label `npm run dev` as tour/static-frontend-only if retained. Update route/test counts. Avoid duplicating setup instructions across multiple files.
+Replace obsolete architecture/setup descriptions with the current system map and make one intended-stack workflow canonical. Document the command that serves both frontend and `/api` functions (likely `vercel dev`) and required environment categories; explicitly label `npm run dev` as tour/static-frontend-only if retained. Update route/test counts. Avoid duplicating setup instructions or preserving outdated setup paths for compatibility.
 
 **Acceptance criteria**
 
@@ -1039,17 +1047,17 @@ Demo-only checks appear in `App`, project/image sync, design setup, project work
 ### Likely candidates requiring validation
 
 - **`src/lib/services/prdPipeline.ts` compatibility shim.** Current imports appear primarily type-oriented while progressive generation owns implementation and a duplicate schema-version constant. Consolidate types/constants into the active module only after checking external/private imports and fixtures.
-- **Expired Gemini model migration in `src/App.tsx:126-147`.** Existing backlog/audit text explicitly targeted removal after 2026-07-01; the audit date is later. Confirm migration adoption/telemetry, then remove the sentinel block and separately decide whether the retired banner-key sweep is still needed.
-- **Legacy Design System fallback paths.** After inventorying saved snapshots, consider migrating old Markdown to structured tokens and shrinking the 782-line dual renderer. Do not delete the fallback before data evidence.
+- **Expired Gemini model migration in `src/App.tsx:126-147`.** Confirm no current reachable path depends on it, then delete the sentinel block and retired banner-key sweep; telemetry/adoption is unnecessary for development-only state.
+- **Legacy Design System fallback paths.** Check the canonical demo and current generation path. If neither needs it, delete the Markdown side, raw-HTML fixtures, and dual-renderer complexity; regenerate canonical structured data.
 - **Repeated status badges/copy.** Once SYN-005 establishes canonical health, delete component-specific mapping tables and duplicate “current/outdated” derivation rather than wrapping them in another abstraction.
 
-### Do not simplify yet
+### Retain only with a concrete current consumer
 
-- **Prompt Pack legacy adapters and `implementationPlanAdapter`.** Prompt Pack is retired but persisted projects still render/export it, and the consolidated plan reads legacy content.
+- **Prompt Pack adapters and `implementationPlanAdapter`.** Retain: the current consolidated Implementation Plan consumes and presents Prompt Packs for implementation work (including its Prompts tab and supported export path). The deletion candidate is only obsolete standalone `prompt_pack` persistence compatibility after a direct check confirms it is not needed by canonical fixtures or exports.
 - **Hidden `component_inventory`.** It is not visible, but mockup generation consumes it. `expandWithHiddenDependencyClosure()` prevents mockups from rebuilding against stale hidden data.
-- **Image namespace/IndexedDB/Blob restore logic.** It is complex because persisted binary data and public snapshots genuinely cross namespaces. Fix incomplete-demo policy without collapsing these layers prematurely.
+- **Image namespace/IndexedDB/Blob restore logic.** Retain its namespace isolation and current public-snapshot restore consumer; simplify representations freely after its current route/generation consumers are verified.
 - **Project conflict/revision handling and pagehide/visibility persistence.** These protect local work and cross-device consistency; simplify only with equivalent failure tests.
-- **Legacy stage migration in `onRehydrateStorage`.** Old saved projects can still contain retired stages. Remove only after telemetry or an explicit compatibility window.
+- **Legacy stage migration in `onRehydrateStorage`.** Delete unless a current canonical fixture or reachable active path still emits a retired stage; reset development projects instead of a compatibility window.
 - **Defensive partial-generation/safety gates.** These are user-visible reliability controls, not ornamental complexity.
 
 ## 7. Cross-cutting themes
@@ -1063,18 +1071,18 @@ Demo-only checks appear in `App`, project/image sync, design setup, project work
 | Page components became controllers | Large workspaces own state selection, business rules, derivation, network/generation coordination, modals, and rendering | SYN-001, 005, 012 |
 | Acquisition paths need first-class constraints | Large eager bundle, ambiguous tour/demo story, inaccessible auth labels, and dead recovery control all affect the first visit | SYN-007, 008, 011, 018 |
 | Documentation and shipped architecture diverged | Backend/auth/sync now gate the workspace, while canonical docs describe a three-route client-only app | SYN-013 |
-| Compatibility code is often load-bearing | Hidden component inventory, prompt-pack adapters, image namespaces, and rehydrate migrations have concrete persisted-data consumers | Simplification section |
+| Compatibility must prove a current consumer | Hidden component inventory and image namespace isolation have identified current consumers; prompt-pack adapters and rehydrate migrations require direct verification, not hypothetical old projects | Simplification section |
 
-The dominant systemic issue is not excessive feature count; it is that newer, richer product concepts were layered beside older helpers and boundaries. Consolidation should follow demonstrated semantic seams, with old paths deleted after migration—not hidden behind more adapters.
+The dominant systemic issue is not excessive feature count; it is that newer, richer product concepts were layered beside older helpers and boundaries. Consolidation should follow demonstrated semantic seams, with obsolete paths deleted after confirming no current consumer—not hidden behind more adapters.
 
 ## 8. Recommended execution sequence
 
 ### Phase 1 — Stabilize
 
-**Findings:** SYN-001, SYN-002, SYN-003, SYN-004  
-**Expected outcome:** The public demo always opens, cannot be persistently damaged, never claims a missing image is generated, and generated Markdown cannot create raw active HTML.  
+**Findings:** SYN-001, SYN-002, SYN-003, SYN-004, SYN-006
+**Expected outcome:** The public demo always opens, cannot be persistently damaged, never claims a missing image is generated, generated Markdown cannot create raw active HTML, and a CI-visible browser contract protects the canonical fixture.
 **Estimated effort:** 6–9 engineering days total; parallelizable after policy decisions.  
-**Dependencies:** Define demo persistent-vs-ephemeral capabilities; inventory legacy raw HTML; identify required demo image manifest.  
+**Dependencies:** Define demo persistent-vs-ephemeral capabilities; identify the canonical demo image manifest. Convert the canonical Design System directly; do not inventory obsolete local snapshots.
 **Recommended commit boundaries:**
 
 1. Raw Markdown security fix + renderer tests.
@@ -1082,19 +1090,20 @@ The dominant systemic issue is not excessive feature count; it is that newer, ri
 3. Central demo capability policy + mutation guards.
 4. Demo reset/cache policy.
 5. Image-aware variant status + snapshot pin validation.
+6. Semantic demo E2E suite against the new canonical snapshot.
 
 ### Phase 2 — Simplify
 
 **Findings:** SYN-005, SYN-010, SYN-012, SYN-014, SYN-018; deletion candidates  
 **Expected outcome:** One artifact-health truth, explicit version/workflow boundaries, fewer fake/dead paths, and smaller controller responsibilities.  
-**Estimated effort:** 2–4 weeks staged; do not bundle into one branch.  
-**Dependencies:** Characterization/E2E tests from Phase 1; content-versus-workflow versioning decision; saved-data migration fixtures.  
+**Estimated effort:** 1.5–3 weeks staged; do not bundle unrelated refactors into one branch.
+**Dependencies:** Characterization/E2E tests from Phase 1; content-versus-workflow versioning decision; canonical fixtures only.
 **Recommended commit boundaries:**
 
 1. Characterize both freshness engines.
-2. Add canonical evaluator selector and migrate one consumer at a time.
-3. Delete `stalenessSlice` after final call-site migration.
-4. Define/migrate immutable content overlays separately from workflow overlays.
+2. Replace both freshness engines and update all consumers in one focused branch.
+3. Delete `stalenessSlice`, duplicate mappings, and obsolete selectors.
+4. Define immutable content revisions separately from workflow overlays; reset and rebuild development fixtures.
 5. Extract finalize/update-plan and artifact-health controllers with narrow selectors.
 6. Delete mocked Linear, dead auth affordance, and confirmed unused CSS.
 
@@ -1125,17 +1134,16 @@ The dominant systemic issue is not excessive feature count; it is that newer, ri
 
 ### Phase 5 — Harden
 
-**Findings:** SYN-006, SYN-011, SYN-013, SYN-015, SYN-016  
+**Findings:** SYN-011, SYN-013, SYN-015, SYN-016
 **Expected outcome:** Cross-layer regressions fail CI, entry payload is materially smaller, local setup is reproducible, and maintenance warnings/advisories are controlled.  
 **Estimated effort:** 5–8 days.  
 **Dependencies:** Stable demo fixture; supported local backend command; baseline bundle/network measurements.  
 **Recommended commit boundaries:**
 
-1. Minimal semantic demo E2E suite.
-2. Route-level lazy loading + accessible fallbacks.
-3. Build-warning cleanup.
-4. Dependency maintenance upgrade.
-5. Canonical architecture/setup documentation and badge updates.
+1. Route-level lazy loading + accessible fallbacks.
+2. Build-warning cleanup.
+3. Dependency maintenance upgrade.
+4. Canonical architecture/setup documentation and badge updates.
 
 ## 9. Priority matrix
 
@@ -1143,14 +1151,14 @@ The dominant systemic issue is not excessive feature count; it is that newer, ri
 | -- | -------------- | ---------: | -------: | -----: | ---------: | -------- | ----- | ---------- |
 | SYN-001 | Enforce read-only demo policy and reset | P1 | S2 | M | High | Demo | Cross-component | Before demo polish |
 | SYN-002 | Hydrate demo at route boundary | P1 | S2 | S | High | Reliability | Cross-component | Coordinate with 001 |
-| SYN-003 | Require real image for generated status; validate pinned snapshot | P1 | S2 | M | High | Demo | Cross-artifact | Image-store inventory |
-| SYN-004 | Remove unsanitized raw HTML rendering | P1 | S2 | S | High | Security | Cross-component | Legacy-content check |
-| SYN-005 | Consolidate freshness on dependency evaluator | P1 | S2 | M | High | State model | Cross-artifact | Characterization tests |
-| SYN-006 | Add semantic demo E2E contract | P1 | N/A | M | High | Testing | Application-wide | Stabilize 001–003 |
+| SYN-003 | Replace image-status models; require complete canonical snapshot | P1 | S2 | S–M | High | Demo | Cross-artifact | Canonical manifest/current consumers |
+| SYN-004 | Delete unsafe raw-HTML path; use structured canonical data | P1 | S2 | S | High | Security | Cross-component | Current renderer check |
+| SYN-005 | Replace freshness engines with one evaluator | P1 | S2 | M | High | State model | Cross-artifact | Desired-behavior characterization |
+| SYN-006 | Add semantic canonical-demo E2E contract | P1 | N/A | M | High | Testing | Application-wide | Canonical fixture after 003/004 |
 | SYN-007 | Label auth fields and associate errors | P1 | N/A | S | High | Accessibility | Local | None |
 | SYN-008 | Align tour/demo story and versions | P2 | S3 | M | High | Content consistency | Cross-component | Stable complete demo |
 | SYN-009 | Constrain Screens filters on narrow widths | P2 | S3 | XS | High | Mobile | Local | None |
-| SYN-010 | Version content edits immutably; split workflow overlays | P2 | S2 | L | High | Versioning | Cross-artifact | Product/migration decision |
+| SYN-010 | Redesign immutable content versions and workflow overlays | P2 | S2 | M–L | High | Versioning | Cross-artifact | Product decision/canonical fixtures |
 | SYN-011 | Route-split eager application bundle | P2 | N/A | M | High | Performance | Application-wide | Baseline measurement |
 | SYN-012 | Extract controllers and narrow Zustand selectors | P2 | N/A | XL | High | Architecture | E2E/characterization first |
 | SYN-013 | Rewrite local setup and architecture docs | P2 | N/A | S | High | Developer experience | Verify supported command |
@@ -1162,16 +1170,18 @@ The dominant systemic issue is not excessive feature count; it is that newer, ri
 
 ## 10. Top ten recommended actions
 
-1. **Make demo persistence read-only and resettable (SYN-001).** This is the highest-impact fix because a public visitor can currently break the core demo with a visible control. Primarily a fix; visible outcome is a deterministic, trustworthy demo. Effort M. Do first with the route loader.
-2. **Make the demo URL self-hydrating (SYN-002).** Shared links must work from a clean browser. Primarily a fix; visible outcome is reliable direct entry and refresh. Effort S. Do alongside action 1.
-3. **Guarantee complete mockup imagery and truthful generated status (SYN-003).** The current contradiction is the demo’s most damaging visual failure. Primarily a fix; visible outcome is a complete mockup instead of an API-key/upload warning. Effort M. Do after loader/cache policy is explicit.
-4. **Remove raw HTML from Design System Markdown (SYN-004).** This closes the clearest concrete content-security boundary with a smaller implementation. Primarily a fix and deletion; visible behavior remains hex swatches with hostile HTML inert. Effort S. Can ship independently and early.
-5. **Unify artifact freshness (SYN-005).** Users must never see “Current” and “Needs update” for the same evidence. Primarily simplification/consolidation; visible outcome is consistent headers, exports, graph, and update plans. Effort M. Start with characterization tests.
-6. **Add the small demo E2E release gate (SYN-006).** It protects the exact composition failures the green unit suite missed. Primarily hardening; visible outcome is fewer deployed demo regressions. Effort M. Add immediately after actions 1–3.
-7. **Make content edits genuinely versioned (SYN-010).** Version history should resolve to historical states, while review checkboxes should not spam versions. Primarily a state-model redesign; visible outcome is meaningful compare/revert. Effort L. Do after freshness semantics settle.
+1. **Guarantee complete mockup imagery and truthful generated status (SYN-003).** Replace the overlapping model, regenerate the canonical demo, and invalidate obsolete development data. This removes the most damaging visible contradiction. Effort S–M.
+2. **Remove raw HTML from Design System rendering (SYN-004).** Delete `rehype-raw` and obsolete fallback content, then render canonical structured data safely. This closes the clearest content-security boundary. Effort S.
+3. **Add the canonical demo E2E release gate (SYN-006).** Once 003/004 establish the supported fixture, lock in cold entry, current-format caching, read-only behavior, imagery, navigation, and responsive behavior in CI. Effort M.
+4. **Unify artifact freshness (SYN-005).** Replace both engines in a focused cutover, delete duplicate status layers, and use characterization tests to define the desired behavior. Effort M.
+5. **Make demo persistence read-only and resettable (SYN-001).** A public visitor must not alter its cached product experience. Effort M.
+6. **Make the demo URL self-hydrating (SYN-002).** Shared links must work from a clean browser. Effort S.
+7. **Make content edits genuinely versioned (SYN-010).** Rebuild the canonical schema so history resolves to immutable content while workflow stays mutable. Effort M–L; no old-project migration.
 8. **Fix authentication semantics (SYN-007).** The core sign-in path needs programmatic labels and announced errors. Primarily a fix; visible design can remain unchanged while assistive technology becomes usable. Effort S. Ship independently.
 9. **Route-split the application (SYN-011).** The measured 575.88 kB gzip entry bundle is avoidably eager. Primarily a performance refactor; visible outcome is faster initial entry on constrained networks with stable loading shells. Effort M. Measure before/after.
 10. **Align the tour and pinned demo into one complete story (SYN-008).** Once reliability is fixed, this produces the largest polish gain: meaningful multi-version history, complete artifacts, and clear CTA choice. Primarily polish/content; visible outcome is a coherent first impression. Effort M. Do last among the top ten so content is built on stable behavior.
+
+The immediate order remains **SYN-003 → SYN-004 → SYN-006 → SYN-005** because it first makes the visible canonical demo truthful, then closes the concrete content-security boundary, locks those supported formats in a browser contract, and finally undertakes the broader freshness cutover with reliable regression coverage. The absence of users removes the need to delay any of these for migrations, telemetry, or compatibility windows.
 
 ---
 


### PR DESCRIPTION
## Summary
- add explicit pre-launch/no-user development assumptions and regression boundary
- revise audit recommendations toward canonical replacements, fixture regeneration, and removal of obsolete development-data compatibility
- clarify that Prompt Packs remain a critical current Implementation Plan capability; only the standalone retired artifact persistence is a deletion candidate

## Why
Synapse has no production user data to preserve, so the audit should recommend clean pre-launch architecture changes without weakening protection for the intended demo, security, sync, versioning, or browser behavior.

## Validation
- `git diff --check`
- Markdown structure check for required sections and findings

This PR changes audit documentation only.