### PR TITLE
fix(snapshots): warn when a demo snapshot has no mockup images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,24 @@ add it to `collectProjectBundle`/`collectScreenImages`/`collectVariantImages`, t
 restore writers, and `namespaceSnapshotForRestore`, or it silently won't travel
 in snapshots.
 
+- **Save-time mockup-image audit (`src/lib/snapshotImageAudit.ts`, pure).**
+  Mockup SPECS (the `mockup` artifact version JSON) and mockup IMAGES (IDB blobs
+  shipped one-per-request) are collected independently, so nothing forces them to
+  agree — it was possible to save, then pin as the public demo, a snapshot whose
+  mockup spec listed screens but carried **zero** images (images generated in
+  another browser, IDB cleared, or only the spec regenerated), and the demo then
+  rendered mockup specs with no previews (the mockups "disappeared"). This is the
+  root cause of the "demo lost its mockups" bug: the pinned demo blob genuinely
+  had `imageCount: 0`. `auditMockupImageCoverage` runs inside `saveSnapshot` and,
+  when the mockup version has ≥1 screen but no mockup image (AI / uploaded /
+  variant) was collected for that version id, returns a warning surfaced through
+  the existing `onWarnings` → `SnapshotsPanel` amber notice. It **never blocks the
+  save** (specs are still worth keeping) — it just makes the gap visible before a
+  pin. `SnapshotsPanel.handleSetDemo` also adds a heads-up when pinning a
+  zero-image snapshot as the demo. A snapshot with no images is a data condition
+  the owner must fix by regenerating the mockup images and re-saving/re-pinning;
+  no restore/render change can recover images the blob never contained.
+
 - **The public demo has one read-only capability boundary.**
   `src/lib/projectCapabilities.ts` is authoritative for durable project actions;
   `getProjectCapabilities` fails conservatively for a missing project and denies

--- a/src/components/SnapshotsPanel.tsx
+++ b/src/components/SnapshotsPanel.tsx
@@ -137,9 +137,18 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
     // the public `?demo=1` endpoint, so no owner token is needed to view it.
     const handleSetDemo = async (id: string) => {
         const willClear = demoSnapshotId === id;
+        const snapshot = snapshots?.find((s) => s.id === id);
+        const imageTotal = snapshot
+            ? snapshot.imageCount + (snapshot.screenImageCount ?? 0)
+            : null;
+        // Pinning a snapshot with no images means the public demo will render
+        // mockup specs with no preview images — warn before it goes live.
+        const noImagesWarning = !willClear && imageTotal === 0
+            ? '\n\nHeads up: this snapshot contains 0 images, so the demo will show mockups with no rendered previews. Re-save a snapshot that includes the mockup images if you want them to appear.'
+            : '';
         const confirmMsg = willClear
             ? 'Unset this snapshot as the public demo? The "View demo project" button will stop working until another snapshot is set.'
-            : 'Make this snapshot the public demo? Any visitor (no owner token required) will be able to load it from the home page.';
+            : `Make this snapshot the public demo? Any visitor (no owner token required) will be able to load it from the home page.${noImagesWarning}`;
         if (!confirm(confirmMsg)) return;
         setBusy(`demo:${id}`);
         setError(null);
@@ -347,7 +356,7 @@ export function SnapshotsPanel({ projectId, onClose, onRestored }: SnapshotsPane
                             </ul>
                             <p className="mt-1.5 text-amber-200/70">
                                 The screen specs and mockup metadata are still saved — only some
-                                variant images were left out.
+                                preview images may be missing.
                             </p>
                         </div>
                     )}

--- a/src/lib/__tests__/snapshotImageAudit.test.ts
+++ b/src/lib/__tests__/snapshotImageAudit.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { auditMockupImageCoverage } from '../snapshotImageAudit';
+import type { Artifact, ArtifactVersion } from '../../types';
+import { MOCKUP_SPEC_V1 } from '../../types';
+
+const MOCKUP_ARTIFACT_ID = 'art-mockup';
+const MOCKUP_VERSION_ID = 'ver-mockup-1';
+
+const mockupArtifact = (currentVersionId: string | null = MOCKUP_VERSION_ID): Artifact => ({
+    id: MOCKUP_ARTIFACT_ID,
+    projectId: 'proj',
+    type: 'mockup',
+    title: 'Mockups',
+    status: 'active',
+    currentVersionId,
+    createdAt: 0,
+    updatedAt: 0,
+});
+
+const mockupVersion = (screenNames: string[]): ArtifactVersion => ({
+    id: MOCKUP_VERSION_ID,
+    artifactId: MOCKUP_ARTIFACT_ID,
+    versionNumber: 1,
+    parentVersionId: null,
+    content: JSON.stringify({
+        version: MOCKUP_SPEC_V1,
+        title: 'Mockups',
+        summary: '',
+        screens: screenNames.map((name, i) => ({ id: `scr-${i}`, name })),
+    }),
+    metadata: { format: MOCKUP_SPEC_V1 },
+    sourceRefs: [],
+    generationPrompt: '',
+    isPreferred: true,
+    createdAt: 0,
+});
+
+const baseInput = () => ({
+    artifacts: [mockupArtifact()],
+    artifactVersions: [mockupVersion(['Home', 'Settings'])],
+    images: [] as Array<{ versionId: string }>,
+    screenImages: [] as Array<{ artifactVersionId: string }>,
+});
+
+describe('auditMockupImageCoverage', () => {
+    it('warns when a mockup spec has screens but no images were collected', () => {
+        const warnings = auditMockupImageCoverage(baseInput());
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toMatch(/2 screens/);
+        expect(warnings[0]).toMatch(/no rendered mockup images/i);
+    });
+
+    it('is silent when at least one AI mockup image exists for the version', () => {
+        const warnings = auditMockupImageCoverage({
+            ...baseInput(),
+            images: [{ versionId: MOCKUP_VERSION_ID }],
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    it('is silent when a user-uploaded mockup image exists for the version', () => {
+        const warnings = auditMockupImageCoverage({
+            ...baseInput(),
+            screenImages: [{ artifactVersionId: MOCKUP_VERSION_ID }],
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    it('is silent when a per-variant mockup image exists for the version', () => {
+        const warnings = auditMockupImageCoverage({
+            ...baseInput(),
+            variantImages: {
+                schemaVersion: 1,
+                projectId: 'proj',
+                exportedAt: '2026-07-11T00:00:00.000Z',
+                records: [{ versionId: MOCKUP_VERSION_ID } as never],
+                summary: { recordCount: 1, historyEntryCount: 0, totalApproxBytes: 0, warnings: [] },
+            },
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    it('ignores images collected for an unrelated version id', () => {
+        const warnings = auditMockupImageCoverage({
+            ...baseInput(),
+            images: [{ versionId: 'some-other-version' }],
+        });
+        expect(warnings).toHaveLength(1);
+    });
+
+    it('is silent when there is no mockup artifact at all', () => {
+        expect(auditMockupImageCoverage({ ...baseInput(), artifacts: [] })).toEqual([]);
+    });
+
+    it('is silent when the mockup spec is unparseable', () => {
+        const version = { ...mockupVersion([]), content: 'not json', metadata: {} };
+        const warnings = auditMockupImageCoverage({
+            ...baseInput(),
+            artifactVersions: [version],
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    it('falls back to the highest-numbered version when currentVersionId is null', () => {
+        const warnings = auditMockupImageCoverage({
+            ...baseInput(),
+            artifacts: [mockupArtifact(null)],
+        });
+        expect(warnings).toHaveLength(1);
+    });
+});

--- a/src/lib/snapshotClient.ts
+++ b/src/lib/snapshotClient.ts
@@ -47,6 +47,7 @@ import {
     type MockupVariantImageSnapshot,
 } from './mockupVariantSnapshot';
 import { useMockupVariantImageStore } from '../store/mockupVariantImageStore';
+import { auditMockupImageCoverage } from './snapshotImageAudit';
 
 export const OWNER_TOKEN_KEY = 'synapse-owner-token';
 
@@ -260,8 +261,24 @@ export const saveSnapshot = async (
     const { snapshot: variantWire, images: variantImages } =
         splitVariantSnapshotImages(fullVariantSnapshot);
     bundle.mockupVariantImages = variantWire;
-    if (onWarnings && fullVariantSnapshot.summary.warnings?.length) {
-        onWarnings(fullVariantSnapshot.summary.warnings);
+
+    // Surface any pre-save integrity warnings (variant size-guard drops PLUS a
+    // "mockup spec has screens but no images were found" gap — the failure mode
+    // that let an image-less snapshot be pinned as the public demo). Reported
+    // together so the owner sees every reason a saved snapshot may be missing
+    // preview images before they pin it.
+    if (onWarnings) {
+        const warnings = [
+            ...auditMockupImageCoverage({
+                artifacts: bundle.artifacts,
+                artifactVersions: bundle.artifactVersions,
+                images,
+                screenImages,
+                variantImages: fullVariantSnapshot,
+            }),
+            ...(fullVariantSnapshot.summary.warnings ?? []),
+        ];
+        if (warnings.length > 0) onWarnings(warnings);
     }
 
     onProgress?.({ phase: 'bundle', completed: 0, total: 0 });

--- a/src/lib/snapshotImageAudit.ts
+++ b/src/lib/snapshotImageAudit.ts
@@ -1,0 +1,92 @@
+// Save-time integrity check for snapshot mockup images.
+//
+// A snapshot bundles a project's mockup SPECS (the `mockup` artifact version's
+// JSON) separately from its rendered mockup IMAGES (IndexedDB blobs shipped one
+// per request). Nothing forces the two to agree, so it is possible to save — and
+// then pin as the public demo — a snapshot whose mockup spec lists screens while
+// carrying zero images (e.g. the images were generated in a different browser, or
+// IndexedDB was cleared, or only the spec was regenerated). The demo then renders
+// mockup specs with no previews and the mockups "disappear".
+//
+// This module is a pure, deterministic audit that detects exactly that mismatch
+// so the save UI can warn the owner BEFORE they pin an image-less demo. It never
+// blocks the save — the specs are still worth keeping — it only surfaces the gap.
+
+import type {
+    Artifact, ArtifactVersion, MockupImageRecord, ScreenInventoryImageRecord,
+} from '../types';
+import { tryParsePayload, readExtraMockupScreens } from './mockupParsing';
+import type { MockupVariantImageSnapshot } from './mockupVariantSnapshot';
+
+export interface MockupImageAuditInput {
+    artifacts: Artifact[];
+    artifactVersions: ArtifactVersion[];
+    /** Mockup images collected for the snapshot (mockupImageStore / IDB). */
+    images: Array<Pick<MockupImageRecord, 'versionId'>>;
+    /** User-uploaded screen-inventory images (also hold user_uploaded mockups,
+     *  keyed by the mockup artifact version id). */
+    screenImages: Array<Pick<ScreenInventoryImageRecord, 'artifactVersionId'>>;
+    /** Per-variant mockup images (Phase 3B/3C) in their portable snapshot form. */
+    variantImages?: MockupVariantImageSnapshot;
+}
+
+// Resolve the mockup artifact's preferred version: its recorded
+// `currentVersionId`, falling back to the highest-numbered version for that
+// artifact so a bundle with a stale/absent pointer still audits sensibly.
+const resolveMockupVersion = (
+    artifact: Artifact,
+    versions: ArtifactVersion[],
+): ArtifactVersion | undefined => {
+    const own = versions.filter((v) => v.artifactId === artifact.id);
+    if (artifact.currentVersionId) {
+        const preferred = own.find((v) => v.id === artifact.currentVersionId);
+        if (preferred) return preferred;
+    }
+    if (own.length === 0) return undefined;
+    return own.reduce((a, b) => (b.versionNumber > a.versionNumber ? b : a));
+};
+
+/**
+ * Returns human-readable warnings for mockup-image gaps in a snapshot bundle.
+ * Empty when the project has no mockup artifact, the mockup spec has no screens,
+ * or at least one mockup image (AI-generated, uploaded, or a variant) was
+ * collected for the mockup version. Pure — safe to unit-test in isolation.
+ */
+export function auditMockupImageCoverage(input: MockupImageAuditInput): string[] {
+    const warnings: string[] = [];
+
+    const mockupArtifact = input.artifacts.find((a) => a.type === 'mockup');
+    if (!mockupArtifact) return warnings;
+
+    const version = resolveMockupVersion(mockupArtifact, input.artifactVersions);
+    if (!version) return warnings;
+
+    const payload = tryParsePayload(version);
+    if (!payload) return warnings;
+    const extraScreens = readExtraMockupScreens(
+        version.metadata as Record<string, unknown> | undefined,
+    );
+    const screenCount = payload.screens.length + extraScreens.length;
+    if (screenCount === 0) return warnings;
+
+    const versionId = version.id;
+    const aiImages = input.images.filter((r) => r.versionId === versionId).length;
+    const uploadedImages = input.screenImages.filter(
+        (r) => r.artifactVersionId === versionId,
+    ).length;
+    const variantRecords = (input.variantImages?.records ?? []).filter(
+        (r) => r.versionId === versionId,
+    ).length;
+
+    if (aiImages + uploadedImages + variantRecords === 0) {
+        warnings.push(
+            `The Mockups artifact describes ${screenCount} screen${screenCount === 1 ? '' : 's'}, `
+            + 'but no rendered mockup images were found on this device. The snapshot will save the '
+            + 'mockup specs without any preview images — generate the mockup images (or open the '
+            + 'project on the device where they were generated) before pinning this snapshot as the '
+            + 'public demo, or the demo will show mockups with no previews.',
+        );
+    }
+
+    return warnings;
+}


### PR DESCRIPTION
## What & why

The demo project's mockups, previously visible, disappeared. I traced it to the actual data: the **currently-pinned demo snapshot** (pinned `2026-07-10`) genuinely contains **zero mockup images** — `manifest.imageCount: 0`, `images: []`, `screenImages: []`, `mockupVariantImages.records: []` — even though its `mockup` artifact carries a valid 5-screen spec (Document Library, Document Validation Workspace, …).

The restore and render paths are **correct** — they simply have no images to show. The real gap is at **save/pin time**: snapshot mockup *specs* (the `mockup` artifact JSON) and mockup *images* (IndexedDB blobs, shipped one-per-request) are collected independently, so it was possible to save — and then pin as the public demo — a snapshot whose spec lists screens while carrying no rendered images. Nothing surfaced that mismatch, so an image-less demo went live silently.

## Change

- **`src/lib/snapshotImageAudit.ts`** (new, pure, unit-tested) — `auditMockupImageCoverage` flags the case where the mockup version has ≥1 screen but **no** mockup image (AI-generated, uploaded, or per-variant) was collected for that version id.
- **`saveSnapshot`** now runs the audit and surfaces its warnings through the existing `onWarnings` → `SnapshotsPanel` amber notice, alongside the existing variant size-guard warnings. It **never blocks the save** — the specs are still worth keeping.
- **`SnapshotsPanel.handleSetDemo`** adds a heads-up when pinning a zero-image snapshot as the public demo. Generalized the "saved with a note" footer copy (no longer variant-specific).
- **`CLAUDE.md`** documents the audit and records the root cause.

## Important note for the owner

A snapshot with no images is a **data** condition — no restore/render change can recover images the blob never contained. To bring the demo mockups back: regenerate the mockup images on the source project, re-save the snapshot (the new audit confirms images are included), and re-pin it as the demo. This change ensures the empty-image state can't be pinned silently again.

## Verification

- `npm run build` ✅ (tsc -b && vite build)
- `npm run lint` ✅
- New test `snapshotImageAudit.test.ts` (8 cases) ✅ plus existing `snapshotClient` / `loadDemoProject` suites ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oak656j5WZs9a9xt69968

---
_Generated by [Claude Code](https://claude.ai/code/session_011oak656j5WZs9a9xt69968)_