### PR TITLE
Update homepage to futuristic mockup and replace app icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/icon.png" />
-    <link rel="apple-touch-icon" href="/icon.png" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Synapse</title>
   </head>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,33 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="22" stdDeviation="26" flood-color="#64748B" flood-opacity=".22"/></filter>
+    <radialGradient id="glow" cx="50%" cy="18%" r="82%"><stop stop-color="#FFFFFF"/><stop offset="1" stop-color="#EEF4FF"/></radialGradient>
+    <linearGradient id="blue" x1="365" y1="616" x2="444" y2="812" gradientUnits="userSpaceOnUse"><stop stop-color="#60A5FA"/><stop offset=".55" stop-color="#2563EB"/><stop offset="1" stop-color="#1E3A8A"/></linearGradient>
+    <linearGradient id="teal" x1="268" y1="353" x2="446" y2="598" gradientUnits="userSpaceOnUse"><stop stop-color="#22D3EE"/><stop offset="1" stop-color="#0F766E"/></linearGradient>
+    <linearGradient id="line1" x1="432" y1="398" x2="696" y2="234" gradientUnits="userSpaceOnUse"><stop stop-color="#38BDF8"/><stop offset="1" stop-color="#2563EB"/></linearGradient>
+    <linearGradient id="line2" x1="438" y1="512" x2="699" y2="386" gradientUnits="userSpaceOnUse"><stop stop-color="#2DD4BF"/><stop offset="1" stop-color="#0891B2"/></linearGradient>
+    <linearGradient id="line3" x1="443" y1="604" x2="702" y2="578" gradientUnits="userSpaceOnUse"><stop stop-color="#22D3EE"/><stop offset="1" stop-color="#4F46E5"/></linearGradient>
+    <linearGradient id="line4" x1="444" y1="654" x2="708" y2="779" gradientUnits="userSpaceOnUse"><stop stop-color="#8B5CF6"/><stop offset="1" stop-color="#6D28D9"/></linearGradient>
+    <linearGradient id="cardBlue" x1="684" y1="152" x2="865" y2="306" gradientUnits="userSpaceOnUse"><stop stop-color="#3B82F6"/><stop offset="1" stop-color="#0B63E5"/></linearGradient>
+    <linearGradient id="cardTeal" x1="684" y1="334" x2="865" y2="488" gradientUnits="userSpaceOnUse"><stop stop-color="#22D3EE"/><stop offset="1" stop-color="#0796A4"/></linearGradient>
+    <linearGradient id="cardPurple" x1="684" y1="516" x2="865" y2="670" gradientUnits="userSpaceOnUse"><stop stop-color="#8B5CF6"/><stop offset="1" stop-color="#5B21B6"/></linearGradient>
+  </defs>
+  <rect x="96" y="96" width="832" height="832" rx="170" fill="#F8FAFF"/>
+  <rect x="96" y="96" width="832" height="832" rx="170" fill="url(#glow)"/>
+  <g filter="url(#shadow)">
+    <path d="M201 680c30-67 102-91 174-91s144 24 174 91c10 23-6 50-31 52-106 8-211 8-317 0-25-2-41-29-31-52z" fill="url(#blue)"/>
+    <path d="M362 405c0-39-30-85-97-102-13-3-25 7-22 20 15 72 69 112 119 115v135c0 12 10 22 22 22s22-10 22-22V438c50-3 104-43 119-115 3-13-9-23-22-20-67 17-97 63-97 102-10 12-19 31-22 54-3-23-12-42-22-54z" fill="url(#teal)"/>
+    <path d="M294 345c35 21 59 50 75 91" stroke="#67E8F9" stroke-width="9" stroke-linecap="round" opacity=".45"/>
+    <path d="M473 345c-34 22-57 51-73 91" stroke="#67E8F9" stroke-width="9" stroke-linecap="round" opacity=".45"/>
+    <path d="M480 494c70-38 70-143 126-200 30-31 63-43 101-43" stroke="url(#line1)" stroke-width="16" stroke-linecap="round"/>
+    <path d="M479 559c70-23 82-111 152-124 26-5 52-4 78-4" stroke="url(#line2)" stroke-width="16" stroke-linecap="round"/>
+    <path d="M479 630c67-7 102-17 160 3 33 12 50 16 71 14" stroke="url(#line3)" stroke-width="16" stroke-linecap="round"/>
+    <path d="M479 679c62 23 74 124 157 145 28 7 51 5 78 5" stroke="url(#line4)" stroke-width="16" stroke-linecap="round"/>
+    <circle cx="725" cy="251" r="32" fill="#2563EB"/><circle cx="725" cy="431" r="32" fill="#0EA5B7"/><circle cx="725" cy="647" r="32" fill="#6D28D9"/><circle cx="725" cy="829" r="32" fill="#7C3AED"/>
+    <rect x="694" y="150" width="216" height="130" rx="28" fill="url(#cardBlue)"/><rect x="694" y="332" width="216" height="130" rx="28" fill="url(#cardTeal)"/><rect x="694" y="514" width="216" height="130" rx="28" fill="url(#cardPurple)"/><rect x="694" y="696" width="216" height="130" rx="28" fill="#EEF2FF"/>
+    <path d="M744 199h108M744 228h56M820 228h42M744 257h82" stroke="white" stroke-width="14" stroke-linecap="round" opacity=".9"/>
+    <circle cx="754" cy="374" r="15" fill="white"/><path d="M734 424l43-56 35 45 22-29 45 60H734z" fill="white" opacity=".93"/>
+    <path d="M800 546v34M760 612h80M720 612h40v32h-40zM840 612h40v32h-40zM780 546h40v34h-40z" stroke="white" stroke-width="16" stroke-linejoin="round"/>
+    <rect x="736" y="725" width="128" height="34" rx="7" fill="#93A8EA"/><rect x="736" y="778" width="56" height="48" rx="7" fill="#93A8EA"/><rect x="808" y="778" width="56" height="48" rx="7" fill="#93A8EA"/><path d="M761 802h18M833 802h18" stroke="white" stroke-width="10" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -301,7 +301,8 @@ export function HomePage() {
             {/* Top bar */}
             <div className="flex items-center justify-between px-6 py-4">
                 <div className="flex items-center gap-3">
-                    <h1 className="text-2xl font-bold tracking-tight">Synapse</h1>
+                    <img src="/icon.svg" alt="Synapse icon" className="h-10 w-10 rounded-xl shadow-sm" />
+                    <h1 className="bg-gradient-to-r from-sky-500 via-blue-600 to-violet-600 bg-clip-text text-2xl font-bold tracking-tight text-transparent">Synapse</h1>
                 </div>
                 <div className="flex items-center gap-2">
                     {user && (
@@ -382,6 +383,10 @@ export function HomePage() {
             {/* Main content — vertically centered */}
             <div className="flex-1 flex flex-col items-center justify-center px-6 pb-12 -mt-8">
                 <div className="w-full max-w-2xl">
+                    <div className="mb-6 flex justify-center">
+                        <img src="/icon.svg" alt="Synapse icon" className="h-28 w-28 rounded-[1.75rem] drop-shadow-xl" />
+                    </div>
+
                     {/* Take the interactive tour + View demo project — inline pills */}
                     <div className="flex flex-wrap justify-center items-center gap-2 mb-8">
                         <button
@@ -404,9 +409,12 @@ export function HomePage() {
                     </div>
 
                     {/* Hero title */}
-                    <h2 className="text-4xl md:text-5xl font-bold text-center mb-8">
+                    <h2 className="mb-3 bg-gradient-to-r from-sky-500 via-blue-600 to-violet-600 bg-clip-text text-center text-4xl font-bold text-transparent md:text-5xl">
                         Welcome to Synapse
                     </h2>
+                    <p className="mb-8 text-center text-lg text-neutral-500">
+                        From plain-language to product blueprint
+                    </p>
 
                     {/* Example prompt pills */}
                     <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-hide">

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -123,29 +123,29 @@ export function LoginPage() {
     }
 
     return (
-        <div className="relative min-h-screen overflow-hidden bg-[#f7faff] text-slate-900">
+        <div className="relative min-h-screen overflow-x-hidden bg-[#f7faff] text-slate-900">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_8%,rgba(255,255,255,0.98),rgba(239,246,255,0.92)_48%,rgba(226,236,255,0.9)_100%)]" />
             <div className="pointer-events-none absolute inset-x-[-20%] top-28 h-48 rotate-[-3deg] bg-[linear-gradient(100deg,transparent,rgba(34,211,238,0.16),rgba(59,130,246,0.13),rgba(124,58,237,0.12),transparent)] blur-xl" />
             <div className="pointer-events-none absolute left-1/2 top-28 h-64 w-[56rem] -translate-x-1/2 rounded-full border border-sky-200/50 opacity-60 [mask-image:linear-gradient(90deg,transparent,black,transparent)]" />
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_28%,rgba(14,165,233,0.22),transparent_2.2rem),radial-gradient(circle_at_79%_16%,rgba(124,58,237,0.16),transparent_2rem),radial-gradient(circle_at_86%_39%,rgba(45,212,191,0.2),transparent_1.6rem)]" />
 
-            <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6 py-10">
-                <div className="w-full max-w-[43.5rem] space-y-7">
+            <div className="relative z-10 flex min-h-screen flex-col items-center justify-start px-5 py-8 sm:justify-center sm:px-6 sm:py-10">
+                <div className="w-full max-w-sm space-y-5 sm:max-w-[43.5rem] sm:space-y-7">
                     {/* Name + tagline */}
                     <div className="flex flex-col items-center text-center">
-                        <img src="/icon.svg" alt="Synapse icon" className="mb-4 h-36 w-36 rounded-[2rem] drop-shadow-2xl md:h-44 md:w-44" />
-                        <h1 className="bg-gradient-to-r from-sky-500 via-blue-600 to-violet-600 bg-clip-text text-6xl font-bold tracking-tight text-transparent md:text-7xl">Synapse</h1>
-                        <p className="mt-3 text-xl text-slate-500 md:text-2xl">
+                        <img src="/icon.svg" alt="Synapse icon" className="mb-3 h-28 w-28 rounded-[1.75rem] drop-shadow-2xl sm:mb-4 sm:h-36 sm:w-36 md:h-44 md:w-44" />
+                        <h1 className="bg-gradient-to-r from-sky-500 via-blue-600 to-violet-600 bg-clip-text text-5xl font-bold tracking-tight text-transparent sm:text-6xl md:text-7xl">Synapse</h1>
+                        <p className="mt-2 text-base text-slate-500 sm:mt-3 sm:text-xl md:text-2xl">
                             From plain-language to product blueprint
                         </p>
                     </div>
 
                     {/* Tour + Demo actions */}
-                    <div className="flex items-center justify-center gap-4">
+                    <div className="grid grid-cols-2 gap-3 sm:flex sm:items-center sm:justify-center sm:gap-4">
                         <button
                             type="button"
                             onClick={() => navigate('/tour')}
-                            className="inline-flex items-center gap-3 rounded-full border border-blue-200 bg-white/45 px-8 py-3 text-lg font-medium text-blue-700 shadow-sm shadow-blue-200/50 backdrop-blur hover:border-blue-300 hover:bg-white/70 transition"
+                            className="inline-flex min-w-0 items-center justify-center gap-2 rounded-full border border-blue-200 bg-white/45 px-3 py-3 text-sm font-semibold text-blue-700 shadow-sm shadow-blue-200/50 backdrop-blur transition hover:border-blue-300 hover:bg-white/70 sm:gap-3 sm:px-8 sm:text-lg"
                         >
                             <Play size={22} className="text-blue-500" />
                             Take the tour
@@ -153,7 +153,7 @@ export function LoginPage() {
                         <button
                             type="button"
                             onClick={handleOpenDemo}
-                            className="inline-flex items-center gap-3 rounded-full border border-cyan-200 bg-white/45 px-8 py-3 text-lg font-medium text-teal-600 shadow-sm shadow-cyan-200/50 backdrop-blur hover:border-cyan-300 hover:bg-white/70 transition"
+                            className="inline-flex min-w-0 items-center justify-center gap-2 rounded-full border border-cyan-200 bg-white/45 px-3 py-3 text-sm font-semibold text-teal-600 shadow-sm shadow-cyan-200/50 backdrop-blur transition hover:border-cyan-300 hover:bg-white/70 sm:gap-3 sm:px-8 sm:text-lg"
                         >
                             <Box size={22} />
                             Demo project
@@ -163,7 +163,7 @@ export function LoginPage() {
                     {/* Login card */}
                     <form
                         onSubmit={handleSubmit}
-                        className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-2xl shadow-slate-300/45 backdrop-blur-xl md:p-8 space-y-5"
+                        className="space-y-4 rounded-[2rem] border border-white/70 bg-white/80 p-5 shadow-2xl shadow-slate-300/45 backdrop-blur-xl sm:space-y-5 sm:p-6 md:p-8"
                         noValidate
                     >
                     {/* Sign In / Sign Up tabs */}
@@ -174,7 +174,7 @@ export function LoginPage() {
                                 setTab('signin');
                                 clearErrors();
                             }}
-                            className={`py-2 rounded-lg text-sm font-medium transition ${
+                            className={`py-2.5 rounded-xl text-sm font-medium transition ${
                                 tab === 'signin'
                                     ? 'bg-white text-blue-700 shadow-md shadow-blue-200/60'
                                     : 'text-slate-500 hover:text-slate-700'
@@ -188,7 +188,7 @@ export function LoginPage() {
                                 setTab('signup');
                                 clearErrors();
                             }}
-                            className={`py-2 rounded-lg text-sm font-medium transition ${
+                            className={`py-2.5 rounded-xl text-sm font-medium transition ${
                                 tab === 'signup'
                                     ? 'bg-white text-blue-700 shadow-md shadow-blue-200/60'
                                     : 'text-slate-500 hover:text-slate-700'
@@ -229,7 +229,7 @@ export function LoginPage() {
                                     autoComplete="name"
                                     aria-invalid={fieldErrors.name ? true : undefined}
                                     aria-describedby={fieldErrors.name ? 'login-name-error' : undefined}
-                                    className={`w-full bg-white/80 border rounded-2xl pl-14 pr-4 py-4 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
+                                    className={`w-full bg-white/80 border rounded-2xl pl-12 pr-4 py-3.5 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
                                         fieldErrors.name
                                             ? 'border-red-300 focus:ring-red-300/50 focus:border-red-400'
                                             : 'border-slate-200 focus:ring-blue-300/60 focus:border-blue-400'
@@ -263,7 +263,7 @@ export function LoginPage() {
                                 autoComplete="email"
                                 aria-invalid={fieldErrors.email ? true : undefined}
                                 aria-describedby={fieldErrors.email ? 'login-email-error' : undefined}
-                                className={`w-full bg-white/80 border rounded-2xl pl-14 pr-4 py-4 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
+                                className={`w-full bg-white/80 border rounded-2xl pl-12 pr-4 py-3.5 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
                                     fieldErrors.email
                                         ? 'border-red-300 focus:ring-red-300/50 focus:border-red-400'
                                         : 'border-slate-200 focus:ring-blue-300/60 focus:border-blue-400'
@@ -296,7 +296,7 @@ export function LoginPage() {
                                 autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
                                 aria-invalid={fieldErrors.password ? true : undefined}
                                 aria-describedby={fieldErrors.password ? 'login-password-error' : undefined}
-                                className={`w-full bg-white/80 border rounded-2xl pl-14 pr-4 py-4 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
+                                className={`w-full bg-white/80 border rounded-2xl pl-12 pr-4 py-3.5 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
                                     fieldErrors.password
                                         ? 'border-red-300 focus:ring-red-300/50 focus:border-red-400'
                                         : 'border-slate-200 focus:ring-blue-300/60 focus:border-blue-400'
@@ -315,24 +315,24 @@ export function LoginPage() {
                     <button
                         type="submit"
                         disabled={disabled}
-                        className="w-full rounded-2xl bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-600 py-4 text-lg font-semibold text-white shadow-lg shadow-indigo-300/60 transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60 inline-flex items-center justify-center gap-2"
+                        className="relative inline-flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-600 px-5 py-3.5 text-base font-semibold text-white shadow-lg shadow-indigo-300/60 transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60 sm:py-4 sm:text-lg"
                     >
-                        {submitting && <Loader2 size={16} className="animate-spin" />}
-                        {primaryLabel}
-                        <ArrowRight size={22} className="ml-auto" />
+                        {submitting && <Loader2 size={16} className="mr-2 animate-spin" />}
+                        <span>{primaryLabel}</span>
+                        <ArrowRight size={22} className="absolute right-5" />
                     </button>
 
                     {/* Divider */}
                     <div className="flex items-center gap-3">
                         <div className="flex-1 h-px bg-slate-200" />
-                        <span className="text-base text-slate-500">or</span>
+                        <span className="text-sm text-slate-500 sm:text-base">or</span>
                         <div className="flex-1 h-px bg-slate-200" />
                     </div>
 
                     {/* GitHub */}
                     <a
                         href="/api/auth/github"
-                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-slate-200 bg-white/90 text-slate-900 hover:bg-white transition text-lg font-medium shadow-sm"
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-slate-200 bg-white/90 text-slate-900 hover:bg-white transition text-base font-medium shadow-sm sm:text-lg"
                     >
                         <Github size={16} />
                         Continue with GitHub
@@ -341,13 +341,13 @@ export function LoginPage() {
                     {/* LinkedIn */}
                     <a
                         href="/api/auth/linkedin"
-                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-slate-200 bg-white/90 text-slate-900 hover:bg-white transition text-lg font-medium shadow-sm"
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-slate-200 bg-white/90 text-slate-900 hover:bg-white transition text-base font-medium shadow-sm sm:text-lg"
                     >
                         <Linkedin size={16} />
                         Continue with LinkedIn
                     </a>
 
-                    <div className="flex items-center justify-center gap-2 pt-1 text-sm text-slate-500">
+                    <div className="flex items-center justify-center gap-2 pt-1 text-center text-xs text-slate-500 sm:text-sm">
                         <ShieldCheck size={18} className="text-violet-500" />
                         Your data is secure. We never share your information.
                     </div>

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Github, Linkedin, Loader2, Lock, Mail, User as UserIcon } from 'lucide-react';
+import { ArrowRight, Box, Eye, Github, Linkedin, Loader2, Lock, Mail, Play, ShieldCheck, User as UserIcon } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { DEMO_PROJECT_ID } from '../data/demoProject';
 
@@ -123,42 +123,51 @@ export function LoginPage() {
     }
 
     return (
-        <div className="min-h-screen flex flex-col items-center justify-center px-6 py-12 bg-neutral-900">
-            <div className="w-full max-w-sm space-y-6">
-                {/* Name + tagline */}
-                <div className="flex flex-col items-center">
-                    <h1 className="text-3xl font-bold tracking-tight text-center">Synapse</h1>
-                    <p className="text-sm text-neutral-400 text-center mt-2">
-                        From plain-language to product blueprint
-                    </p>
-                </div>
+        <div className="relative min-h-screen overflow-hidden bg-[#f7faff] text-slate-900">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_8%,rgba(255,255,255,0.98),rgba(239,246,255,0.92)_48%,rgba(226,236,255,0.9)_100%)]" />
+            <div className="pointer-events-none absolute inset-x-[-20%] top-28 h-48 rotate-[-3deg] bg-[linear-gradient(100deg,transparent,rgba(34,211,238,0.16),rgba(59,130,246,0.13),rgba(124,58,237,0.12),transparent)] blur-xl" />
+            <div className="pointer-events-none absolute left-1/2 top-28 h-64 w-[56rem] -translate-x-1/2 rounded-full border border-sky-200/50 opacity-60 [mask-image:linear-gradient(90deg,transparent,black,transparent)]" />
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_28%,rgba(14,165,233,0.22),transparent_2.2rem),radial-gradient(circle_at_79%_16%,rgba(124,58,237,0.16),transparent_2rem),radial-gradient(circle_at_86%_39%,rgba(45,212,191,0.2),transparent_1.6rem)]" />
 
-                {/* Tour + Demo actions */}
-                <div className="flex items-center justify-center gap-3">
-                    <button
-                        type="button"
-                        onClick={() => navigate('/tour')}
-                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 text-sm text-indigo-300 hover:border-indigo-400/60 hover:text-indigo-200 transition"
-                    >
-                        Take the tour
-                    </button>
-                    <button
-                        type="button"
-                        onClick={handleOpenDemo}
-                        className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 text-sm text-indigo-300 hover:border-indigo-400/60 hover:text-indigo-200 transition"
-                    >
-                        Demo project
-                    </button>
-                </div>
+            <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6 py-10">
+                <div className="w-full max-w-[43.5rem] space-y-7">
+                    {/* Name + tagline */}
+                    <div className="flex flex-col items-center text-center">
+                        <img src="/icon.svg" alt="Synapse icon" className="mb-4 h-36 w-36 rounded-[2rem] drop-shadow-2xl md:h-44 md:w-44" />
+                        <h1 className="bg-gradient-to-r from-sky-500 via-blue-600 to-violet-600 bg-clip-text text-6xl font-bold tracking-tight text-transparent md:text-7xl">Synapse</h1>
+                        <p className="mt-3 text-xl text-slate-500 md:text-2xl">
+                            From plain-language to product blueprint
+                        </p>
+                    </div>
 
-                {/* Login card */}
-                <form
-                    onSubmit={handleSubmit}
-                    className="rounded-3xl bg-neutral-900/80 backdrop-blur-xl border border-white/10 p-6 space-y-5"
-                    noValidate
-                >
+                    {/* Tour + Demo actions */}
+                    <div className="flex items-center justify-center gap-4">
+                        <button
+                            type="button"
+                            onClick={() => navigate('/tour')}
+                            className="inline-flex items-center gap-3 rounded-full border border-blue-200 bg-white/45 px-8 py-3 text-lg font-medium text-blue-700 shadow-sm shadow-blue-200/50 backdrop-blur hover:border-blue-300 hover:bg-white/70 transition"
+                        >
+                            <Play size={22} className="text-blue-500" />
+                            Take the tour
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleOpenDemo}
+                            className="inline-flex items-center gap-3 rounded-full border border-cyan-200 bg-white/45 px-8 py-3 text-lg font-medium text-teal-600 shadow-sm shadow-cyan-200/50 backdrop-blur hover:border-cyan-300 hover:bg-white/70 transition"
+                        >
+                            <Box size={22} />
+                            Demo project
+                        </button>
+                    </div>
+
+                    {/* Login card */}
+                    <form
+                        onSubmit={handleSubmit}
+                        className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-2xl shadow-slate-300/45 backdrop-blur-xl md:p-8 space-y-5"
+                        noValidate
+                    >
                     {/* Sign In / Sign Up tabs */}
-                    <div className="grid grid-cols-2 gap-1 p-1 rounded-xl bg-black/40 border border-white/10">
+                    <div className="grid grid-cols-2 gap-1 p-1 rounded-2xl bg-slate-100/80 border border-slate-200">
                         <button
                             type="button"
                             onClick={() => {
@@ -167,8 +176,8 @@ export function LoginPage() {
                             }}
                             className={`py-2 rounded-lg text-sm font-medium transition ${
                                 tab === 'signin'
-                                    ? 'bg-white/10 text-white'
-                                    : 'text-neutral-400 hover:text-neutral-200'
+                                    ? 'bg-white text-blue-700 shadow-md shadow-blue-200/60'
+                                    : 'text-slate-500 hover:text-slate-700'
                             }`}
                         >
                             Sign In
@@ -181,8 +190,8 @@ export function LoginPage() {
                             }}
                             className={`py-2 rounded-lg text-sm font-medium transition ${
                                 tab === 'signup'
-                                    ? 'bg-white/10 text-white'
-                                    : 'text-neutral-400 hover:text-neutral-200'
+                                    ? 'bg-white text-blue-700 shadow-md shadow-blue-200/60'
+                                    : 'text-slate-500 hover:text-slate-700'
                             }`}
                         >
                             Sign Up
@@ -194,7 +203,7 @@ export function LoginPage() {
                         <div
                             role="alert"
                             aria-live="polite"
-                            className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+                            className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
                         >
                             {banner}
                         </div>
@@ -209,7 +218,7 @@ export function LoginPage() {
                             <div className="relative">
                                 <UserIcon
                                     size={16}
-                                    className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+                                    className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
                                 />
                                 <input
                                     id="login-name"
@@ -220,15 +229,15 @@ export function LoginPage() {
                                     autoComplete="name"
                                     aria-invalid={fieldErrors.name ? true : undefined}
                                     aria-describedby={fieldErrors.name ? 'login-name-error' : undefined}
-                                    className={`w-full bg-black/40 border rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 transition ${
+                                    className={`w-full bg-white/80 border rounded-2xl pl-14 pr-4 py-4 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
                                         fieldErrors.name
-                                            ? 'border-red-500/60 focus:ring-red-500/40 focus:border-red-500/60'
-                                            : 'border-white/10 focus:ring-indigo-500/50 focus:border-indigo-500/50'
+                                            ? 'border-red-300 focus:ring-red-300/50 focus:border-red-400'
+                                            : 'border-slate-200 focus:ring-blue-300/60 focus:border-blue-400'
                                     }`}
                                 />
                             </div>
                             {fieldErrors.name && (
-                                <p id="login-name-error" className="mt-1.5 text-xs text-red-300">
+                                <p id="login-name-error" className="mt-1.5 text-xs text-red-600">
                                     {fieldErrors.name}
                                 </p>
                             )}
@@ -243,7 +252,7 @@ export function LoginPage() {
                         <div className="relative">
                             <Mail
                                 size={16}
-                                className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+                                className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
                             />
                             <input
                                 id="login-email"
@@ -254,15 +263,15 @@ export function LoginPage() {
                                 autoComplete="email"
                                 aria-invalid={fieldErrors.email ? true : undefined}
                                 aria-describedby={fieldErrors.email ? 'login-email-error' : undefined}
-                                className={`w-full bg-black/40 border rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 transition ${
+                                className={`w-full bg-white/80 border rounded-2xl pl-14 pr-4 py-4 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
                                     fieldErrors.email
-                                        ? 'border-red-500/60 focus:ring-red-500/40 focus:border-red-500/60'
-                                        : 'border-white/10 focus:ring-indigo-500/50 focus:border-indigo-500/50'
+                                        ? 'border-red-300 focus:ring-red-300/50 focus:border-red-400'
+                                        : 'border-slate-200 focus:ring-blue-300/60 focus:border-blue-400'
                                 }`}
                             />
                         </div>
                         {fieldErrors.email && (
-                            <p id="login-email-error" className="mt-1.5 text-xs text-red-300">
+                            <p id="login-email-error" className="mt-1.5 text-xs text-red-600">
                                 {fieldErrors.email}
                             </p>
                         )}
@@ -276,7 +285,7 @@ export function LoginPage() {
                         <div className="relative">
                             <Lock
                                 size={16}
-                                className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none"
+                                className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
                             />
                             <input
                                 id="login-password"
@@ -287,15 +296,16 @@ export function LoginPage() {
                                 autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
                                 aria-invalid={fieldErrors.password ? true : undefined}
                                 aria-describedby={fieldErrors.password ? 'login-password-error' : undefined}
-                                className={`w-full bg-black/40 border rounded-xl pl-11 pr-4 py-3 text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 transition ${
+                                className={`w-full bg-white/80 border rounded-2xl pl-14 pr-4 py-4 text-base text-slate-900 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 transition ${
                                     fieldErrors.password
-                                        ? 'border-red-500/60 focus:ring-red-500/40 focus:border-red-500/60'
-                                        : 'border-white/10 focus:ring-indigo-500/50 focus:border-indigo-500/50'
+                                        ? 'border-red-300 focus:ring-red-300/50 focus:border-red-400'
+                                        : 'border-slate-200 focus:ring-blue-300/60 focus:border-blue-400'
                                 }`}
                             />
+                        <Eye size={18} className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
                         </div>
                         {fieldErrors.password && (
-                            <p id="login-password-error" className="mt-1.5 text-xs text-red-300">
+                            <p id="login-password-error" className="mt-1.5 text-xs text-red-600">
                                 {fieldErrors.password}
                             </p>
                         )}
@@ -305,23 +315,24 @@ export function LoginPage() {
                     <button
                         type="submit"
                         disabled={disabled}
-                        className="w-full py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-60 disabled:cursor-not-allowed font-semibold text-white transition inline-flex items-center justify-center gap-2"
+                        className="w-full rounded-2xl bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-600 py-4 text-lg font-semibold text-white shadow-lg shadow-indigo-300/60 transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60 inline-flex items-center justify-center gap-2"
                     >
                         {submitting && <Loader2 size={16} className="animate-spin" />}
                         {primaryLabel}
+                        <ArrowRight size={22} className="ml-auto" />
                     </button>
 
                     {/* Divider */}
                     <div className="flex items-center gap-3">
-                        <div className="flex-1 h-px bg-white/10" />
-                        <span className="text-xs text-neutral-500">or</span>
-                        <div className="flex-1 h-px bg-white/10" />
+                        <div className="flex-1 h-px bg-slate-200" />
+                        <span className="text-base text-slate-500">or</span>
+                        <div className="flex-1 h-px bg-slate-200" />
                     </div>
 
                     {/* GitHub */}
                     <a
                         href="/api/auth/github"
-                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-white/10 bg-neutral-800 text-white hover:bg-neutral-700 transition text-sm font-medium"
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-slate-200 bg-white/90 text-slate-900 hover:bg-white transition text-lg font-medium shadow-sm"
                     >
                         <Github size={16} />
                         Continue with GitHub
@@ -330,13 +341,19 @@ export function LoginPage() {
                     {/* LinkedIn */}
                     <a
                         href="/api/auth/linkedin"
-                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-[#0a66c2]/50 bg-[#0a66c2]/15 text-[#9bc9f5] hover:bg-[#0a66c2]/25 transition text-sm font-medium"
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-slate-200 bg-white/90 text-slate-900 hover:bg-white transition text-lg font-medium shadow-sm"
                     >
                         <Linkedin size={16} />
                         Continue with LinkedIn
                     </a>
+
+                    <div className="flex items-center justify-center gap-2 pt-1 text-sm text-slate-500">
+                        <ShieldCheck size={18} className="text-violet-500" />
+                        Your data is secure. We never share your information.
+                    </div>
                 </form>
             </div>
+        </div>
         </div>
     );
 }


### PR DESCRIPTION
### Motivation
- Refresh the unauthenticated and signed-in homepage visuals to match the futuristic mockup and improve first‑impression branding. 
- Replace the legacy PNG icon with the new SVG icon so the new mark appears everywhere the app shell references a favicon or touch icon. 

### Description
- Added the new icon asset at `public/icon.svg` and switched the app shell to use it by updating `index.html` to reference `/icon.svg` for the favicon and Apple touch icon. 
- Restyled the unauthenticated Login/landing UI in `src/components/LoginPage.tsx` to implement the mockup look: bright radial/linear background accents, large icon hero, gradient wordmark, pill CTAs, glassy auth card, refreshed form visuals, and a gradient submit button. 
- Updated the signed-in homepage in `src/components/HomePage.tsx` to show the new icon in the header and hero and apply a gradient wordmark and tagline treatment consistent with the mockup. 
- Small UI polish changes: swapped some Lucide icons used on the auth card (`Play`, `Box`, `Eye`, `ArrowRight`, `ShieldCheck`) and adjusted many Tailwind classes to achieve the new layout and visual style. 

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Built the production bundle with `npm run build` and the build completed successfully. 
- Ran unit/interaction tests with `npm run test -- src/components/__tests__/LoginPageA11y.test.tsx src/components/__tests__/DemoEntryRouting.test.tsx` and all specified tests passed. 
- Attempted a headless browser screenshot via Playwright to capture the new homepage, but `npx playwright install chromium` failed due to the environment CDN returning `403 Forbidden`, so no screenshot could be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52995eb60083219778cd53d02588de)